### PR TITLE
W01 closeout: normalization helpers, DOM knowledge tables, the event invoker system, and per-area CI

### DIFF
--- a/.github/actions/setup-dotnet-wasm/action.yml
+++ b/.github/actions/setup-dotnet-wasm/action.yml
@@ -1,0 +1,36 @@
+# The single point of CI environment setup ([V01.01.12.02]): every workflow consumes this
+# composite instead of duplicating SDK/workload/cache steps, so wasm-tools version drift cannot
+# occur between areas. The repository checkout stays in each workflow — a local composite action
+# cannot run before the repository that contains it is checked out.
+name: Set up .NET for Vuecs
+description: >-
+  .NET 10 SDK (pinned by global.json), NuGet + workload-pack caching, and optionally the
+  wasm-tools workload for WebAssembly app builds.
+
+inputs:
+  install-wasm-tools:
+    description: Install the wasm-tools workload (needed only for WebAssembly app builds).
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Cache NuGet packages (includes workload packs)
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        # Central package versions live in the build targets; global.json pins the SDK.
+        key: nuget-${{ runner.os }}-${{ hashFiles('build/Targets/Build.References.Packages.targets', 'global.json') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
+    - name: Install wasm-tools workload
+      if: inputs.install-wasm-tools == 'true'
+      shell: bash
+      run: dotnet workload install wasm-tools --skip-manifest-update

--- a/.github/workflows/area-reactivity.yml
+++ b/.github/workflows/area-reactivity.yml
@@ -1,0 +1,46 @@
+# Area build+test for Assimalign.Vue.Reactivity ([V01.01.12.02]): path-filtered so a PR only
+# runs the areas it touches; shared build files trigger every area. The build scope is the
+# per-area slnx, keeping CI and local builds in lockstep. Jobs are independent by design —
+# cross-area contracts are enforced by project references at build time, not workflow ordering.
+name: area-reactivity
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Reactivity/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-reactivity.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Reactivity/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-reactivity.yml'
+
+jobs:
+  build-test:
+    name: build+test Reactivity
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.Reactivity/Assimalign.Vue.Reactivity.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.Reactivity/Assimalign.Vue.Reactivity.slnx --configuration Release --no-build

--- a/.github/workflows/area-runtimecore.yml
+++ b/.github/workflows/area-runtimecore.yml
@@ -1,0 +1,46 @@
+# Area build+test for Assimalign.Vue.RuntimeCore ([V01.01.12.02]): path-filtered so a PR only
+# runs the areas it touches; shared build files trigger every area. The build scope is the
+# per-area slnx, keeping CI and local builds in lockstep. Jobs are independent by design —
+# cross-area contracts are enforced by project references at build time, not workflow ordering.
+name: area-runtimecore
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.RuntimeCore/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-runtimecore.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.RuntimeCore/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-runtimecore.yml'
+
+jobs:
+  build-test:
+    name: build+test RuntimeCore
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.RuntimeCore/Assimalign.Vue.RuntimeCore.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.RuntimeCore/Assimalign.Vue.RuntimeCore.slnx --configuration Release --no-build

--- a/.github/workflows/area-runtimedom.yml
+++ b/.github/workflows/area-runtimedom.yml
@@ -1,0 +1,46 @@
+# Area build+test for Assimalign.Vue.RuntimeDom ([V01.01.12.02]): path-filtered so a PR only
+# runs the areas it touches; shared build files trigger every area. The build scope is the
+# per-area slnx, keeping CI and local builds in lockstep. Jobs are independent by design —
+# cross-area contracts are enforced by project references at build time, not workflow ordering.
+name: area-runtimedom
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.RuntimeDom/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-runtimedom.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.RuntimeDom/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-runtimedom.yml'
+
+jobs:
+  build-test:
+    name: build+test RuntimeDom
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.RuntimeDom/Assimalign.Vue.RuntimeDom.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.RuntimeDom/Assimalign.Vue.RuntimeDom.slnx --configuration Release --no-build

--- a/.github/workflows/area-shared.yml
+++ b/.github/workflows/area-shared.yml
@@ -1,0 +1,46 @@
+# Area build+test for Assimalign.Vue.Shared ([V01.01.12.02]): path-filtered so a PR only
+# runs the areas it touches; shared build files trigger every area. The build scope is the
+# per-area slnx, keeping CI and local builds in lockstep. Jobs are independent by design —
+# cross-area contracts are enforced by project references at build time, not workflow ordering.
+name: area-shared
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Shared/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-shared.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Shared/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-shared.yml'
+
+jobs:
+  build-test:
+    name: build+test Shared
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.Shared/Assimalign.Vue.Shared.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.Shared/Assimalign.Vue.Shared.slnx --configuration Release --no-build

--- a/.github/workflows/area-testing.yml
+++ b/.github/workflows/area-testing.yml
@@ -1,0 +1,46 @@
+# Area build+test for Assimalign.Vue.Testing ([V01.01.12.02]): path-filtered so a PR only
+# runs the areas it touches; shared build files trigger every area. The build scope is the
+# per-area slnx, keeping CI and local builds in lockstep. Jobs are independent by design —
+# cross-area contracts are enforced by project references at build time, not workflow ordering.
+name: area-testing
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Testing/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-testing.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Testing/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-testing.yml'
+
+jobs:
+  build-test:
+    name: build+test Testing
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.Testing/Assimalign.Vue.Testing.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.Testing/Assimalign.Vue.Testing.slnx --configuration Release --no-build

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -1,0 +1,46 @@
+# WebAssembly example-app build ([V01.01.12.02]): proves the wasm-tools toolchain and the
+# static-web-asset flow stay healthy. Runs when the example, any library, or shared build
+# files change (the app references every area transitively).
+name: webapp
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/webapp.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/webapp.yml'
+
+jobs:
+  build:
+    name: build WASM example
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET (with wasm-tools)
+        uses: ./.github/actions/setup-dotnet-wasm
+        with:
+          install-wasm-tools: 'true'
+
+      - name: Build
+        run: dotnet build examples/Assimalign.Vue.WebApp/Assimalign.Vue.WebApp.csproj --configuration Release -warnaserror

--- a/Assimalign.Vuecs.slnx
+++ b/Assimalign.Vuecs.slnx
@@ -34,6 +34,7 @@
 	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/">
 		<Project Path="libraries/Assimalign.Vue.Shared/src/Assimalign.Vue.Shared.csproj" />
 		<Project Path="libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.Tests.csproj" />
+		<Project Path="libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/Assimalign.Vue.Shared.GeneratorFixture.csproj" />
 	</Folder>
 	<Folder Name="/vuecs/libraries/Assimalign.Vue.Testing/">
 		<Project Path="libraries/Assimalign.Vue.Testing/src/Assimalign.Vue.Testing.csproj" />

--- a/Assimalign.Vuecs.slnx
+++ b/Assimalign.Vuecs.slnx
@@ -5,39 +5,120 @@
 		<Platform Name="x86" />
 	</Configurations>
 	<Folder Name="/vuecs/">
+		<File Path=".editorconfig" />
 		<File Path=".gitignore" />
 		<File Path="Directory.Build.props" />
 		<File Path="Directory.Build.targets" />
+		<File Path="global.json" />
 		<File Path="LICENSE" />
 		<File Path="nuget.config" />
 		<File Path="README.md" />
 	</Folder>
+	<Folder Name="/vuecs/.claude/">
+		<File Path=".claude/CLAUDE.md" />
+		<File Path=".claude/launch.json" />
+	</Folder>
+	<Folder Name="/vuecs/.claude/rules/">
+		<File Path=".claude/rules/build-system.md" />
+		<File Path=".claude/rules/checklist.md" />
+		<File Path=".claude/rules/deviations.md" />
+		<File Path=".claude/rules/documentation.md" />
+		<File Path=".claude/rules/general-rules.md" />
+		<File Path=".claude/rules/testing.md" />
+		<File Path=".claude/rules/workflow.md" />
+	</Folder>
+	<Folder Name="/vuecs/.claude/skills/" />
+	<Folder Name="/vuecs/.claude/skills/vuecs-work-items/">
+		<File Path=".claude/skills/vuecs-work-items/SKILL.md" />
+	</Folder>
+	<Folder Name="/vuecs/.claude/skills/vuecs-work-items/reference/">
+		<File Path=".claude/skills/vuecs-work-items/reference/project-schema.md" />
+	</Folder>
+	<Folder Name="/vuecs/.claude/skills/vuecs-work-items/scripts/">
+		<File Path=".claude/skills/vuecs-work-items/scripts/New-VuecsWorkItem.ps1" />
+	</Folder>
+	<Folder Name="/vuecs/.claude/worktrees/" />
+	<Folder Name="/vuecs/.github/">
+		<File Path=".github/pull_request_template.md" />
+	</Folder>
+	<Folder Name="/vuecs/.github/actions/" />
+	<Folder Name="/vuecs/.github/actions/setup-dotnet-wasm/">
+		<File Path=".github/actions/setup-dotnet-wasm/action.yml" />
+	</Folder>
+	<Folder Name="/vuecs/.github/ISSUE_TEMPLATE/">
+		<File Path=".github/ISSUE_TEMPLATE/config.yml" />
+		<File Path=".github/ISSUE_TEMPLATE/feature.yml" />
+		<File Path=".github/ISSUE_TEMPLATE/scope-creep.yml" />
+		<File Path=".github/ISSUE_TEMPLATE/task.yml" />
+	</Folder>
+	<Folder Name="/vuecs/.github/workflows/">
+		<File Path=".github/workflows/area-reactivity.yml" />
+		<File Path=".github/workflows/area-runtimecore.yml" />
+		<File Path=".github/workflows/area-runtimedom.yml" />
+		<File Path=".github/workflows/area-shared.yml" />
+		<File Path=".github/workflows/area-testing.yml" />
+		<File Path=".github/workflows/webapp.yml" />
+	</Folder>
+	<Folder Name="/vuecs/build/">
+		<File Path="build/Build.props" />
+		<File Path="build/Build.targets" />
+	</Folder>
+	<Folder Name="/vuecs/build/Targets/">
+		<File Path="build/Targets/Build.Branding.props" />
+		<File Path="build/Targets/Build.Global.props" />
+		<File Path="build/Targets/Build.References.Analyzers.targets" />
+		<File Path="build/Targets/Build.References.Packages.targets" />
+		<File Path="build/Targets/Build.References.Projects.targets" />
+		<File Path="build/Targets/Build.StaticWebAssets.targets" />
+		<File Path="build/Targets/Build.TargetFramework.props" />
+		<File Path="build/Targets/Build.Version.props" />
+	</Folder>
 	<Folder Name="/vuecs/docs/">
 		<File Path="docs/PLAN.md" />
 	</Folder>
-	<Folder Name="/vuecs/examples/">
+	<Folder Name="/vuecs/examples/" />
+	<Folder Name="/vuecs/examples/Assimalign.Vue.WebApp/">
 		<Project Path="examples/Assimalign.Vue.WebApp/Assimalign.Vue.WebApp.csproj" />
 	</Folder>
 	<Folder Name="/vuecs/libraries/" />
-	<Folder Name="/vuecs/libraries/Assimalign.Vue.Reactivity/">
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Reactivity/" />
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Reactivity/src/">
 		<Project Path="libraries/Assimalign.Vue.Reactivity/src/Assimalign.Vue.Reactivity.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Reactivity/test/">
 		<Project Path="libraries/Assimalign.Vue.Reactivity/test/Assimalign.Vue.Reactivity.Tests.csproj" />
 	</Folder>
-	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeCore/">
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeCore/" />
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeCore/src/">
 		<Project Path="libraries/Assimalign.Vue.RuntimeCore/src/Assimalign.Vue.RuntimeCore.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeCore/test/">
 		<Project Path="libraries/Assimalign.Vue.RuntimeCore/test/Assimalign.Vue.RuntimeCore.Tests.csproj" />
 	</Folder>
-	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/">
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/" />
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/docs/">
+		<File Path="libraries/Assimalign.Vue.RuntimeDom/docs/ADR-0001-interop-marshaling.md" />
+		<File Path="libraries/Assimalign.Vue.RuntimeDom/docs/DESIGN.md" />
+		<File Path="libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/src/">
 		<Project Path="libraries/Assimalign.Vue.RuntimeDom/src/Assimalign.Vue.RuntimeDom.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/test/">
 		<Project Path="libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.Tests.csproj" />
 	</Folder>
-	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/">
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/" />
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/src/">
 		<Project Path="libraries/Assimalign.Vue.Shared/src/Assimalign.Vue.Shared.csproj" />
-		<Project Path="libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.Tests.csproj" />
-		<Project Path="libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/Assimalign.Vue.Shared.GeneratorFixture.csproj" />
 	</Folder>
-	<Folder Name="/vuecs/libraries/Assimalign.Vue.Testing/">
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/test/">
+		<Project Path="libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.Tests.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Testing/" />
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Testing/src/">
 		<Project Path="libraries/Assimalign.Vue.Testing/src/Assimalign.Vue.Testing.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Testing/test/">
 		<Project Path="libraries/Assimalign.Vue.Testing/test/Assimalign.Vue.Testing.Tests.csproj" />
 	</Folder>
 </Solution>

--- a/libraries/Assimalign.Vue.Reactivity/Assimalign.Vue.Reactivity.slnx
+++ b/libraries/Assimalign.Vue.Reactivity/Assimalign.Vue.Reactivity.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.Reactivity.csproj" />
+	<Project Path="test/Assimalign.Vue.Reactivity.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Vue.RuntimeCore/Assimalign.Vue.RuntimeCore.slnx
+++ b/libraries/Assimalign.Vue.RuntimeCore/Assimalign.Vue.RuntimeCore.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.RuntimeCore.csproj" />
+	<Project Path="test/Assimalign.Vue.RuntimeCore.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Vue.RuntimeDom/Assimalign.Vue.RuntimeDom.slnx
+++ b/libraries/Assimalign.Vue.RuntimeDom/Assimalign.Vue.RuntimeDom.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.RuntimeDom.csproj" />
+	<Project Path="test/Assimalign.Vue.RuntimeDom.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Vue.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.RuntimeDom/docs/DESIGN.md
@@ -65,10 +65,22 @@ consuming WASM app's source `wwwroot/_content/<AssemblyName>/` (gitignored) — 
 the RCL convention, so call sites won't change when NuGet packaging ships the files as real
 static web assets later.
 
+## Events: the invoker pattern ([V01.01.04.03])
+
+One JS listener is attached per (element, event, capture); a re-rendered handler is a .NET
+delegate swap on the invoker — zero `addEventListener`/`removeEventListener` interop between
+renders. Prop-name suffixes (`onClickOnce`/`Capture`/`Passive`, combined) map to listener
+options at attach time. The listener applies Vue's attach-timestamp guard JS-side
+(`e.timeStamp < attached` ignores events that fired before their patch attached the listener —
+zero interop for guarded events) and forwards the complete typed payload as primitives through
+the single `[JSExport]` dispatch entry (`BrowserEventDispatch.DispatchBrowserEvent`), which
+returns stop/prevent flags the listener applies to the live event. `BrowserEvents.WithModifiers`
+and `.WithKeys` port `withModifiers`/`withKeys` (guards run .NET-side over the payload).
+Handler exceptions route to the registry's error sink — a debug trace until the app
+error-handling pipeline ([V01.01.03.12]) replaces it — and never escape into the JS listener.
+
 ## Non-goals (sequenced work)
 
-- Event invoker pattern, modifiers, and the typed event contract — [V01.01.04.03] (#41). Until
-  then listeners are `Action`/`Action<object?>` delegates dispatched by `(handle, event name)`.
 - Interop command-buffer batching — [V01.01.04.05] (#43).
 - App bootstrap (`CreateApp`-equivalent, container clearing) — [V01.01.04.04] (#42).
 - `v-model` runtime — [V01.01.04.06].

--- a/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
@@ -15,7 +15,11 @@ node-ops and prop patching that the platform-agnostic renderer
   node handle.
 - **`vuecs-dom.js`** (`src/wwwroot/`, shipped with the package): the JS half — the handle
   registry, the `nodeOps` leaves (create/insert/remove/text/static-content, SVG and MathML
-  namespaces), the property/style/attribute leaf appliers, and minimal event listener wiring.
+  namespaces), the property/style/attribute leaf appliers, and the per-(element, event)
+  listeners feeding the single `[JSExport]` event dispatch.
+- **`BrowserEvent` / `BrowserEventModifiers` / `BrowserEvents`** (public): the typed event
+  payload with `StopPropagation()`/`PreventDefault()`, and the `WithModifiers`/`WithKeys`
+  guard helpers ([V01.01.04.03]).
 - **Internal:** `BrowserDomBridge` (`[JSImport]` bindings + typed-error wrappers),
   `BrowserPropertyPatcher` + `BrowserPropertyLeafOperations` (the `patchProp` decision tree over
   injected leaves), `BrowserNodeOperations` (the `RendererOptions<int>` factory and event

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvent.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvent.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The typed event arguments a Vuecs handler receives — the fields of the underlying DOM event
+/// (W3C UI Events, https://www.w3.org/TR/uievents/) that Vue's modifier and key guards need,
+/// extracted JS-side and marshaled in the single dispatch call ([V01.01.04.03]): no per-field
+/// <c>JSObject</c> property reads and no proxy retained per event.
+/// <see cref="StopPropagation"/>/<see cref="PreventDefault"/> record intents the bridge applies
+/// to the live JS event when the synchronous dispatch returns.
+/// </summary>
+public sealed class BrowserEvent
+{
+    internal BrowserEvent(
+        string eventName,
+        double timeStamp,
+        string key,
+        string code,
+        BrowserEventModifiers modifiers,
+        int button,
+        int buttons,
+        double clientX,
+        double clientY,
+        int detail,
+        bool isSelfTarget,
+        string? targetValue,
+        bool targetChecked)
+    {
+        EventName = eventName;
+        TimeStamp = timeStamp;
+        Key = key;
+        Code = code;
+        Modifiers = modifiers;
+        Button = button;
+        Buttons = buttons;
+        ClientX = clientX;
+        ClientY = clientY;
+        Detail = detail;
+        IsSelfTarget = isSelfTarget;
+        TargetValue = targetValue;
+        TargetChecked = targetChecked;
+    }
+
+    /// <summary>The DOM event type (e.g. <c>"click"</c>, <c>"keydown"</c>).</summary>
+    public string EventName { get; }
+
+    /// <summary>The event's <c>timeStamp</c> (milliseconds relative to the page's time origin).</summary>
+    public double TimeStamp { get; }
+
+    /// <summary>The keyboard <c>key</c> value, or empty for non-keyboard events.</summary>
+    public string Key { get; }
+
+    /// <summary>The keyboard <c>code</c> value, or empty for non-keyboard events.</summary>
+    public string Code { get; }
+
+    /// <summary>The system-modifier state at dispatch.</summary>
+    public BrowserEventModifiers Modifiers { get; }
+
+    /// <summary>The mouse <c>button</c> (0 left, 1 middle, 2 right), or -1 for non-mouse events.</summary>
+    public int Button { get; }
+
+    /// <summary>The mouse <c>buttons</c> bitmask at dispatch.</summary>
+    public int Buttons { get; }
+
+    /// <summary>The pointer's viewport X coordinate, or 0 for non-pointer events.</summary>
+    public double ClientX { get; }
+
+    /// <summary>The pointer's viewport Y coordinate, or 0 for non-pointer events.</summary>
+    public double ClientY { get; }
+
+    /// <summary>The UI event <c>detail</c> value (e.g. click count).</summary>
+    public int Detail { get; }
+
+    /// <summary>
+    /// Whether <c>event.target === event.currentTarget</c> (evaluated JS-side) — the
+    /// <c>.self</c> modifier's guard.
+    /// </summary>
+    public bool IsSelfTarget { get; }
+
+    /// <summary>The target element's <c>value</c> at dispatch, when it has one (inputs, selects).</summary>
+    public string? TargetValue { get; }
+
+    /// <summary>The target element's <c>checked</c> state at dispatch, when it has one.</summary>
+    public bool TargetChecked { get; }
+
+    /// <summary>Whether <see cref="StopPropagation"/> was requested.</summary>
+    public bool PropagationStopped { get; private set; }
+
+    /// <summary>Whether <see cref="PreventDefault"/> was requested.</summary>
+    public bool DefaultPrevented { get; private set; }
+
+    /// <summary>
+    /// Requests <c>stopPropagation()</c> on the live event when this synchronous dispatch
+    /// returns (Vue's <c>.stop</c> modifier calls this).
+    /// </summary>
+    public void StopPropagation() => PropagationStopped = true;
+
+    /// <summary>
+    /// Requests <c>preventDefault()</c> on the live event when this synchronous dispatch
+    /// returns (Vue's <c>.prevent</c> modifier calls this).
+    /// </summary>
+    public void PreventDefault() => DefaultPrevented = true;
+
+    internal int ToResponseFlags()
+        => (PropagationStopped ? 1 : 0) | (DefaultPrevented ? 2 : 0);
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEventModifiers.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEventModifiers.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The system-modifier state of a dispatched DOM event, extracted JS-side and marshaled as one
+/// integer (W3C UI Events <c>ctrlKey</c>/<c>shiftKey</c>/<c>altKey</c>/<c>metaKey</c>,
+/// https://www.w3.org/TR/uievents/). Consumed by <see cref="BrowserEvents.WithModifiers"/>'s
+/// system-modifier and <c>.exact</c> guards.
+/// </summary>
+[Flags]
+public enum BrowserEventModifiers
+{
+    /// <summary>No system modifier was pressed.</summary>
+    None = 0,
+
+    /// <summary>The Control key was pressed.</summary>
+    Control = 1,
+
+    /// <summary>The Shift key was pressed.</summary>
+    Shift = 1 << 1,
+
+    /// <summary>The Alt (Option) key was pressed.</summary>
+    Alt = 1 << 2,
+
+    /// <summary>The Meta (Command/Windows) key was pressed.</summary>
+    Meta = 1 << 3,
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvents.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvents.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The event-handler modifier and key guards — the C# port of <c>withModifiers</c> and
+/// <c>withKeys</c> from <c>@vue/runtime-dom</c>
+/// (<c>packages/runtime-dom/src/directives/vOn.ts</c>,
+/// https://vuejs.org/guide/essentials/event-handling.html). Guards run before the wrapped
+/// handler: a failed guard skips it entirely. <c>.stop</c>/<c>.prevent</c> record intents on
+/// the <see cref="BrowserEvent"/>, which the bridge applies to the live JS event when the
+/// synchronous dispatch returns.
+/// </summary>
+public static class BrowserEvents
+{
+    // Upstream keyNames: aliases whose hyphenated event.key form differs from the alias.
+    private static readonly Dictionary<string, string> KeyAliases = new(StringComparer.Ordinal)
+    {
+        ["esc"] = "escape",
+        ["space"] = " ",
+        ["up"] = "arrow-up",
+        ["left"] = "arrow-left",
+        ["right"] = "arrow-right",
+        ["down"] = "arrow-down",
+        ["delete"] = "backspace",
+    };
+
+    /// <summary>
+    /// Wraps <paramref name="handler"/> with Vue's event modifiers (upstream:
+    /// <c>withModifiers</c>): <c>stop</c>, <c>prevent</c>, <c>self</c>, system modifiers
+    /// (<c>ctrl</c>/<c>shift</c>/<c>alt</c>/<c>meta</c>), mouse-button guards
+    /// (<c>left</c>/<c>middle</c>/<c>right</c>), and <c>exact</c>.
+    /// </summary>
+    /// <param name="handler">The handler to guard.</param>
+    /// <param name="modifiers">The modifier names, unprefixed (e.g. <c>"stop"</c>, <c>"ctrl"</c>).</param>
+    /// <returns>The guarded handler.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="handler"/> or <paramref name="modifiers"/> is null.</exception>
+    public static Action<BrowserEvent> WithModifiers(Action<BrowserEvent> handler, params string[] modifiers)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        ArgumentNullException.ThrowIfNull(modifiers);
+        return browserEvent =>
+        {
+            foreach (var modifier in modifiers)
+            {
+                if (!PassesModifierGuard(browserEvent, modifier, modifiers))
+                {
+                    return;
+                }
+            }
+            handler(browserEvent);
+        };
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="handler"/> to run only for the named keys (upstream:
+    /// <c>withKeys</c>), matching Vue's key aliases (<c>enter</c>, <c>tab</c>, <c>delete</c>,
+    /// <c>esc</c>, <c>space</c>, <c>up</c>, <c>down</c>, <c>left</c>, <c>right</c>) against
+    /// the hyphenated <c>event.key</c>.
+    /// </summary>
+    /// <param name="handler">The handler to guard.</param>
+    /// <param name="keys">The key names.</param>
+    /// <returns>The guarded handler.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="handler"/> or <paramref name="keys"/> is null.</exception>
+    public static Action<BrowserEvent> WithKeys(Action<BrowserEvent> handler, params string[] keys)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        ArgumentNullException.ThrowIfNull(keys);
+        return browserEvent =>
+        {
+            if (browserEvent.Key.Length == 0)
+            {
+                return;
+            }
+            var eventKey = StyleAndClassNormalization.Hyphenate(browserEvent.Key).ToLowerInvariant();
+            foreach (var key in keys)
+            {
+                if (string.Equals(key, eventKey, StringComparison.Ordinal)
+                    || (KeyAliases.TryGetValue(key, out var alias)
+                        && string.Equals(alias, eventKey, StringComparison.Ordinal)))
+                {
+                    handler(browserEvent);
+                    return;
+                }
+            }
+        };
+    }
+
+    private static bool PassesModifierGuard(BrowserEvent browserEvent, string modifier, string[] allModifiers)
+    {
+        // Upstream modifierGuards parity, one guard per modifier name.
+        switch (modifier)
+        {
+            case "stop":
+                browserEvent.StopPropagation();
+                return true;
+            case "prevent":
+                browserEvent.PreventDefault();
+                return true;
+            case "self":
+                return browserEvent.IsSelfTarget;
+            case "ctrl":
+                return (browserEvent.Modifiers & BrowserEventModifiers.Control) != 0;
+            case "shift":
+                return (browserEvent.Modifiers & BrowserEventModifiers.Shift) != 0;
+            case "alt":
+                return (browserEvent.Modifiers & BrowserEventModifiers.Alt) != 0;
+            case "meta":
+                return (browserEvent.Modifiers & BrowserEventModifiers.Meta) != 0;
+            case "left":
+                return browserEvent.Button <= 0;
+            case "middle":
+                return browserEvent.Button is < 0 or 1;
+            case "right":
+                return browserEvent.Button is < 0 or 2;
+            case "exact":
+                return MatchesExactly(browserEvent, allModifiers);
+            default:
+                return true;
+        }
+    }
+
+    private static bool MatchesExactly(BrowserEvent browserEvent, string[] modifiers)
+    {
+        // Upstream .exact: every PRESSED system modifier must be listed on the handler.
+        var required = BrowserEventModifiers.None;
+        foreach (var modifier in modifiers)
+        {
+            required |= modifier switch
+            {
+                "ctrl" => BrowserEventModifiers.Control,
+                "shift" => BrowserEventModifiers.Shift,
+                "alt" => BrowserEventModifiers.Alt,
+                "meta" => BrowserEventModifiers.Meta,
+                _ => BrowserEventModifiers.None,
+            };
+        }
+        return browserEvent.Modifiers == required;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
@@ -69,7 +69,9 @@ public static class BrowserRuntime
             BrowserDomBridge.ModuleName,
             "/_content/Assimalign.Vue.RuntimeDom/vuecs-dom.js",
             cancellationToken);
-        BrowserDomBridge.Initialize(BrowserNodeOperations.DispatchEvent);
+        // The module resolves this assembly's exports and binds the single event-dispatch
+        // entry point ([V01.01.04.03]).
+        await BrowserDomBridge.InitializeModuleAsync();
     }
 
     private static void EnsureInitialized()

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
@@ -18,8 +18,8 @@ internal static partial class BrowserDomBridge
     /// <summary>The JS module name; must match <c>BrowserRuntime</c>'s import.</summary>
     internal const string ModuleName = "Assimalign.Vue.RuntimeDom";
 
-    internal static void Initialize(Action<int, string> dispatchCallback)
-        => Imports.Initialize(dispatchCallback);
+    internal static System.Threading.Tasks.Task InitializeModuleAsync()
+        => Imports.Initialize();
 
     internal static int QuerySelector(string selector)
     {
@@ -285,11 +285,11 @@ internal static partial class BrowserDomBridge
         }
     }
 
-    internal static void AddEventListener(int nodeHandle, string eventName)
+    internal static void AddEventListener(int nodeHandle, string eventName, bool once, bool capture, bool passive)
     {
         try
         {
-            Imports.AddEventListener(nodeHandle, eventName);
+            Imports.AddEventListener(nodeHandle, eventName, once, capture, passive);
         }
         catch (JSException exception)
         {
@@ -297,11 +297,11 @@ internal static partial class BrowserDomBridge
         }
     }
 
-    internal static void RemoveEventListener(int nodeHandle, string eventName)
+    internal static void RemoveEventListener(int nodeHandle, string eventName, bool capture)
     {
         try
         {
-            Imports.RemoveEventListener(nodeHandle, eventName);
+            Imports.RemoveEventListener(nodeHandle, eventName, capture);
         }
         catch (JSException exception)
         {
@@ -409,15 +409,16 @@ internal static partial class BrowserDomBridge
         internal static partial void RemoveStyleProperty(int nodeHandle, string name);
 
         [JSImport("dom.addEventListener", ModuleName)]
-        internal static partial void AddEventListener(int nodeHandle, string eventName);
+        internal static partial void AddEventListener(int nodeHandle, string eventName, bool once, bool capture, bool passive);
 
         [JSImport("dom.removeEventListener", ModuleName)]
-        internal static partial void RemoveEventListener(int nodeHandle, string eventName);
+        internal static partial void RemoveEventListener(int nodeHandle, string eventName, bool capture);
 
         [JSImport("dom.getRegistrySizes", ModuleName)]
         internal static partial int[] GetRegistrySizes();
 
         [JSImport("initialize", ModuleName)]
-        internal static partial void Initialize([JSMarshalAs<JSType.Function<JSType.Number, JSType.String>>] Action<int, string> dispatchCallback);
+        [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
+        internal static partial System.Threading.Tasks.Task Initialize();
     }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventDispatch.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventDispatch.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The single <c>[JSExport]</c> dispatch entry point of the event system ([V01.01.04.03]): the
+/// bridge's one JS listener per (element, event, options) forwards the complete typed payload
+/// as primitives in this one call — no per-field <c>JSObject</c> reads, no proxy retained per
+/// event — and applies the returned flags (bit 0 <c>stopPropagation</c>, bit 1
+/// <c>preventDefault</c>) to the live event.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static partial class BrowserEventDispatch
+{
+    [JSExport]
+    internal static int DispatchBrowserEvent(
+        int nodeHandle,
+        string eventName,
+        bool capture,
+        double timeStamp,
+        string key,
+        string code,
+        int modifierFlags,
+        int button,
+        int buttons,
+        double clientX,
+        double clientY,
+        int detail,
+        bool isSelfTarget,
+        string? targetValue,
+        bool targetChecked)
+    {
+        var browserEvent = new BrowserEvent(
+            eventName,
+            timeStamp,
+            key,
+            code,
+            (BrowserEventModifiers)modifierFlags,
+            button,
+            buttons,
+            clientX,
+            clientY,
+            detail,
+            isSelfTarget,
+            targetValue,
+            targetChecked);
+        return BrowserNodeOperations.DispatchEvent(nodeHandle, capture, browserEvent);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventInvokerRegistry.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventInvokerRegistry.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The invoker pattern of <c>@vue/runtime-dom</c>'s events module
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/modules/events.ts):
+/// exactly one DOM listener is attached per (element, event, options-signature), and a
+/// re-render that changes the handler only swaps the invoker's .NET delegate — zero
+/// <c>addEventListener</c>/<c>removeEventListener</c> interop calls. Prop-name suffixes parse
+/// per Vue (<c>onClickOnce</c>, <c>onClickCapture</c>, <c>onClickPassive</c>, combined).
+/// Bridge calls are injected delegates so the registry is unit-testable with no browser.
+/// Handler exceptions route to <see cref="ErrorSink"/> instead of escaping into the JS
+/// listener (the app-level pipeline plugs in with [V01.01.03.12]).
+/// Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+internal sealed class BrowserEventInvokerRegistry
+{
+    private readonly Dictionary<(int NodeHandle, string EventName, bool Capture), BrowserEventInvoker> _invokers = [];
+    private readonly Action<int, string, bool, bool, bool> _addListener;
+    private readonly Action<int, string, bool> _removeListener;
+
+    internal BrowserEventInvokerRegistry(
+        Action<int, string, bool, bool, bool> addListener,
+        Action<int, string, bool> removeListener)
+    {
+        _addListener = addListener;
+        _removeListener = removeListener;
+    }
+
+    /// <summary>
+    /// The sink for handler exceptions. Defaults to a debug trace; the app error-handling
+    /// pipeline ([V01.01.03.12]) replaces it. Never null.
+    /// </summary>
+    internal Action<Exception> ErrorSink { get; set; } = static exception =>
+        Debug.WriteLine($"[Vue warn] Unhandled error in event handler: {exception}");
+
+    /// <summary>The number of live invokers (diagnostics).</summary>
+    internal int InvokerCount => _invokers.Count;
+
+    /// <summary>
+    /// Sets, swaps, or removes the handler for a raw event prop (upstream: <c>patchEvent</c>).
+    /// </summary>
+    /// <param name="nodeHandle">The element handle.</param>
+    /// <param name="rawPropertyName">The full prop name (e.g. <c>"onClickCaptureOnce"</c>).</param>
+    /// <param name="handler">The handler delegate, or null to remove.</param>
+    internal void SetListener(int nodeHandle, string rawPropertyName, Delegate? handler)
+    {
+        var (eventName, once, capture, passive) = ParseEventName(rawPropertyName);
+        var key = (nodeHandle, eventName, capture);
+        if (handler is null)
+        {
+            if (_invokers.Remove(key))
+            {
+                _removeListener(nodeHandle, eventName, capture);
+            }
+            return;
+        }
+        if (_invokers.TryGetValue(key, out var invoker))
+        {
+            // The whole point of the pattern: a re-rendered handler is a delegate swap only.
+            invoker.Handler = handler;
+            return;
+        }
+        _invokers[key] = new BrowserEventInvoker { Handler = handler };
+        _addListener(nodeHandle, eventName, once, capture, passive);
+    }
+
+    /// <summary>
+    /// Routes one dispatched event to its invoker, returning the response flags
+    /// (bit 0: stopPropagation, bit 1: preventDefault) the bridge applies to the live event.
+    /// </summary>
+    /// <param name="nodeHandle">The element handle the listener is attached to.</param>
+    /// <param name="capture">Whether the capture-phase listener fired.</param>
+    /// <param name="browserEvent">The marshaled event payload.</param>
+    internal int Dispatch(int nodeHandle, bool capture, BrowserEvent browserEvent)
+    {
+        if (!_invokers.TryGetValue((nodeHandle, browserEvent.EventName, capture), out var invoker))
+        {
+            return 0;
+        }
+        try
+        {
+            // Reflection-free dispatch; a multicast delegate of either shape invokes every
+            // merged target natively (MergeProperties chains same-typed handlers).
+            switch (invoker.Handler)
+            {
+                case Action<BrowserEvent> typedHandler:
+                    typedHandler(browserEvent);
+                    break;
+                case Action untypedHandler:
+                    untypedHandler();
+                    break;
+                default:
+                    throw new NotSupportedException(
+                        $"Event handler for '{browserEvent.EventName}' is a "
+                        + $"{invoker.Handler.GetType().Name}; handlers must be Action or Action<BrowserEvent>.");
+            }
+        }
+        catch (Exception exception)
+        {
+            // Never escape into the JS listener; route to the error seam ([V01.01.03.12]).
+            ErrorSink(exception);
+        }
+        return browserEvent.ToResponseFlags();
+    }
+
+    /// <summary>Drops the invokers of released node handles (bridge removal already detached DOM listeners).</summary>
+    /// <param name="releasedHandles">The handles the bridge released.</param>
+    internal void PurgeReleasedHandles(int[]? releasedHandles)
+    {
+        if (releasedHandles is null || releasedHandles.Length == 0 || _invokers.Count == 0)
+        {
+            return;
+        }
+        List<(int, string, bool)>? stale = null;
+        foreach (var key in _invokers.Keys)
+        {
+            if (Array.IndexOf(releasedHandles, key.NodeHandle) >= 0)
+            {
+                (stale ??= []).Add(key);
+            }
+        }
+        if (stale is not null)
+        {
+            foreach (var key in stale)
+            {
+                _invokers.Remove(key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a Vue event prop name (upstream: <c>parseName</c>): the trailing
+    /// <c>Once</c>/<c>Capture</c>/<c>Passive</c> suffixes map to listener options, in any
+    /// combination; the rest is the lower-cased event name.
+    /// </summary>
+    /// <param name="rawPropertyName">The full prop name (e.g. <c>"onClickOnce"</c>).</param>
+    internal static (string EventName, bool Once, bool Capture, bool Passive) ParseEventName(string rawPropertyName)
+    {
+        var name = rawPropertyName.StartsWith("on", StringComparison.Ordinal)
+            ? rawPropertyName[2..]
+            : rawPropertyName;
+        var once = false;
+        var capture = false;
+        var passive = false;
+        while (true)
+        {
+            if (!once && name.EndsWith("Once", StringComparison.Ordinal))
+            {
+                name = name[..^4];
+                once = true;
+                continue;
+            }
+            if (!capture && name.EndsWith("Capture", StringComparison.Ordinal))
+            {
+                name = name[..^7];
+                capture = true;
+                continue;
+            }
+            if (!passive && name.EndsWith("Passive", StringComparison.Ordinal))
+            {
+                name = name[..^7];
+                passive = true;
+                continue;
+            }
+            break;
+        }
+        return (name.ToLowerInvariant(), once, capture, passive);
+    }
+
+    private sealed class BrowserEventInvoker
+    {
+        internal required Delegate Handler { get; set; }
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.Versioning;
 
 using Assimalign.Vue.RuntimeCore;
@@ -12,15 +11,19 @@ namespace Assimalign.Vue.RuntimeDom;
 /// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/nodeOps.ts). Handles are
 /// ints (see the marshaling ADR in <c>libraries/Assimalign.Vue.RuntimeDom/docs/</c>); 0 is the
 /// "no node" sentinel. Node removal releases the removed subtree's JS handles and DOM
-/// listeners deterministically, and the returned handle list purges the C#-side listener
-/// registry in the same call — no leaks on either side of the boundary ([V01.01.04.01]).
+/// listeners deterministically, and the returned handle list purges the invoker registry in
+/// the same call — no leaks on either side of the boundary ([V01.01.04.01]). Event handling
+/// goes through the invoker registry ([V01.01.04.03]): handler changes between renders swap a
+/// delegate with zero listener-management interop.
 /// </summary>
 [SupportedOSPlatform("browser")]
 internal static class BrowserNodeOperations
 {
-    // Listener delegates keyed by (handle, lower-case event name); the JS side dispatches back
-    // by the same pair. Multicast delegates (merged props) invoke every target.
-    private static readonly Dictionary<(int NodeHandle, string EventName), Delegate> EventListeners = [];
+    private static readonly BrowserEventInvokerRegistry Invokers = new(
+        static (handle, eventName, once, capture, passive) =>
+            BrowserDomBridge.AddEventListener(handle, eventName, once, capture, passive),
+        static (handle, eventName, capture) =>
+            BrowserDomBridge.RemoveEventListener(handle, eventName, capture));
 
     private static readonly BrowserPropertyLeafOperations LeafOperations = new()
     {
@@ -35,30 +38,19 @@ internal static class BrowserNodeOperations
         SetStyleText = static (element, cssText) => BrowserDomBridge.SetStyleText(element, cssText),
         SetStyleProperty = static (element, name, value, important) => BrowserDomBridge.SetStyleProperty(element, name, value, important),
         RemoveStyleProperty = static (element, name) => BrowserDomBridge.RemoveStyleProperty(element, name),
-        SetEventListener = static (element, eventName, listener) =>
-        {
-            if (listener is null)
-            {
-                EventListeners.Remove((element, eventName));
-                BrowserDomBridge.RemoveEventListener(element, eventName);
-            }
-            else
-            {
-                EventListeners[(element, eventName)] = listener;
-                BrowserDomBridge.AddEventListener(element, eventName);
-            }
-        },
+        SetEventListener = static (element, rawPropertyName, listener) =>
+            Invokers.SetListener(element, rawPropertyName, listener),
     };
 
     internal static RendererOptions<int> Create() => new()
     {
         Insert = static (child, parent, anchor) => BrowserDomBridge.Insert(parent, child, anchor),
-        Remove = static child => PurgeListeners(BrowserDomBridge.Remove(child)),
+        Remove = static child => Invokers.PurgeReleasedHandles(BrowserDomBridge.Remove(child)),
         CreateElement = static (tag, elementNamespace) => BrowserDomBridge.CreateElement(tag, elementNamespace),
         CreateText = static text => BrowserDomBridge.CreateText(text),
         CreateComment = static text => BrowserDomBridge.CreateComment(text),
         SetText = static (node, text) => BrowserDomBridge.SetText(node, text),
-        SetElementText = static (node, text) => PurgeListeners(BrowserDomBridge.SetElementText(node, text)),
+        SetElementText = static (node, text) => Invokers.PurgeReleasedHandles(BrowserDomBridge.SetElementText(node, text)),
         ParentNode = static node => BrowserDomBridge.ParentNode(node),
         NextSibling = static node => BrowserDomBridge.NextSibling(node),
         PatchProperty = static (element, elementTag, propertyName, previousValue, nextValue, elementNamespace) =>
@@ -71,61 +63,13 @@ internal static class BrowserNodeOperations
         },
     };
 
-    internal static void DispatchEvent(int nodeHandle, string eventName)
-    {
-        if (!EventListeners.TryGetValue((nodeHandle, eventName), out var listener))
-        {
-            return;
-        }
-        // No DynamicInvoke — reflection-free dispatch over the supported delegate shapes; the
-        // typed event contract lands with [V01.01.04.03].
-        foreach (var target in listener.GetInvocationList())
-        {
-            switch (target)
-            {
-                case Action action:
-                    action();
-                    break;
-                case Action<object?> payloadAction:
-                    payloadAction(null);
-                    break;
-                default:
-                    throw new NotSupportedException(
-                        $"Event listener for '{eventName}' is a {target.GetType().Name}; the bridge dispatches "
-                        + "Action or Action<object?> listeners until [V01.01.04.03] lands the typed event contract.");
-            }
-        }
-    }
+    internal static int DispatchEvent(int nodeHandle, bool capture, BrowserEvent browserEvent)
+        => Invokers.Dispatch(nodeHandle, capture, browserEvent);
 
-    /// <summary>Registry sizes for leak diagnostics: JS nodes, JS listener maps, C# listener entries.</summary>
+    /// <summary>Registry sizes for leak diagnostics: JS nodes, JS listener maps, .NET invokers.</summary>
     internal static (int JsNodes, int JsListenerMaps, int DotnetListeners) GetRegistryDiagnostics()
     {
         var sizes = BrowserDomBridge.GetRegistrySizes();
-        return (sizes[0], sizes[1], EventListeners.Count);
-    }
-
-    private static void PurgeListeners(int[]? releasedHandles)
-    {
-        // The bridge reports every handle it released; drop their listener delegates so the
-        // C# side cannot leak either.
-        if (releasedHandles is null || releasedHandles.Length == 0 || EventListeners.Count == 0)
-        {
-            return;
-        }
-        List<(int, string)>? stale = null;
-        foreach (var key in EventListeners.Keys)
-        {
-            if (Array.IndexOf(releasedHandles, key.NodeHandle) >= 0)
-            {
-                (stale ??= []).Add(key);
-            }
-        }
-        if (stale is not null)
-        {
-            foreach (var key in stale)
-            {
-                EventListeners.Remove(key);
-            }
-        }
+        return (sizes[0], sizes[1], Invokers.InvokerCount);
     }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserPropertyPatcher.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserPropertyPatcher.cs
@@ -72,11 +72,9 @@ internal static class BrowserPropertyPatcher
         }
         else if (VirtualNodeFactory.IsEventListenerName(propertyName))
         {
-            // onClick -> "click"; invoker pattern and modifiers land with [V01.01.04.03].
-            leafOperations.SetEventListener(
-                element,
-                propertyName[2..].ToLowerInvariant(),
-                nextValue as Delegate);
+            // The raw prop name flows through: the invoker registry parses the
+            // Once/Capture/Passive suffixes and event name ([V01.01.04.03]).
+            leafOperations.SetEventListener(element, propertyName, nextValue as Delegate);
         }
         else if (ShouldSetAsProperty(elementTag, propertyName, elementNamespace))
         {

--- a/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
@@ -23,7 +23,7 @@ const nodes = new Map()          // handle -> Node
 const nodeHandles = new WeakMap() // Node -> handle
 const listeners = new Map()      // handle -> Map(eventName -> listener)
 
-let dispatchEvent = null         // .NET callback: (handle, eventName) => void
+let dispatchEvent = null         // the single [JSExport] dispatch entry ([V01.01.04.03])
 
 function fail(operation, handle, message) {
     throw new Error(`vuecs-dom|${operation}|${handle}|${message}`)
@@ -58,8 +58,8 @@ function releaseNodeHandle(node, released) {
 
     const nodeListeners = listeners.get(handle)
     if (nodeListeners) {
-        for (const [eventName, listener] of nodeListeners.entries()) {
-            node.removeEventListener(eventName, listener)
+        for (const entry of nodeListeners.values()) {
+            node.removeEventListener(entry.eventName, entry.listener, { capture: entry.capture })
         }
         listeners.delete(handle)
     }
@@ -88,8 +88,12 @@ function releaseSubtree(node, released) {
     return released
 }
 
-export function initialize(dispatchCallback) {
-    dispatchEvent = dispatchCallback
+export async function initialize() {
+    // Bind the single .NET dispatch entry point ([V01.01.04.03]): one JSExport carries the
+    // whole typed payload as primitives and returns stop/prevent flags for the live event.
+    const { getAssemblyExports } = await globalThis.getDotnetRuntime(0)
+    const exports = await getAssemblyExports('Assimalign.Vue.RuntimeDom')
+    dispatchEvent = exports.Assimalign.Vue.RuntimeDom.BrowserEventDispatch.DispatchBrowserEvent
 }
 
 export const dom = {
@@ -257,10 +261,12 @@ export const dom = {
         getNode('removeStyleProperty', nodeHandle).style.removeProperty(name)
     },
 
-    // --- events (minimal set/remove; the invoker pattern and modifiers land with
-    // [V01.01.04.03]) ------------------------------------------------------------------------
+    // --- events (invoker pattern: one listener per (element, event, capture); handler
+    // changes are .NET-side delegate swaps with no listener churn; the attach-timestamp guard
+    // ignores events that fired before their listener was attached, matching Vue's
+    // e.timeStamp < invoker.attached check) --------------------------------------------------
 
-    addEventListener: (nodeHandle, eventName) => {
+    addEventListener: (nodeHandle, eventName, once, capture, passive) => {
         const node = getNode('addEventListener', nodeHandle)
         let nodeListeners = listeners.get(nodeHandle)
         if (!nodeListeners) {
@@ -268,34 +274,70 @@ export const dom = {
             listeners.set(nodeHandle, nodeListeners)
         }
 
-        if (nodeListeners.has(eventName)) {
+        const listenerKey = capture ? eventName + '|capture' : eventName
+        if (nodeListeners.has(listenerKey)) {
             return
         }
 
-        const listener = () => {
-            if (dispatchEvent) {
-                dispatchEvent(nodeHandle, eventName)
+        const attached = performance.now()
+        const listener = event => {
+            // Upstream parity: an event that fired before this listener attached (e.g. one
+            // bubbling into a parent whose handler landed in the same patch) is ignored.
+            if (event.timeStamp < attached) {
+                return
+            }
+            if (!dispatchEvent) {
+                return
+            }
+
+            const target = event.target
+            const hasValue = target && typeof target.value !== 'undefined'
+            const flags = dispatchEvent(
+                nodeHandle,
+                eventName,
+                capture,
+                event.timeStamp,
+                event.key ?? '',
+                event.code ?? '',
+                (event.ctrlKey ? 1 : 0) | (event.shiftKey ? 2 : 0) | (event.altKey ? 4 : 0) | (event.metaKey ? 8 : 0),
+                typeof event.button === 'number' ? event.button : -1,
+                event.buttons ?? 0,
+                event.clientX ?? 0,
+                event.clientY ?? 0,
+                event.detail ?? 0,
+                target === event.currentTarget,
+                hasValue ? String(target.value) : null,
+                !!(target && target.checked))
+            if (flags & 1) {
+                event.stopPropagation()
+            }
+            if (flags & 2) {
+                event.preventDefault()
             }
         }
 
-        node.addEventListener(eventName, listener)
-        nodeListeners.set(eventName, listener)
+        node.addEventListener(eventName, listener, { once: !!once, capture: !!capture, passive: !!passive })
+        nodeListeners.set(listenerKey, { eventName, listener, capture: !!capture })
     },
 
-    removeEventListener: (nodeHandle, eventName) => {
+    removeEventListener: (nodeHandle, eventName, capture) => {
         const node = nodes.get(nodeHandle)
         if (!node) {
             return
         }
 
         const nodeListeners = listeners.get(nodeHandle)
-        const listener = nodeListeners?.get(eventName)
-        if (!listener) {
+        const listenerKey = capture ? eventName + '|capture' : eventName
+        const entry = nodeListeners?.get(listenerKey)
+        if (!entry) {
             return
         }
 
-        node.removeEventListener(eventName, listener)
-        nodeListeners.delete(eventName)
+        node.removeEventListener(eventName, entry.listener, { capture: entry.capture })
+        nodeListeners.delete(listenerKey)
+        if (nodeListeners.size === 0) {
+            listeners.delete(nodeHandle)
+        }
     },
 
     // --- diagnostics ------------------------------------------------------------------------

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventInvokerRegistryTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventInvokerRegistryTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins the invoker pattern of @vue/runtime-dom's events module
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/modules/events.ts):
+// handler updates between renders are delegate swaps with ZERO listener-management interop,
+// asserted through an instrumented bridge (recorded add/remove delegates).
+public class BrowserEventInvokerRegistryTests
+{
+    private const int Element = 9;
+
+    private readonly List<string> _bridgeCalls = [];
+    private readonly BrowserEventInvokerRegistry _registry;
+
+    public BrowserEventInvokerRegistryTests()
+    {
+        _registry = new BrowserEventInvokerRegistry(
+            (handle, eventName, once, capture, passive) =>
+                _bridgeCalls.Add($"add({handle},{eventName},once:{once},capture:{capture},passive:{passive})"),
+            (handle, eventName, capture) =>
+                _bridgeCalls.Add($"remove({handle},{eventName},capture:{capture})"));
+    }
+
+    private static BrowserEvent Event(
+        string eventName = "click",
+        string key = "",
+        BrowserEventModifiers modifiers = BrowserEventModifiers.None,
+        int button = 0,
+        bool isSelfTarget = true)
+        => new(eventName, 100, key, string.Empty, modifiers, button, 0, 0, 0, 1, isSelfTarget, null, false);
+
+    [Fact]
+    public void SwappingTheHandlerBetweenRenders_MakesZeroBridgeCalls()
+    {
+        var invoked = new List<string>();
+        _registry.SetListener(Element, "onClick", (Action)(() => invoked.Add("first")));
+        _bridgeCalls.Count.ShouldBe(1); // the one and only addEventListener
+
+        _registry.SetListener(Element, "onClick", (Action)(() => invoked.Add("second")));
+        _registry.SetListener(Element, "onClick", (Action)(() => invoked.Add("third")));
+
+        // The whole point of the invoker pattern: swaps cost nothing at the boundary.
+        _bridgeCalls.Count.ShouldBe(1);
+
+        _registry.Dispatch(Element, capture: false, Event());
+        invoked.ShouldBe(["third"]); // the swapped-in handler runs
+    }
+
+    [Fact]
+    public void RemovingTheHandler_RemovesTheListenerOnce()
+    {
+        _registry.SetListener(Element, "onClick", (Action)(() => { }));
+        _registry.SetListener(Element, "onClick", null);
+
+        _bridgeCalls.ShouldBe(
+        [
+            $"add({Element},click,once:False,capture:False,passive:False)",
+            $"remove({Element},click,capture:False)",
+        ]);
+        _registry.InvokerCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SuffixParsing_MapsToListenerOptions()
+    {
+        // Upstream parseName: onClickOnce / onClickCapture / onClickPassive and combinations.
+        BrowserEventInvokerRegistry.ParseEventName("onClick").ShouldBe(("click", false, false, false));
+        BrowserEventInvokerRegistry.ParseEventName("onClickOnce").ShouldBe(("click", true, false, false));
+        BrowserEventInvokerRegistry.ParseEventName("onClickCapture").ShouldBe(("click", false, true, false));
+        BrowserEventInvokerRegistry.ParseEventName("onClickPassive").ShouldBe(("click", false, false, true));
+        BrowserEventInvokerRegistry.ParseEventName("onClickCaptureOnce").ShouldBe(("click", true, true, false));
+        BrowserEventInvokerRegistry.ParseEventName("onScrollPassiveCapture").ShouldBe(("scroll", false, true, true));
+        BrowserEventInvokerRegistry.ParseEventName("onKeydown").ShouldBe(("keydown", false, false, false));
+    }
+
+    [Fact]
+    public void SuffixedListeners_AttachWithTheCorrespondingOptions()
+    {
+        _registry.SetListener(Element, "onClickCaptureOnce", (Action)(() => { }));
+        _bridgeCalls.ShouldBe([$"add({Element},click,once:True,capture:True,passive:False)"]);
+    }
+
+    [Fact]
+    public void CaptureAndBubbleListeners_AreIndependentInvokers()
+    {
+        var invoked = new List<string>();
+        _registry.SetListener(Element, "onClick", (Action)(() => invoked.Add("bubble")));
+        _registry.SetListener(Element, "onClickCapture", (Action)(() => invoked.Add("capture")));
+
+        _bridgeCalls.Count.ShouldBe(2);
+        _registry.Dispatch(Element, capture: true, Event());
+        _registry.Dispatch(Element, capture: false, Event());
+        invoked.ShouldBe(["capture", "bubble"]);
+    }
+
+    [Fact]
+    public void Dispatch_SupportsTypedHandlers_AndReturnsResponseFlags()
+    {
+        string? seenKey = null;
+        _registry.SetListener(Element, "onKeydown", (Action<BrowserEvent>)(browserEvent =>
+        {
+            seenKey = browserEvent.Key;
+            browserEvent.StopPropagation();
+            browserEvent.PreventDefault();
+        }));
+
+        var flags = _registry.Dispatch(Element, capture: false, Event("keydown", key: "Enter"));
+
+        seenKey.ShouldBe("Enter");
+        flags.ShouldBe(3); // bit 0 stopPropagation, bit 1 preventDefault
+    }
+
+    [Fact]
+    public void Dispatch_WithNoInvoker_ReturnsZero()
+        => _registry.Dispatch(Element, capture: false, Event()).ShouldBe(0);
+
+    [Fact]
+    public void HandlerExceptions_RouteToTheErrorSink_NeverEscapeToTheListener()
+    {
+        Exception? sunk = null;
+        _registry.ErrorSink = exception => sunk = exception;
+        _registry.SetListener(Element, "onClick", (Action)(() => throw new InvalidOperationException("handler boom")));
+
+        var flags = 0;
+        Should.NotThrow(() => flags = _registry.Dispatch(Element, capture: false, Event()));
+
+        sunk.ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("handler boom");
+        flags.ShouldBe(0);
+    }
+
+    [Fact]
+    public void PurgeReleasedHandles_DropsInvokersForRemovedNodes()
+    {
+        _registry.SetListener(Element, "onClick", (Action)(() => { }));
+        _registry.SetListener(31, "onInput", (Action)(() => { }));
+
+        _registry.PurgeReleasedHandles([Element]);
+
+        _registry.InvokerCount.ShouldBe(1);
+        _registry.Dispatch(Element, capture: false, Event()).ShouldBe(0);
+    }
+
+    [Fact]
+    public void MulticastHandlers_InvokeEveryTargetInOrder()
+    {
+        // MergeProperties chains same-typed handlers into one multicast delegate.
+        var invoked = new List<string>();
+        var merged = Delegate.Combine(
+            (Action<BrowserEvent>)(_ => invoked.Add("first")),
+            (Action<BrowserEvent>)(browserEvent => invoked.Add("second:" + browserEvent.EventName)));
+        _registry.SetListener(Element, "onClick", merged);
+
+        _registry.Dispatch(Element, capture: false, Event());
+
+        invoked.ShouldBe(["first", "second:click"]);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventsTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventsTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins withModifiers/withKeys parity with @vue/runtime-dom's vOn helpers —
+// https://vuejs.org/guide/essentials/event-handling.html.
+public class BrowserEventsTests
+{
+    private static BrowserEvent Event(
+        string eventName = "click",
+        string key = "",
+        BrowserEventModifiers modifiers = BrowserEventModifiers.None,
+        int button = 0,
+        bool isSelfTarget = true)
+        => new(eventName, 100, key, string.Empty, modifiers, button, 0, 0, 0, 1, isSelfTarget, null, false);
+
+    [Fact]
+    public void WithModifiers_StopAndPrevent_RecordIntentsAndStillRunTheHandler()
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithModifiers(_ => runs++, "stop", "prevent");
+        var browserEvent = Event();
+
+        handler(browserEvent);
+
+        runs.ShouldBe(1);
+        browserEvent.PropagationStopped.ShouldBeTrue();
+        browserEvent.DefaultPrevented.ShouldBeTrue();
+        browserEvent.ToResponseFlags().ShouldBe(3);
+    }
+
+    [Fact]
+    public void WithModifiers_Self_SkipsBubbledEvents()
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithModifiers(_ => runs++, "self");
+
+        handler(Event(isSelfTarget: false));
+        runs.ShouldBe(0);
+
+        handler(Event(isSelfTarget: true));
+        runs.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData("ctrl", BrowserEventModifiers.Control)]
+    [InlineData("shift", BrowserEventModifiers.Shift)]
+    [InlineData("alt", BrowserEventModifiers.Alt)]
+    [InlineData("meta", BrowserEventModifiers.Meta)]
+    public void WithModifiers_SystemModifiers_GateOnTheKeyState(string modifier, BrowserEventModifiers flag)
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithModifiers(_ => runs++, modifier);
+
+        handler(Event());
+        runs.ShouldBe(0);
+
+        handler(Event(modifiers: flag));
+        runs.ShouldBe(1);
+
+        // Non-exact: extra modifiers still pass.
+        handler(Event(modifiers: flag | BrowserEventModifiers.Shift | BrowserEventModifiers.Control));
+        runs.ShouldBe(2);
+    }
+
+    [Fact]
+    public void WithModifiers_MouseButtons_GateOnTheButton()
+    {
+        var leftRuns = 0;
+        var rightRuns = 0;
+        var middleRuns = 0;
+        var left = BrowserEvents.WithModifiers(_ => leftRuns++, "left");
+        var right = BrowserEvents.WithModifiers(_ => rightRuns++, "right");
+        var middle = BrowserEvents.WithModifiers(_ => middleRuns++, "middle");
+
+        left(Event(button: 0));
+        left(Event(button: 2));
+        right(Event(button: 2));
+        right(Event(button: 0));
+        middle(Event(button: 1));
+        middle(Event(button: 0));
+
+        leftRuns.ShouldBe(1);
+        rightRuns.ShouldBe(1);
+        middleRuns.ShouldBe(1);
+    }
+
+    [Fact]
+    public void WithModifiers_Exact_RequiresExactlyTheListedSystemModifiers()
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithModifiers(_ => runs++, "ctrl", "exact");
+
+        handler(Event(modifiers: BrowserEventModifiers.Control));
+        runs.ShouldBe(1);
+
+        // An extra pressed modifier fails .exact.
+        handler(Event(modifiers: BrowserEventModifiers.Control | BrowserEventModifiers.Shift));
+        runs.ShouldBe(1);
+
+        // .exact with no system modifiers listed: none may be pressed.
+        var bare = BrowserEvents.WithModifiers(_ => runs++, "exact");
+        bare(Event());
+        runs.ShouldBe(2);
+        bare(Event(modifiers: BrowserEventModifiers.Meta));
+        runs.ShouldBe(2);
+    }
+
+    [Fact]
+    public void WithKeys_MatchesPlainKeysCaseInsensitively()
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithKeys(_ => runs++, "enter");
+
+        handler(Event("keydown", key: "Enter"));
+        runs.ShouldBe(1);
+
+        handler(Event("keydown", key: "Tab"));
+        runs.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData("esc", "Escape")]
+    [InlineData("up", "ArrowUp")]
+    [InlineData("down", "ArrowDown")]
+    [InlineData("left", "ArrowLeft")]
+    [InlineData("right", "ArrowRight")]
+    [InlineData("delete", "Backspace")]
+    [InlineData("tab", "Tab")]
+    [InlineData("space", " ")]
+    public void WithKeys_MatchesVueKeyAliases(string alias, string domKey)
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithKeys(_ => runs++, alias);
+
+        handler(Event("keydown", key: domKey));
+
+        runs.ShouldBe(1);
+    }
+
+    [Fact]
+    public void WithKeys_IgnoresNonKeyboardEvents()
+    {
+        var runs = 0;
+        var handler = BrowserEvents.WithKeys(_ => runs++, "enter");
+
+        handler(Event("click", key: ""));
+
+        runs.ShouldBe(0);
+    }
+
+    [Fact]
+    public void WithModifiers_ComposesWithWithKeys()
+    {
+        var seen = new List<string>();
+        var handler = BrowserEvents.WithKeys(
+            BrowserEvents.WithModifiers(browserEvent => seen.Add(browserEvent.Key), "ctrl"),
+            "enter");
+
+        handler(Event("keydown", key: "Enter"));
+        handler(Event("keydown", key: "Enter", modifiers: BrowserEventModifiers.Control));
+
+        seen.ShouldBe(["Enter"]);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserPropertyPatcherTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserPropertyPatcherTests.cs
@@ -276,15 +276,19 @@ public class BrowserPropertyPatcherTests
     // --- events -------------------------------------------------------------------------------
 
     [Fact]
-    public void EventProps_RegisterAndRemoveListenersByLowerCaseEventName()
+    public void EventProps_FlowTheRawNameToTheInvokerRegistry()
     {
+        // The registry parses the event name and Once/Capture/Passive suffixes
+        // ([V01.01.04.03]); the patcher passes the raw prop through untouched.
         var handler = (Action)(() => { });
         Patch("button", "onClick", null, handler);
+        Patch("button", "onClickCaptureOnce", null, handler);
         Patch("button", "onClick", handler, null);
         _calls.ShouldBe(
         [
-            $"setEventListener({Element},click,delegate)",
-            $"setEventListener({Element},click,null)",
+            $"setEventListener({Element},onClick,delegate)",
+            $"setEventListener({Element},onClickCaptureOnce,delegate)",
+            $"setEventListener({Element},onClick,null)",
         ]);
     }
 

--- a/libraries/Assimalign.Vue.Shared/Assimalign.Vue.Shared.slnx
+++ b/libraries/Assimalign.Vue.Shared/Assimalign.Vue.Shared.slnx
@@ -1,0 +1,5 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.Shared.csproj" />
+	<Project Path="test/Assimalign.Vue.Shared.Tests.csproj" />
+	<Project Path="test/Assimalign.Vue.Shared.GeneratorFixture/Assimalign.Vue.Shared.GeneratorFixture.csproj" />
+</Solution>

--- a/libraries/Assimalign.Vue.Shared/src/DisplayStringFormatter.cs
+++ b/libraries/Assimalign.Vue.Shared/src/DisplayStringFormatter.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// Text-interpolation formatting — the C# port of <c>toDisplayString</c> from
+/// <c>@vue/shared</c> (<c>packages/shared/src/toDisplayString.ts</c>,
+/// https://vuejs.org/guide/essentials/template-syntax.html). Null renders empty, scalars via
+/// invariant culture (mandatory so SSR output and client hydration agree), and collections
+/// render in upstream's JSON-like two-space-indented shape, including its Map/Set replacer
+/// conventions for non-string-keyed dictionaries and sets. Hand-written recursion over
+/// <see cref="IDictionary"/>/<see cref="IEnumerable"/> — no reflection-based serialization
+/// (WASM AOT/trimming constraint).
+/// </summary>
+public static class DisplayStringFormatter
+{
+    /// <summary>Formats <paramref name="value"/> for text interpolation (upstream: <c>toDisplayString</c>).</summary>
+    /// <param name="value">The interpolated value.</param>
+    /// <returns>The display string; never null.</returns>
+    public static string ToDisplayString(object? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+        if (value is string text)
+        {
+            return text;
+        }
+        if (IsJsonShaped(value))
+        {
+            var builder = new StringBuilder();
+            WriteJson(builder, value, 0);
+            return builder.ToString();
+        }
+        return FormatScalar(value);
+    }
+
+    /// <summary>
+    /// Scalar formatting with invariant culture: JavaScript-style booleans
+    /// (<c>true</c>/<c>false</c>), <see cref="IFormattable"/> via
+    /// <see cref="CultureInfo.InvariantCulture"/>, everything else via <c>ToString()</c>.
+    /// </summary>
+    /// <param name="value">The scalar value.</param>
+    public static string FormatScalar(object value) => value switch
+    {
+        string text => text,
+        bool boolValue => boolValue ? "true" : "false",
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
+        _ => value.ToString() ?? string.Empty,
+    };
+
+    private static bool IsJsonShaped(object value)
+        => value is IDictionary
+            || value is IEnumerable and not string
+            || value is IReadOnlyDictionary<string, object?>;
+
+    private static void WriteJson(StringBuilder builder, object? value, int depth)
+    {
+        switch (value)
+        {
+            case null:
+                builder.Append("null");
+                break;
+            case string text:
+                WriteJsonString(builder, text);
+                break;
+            case bool boolValue:
+                builder.Append(boolValue ? "true" : "false");
+                break;
+            case IReadOnlyDictionary<string, object?> readOnlyMap:
+                WriteJsonObject(builder, EnumeratePairs(readOnlyMap), depth);
+                break;
+            case IDictionary dictionary when HasStringKeys(dictionary):
+                WriteJsonObject(builder, EnumeratePairs(dictionary), depth);
+                break;
+            case IDictionary dictionary:
+                // Upstream Map replacer: { "Map(n)": { "key =>": value } }.
+                WriteMapConvention(builder, dictionary, depth);
+                break;
+            case IEnumerable enumerable when IsSetLike(value):
+                // Upstream Set replacer: { "Set(n)": [ ... ] }.
+                WriteSetConvention(builder, enumerable, depth);
+                break;
+            case IEnumerable enumerable:
+                WriteJsonArray(builder, enumerable, depth);
+                break;
+            case sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal:
+                builder.Append(FormatScalar(value));
+                break;
+            default:
+                WriteJsonString(builder, FormatScalar(value));
+                break;
+        }
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> EnumeratePairs(IReadOnlyDictionary<string, object?> map)
+        => map;
+
+    private static IEnumerable<KeyValuePair<string, object?>> EnumeratePairs(IDictionary dictionary)
+    {
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            yield return new KeyValuePair<string, object?>((string)entry.Key, entry.Value);
+        }
+    }
+
+    private static bool HasStringKeys(IDictionary dictionary)
+    {
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            if (entry.Key is not string)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // ISet<T> has no non-generic or covariant view, so set-ness is detected by an interface
+    // test on the live instance's type, cached per type. No member is ever read reflectively
+    // (the recursion serializes only through IDictionary/IEnumerable dispatch).
+    private static readonly Dictionary<Type, bool> SetLikeCache = [];
+
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075:UnrecognizedReflectionPattern",
+        Justification = "Selects a display convention only: if the trimmer removes an unused "
+            + "ISet<T> implementation from a type's interface list, the value degrades to the "
+            + "array display shape - output cosmetics, never a correctness or activation path.")]
+    private static bool IsSetLike(object value)
+    {
+        var type = value.GetType();
+        if (SetLikeCache.TryGetValue(type, out var isSetLike))
+        {
+            return isSetLike;
+        }
+        isSetLike = false;
+        foreach (var candidate in type.GetInterfaces())
+        {
+            if (candidate.IsGenericType)
+            {
+                var definition = candidate.GetGenericTypeDefinition();
+                if (definition == typeof(ISet<>) || definition == typeof(IReadOnlySet<>))
+                {
+                    isSetLike = true;
+                    break;
+                }
+            }
+        }
+        SetLikeCache[type] = isSetLike;
+        return isSetLike;
+    }
+
+    private static void WriteJsonObject(StringBuilder builder, IEnumerable<KeyValuePair<string, object?>> pairs, int depth)
+    {
+        builder.Append('{');
+        var first = true;
+        foreach (var (name, entryValue) in pairs)
+        {
+            builder.Append(first ? "\n" : ",\n");
+            first = false;
+            AppendIndent(builder, depth + 1);
+            WriteJsonString(builder, name);
+            builder.Append(": ");
+            WriteJson(builder, entryValue, depth + 1);
+        }
+        if (!first)
+        {
+            builder.Append('\n');
+            AppendIndent(builder, depth);
+        }
+        builder.Append('}');
+    }
+
+    private static void WriteJsonArray(StringBuilder builder, IEnumerable values, int depth)
+    {
+        builder.Append('[');
+        var first = true;
+        foreach (var entry in values)
+        {
+            builder.Append(first ? "\n" : ",\n");
+            first = false;
+            AppendIndent(builder, depth + 1);
+            WriteJson(builder, entry, depth + 1);
+        }
+        if (!first)
+        {
+            builder.Append('\n');
+            AppendIndent(builder, depth);
+        }
+        builder.Append(']');
+    }
+
+    private static void WriteMapConvention(StringBuilder builder, IDictionary dictionary, int depth)
+    {
+        builder.Append("{\n");
+        AppendIndent(builder, depth + 1);
+        WriteJsonString(builder, $"Map({dictionary.Count.ToString(CultureInfo.InvariantCulture)})");
+        builder.Append(": {");
+        var first = true;
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            builder.Append(first ? "\n" : ",\n");
+            first = false;
+            AppendIndent(builder, depth + 2);
+            WriteJsonString(builder, $"{FormatScalar(entry.Key)} =>");
+            builder.Append(": ");
+            WriteJson(builder, entry.Value, depth + 2);
+        }
+        if (!first)
+        {
+            builder.Append('\n');
+            AppendIndent(builder, depth + 1);
+        }
+        builder.Append("}\n");
+        AppendIndent(builder, depth);
+        builder.Append('}');
+    }
+
+    private static void WriteSetConvention(StringBuilder builder, IEnumerable values, int depth)
+    {
+        var count = 0;
+        foreach (var _ in values)
+        {
+            count++;
+        }
+        builder.Append("{\n");
+        AppendIndent(builder, depth + 1);
+        WriteJsonString(builder, $"Set({count.ToString(CultureInfo.InvariantCulture)})");
+        builder.Append(": ");
+        WriteJsonArray(builder, values, depth + 1);
+        builder.Append('\n');
+        AppendIndent(builder, depth);
+        builder.Append('}');
+    }
+
+    private static void WriteJsonString(StringBuilder builder, string text)
+    {
+        builder.Append('"');
+        foreach (var character in text)
+        {
+            switch (character)
+            {
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                default:
+                    if (character < ' ')
+                    {
+                        builder.Append("\\u").Append(((int)character).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        builder.Append(character);
+                    }
+                    break;
+            }
+        }
+        builder.Append('"');
+    }
+
+    private static void AppendIndent(StringBuilder builder, int depth)
+        => builder.Append(' ', depth * 2);
+}

--- a/libraries/Assimalign.Vue.Shared/src/DomKnowledge.cs
+++ b/libraries/Assimalign.Vue.Shared/src/DomKnowledge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 
@@ -41,33 +42,92 @@ public static class DomKnowledge
 
     private static readonly FrozenDictionary<string, string> PropertyToAttributeMap = BuildPropertyToAttributeMap();
 
+    // Span alternate lookups (net9+): the template compiler tokenizes source text into spans,
+    // so membership tests must not materialize a string per tag/attribute token. Declared
+    // after the sets they view (field initializers run in declaration order).
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> HtmlTagLookup =
+        HtmlTagSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> SvgTagLookup =
+        SvgTagSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> MathTagLookup =
+        MathTagSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> VoidTagLookup =
+        VoidTagSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> BooleanAttributeLookup =
+        BooleanAttributeSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> KnownHtmlAttributeLookup =
+        KnownHtmlAttributeSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> KnownSvgAttributeLookup =
+        KnownSvgAttributeSet.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    private static readonly FrozenDictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> PropertyToAttributeLookup =
+        PropertyToAttributeMap.GetAlternateLookup<ReadOnlySpan<char>>();
+
+    // The unsafe characters plus the full C0 control range, vectorized (SearchValues is the
+    // .NET 8+ fast path for repeated membership scans over a fixed character set).
+    private static readonly SearchValues<char> UnsafeAttributeNameSearchValues = BuildUnsafeAttributeNameSearchValues();
+
     /// <summary>Whether <paramref name="tag"/> is a known HTML element (upstream: <c>isHTMLTag</c>).</summary>
     /// <param name="tag">The tag name (case-insensitive per WHATWG).</param>
     public static bool IsHtmlTag(string tag) => HtmlTagSet.Contains(tag);
+
+    /// <inheritdoc cref="IsHtmlTag(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsHtmlTag(ReadOnlySpan<char> tag) => HtmlTagLookup.Contains(tag);
 
     /// <summary>Whether <paramref name="tag"/> is a known SVG element (upstream: <c>isSVGTag</c>).</summary>
     /// <param name="tag">The tag name (case-sensitive per SVG 2).</param>
     public static bool IsSvgTag(string tag) => SvgTagSet.Contains(tag);
 
+    /// <inheritdoc cref="IsSvgTag(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsSvgTag(ReadOnlySpan<char> tag) => SvgTagLookup.Contains(tag);
+
     /// <summary>Whether <paramref name="tag"/> is a known MathML element (upstream: <c>isMathMLTag</c>).</summary>
     /// <param name="tag">The tag name (case-sensitive per MathML Core).</param>
     public static bool IsMathMLTag(string tag) => MathTagSet.Contains(tag);
+
+    /// <inheritdoc cref="IsMathMLTag(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsMathMLTag(ReadOnlySpan<char> tag) => MathTagLookup.Contains(tag);
 
     /// <summary>Whether <paramref name="tag"/> is a void element (upstream: <c>isVoidTag</c>, WHATWG).</summary>
     /// <param name="tag">The tag name.</param>
     public static bool IsVoidTag(string tag) => VoidTagSet.Contains(tag);
 
+    /// <inheritdoc cref="IsVoidTag(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsVoidTag(ReadOnlySpan<char> tag) => VoidTagLookup.Contains(tag);
+
     /// <summary>Whether <paramref name="attributeName"/> is a boolean attribute (upstream: <c>isBooleanAttr</c>).</summary>
     /// <param name="attributeName">The attribute name.</param>
     public static bool IsBooleanAttribute(string attributeName) => BooleanAttributeSet.Contains(attributeName);
+
+    /// <inheritdoc cref="IsBooleanAttribute(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsBooleanAttribute(ReadOnlySpan<char> attributeName) => BooleanAttributeLookup.Contains(attributeName);
 
     /// <summary>Whether <paramref name="attributeName"/> is a known HTML attribute (upstream: <c>isKnownHtmlAttr</c>).</summary>
     /// <param name="attributeName">The attribute name.</param>
     public static bool IsKnownHtmlAttribute(string attributeName) => KnownHtmlAttributeSet.Contains(attributeName);
 
+    /// <inheritdoc cref="IsKnownHtmlAttribute(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsKnownHtmlAttribute(ReadOnlySpan<char> attributeName) => KnownHtmlAttributeLookup.Contains(attributeName);
+
     /// <summary>Whether <paramref name="attributeName"/> is a known SVG attribute (upstream: <c>isKnownSvgAttr</c>).</summary>
     /// <param name="attributeName">The attribute name.</param>
     public static bool IsKnownSvgAttribute(string attributeName) => KnownSvgAttributeSet.Contains(attributeName);
+
+    /// <inheritdoc cref="IsKnownSvgAttribute(string)"/>
+    /// <remarks>Allocation-free for span-shaped tokens (compiler tokenization).</remarks>
+    public static bool IsKnownSvgAttribute(ReadOnlySpan<char> attributeName) => KnownSvgAttributeLookup.Contains(attributeName);
 
     /// <summary>
     /// Whether <paramref name="attributeName"/> is safe to serialize in SSR output (upstream:
@@ -75,18 +135,17 @@ public static class DomKnowledge
     /// or whitespace/control characters are excluded rather than escaped.
     /// </summary>
     /// <param name="attributeName">The attribute name.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="attributeName"/> is null.</exception>
     public static bool IsSsrSafeAttributeName(string attributeName)
     {
         ArgumentNullException.ThrowIfNull(attributeName);
-        foreach (var character in attributeName)
-        {
-            if (character < ' ' || DomKnowledgeData.UnsafeAttributeNameCharacters.IndexOf(character) >= 0)
-            {
-                return false;
-            }
-        }
-        return attributeName.Length > 0;
+        return IsSsrSafeAttributeName(attributeName.AsSpan());
     }
+
+    /// <inheritdoc cref="IsSsrSafeAttributeName(string)"/>
+    /// <remarks>Vectorized over <see cref="SearchValues{T}"/>.</remarks>
+    public static bool IsSsrSafeAttributeName(ReadOnlySpan<char> attributeName)
+        => attributeName.Length > 0 && !attributeName.ContainsAny(UnsafeAttributeNameSearchValues);
 
     /// <summary>
     /// Maps a camelCase prop name to its attribute name, covering upstream's
@@ -97,6 +156,29 @@ public static class DomKnowledge
     /// <param name="propertyName">The prop name.</param>
     public static string GetAttributeName(string propertyName)
         => PropertyToAttributeMap.TryGetValue(propertyName, out var attributeName) ? attributeName : propertyName;
+
+    /// <summary>
+    /// Looks up a casing-exception attribute name for a span-shaped prop token, allocation-free
+    /// (compiler tokenization): returns false for pass-through names so the caller keeps its
+    /// span instead of materializing a string.
+    /// </summary>
+    /// <param name="propertyName">The prop name token.</param>
+    /// <param name="attributeName">The mapped attribute name when an exception applies.</param>
+    public static bool TryGetAttributeName(ReadOnlySpan<char> propertyName, out string attributeName)
+        => PropertyToAttributeLookup.TryGetValue(propertyName, out attributeName!);
+
+    private static SearchValues<char> BuildUnsafeAttributeNameSearchValues()
+    {
+        // The named unsafe characters plus the full C0 control range in one vectorized set
+        // (tab/newline/form feed appear in both; SearchValues deduplicates).
+        Span<char> characters = stackalloc char[DomKnowledgeData.UnsafeAttributeNameCharacters.Length + 32];
+        DomKnowledgeData.UnsafeAttributeNameCharacters.CopyTo(characters);
+        for (var control = 0; control < 32; control++)
+        {
+            characters[DomKnowledgeData.UnsafeAttributeNameCharacters.Length + control] = (char)control;
+        }
+        return SearchValues.Create(characters);
+    }
 
     private static FrozenDictionary<string, string> BuildPropertyToAttributeMap()
     {

--- a/libraries/Assimalign.Vue.Shared/src/DomKnowledge.cs
+++ b/libraries/Assimalign.Vue.Shared/src/DomKnowledge.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// The frozen DOM knowledge tables — the C# port of <c>@vue/shared</c>'s
+/// <c>domTagConfig.ts</c>/<c>domAttrConfig.ts</c>. The template compiler resolves native
+/// elements vs components and infers namespaces from these at build time; runtime-dom uses
+/// them for attribute-vs-property decisions; the SSR renderer uses them for void-tag and
+/// boolean-attribute serialization. Lookups are allocation-free over
+/// <see cref="FrozenSet{T}"/>/<see cref="FrozenDictionary{TKey,TValue}"/> built from the
+/// single authoritative data definition (<c>Internal/DomKnowledgeData.cs</c>, the linked
+/// shared-source seam for the netstandard2.0 generator host — see that file's header).
+/// HTML tag lookups are case-insensitive per WHATWG; SVG and MathML are case-sensitive per
+/// their specs.
+/// </summary>
+public static class DomKnowledge
+{
+    private static readonly FrozenSet<string> HtmlTagSet =
+        DomKnowledgeData.HtmlTags.Split(',').ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenSet<string> SvgTagSet =
+        DomKnowledgeData.SvgTags.Split(',').ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly FrozenSet<string> MathTagSet =
+        DomKnowledgeData.MathTags.Split(',').ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly FrozenSet<string> VoidTagSet =
+        DomKnowledgeData.VoidTags.Split(',').ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenSet<string> BooleanAttributeSet =
+        DomKnowledgeData.BooleanAttributes.Split(',').ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly FrozenSet<string> KnownHtmlAttributeSet =
+        DomKnowledgeData.KnownHtmlAttributes.Split(',').ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly FrozenSet<string> KnownSvgAttributeSet =
+        DomKnowledgeData.KnownSvgAttributes.Split(',').ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly FrozenDictionary<string, string> PropertyToAttributeMap = BuildPropertyToAttributeMap();
+
+    /// <summary>Whether <paramref name="tag"/> is a known HTML element (upstream: <c>isHTMLTag</c>).</summary>
+    /// <param name="tag">The tag name (case-insensitive per WHATWG).</param>
+    public static bool IsHtmlTag(string tag) => HtmlTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="tag"/> is a known SVG element (upstream: <c>isSVGTag</c>).</summary>
+    /// <param name="tag">The tag name (case-sensitive per SVG 2).</param>
+    public static bool IsSvgTag(string tag) => SvgTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="tag"/> is a known MathML element (upstream: <c>isMathMLTag</c>).</summary>
+    /// <param name="tag">The tag name (case-sensitive per MathML Core).</param>
+    public static bool IsMathMLTag(string tag) => MathTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="tag"/> is a void element (upstream: <c>isVoidTag</c>, WHATWG).</summary>
+    /// <param name="tag">The tag name.</param>
+    public static bool IsVoidTag(string tag) => VoidTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="attributeName"/> is a boolean attribute (upstream: <c>isBooleanAttr</c>).</summary>
+    /// <param name="attributeName">The attribute name.</param>
+    public static bool IsBooleanAttribute(string attributeName) => BooleanAttributeSet.Contains(attributeName);
+
+    /// <summary>Whether <paramref name="attributeName"/> is a known HTML attribute (upstream: <c>isKnownHtmlAttr</c>).</summary>
+    /// <param name="attributeName">The attribute name.</param>
+    public static bool IsKnownHtmlAttribute(string attributeName) => KnownHtmlAttributeSet.Contains(attributeName);
+
+    /// <summary>Whether <paramref name="attributeName"/> is a known SVG attribute (upstream: <c>isKnownSvgAttr</c>).</summary>
+    /// <param name="attributeName">The attribute name.</param>
+    public static bool IsKnownSvgAttribute(string attributeName) => KnownSvgAttributeSet.Contains(attributeName);
+
+    /// <summary>
+    /// Whether <paramref name="attributeName"/> is safe to serialize in SSR output (upstream:
+    /// <c>isSSRSafeAttrName</c>): names containing <c>&gt;</c>, <c>/</c>, <c>=</c>, quotes,
+    /// or whitespace/control characters are excluded rather than escaped.
+    /// </summary>
+    /// <param name="attributeName">The attribute name.</param>
+    public static bool IsSsrSafeAttributeName(string attributeName)
+    {
+        ArgumentNullException.ThrowIfNull(attributeName);
+        foreach (var character in attributeName)
+        {
+            if (character < ' ' || DomKnowledgeData.UnsafeAttributeNameCharacters.IndexOf(character) >= 0)
+            {
+                return false;
+            }
+        }
+        return attributeName.Length > 0;
+    }
+
+    /// <summary>
+    /// Maps a camelCase prop name to its attribute name, covering upstream's
+    /// <c>propsToAttrMap</c> casing exceptions (<c>className</c> → <c>class</c>,
+    /// <c>htmlFor</c> → <c>for</c>, <c>acceptCharset</c> → <c>accept-charset</c>,
+    /// <c>httpEquiv</c> → <c>http-equiv</c>); other names pass through unchanged.
+    /// </summary>
+    /// <param name="propertyName">The prop name.</param>
+    public static string GetAttributeName(string propertyName)
+        => PropertyToAttributeMap.TryGetValue(propertyName, out var attributeName) ? attributeName : propertyName;
+
+    private static FrozenDictionary<string, string> BuildPropertyToAttributeMap()
+    {
+        var pairs = DomKnowledgeData.PropertyToAttributePairs;
+        var map = new Dictionary<string, string>(pairs.Length / 2, StringComparer.Ordinal);
+        for (var index = 0; index < pairs.Length; index += 2)
+        {
+            map[pairs[index]] = pairs[index + 1];
+        }
+        return map.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/src/Internal/DomKnowledgeData.cs
+++ b/libraries/Assimalign.Vue.Shared/src/Internal/DomKnowledgeData.cs
@@ -1,0 +1,131 @@
+// LINKED SHARED-SOURCE SEAM — [V01.01.01.03] decision: this file is the single authoritative
+// definition of the DOM knowledge lists, written against the lowest common denominator
+// (netstandard2.0-compatible C#: constants only, no modern BCL APIs) so the Roslyn template
+// compiler (a netstandard2.0 generator host) links THIS FILE via <Compile Include="..."/>
+// while the net10.0 runtime exposes it through DomKnowledge's frozen lookups. Multi-targeting
+// the whole Shared assembly was rejected: it would tax every hot-path file with polyfills for
+// one consumer. See the Assimalign.Vue.Shared.GeneratorFixture test project, which proves the
+// generator-context consumption path compiles and agrees with the runtime tables.
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// The raw comma-joined DOM knowledge lists mirroring <c>@vue/shared</c>'s
+/// <c>domTagConfig.ts</c>/<c>domAttrConfig.ts</c> (upstream's <c>makeMap</c> input format,
+/// cross-checked against WHATWG HTML for void elements and boolean attributes).
+/// </summary>
+internal static class DomKnowledgeData
+{
+    /// <summary>Upstream <c>HTML_TAGS</c>.</summary>
+    internal const string HtmlTags =
+        "html,body,base,head,link,meta,style,title,address,article,aside,footer,header,hgroup,"
+        + "h1,h2,h3,h4,h5,h6,nav,section,div,dd,dl,dt,figcaption,figure,picture,hr,img,li,main,"
+        + "ol,p,pre,ul,a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,ruby,s,samp,"
+        + "small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,embed,object,"
+        + "param,source,canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,"
+        + "th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,option,output,"
+        + "progress,select,textarea,details,dialog,menu,summary,template,blockquote,iframe,tfoot";
+
+    /// <summary>Upstream <c>SVG_TAGS</c> (case-sensitive per the SVG 2 element tables).</summary>
+    internal const string SvgTags =
+        "svg,animate,animateMotion,animateTransform,circle,clipPath,color-profile,defs,desc,"
+        + "discard,ellipse,feBlend,feColorMatrix,feComponentTransfer,feComposite,feConvolveMatrix,"
+        + "feDiffuseLighting,feDisplacementMap,feDistantLight,feDropShadow,feFlood,feFuncA,"
+        + "feFuncB,feFuncG,feFuncR,feGaussianBlur,feImage,feMerge,feMergeNode,feMorphology,"
+        + "feOffset,fePointLight,feSpecularLighting,feSpotLight,feTile,feTurbulence,filter,"
+        + "foreignObject,g,hatch,hatchpath,image,line,linearGradient,marker,mask,mesh,"
+        + "meshgradient,meshpatch,meshrow,metadata,mpath,path,pattern,polygon,polyline,"
+        + "radialGradient,rect,set,solidcolor,stop,switch,symbol,text,textPath,title,tspan,"
+        + "unknown,use,view";
+
+    /// <summary>Upstream <c>MATH_TAGS</c> (MathML Core element tables).</summary>
+    internal const string MathTags =
+        "annotation,annotation-xml,maction,maligngroup,malignmark,math,menclose,merror,mfenced,"
+        + "mfrac,mfraction,mglyph,mi,mlabeledtr,mlongdiv,mmultiscripts,mn,mo,mover,mpadded,"
+        + "mphantom,mprescripts,mroot,mrow,ms,mscarries,mscarry,msgroup,msline,mspace,msqrt,"
+        + "msrow,mstack,mstyle,msub,msubsup,msup,mtable,mtd,mtext,mtr,munder,munderover,none,"
+        + "semantics";
+
+    /// <summary>Upstream <c>VOID_TAGS</c> (WHATWG void elements).</summary>
+    internal const string VoidTags = "area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr";
+
+    /// <summary>
+    /// Upstream <c>isBooleanAttr</c>'s input: the special boolean attributes plus the common
+    /// set (WHATWG boolean attributes).
+    /// </summary>
+    internal const string BooleanAttributes =
+        "itemscope,allowfullscreen,formnovalidate,ismap,nomodule,novalidate,readonly,"
+        + "async,autofocus,autoplay,controls,default,defer,disabled,hidden,inert,loop,open,"
+        + "required,reversed,scoped,seamless,checked,muted,multiple,selected";
+
+    /// <summary>Upstream <c>isKnownHtmlAttr</c>'s input.</summary>
+    internal const string KnownHtmlAttributes =
+        "accept,accept-charset,accesskey,action,align,allow,alt,async,autocapitalize,"
+        + "autocomplete,autofocus,autoplay,background,bgcolor,border,buffered,capture,challenge,"
+        + "charset,checked,cite,class,code,codebase,color,cols,colspan,content,contenteditable,"
+        + "contextmenu,controls,coords,crossorigin,csp,data,datetime,decoding,default,defer,dir,"
+        + "dirname,disabled,download,draggable,dropzone,enctype,enterkeyhint,for,form,formaction,"
+        + "formenctype,formmethod,formnovalidate,formtarget,headers,height,hidden,high,href,"
+        + "hreflang,http-equiv,icon,id,importance,inert,integrity,ismap,itemprop,keytype,kind,"
+        + "label,lang,language,loading,list,loop,low,manifest,max,maxlength,minlength,media,min,"
+        + "multiple,muted,name,novalidate,open,optimum,pattern,ping,placeholder,poster,preload,"
+        + "radiogroup,readonly,referrerpolicy,rel,required,reversed,rows,rowspan,sandbox,scope,"
+        + "scoped,selected,shape,size,sizes,slot,span,spellcheck,src,srcdoc,srclang,srcset,start,"
+        + "step,style,summary,tabindex,target,title,translate,type,usemap,value,width,wrap";
+
+    /// <summary>Upstream <c>isKnownSvgAttr</c>'s input (SVG 2 attribute tables).</summary>
+    internal const string KnownSvgAttributes =
+        "xmlns,accent-height,accumulate,additive,alignment-baseline,alphabetic,amplitude,"
+        + "arabic-form,ascent,attributeName,attributeType,azimuth,baseFrequency,baseline-shift,"
+        + "baseProfile,bbox,begin,bias,by,calcMode,cap-height,class,clip,clipPathUnits,clip-path,"
+        + "clip-rule,color,color-interpolation,color-interpolation-filters,color-profile,"
+        + "color-rendering,contentScriptType,contentStyleType,crossorigin,cursor,cx,cy,d,"
+        + "decelerate,descent,diffuseConstant,direction,display,divisor,dominant-baseline,dur,dx,"
+        + "dy,edgeMode,elevation,enable-background,end,exponent,fill,fill-opacity,fill-rule,"
+        + "filter,filterRes,filterUnits,flood-color,flood-opacity,font-family,font-size,"
+        + "font-size-adjust,font-stretch,font-style,font-variant,font-weight,format,from,fr,fx,"
+        + "fy,g1,g2,glyph-name,glyph-orientation-horizontal,glyph-orientation-vertical,"
+        + "glyphRef,gradientTransform,gradientUnits,hanging,height,href,hreflang,horiz-adv-x,"
+        + "horiz-origin-x,id,ideographic,image-rendering,in,in2,intercept,k,k1,k2,k3,k4,"
+        + "kernelMatrix,kernelUnitLength,kerning,keyPoints,keySplines,keyTimes,lang,"
+        + "lengthAdjust,letter-spacing,lighting-color,limitingConeAngle,local,marker-end,"
+        + "marker-mid,marker-start,markerHeight,markerUnits,markerWidth,mask,maskContentUnits,"
+        + "maskUnits,mathematical,max,media,method,min,mode,name,numOctaves,offset,opacity,"
+        + "operator,order,orient,orientation,origin,overflow,overline-position,"
+        + "overline-thickness,panose-1,paint-order,path,pathLength,patternContentUnits,"
+        + "patternTransform,patternUnits,ping,pointer-events,points,pointsAtX,pointsAtY,"
+        + "pointsAtZ,preserveAlpha,preserveAspectRatio,primitiveUnits,r,radius,referrerPolicy,"
+        + "refX,refY,rel,rendering-intent,repeatCount,repeatDur,requiredExtensions,"
+        + "requiredFeatures,restart,result,rotate,rx,ry,scale,seed,shape-rendering,slope,"
+        + "spacing,specularConstant,specularExponent,speed,spreadMethod,startOffset,"
+        + "stdDeviation,stemh,stemv,stitchTiles,stop-color,stop-opacity,"
+        + "strikethrough-position,strikethrough-thickness,string,stroke,stroke-dasharray,"
+        + "stroke-dashoffset,stroke-linecap,stroke-linejoin,stroke-miterlimit,stroke-opacity,"
+        + "stroke-width,style,surfaceScale,systemLanguage,tabindex,tableValues,target,targetX,"
+        + "targetY,text-anchor,text-decoration,text-rendering,textLength,to,transform,"
+        + "transform-origin,type,u1,u2,underline-position,underline-thickness,unicode,"
+        + "unicode-bidi,unicode-range,units-per-em,v-alphabetic,v-hanging,v-ideographic,"
+        + "v-mathematical,values,vector-effect,version,vert-adv-y,vert-origin-x,vert-origin-y,"
+        + "viewBox,viewTarget,visibility,width,widths,word-spacing,writing-mode,x,x-height,x1,"
+        + "x2,xChannelSelector,xlink:actuate,xlink:arcrole,xlink:href,xlink:role,xlink:show,"
+        + "xlink:title,xlink:type,xmlns:xlink,xml:base,xml:lang,xml:space,y,y1,y2,"
+        + "yChannelSelector,z,zoomAndPan";
+
+    /// <summary>
+    /// Upstream's unsafe attribute-name characters (SSR): <c>&gt;</c>, <c>/</c>, <c>=</c>,
+    /// quotes, tab, newline, form feed, and space.
+    /// </summary>
+    internal const string UnsafeAttributeNameCharacters = ">/=\"'\u0009\u000A\u000C\u0020";
+
+    /// <summary>
+    /// Upstream <c>propsToAttrMap</c>: the camelCase prop → attribute casing exceptions, as
+    /// alternating name/value entries.
+    /// </summary>
+    internal static readonly string[] PropertyToAttributePairs =
+    [
+        "acceptCharset", "accept-charset",
+        "className", "class",
+        "htmlFor", "for",
+        "httpEquiv", "http-equiv",
+    ];
+}

--- a/libraries/Assimalign.Vue.Shared/src/LooseEquality.cs
+++ b/libraries/Assimalign.Vue.Shared/src/LooseEquality.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// Vue's loose equality — the C# port of <c>looseEqual</c>/<c>looseIndexOf</c> from
+/// <c>@vue/shared</c> (<c>packages/shared/src/looseEqual.ts</c>). Checkbox and select
+/// <c>v-model</c> value matching depends on these semantics: dates compare by instant,
+/// enumerables element-wise, dictionaries key-wise, and everything else falls back to
+/// invariant display-string comparison (JavaScript's <c>String(a) === String(b)</c> coercion,
+/// so <c>1</c> loosely equals <c>"1"</c>).
+/// </summary>
+public static class LooseEquality
+{
+    /// <summary>Whether <paramref name="left"/> and <paramref name="right"/> are loosely equal (upstream: <c>looseEqual</c>).</summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    public static bool LooseEqual(object? left, object? right)
+    {
+        if (Equals(left, right))
+        {
+            return true;
+        }
+        if (left is null || right is null)
+        {
+            return false;
+        }
+        var leftIsDate = TryGetInstant(left, out var leftInstant);
+        var rightIsDate = TryGetInstant(right, out var rightInstant);
+        if (leftIsDate || rightIsDate)
+        {
+            return leftIsDate && rightIsDate && leftInstant == rightInstant;
+        }
+        var leftIsEnumerable = left is IEnumerable and not string and not IDictionary;
+        var rightIsEnumerable = right is IEnumerable and not string and not IDictionary;
+        var leftIsMap = IsMap(left);
+        var rightIsMap = IsMap(right);
+        if (leftIsMap || rightIsMap)
+        {
+            return leftIsMap && rightIsMap && MapsLooselyEqual(left, right);
+        }
+        if (leftIsEnumerable || rightIsEnumerable)
+        {
+            return leftIsEnumerable && rightIsEnumerable
+                && SequencesLooselyEqual((IEnumerable)left, (IEnumerable)right);
+        }
+        // JavaScript's final fallback: String(a) === String(b).
+        return string.Equals(
+            DisplayStringFormatter.FormatScalar(left),
+            DisplayStringFormatter.FormatScalar(right),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The index of the first element loosely equal to <paramref name="value"/>, or -1
+    /// (upstream: <c>looseIndexOf</c>) — how <c>v-model</c> matches a checkbox/select value
+    /// against a bound collection.
+    /// </summary>
+    /// <param name="values">The collection to search.</param>
+    /// <param name="value">The value to match.</param>
+    public static int LooseIndexOf(IEnumerable values, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var index = 0;
+        foreach (var entry in values)
+        {
+            if (LooseEqual(entry, value))
+            {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    private static bool TryGetInstant(object value, out long instant)
+    {
+        switch (value)
+        {
+            case DateTime dateTime:
+                instant = dateTime.ToUniversalTime().Ticks;
+                return true;
+            case DateTimeOffset dateTimeOffset:
+                instant = dateTimeOffset.UtcTicks;
+                return true;
+            default:
+                instant = 0;
+                return false;
+        }
+    }
+
+    private static bool IsMap(object value)
+        => value is IDictionary || value is IReadOnlyDictionary<string, object?>;
+
+    private static bool MapsLooselyEqual(object left, object right)
+    {
+        var leftPairs = EnumerateMap(left);
+        var rightPairs = EnumerateMap(right);
+        if (leftPairs.Count != rightPairs.Count)
+        {
+            return false;
+        }
+        foreach (var (name, leftValue) in leftPairs)
+        {
+            if (!rightPairs.TryGetValue(name, out var rightValue) || !LooseEqual(leftValue, rightValue))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Dictionary<string, object?> EnumerateMap(object value)
+    {
+        var pairs = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (value is IReadOnlyDictionary<string, object?> readOnlyMap)
+        {
+            foreach (var (name, entryValue) in readOnlyMap)
+            {
+                pairs[name] = entryValue;
+            }
+        }
+        else if (value is IDictionary dictionary)
+        {
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                pairs[DisplayStringFormatter.FormatScalar(entry.Key)] = entry.Value;
+            }
+        }
+        return pairs;
+    }
+
+    private static bool SequencesLooselyEqual(IEnumerable left, IEnumerable right)
+    {
+        var leftEnumerator = left.GetEnumerator();
+        var rightEnumerator = right.GetEnumerator();
+        try
+        {
+            while (true)
+            {
+                var leftHasNext = leftEnumerator.MoveNext();
+                var rightHasNext = rightEnumerator.MoveNext();
+                if (leftHasNext != rightHasNext)
+                {
+                    return false;
+                }
+                if (!leftHasNext)
+                {
+                    return true;
+                }
+                if (!LooseEqual(leftEnumerator.Current, rightEnumerator.Current))
+                {
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            (leftEnumerator as IDisposable)?.Dispose();
+            (rightEnumerator as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/src/StyleAndClassNormalization.cs
+++ b/libraries/Assimalign.Vue.Shared/src/StyleAndClassNormalization.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// Class and style value normalization — the C# port of <c>normalizeClass</c>,
+/// <c>normalizeStyle</c>, <c>parseStringStyle</c>, and <c>stringifyStyle</c> from
+/// <c>@vue/shared</c> (<c>packages/shared/src/normalizeProp.ts</c>,
+/// https://vuejs.org/guide/essentials/class-and-style.html). Bindings accept string, nested
+/// enumerable, and dictionary (name → truthy) forms exactly as Vue 3 does; truthiness follows
+/// JavaScript semantics (false, null, numeric zero, NaN, and "" are falsy). These run per vnode
+/// on the patch hot path — string inputs take allocation-free fast paths.
+/// </summary>
+public static partial class StyleAndClassNormalization
+{
+    /// <summary>
+    /// Normalizes a class binding to its space-joined string form (upstream:
+    /// <c>normalizeClass</c>). Strings pass through trimmed; enumerables recurse; dictionaries
+    /// contribute the keys whose values are truthy, in entry order.
+    /// </summary>
+    /// <param name="value">The class binding: string, enumerable, dictionary, or null.</param>
+    /// <returns>The normalized class string (possibly empty).</returns>
+    public static string NormalizeClass(object? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+        if (value is string text)
+        {
+            return text.Trim();
+        }
+        var builder = new StringBuilder();
+        AppendClass(builder, value);
+        return builder.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Normalizes a style binding (upstream: <c>normalizeStyle</c>): enumerables merge into one
+    /// dictionary with later entries winning (string entries parse via
+    /// <see cref="ParseStringStyle"/>); strings and dictionaries pass through.
+    /// </summary>
+    /// <param name="value">The style binding: string, dictionary, enumerable of either, or null.</param>
+    /// <returns>A string, a merged dictionary, or null.</returns>
+    public static object? NormalizeStyle(object? value)
+    {
+        if (value is string || value is null)
+        {
+            return value;
+        }
+        if (value is IReadOnlyDictionary<string, object?> || value is IDictionary<string, object?>)
+        {
+            return value;
+        }
+        if (value is IEnumerable enumerable)
+        {
+            var merged = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var entry in enumerable)
+            {
+                var normalized = NormalizeStyle(entry);
+                if (normalized is string entryText)
+                {
+                    foreach (var (name, entryValue) in ParseStringStyle(entryText))
+                    {
+                        merged[name] = entryValue;
+                    }
+                }
+                else if (normalized is IReadOnlyDictionary<string, object?> readOnlyMap)
+                {
+                    foreach (var (name, entryValue) in readOnlyMap)
+                    {
+                        merged[name] = entryValue;
+                    }
+                }
+                else if (normalized is IDictionary<string, object?> map)
+                {
+                    foreach (var pair in map)
+                    {
+                        merged[pair.Key] = pair.Value;
+                    }
+                }
+            }
+            return merged;
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Parses a CSS declaration string into a name → value dictionary (upstream:
+    /// <c>parseStringStyle</c>): comments are stripped, declarations split on <c>;</c> except
+    /// inside parentheses (so <c>url(data:...)</c> survives), and each declaration splits on
+    /// its first <c>:</c>.
+    /// </summary>
+    /// <param name="cssText">The inline style text.</param>
+    /// <returns>The parsed declarations, in source order.</returns>
+    public static Dictionary<string, object?> ParseStringStyle(string cssText)
+    {
+        ArgumentNullException.ThrowIfNull(cssText);
+        var declarations = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var withoutComments = StyleCommentPattern().Replace(cssText, string.Empty);
+        foreach (var declaration in ListDelimiterPattern().Split(withoutComments))
+        {
+            if (declaration.Length == 0)
+            {
+                continue;
+            }
+            var separatorIndex = declaration.IndexOf(':', StringComparison.Ordinal);
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+            var name = declaration[..separatorIndex].Trim();
+            var declarationValue = declaration[(separatorIndex + 1)..].Trim();
+            if (name.Length > 0 && declarationValue.Length > 0)
+            {
+                declarations[name] = declarationValue;
+            }
+        }
+        return declarations;
+    }
+
+    /// <summary>
+    /// Serializes a style value to inline CSS text (upstream: <c>stringifyStyle</c>): strings
+    /// pass through; dictionary keys emit as-is when kebab-case or <c>--custom</c>, camelCase
+    /// keys hyphenate.
+    /// </summary>
+    /// <param name="style">The style value: string, dictionary, or null.</param>
+    /// <returns>The CSS text (possibly empty).</returns>
+    public static string StringifyStyle(object? style)
+    {
+        if (style is null)
+        {
+            return string.Empty;
+        }
+        if (style is string text)
+        {
+            return text;
+        }
+        var builder = new StringBuilder();
+        if (style is IReadOnlyDictionary<string, object?> readOnlyMap)
+        {
+            foreach (var (name, value) in readOnlyMap)
+            {
+                AppendStyleDeclaration(builder, name, value);
+            }
+        }
+        else if (style is IDictionary<string, object?> map)
+        {
+            foreach (var pair in map)
+            {
+                AppendStyleDeclaration(builder, pair.Key, pair.Value);
+            }
+        }
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// JavaScript truthiness for binding values (upstream's implicit coercion): false, null,
+    /// numeric zero, NaN, and the empty string are falsy; everything else is truthy.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    public static bool IsTruthy(object? value) => value switch
+    {
+        null => false,
+        bool boolValue => boolValue,
+        string text => text.Length > 0,
+        sbyte number => number != 0,
+        byte number => number != 0,
+        short number => number != 0,
+        ushort number => number != 0,
+        int number => number != 0,
+        uint number => number != 0,
+        long number => number != 0,
+        ulong number => number != 0,
+        float number => number != 0 && !float.IsNaN(number),
+        double number => number != 0 && !double.IsNaN(number),
+        decimal number => number != 0,
+        _ => true,
+    };
+
+    private static void AppendClass(StringBuilder builder, object? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+        if (value is string text)
+        {
+            AppendClassToken(builder, text);
+            return;
+        }
+        if (value is IReadOnlyDictionary<string, object?> readOnlyMap)
+        {
+            foreach (var (name, condition) in readOnlyMap)
+            {
+                if (IsTruthy(condition))
+                {
+                    AppendClassToken(builder, name);
+                }
+            }
+            return;
+        }
+        if (value is IDictionary<string, object?> map)
+        {
+            foreach (var pair in map)
+            {
+                if (IsTruthy(pair.Value))
+                {
+                    AppendClassToken(builder, pair.Key);
+                }
+            }
+            return;
+        }
+        if (value is IEnumerable enumerable)
+        {
+            foreach (var entry in enumerable)
+            {
+                AppendClass(builder, entry);
+            }
+            return;
+        }
+        AppendClassToken(builder, value.ToString());
+    }
+
+    private static void AppendClassToken(StringBuilder builder, string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return;
+        }
+        if (builder.Length > 0)
+        {
+            builder.Append(' ');
+        }
+        builder.Append(token.Trim());
+    }
+
+    private static void AppendStyleDeclaration(StringBuilder builder, string name, object? value)
+    {
+        if (value is null || name.Length == 0)
+        {
+            return;
+        }
+        var propertyName = name.StartsWith("--", StringComparison.Ordinal) ? name : Hyphenate(name);
+        builder.Append(propertyName).Append(':').Append(DisplayStringFormatter.FormatScalar(value)).Append(';');
+    }
+
+    /// <summary>
+    /// Converts camelCase to kebab-case (upstream: <c>hyphenate</c>, whose <c>\B([A-Z])</c>
+    /// inserts no hyphen before a leading capital: <c>WebkitTransition</c> →
+    /// <c>webkit-transition</c>).
+    /// </summary>
+    /// <param name="name">The camelCase name.</param>
+    public static string Hyphenate(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        var hyphenCount = 0;
+        for (var index = 1; index < name.Length; index++)
+        {
+            if (char.IsAsciiLetterUpper(name[index]))
+            {
+                hyphenCount++;
+            }
+        }
+        if (hyphenCount == 0 && (name.Length == 0 || !char.IsAsciiLetterUpper(name[0])))
+        {
+            return name;
+        }
+        return string.Create(name.Length + hyphenCount, name, static (span, source) =>
+        {
+            var position = 0;
+            for (var index = 0; index < source.Length; index++)
+            {
+                var character = source[index];
+                if (char.IsAsciiLetterUpper(character))
+                {
+                    if (index > 0)
+                    {
+                        span[position++] = '-';
+                    }
+                    span[position++] = char.ToLowerInvariant(character);
+                }
+                else
+                {
+                    span[position++] = character;
+                }
+            }
+        });
+    }
+
+    // Upstream listDelimiterRE: split on ';' not inside parentheses.
+    [GeneratedRegex(@";(?![^(]*\))")]
+    private static partial Regex ListDelimiterPattern();
+
+    // Upstream styleCommentRE: strip /* ... */ comments (JS [^] becomes [\s\S] in .NET).
+    [GeneratedRegex(@"/\*[\s\S]*?\*/")]
+    private static partial Regex StyleCommentPattern();
+}

--- a/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/Assimalign.Vue.Shared.GeneratorFixture.csproj
+++ b/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/Assimalign.Vue.Shared.GeneratorFixture.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- The Roslyn generator host target: proves the linked shared-source seam compiles in a
+         netstandard2.0 context ([V01.01.01.03] multi-targeting decision — see the header of
+         src/Internal/DomKnowledgeData.cs). -->
+    <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\Internal\DomKnowledgeData.cs" Link="DomKnowledgeData.cs" />
+  </ItemGroup>
+</Project>

--- a/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/GeneratorHostDomKnowledge.cs
+++ b/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.GeneratorFixture/GeneratorHostDomKnowledge.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// The generator-host consumption path of the DOM knowledge data: builds plain
+/// <see cref="HashSet{T}"/> lookups from the linked <c>DomKnowledgeData</c> source exactly as
+/// the Roslyn template compiler will. The runtime test suite asserts full membership parity
+/// between this surface and the net10.0 <c>DomKnowledge</c> frozen tables, pinning the
+/// one-authoritative-definition contract of [V01.01.01.03].
+/// </summary>
+public static class GeneratorHostDomKnowledge
+{
+    private static readonly HashSet<string> HtmlTagSet = Build(DomKnowledgeData.HtmlTags, StringComparer.OrdinalIgnoreCase);
+    private static readonly HashSet<string> SvgTagSet = Build(DomKnowledgeData.SvgTags, StringComparer.Ordinal);
+    private static readonly HashSet<string> MathTagSet = Build(DomKnowledgeData.MathTags, StringComparer.Ordinal);
+    private static readonly HashSet<string> VoidTagSet = Build(DomKnowledgeData.VoidTags, StringComparer.OrdinalIgnoreCase);
+    private static readonly HashSet<string> BooleanAttributeSet = Build(DomKnowledgeData.BooleanAttributes, StringComparer.Ordinal);
+
+    /// <summary>All HTML tags from the shared data definition.</summary>
+    public static IEnumerable<string> HtmlTags => HtmlTagSet;
+
+    /// <summary>All SVG tags from the shared data definition.</summary>
+    public static IEnumerable<string> SvgTags => SvgTagSet;
+
+    /// <summary>All MathML tags from the shared data definition.</summary>
+    public static IEnumerable<string> MathTags => MathTagSet;
+
+    /// <summary>All void tags from the shared data definition.</summary>
+    public static IEnumerable<string> VoidTags => VoidTagSet;
+
+    /// <summary>All boolean attributes from the shared data definition.</summary>
+    public static IEnumerable<string> BooleanAttributes => BooleanAttributeSet;
+
+    /// <summary>Whether <paramref name="tag"/> is a known HTML element in the generator-host tables.</summary>
+    /// <param name="tag">The tag name.</param>
+    public static bool IsHtmlTag(string tag) => HtmlTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="tag"/> is a known SVG element in the generator-host tables.</summary>
+    /// <param name="tag">The tag name.</param>
+    public static bool IsSvgTag(string tag) => SvgTagSet.Contains(tag);
+
+    /// <summary>Whether <paramref name="tag"/> is a void element in the generator-host tables.</summary>
+    /// <param name="tag">The tag name.</param>
+    public static bool IsVoidTag(string tag) => VoidTagSet.Contains(tag);
+
+    private static HashSet<string> Build(string list, StringComparer comparer)
+    {
+        var set = new HashSet<string>(comparer);
+        foreach (var entry in list.Split(','))
+        {
+            set.Add(entry);
+        }
+        return set;
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.Tests.csproj
+++ b/libraries/Assimalign.Vue.Shared/test/Assimalign.Vue.Shared.Tests.csproj
@@ -4,6 +4,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <!-- The GeneratorFixture project nests under test/; keep its sources out of this
+         project's implicit globs. -->
+    <Compile Remove="Assimalign.Vue.Shared.GeneratorFixture/**" />
+    <None Remove="Assimalign.Vue.Shared.GeneratorFixture/**" />
+  </ItemGroup>
+  <ItemGroup>
     <VuecsPackageReference Include="Microsoft.NET.Test.Sdk" />
     <VuecsPackageReference Include="xunit" />
     <VuecsPackageReference Include="xunit.runner.visualstudio" />
@@ -11,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <VuecsProjectReference Include="Assimalign.Vue.Shared" />
+    <VuecsProjectReference Include="Assimalign.Vue.Shared.GeneratorFixture" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Vue.Shared/test/DisplayStringFormatterTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/DisplayStringFormatterTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Shared.Tests;
+
+// Pins the text-interpolation contract of @vue/shared's toDisplayString.ts —
+// https://vuejs.org/guide/essentials/template-syntax.html. Invariant culture is mandatory so
+// SSR output and client hydration agree byte-for-byte.
+public class DisplayStringFormatterTests
+{
+    [Fact]
+    public void ToDisplayString_NullRendersEmpty_AndStringsPassThrough()
+    {
+        DisplayStringFormatter.ToDisplayString(null).ShouldBe(string.Empty);
+        DisplayStringFormatter.ToDisplayString("hello").ShouldBe("hello");
+    }
+
+    [Fact]
+    public void ToDisplayString_ScalarsUseInvariantCulture_UnderAnyCurrentCulture()
+    {
+        var previous = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            // de-DE writes 1,5 — invariant output must stay 1.5 regardless.
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            DisplayStringFormatter.ToDisplayString(1.5).ShouldBe("1.5");
+            DisplayStringFormatter.ToDisplayString(1234567.25m).ShouldBe("1234567.25");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = previous;
+        }
+    }
+
+    [Fact]
+    public void ToDisplayString_BooleansRenderJavaScriptStyle()
+    {
+        DisplayStringFormatter.ToDisplayString(true).ShouldBe("true");
+        DisplayStringFormatter.ToDisplayString(false).ShouldBe("false");
+    }
+
+    [Fact]
+    public void ToDisplayString_ArraysRenderAsTwoSpaceIndentedJson()
+    {
+        DisplayStringFormatter.ToDisplayString(new object?[] { 1, "two", null })
+            .ShouldBe("[\n  1,\n  \"two\",\n  null\n]");
+    }
+
+    [Fact]
+    public void ToDisplayString_StringKeyedDictionariesRenderAsJsonObjects()
+    {
+        var value = new Dictionary<string, object?> { ["a"] = 1, ["b"] = "text" };
+
+        DisplayStringFormatter.ToDisplayString(value)
+            .ShouldBe("{\n  \"a\": 1,\n  \"b\": \"text\"\n}");
+    }
+
+    [Fact]
+    public void ToDisplayString_NestedShapesIndentPerLevel()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["items"] = new object?[] { 1 },
+        };
+
+        DisplayStringFormatter.ToDisplayString(value)
+            .ShouldBe("{\n  \"items\": [\n    1\n  ]\n}");
+    }
+
+    [Fact]
+    public void ToDisplayString_NonStringKeyedDictionaries_UseTheMapConvention()
+    {
+        // Upstream replacer: Map -> { "Map(n)": { "key =>": value } }.
+        var value = new Dictionary<int, object?> { [1] = "one" };
+
+        DisplayStringFormatter.ToDisplayString(value)
+            .ShouldBe("{\n  \"Map(1)\": {\n    \"1 =>\": \"one\"\n  }\n}");
+    }
+
+    [Fact]
+    public void ToDisplayString_Sets_UseTheSetConvention()
+    {
+        // Upstream replacer: Set -> { "Set(n)": [ ... ] }.
+        var value = new HashSet<int> { 7 };
+
+        DisplayStringFormatter.ToDisplayString(value)
+            .ShouldBe("{\n  \"Set(1)\": [\n    7\n  ]\n}");
+    }
+
+    [Fact]
+    public void ToDisplayString_EscapesJsonStrings()
+    {
+        DisplayStringFormatter.ToDisplayString(new object?[] { "quote\" and \\ and\nnewline" })
+            .ShouldBe("[\n  \"quote\\\" and \\\\ and\\nnewline\"\n]");
+    }
+
+    [Fact]
+    public void FormatScalar_InvariantForFormattables()
+    {
+        DisplayStringFormatter.FormatScalar(42).ShouldBe("42");
+        DisplayStringFormatter.FormatScalar(true).ShouldBe("true");
+        DisplayStringFormatter.FormatScalar("x").ShouldBe("x");
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/test/DomKnowledgeTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/DomKnowledgeTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Shouldly;
 using Xunit;
 
@@ -148,6 +150,54 @@ public class DomKnowledgeTests
     [Fact]
     public void IsKnownSvgAttribute_RejectsUnknownNames()
         => DomKnowledge.IsKnownSvgAttribute("not-an-svg-attr").ShouldBeFalse();
+
+    // --- span alternate lookups: allocation-free membership for compiler tokenization -------
+
+    [Fact]
+    public void SpanOverloads_AgreeWithTheStringLookups()
+    {
+        // The compiler tests tag/attribute tokens as spans over source text; both surfaces
+        // must answer identically (same frozen sets through alternate lookups).
+        DomKnowledge.IsHtmlTag("div".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsHtmlTag("DIV".AsSpan()).ShouldBeTrue(); // case-insensitive holds for spans
+        DomKnowledge.IsHtmlTag("my-component".AsSpan()).ShouldBeFalse();
+        DomKnowledge.IsSvgTag("foreignObject".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsSvgTag("foreignobject".AsSpan()).ShouldBeFalse(); // case-sensitive holds
+        DomKnowledge.IsMathMLTag("annotation-xml".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsVoidTag("br".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsBooleanAttribute("checked".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsKnownHtmlAttribute("tabindex".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsKnownSvgAttribute("viewBox".AsSpan()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SpanOverloads_MatchSlicedTokens_WithoutMaterializingStrings()
+    {
+        // A token sliced out of larger source text, never turned into a string.
+        var source = "<template><div class=\"x\"></div></template>".AsSpan();
+        DomKnowledge.IsHtmlTag(source.Slice(1, 8)).ShouldBeTrue();  // "template"
+        DomKnowledge.IsHtmlTag(source.Slice(11, 3)).ShouldBeTrue(); // "div"
+    }
+
+    [Fact]
+    public void TryGetAttributeName_MapsExceptionsAndReportsPassThroughs()
+    {
+        DomKnowledge.TryGetAttributeName("htmlFor".AsSpan(), out var mapped).ShouldBeTrue();
+        mapped.ShouldBe("for");
+        DomKnowledge.TryGetAttributeName("className".AsSpan(), out mapped).ShouldBeTrue();
+        mapped.ShouldBe("class");
+        DomKnowledge.TryGetAttributeName("id".AsSpan(), out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSsrSafeAttributeName_SpanAndStringSurfacesAgree_IncludingControlCharacters()
+    {
+        DomKnowledge.IsSsrSafeAttributeName("data-x".AsSpan()).ShouldBeTrue();
+        DomKnowledge.IsSsrSafeAttributeName("bad=name".AsSpan()).ShouldBeFalse();
+        DomKnowledge.IsSsrSafeAttributeName("bad\u0001name").ShouldBeFalse(); // C0 control char
+        DomKnowledge.IsSsrSafeAttributeName("bad\u0001name".AsSpan()).ShouldBeFalse();
+        DomKnowledge.IsSsrSafeAttributeName(default(ReadOnlySpan<char>)).ShouldBeFalse(); // empty
+    }
 
     // --- generator-fixture parity: both consumption paths read one data definition ----------
 

--- a/libraries/Assimalign.Vue.Shared/test/DomKnowledgeTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/DomKnowledgeTests.cs
@@ -1,0 +1,191 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Shared.Tests;
+
+// Pins the DOM knowledge tables of @vue/shared's domTagConfig.ts/domAttrConfig.ts,
+// cross-checked against WHATWG void elements and boolean attributes, plus the
+// one-authoritative-definition contract: the netstandard2.0 generator fixture (linked
+// shared-source) must agree with the net10.0 frozen tables member-for-member.
+public class DomKnowledgeTests
+{
+    [Theory]
+    [InlineData("div")]
+    [InlineData("template")]
+    [InlineData("blockquote")]
+    [InlineData("tfoot")]
+    public void IsHtmlTag_KnowsRepresentativeMembers(string tag)
+        => DomKnowledge.IsHtmlTag(tag).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("my-component")]
+    [InlineData("circle")]
+    [InlineData("math")]
+    public void IsHtmlTag_RejectsNonMembers(string tag)
+        => DomKnowledge.IsHtmlTag(tag).ShouldBeFalse();
+
+    [Fact]
+    public void IsHtmlTag_IsCaseInsensitivePerWhatwg()
+    {
+        DomKnowledge.IsHtmlTag("DIV").ShouldBeTrue();
+        DomKnowledge.IsHtmlTag("Template").ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("svg")]
+    [InlineData("foreignObject")]
+    [InlineData("feGaussianBlur")]
+    [InlineData("textPath")]
+    [InlineData("animateMotion")]
+    public void IsSvgTag_KnowsRepresentativeMembers(string tag)
+        => DomKnowledge.IsSvgTag(tag).ShouldBeTrue();
+
+    [Fact]
+    public void IsSvgTag_IsCaseSensitivePerSpec()
+    {
+        // foreignObject is camelCase in SVG; the lower-cased form is not an SVG element.
+        DomKnowledge.IsSvgTag("foreignobject").ShouldBeFalse();
+        DomKnowledge.IsSvgTag("FEGAUSSIANBLUR").ShouldBeFalse();
+        DomKnowledge.IsSvgTag("div").ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("math")]
+    [InlineData("mi")]
+    [InlineData("mfrac")]
+    [InlineData("annotation-xml")]
+    [InlineData("munderover")]
+    public void IsMathMLTag_KnowsRepresentativeMembers(string tag)
+        => DomKnowledge.IsMathMLTag(tag).ShouldBeTrue();
+
+    [Fact]
+    public void IsMathMLTag_RejectsNonMembers()
+    {
+        DomKnowledge.IsMathMLTag("div").ShouldBeFalse();
+        DomKnowledge.IsMathMLTag("svg").ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("br")]
+    [InlineData("img")]
+    [InlineData("input")]
+    [InlineData("wbr")]
+    [InlineData("source")]
+    public void IsVoidTag_MatchesWhatwgVoidElements(string tag)
+        => DomKnowledge.IsVoidTag(tag).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("div")]
+    [InlineData("script")]
+    [InlineData("template")]
+    public void IsVoidTag_RejectsNonVoidElements(string tag)
+        => DomKnowledge.IsVoidTag(tag).ShouldBeFalse();
+
+    [Theory]
+    [InlineData("checked")]
+    [InlineData("disabled")]
+    [InlineData("readonly")]
+    [InlineData("itemscope")]
+    [InlineData("allowfullscreen")]
+    [InlineData("inert")]
+    public void IsBooleanAttribute_MatchesWhatwgBooleanAttributes(string attribute)
+        => DomKnowledge.IsBooleanAttribute(attribute).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("title")]
+    [InlineData("value")]
+    [InlineData("spellcheck")] // enumerated, not boolean
+    public void IsBooleanAttribute_RejectsNonBooleanAttributes(string attribute)
+        => DomKnowledge.IsBooleanAttribute(attribute).ShouldBeFalse();
+
+    [Theory]
+    [InlineData("id")]
+    [InlineData("data-testid")]
+    [InlineData("aria-label")]
+    [InlineData("Custom_Attribute.name:x")]
+    public void IsSsrSafeAttributeName_AcceptsSafeNames(string name)
+        => DomKnowledge.IsSsrSafeAttributeName(name).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("bad>name")]
+    [InlineData("bad/name")]
+    [InlineData("bad=name")]
+    [InlineData("bad\"name")]
+    [InlineData("bad'name")]
+    [InlineData("bad name")]
+    [InlineData("bad\tname")]
+    [InlineData("bad\nname")]
+    [InlineData("")]
+    public void IsSsrSafeAttributeName_RejectsUnsafeNames(string name)
+        => DomKnowledge.IsSsrSafeAttributeName(name).ShouldBeFalse();
+
+    [Fact]
+    public void GetAttributeName_CoversTheUpstreamCasingExceptions()
+    {
+        DomKnowledge.GetAttributeName("acceptCharset").ShouldBe("accept-charset");
+        DomKnowledge.GetAttributeName("className").ShouldBe("class");
+        DomKnowledge.GetAttributeName("htmlFor").ShouldBe("for");
+        DomKnowledge.GetAttributeName("httpEquiv").ShouldBe("http-equiv");
+        DomKnowledge.GetAttributeName("id").ShouldBe("id"); // passthrough
+    }
+
+    [Theory]
+    [InlineData("class")]
+    [InlineData("http-equiv")]
+    [InlineData("tabindex")]
+    [InlineData("srcset")]
+    public void IsKnownHtmlAttribute_KnowsRepresentativeMembers(string attribute)
+        => DomKnowledge.IsKnownHtmlAttribute(attribute).ShouldBeTrue();
+
+    [Theory]
+    [InlineData("viewBox")]
+    [InlineData("stroke-width")]
+    [InlineData("xlink:href")]
+    [InlineData("preserveAspectRatio")]
+    public void IsKnownSvgAttribute_KnowsRepresentativeMembers(string attribute)
+        => DomKnowledge.IsKnownSvgAttribute(attribute).ShouldBeTrue();
+
+    [Fact]
+    public void IsKnownSvgAttribute_RejectsUnknownNames()
+        => DomKnowledge.IsKnownSvgAttribute("not-an-svg-attr").ShouldBeFalse();
+
+    // --- generator-fixture parity: both consumption paths read one data definition ----------
+
+    [Fact]
+    public void GeneratorFixture_HtmlTags_AgreeWithTheRuntimeTables()
+    {
+        foreach (var tag in GeneratorHostDomKnowledge.HtmlTags)
+        {
+            DomKnowledge.IsHtmlTag(tag).ShouldBeTrue($"runtime tables miss HTML tag '{tag}'");
+        }
+        GeneratorHostDomKnowledge.IsHtmlTag("div").ShouldBeTrue();
+        GeneratorHostDomKnowledge.IsHtmlTag("DIV").ShouldBeTrue();
+        GeneratorHostDomKnowledge.IsHtmlTag("circle").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GeneratorFixture_SvgAndVoidTags_AgreeWithTheRuntimeTables()
+    {
+        foreach (var tag in GeneratorHostDomKnowledge.SvgTags)
+        {
+            DomKnowledge.IsSvgTag(tag).ShouldBeTrue($"runtime tables miss SVG tag '{tag}'");
+        }
+        foreach (var tag in GeneratorHostDomKnowledge.VoidTags)
+        {
+            DomKnowledge.IsVoidTag(tag).ShouldBeTrue($"runtime tables miss void tag '{tag}'");
+        }
+        GeneratorHostDomKnowledge.IsSvgTag("foreignObject").ShouldBeTrue();
+        GeneratorHostDomKnowledge.IsSvgTag("foreignobject").ShouldBeFalse();
+        GeneratorHostDomKnowledge.IsVoidTag("br").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GeneratorFixture_BooleanAttributes_AgreeWithTheRuntimeTables()
+    {
+        foreach (var attribute in GeneratorHostDomKnowledge.BooleanAttributes)
+        {
+            DomKnowledge.IsBooleanAttribute(attribute)
+                .ShouldBeTrue($"runtime tables miss boolean attribute '{attribute}'");
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/test/LooseEqualityTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/LooseEqualityTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Shared.Tests;
+
+// Pins Vue's loose equality (looseEqual.ts, vectors from vuejs/core's looseEqual.spec.ts) —
+// the semantics behind checkbox/select v-model value matching.
+public class LooseEqualityTests
+{
+    [Fact]
+    public void LooseEqual_StrictlyEqualValues()
+    {
+        LooseEquality.LooseEqual(1, 1).ShouldBeTrue();
+        LooseEquality.LooseEqual("a", "a").ShouldBeTrue();
+        LooseEquality.LooseEqual(null, null).ShouldBeTrue();
+        LooseEquality.LooseEqual(true, true).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LooseEqual_CoercesNumberAndStringLikeJavaScript()
+    {
+        // Upstream fallback: String(a) === String(b).
+        LooseEquality.LooseEqual(1, "1").ShouldBeTrue();
+        LooseEquality.LooseEqual(1.5, "1.5").ShouldBeTrue();
+        LooseEquality.LooseEqual(1, "2").ShouldBeFalse();
+        LooseEquality.LooseEqual(true, "true").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LooseEqual_NullAgainstAnythingElse_IsFalse()
+    {
+        LooseEquality.LooseEqual(null, 0).ShouldBeFalse();
+        LooseEquality.LooseEqual("", null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LooseEqual_ArraysCompareElementWise()
+    {
+        LooseEquality.LooseEqual(new object?[] { 1, 2 }, new object?[] { 1, 2 }).ShouldBeTrue();
+        LooseEquality.LooseEqual(new object?[] { 1, 2 }, new object?[] { "1", "2" }).ShouldBeTrue();
+        LooseEquality.LooseEqual(new object?[] { 1, 2 }, new object?[] { 1 }).ShouldBeFalse();
+        LooseEquality.LooseEqual(new object?[] { 1 }, 1).ShouldBeFalse();
+        LooseEquality.LooseEqual(
+            new object?[] { new object?[] { 1 } },
+            new object?[] { new object?[] { "1" } }).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LooseEqual_DictionariesCompareKeyWise()
+    {
+        LooseEquality.LooseEqual(
+            new Dictionary<string, object?> { ["a"] = 1 },
+            new Dictionary<string, object?> { ["a"] = "1" }).ShouldBeTrue();
+        LooseEquality.LooseEqual(
+            new Dictionary<string, object?> { ["a"] = 1 },
+            new Dictionary<string, object?> { ["a"] = 1, ["b"] = 2 }).ShouldBeFalse();
+        LooseEquality.LooseEqual(
+            new Dictionary<string, object?> { ["a"] = 1 },
+            new Dictionary<string, object?> { ["b"] = 1 }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LooseEqual_DatesCompareByInstant()
+    {
+        var moment = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        LooseEquality.LooseEqual(moment, new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc)).ShouldBeTrue();
+        LooseEquality.LooseEqual(moment, moment.AddTicks(1)).ShouldBeFalse();
+        LooseEquality.LooseEqual(moment, "not a date").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LooseIndexOf_MatchesLoosely()
+    {
+        var values = new object?[] { "1", "2", "3" };
+        LooseEquality.LooseIndexOf(values, 2).ShouldBe(1);
+        LooseEquality.LooseIndexOf(values, "3").ShouldBe(2);
+        LooseEquality.LooseIndexOf(values, 4).ShouldBe(-1);
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/test/StyleAndClassNormalizationTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/StyleAndClassNormalizationTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Shared.Tests;
+
+// Pins the class/style binding normalization contract of @vue/shared's normalizeProp.ts
+// (test vectors ported from vuejs/core's normalizeProp.spec.ts) —
+// https://vuejs.org/guide/essentials/class-and-style.html.
+public class StyleAndClassNormalizationTests
+{
+    [Fact]
+    public void NormalizeClass_StringsPassThroughTrimmed()
+    {
+        StyleAndClassNormalization.NormalizeClass("foo").ShouldBe("foo");
+        StyleAndClassNormalization.NormalizeClass("foo bar ").ShouldBe("foo bar");
+        StyleAndClassNormalization.NormalizeClass(null).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void NormalizeClass_EnumerablesJoinAndRecurse()
+    {
+        StyleAndClassNormalization.NormalizeClass(new object?[] { "foo", "bar" }).ShouldBe("foo bar");
+        StyleAndClassNormalization.NormalizeClass(new object?[] { "foo", null, "bar" }).ShouldBe("foo bar");
+        StyleAndClassNormalization.NormalizeClass(
+            new object?[] { "a", new object?[] { "b", new object?[] { "c" } } }).ShouldBe("a b c");
+    }
+
+    [Fact]
+    public void NormalizeClass_DictionariesContributeTruthyKeysInOrder()
+    {
+        var binding = new Dictionary<string, object?>
+        {
+            ["active"] = true,
+            ["disabled"] = false,
+            ["highlighted"] = 1,
+            ["hidden"] = 0,
+            ["empty"] = "",
+            ["named"] = "anything",
+        };
+
+        StyleAndClassNormalization.NormalizeClass(binding).ShouldBe("active highlighted named");
+    }
+
+    [Fact]
+    public void NormalizeClass_MixedArrayAndDictionaryForms()
+    {
+        StyleAndClassNormalization.NormalizeClass(
+            new object?[]
+            {
+                "base",
+                new Dictionary<string, object?> { ["active"] = true, ["off"] = null },
+            }).ShouldBe("base active");
+    }
+
+    [Fact]
+    public void NormalizeStyle_ArraysMergeWithLaterEntriesWinning()
+    {
+        var merged = StyleAndClassNormalization.NormalizeStyle(
+            new object?[]
+            {
+                new Dictionary<string, object?> { ["color"] = "red", ["width"] = "10px" },
+                "color: blue; height: 2px",
+            }).ShouldBeAssignableTo<IReadOnlyDictionary<string, object?>>();
+
+        merged!["color"].ShouldBe("blue");
+        merged["width"].ShouldBe("10px");
+        merged["height"].ShouldBe("2px");
+    }
+
+    [Fact]
+    public void NormalizeStyle_StringsAndDictionariesPassThrough()
+    {
+        StyleAndClassNormalization.NormalizeStyle("color:red").ShouldBe("color:red");
+        var map = new Dictionary<string, object?> { ["color"] = "red" };
+        StyleAndClassNormalization.NormalizeStyle(map).ShouldBeSameAs(map);
+        StyleAndClassNormalization.NormalizeStyle(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseStringStyle_SplitsDeclarationsOnFirstColon()
+    {
+        var parsed = StyleAndClassNormalization.ParseStringStyle("color: red; margin: 0 10px");
+
+        parsed["color"].ShouldBe("red");
+        parsed["margin"].ShouldBe("0 10px");
+    }
+
+    [Fact]
+    public void ParseStringStyle_KeepsSemicolonsInsideParentheses()
+    {
+        // Upstream listDelimiterRE: /;(?![^(]*\))/ — the url(data:...;base64,...) survives.
+        var parsed = StyleAndClassNormalization.ParseStringStyle(
+            "background-image: url(data:image/png;base64,abc123); color: red");
+
+        parsed["background-image"].ShouldBe("url(data:image/png;base64,abc123)");
+        parsed["color"].ShouldBe("red");
+    }
+
+    [Fact]
+    public void ParseStringStyle_StripsCssComments()
+    {
+        var parsed = StyleAndClassNormalization.ParseStringStyle(
+            "/* comment; with : symbols */ color: red; /* another */ width: 1px");
+
+        parsed.Count.ShouldBe(2);
+        parsed["color"].ShouldBe("red");
+        parsed["width"].ShouldBe("1px");
+    }
+
+    [Fact]
+    public void StringifyStyle_HyphenatesCamelCaseAndPreservesCustomProperties()
+    {
+        var text = StyleAndClassNormalization.StringifyStyle(new Dictionary<string, object?>
+        {
+            ["backgroundColor"] = "red",
+            ["--brand-color"] = "#123",
+            ["width"] = "1px",
+        });
+
+        text.ShouldBe("background-color:red;--brand-color:#123;width:1px;");
+    }
+
+    [Fact]
+    public void StringifyStyle_StringsAndNullPassThrough()
+    {
+        StyleAndClassNormalization.StringifyStyle("color:red;").ShouldBe("color:red;");
+        StyleAndClassNormalization.StringifyStyle(null).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void RoundTrip_ParseThenStringify_IsStable()
+    {
+        // Runtime and SSR consume the same helpers; deterministic ordering means a parse →
+        // stringify → parse cycle is lossless.
+        const string css = "color:red;background-image:url(data:image/png;base64,x);width:1px;";
+        var parsed = StyleAndClassNormalization.ParseStringStyle(css);
+        var stringified = StyleAndClassNormalization.StringifyStyle(parsed);
+        var reparsed = StyleAndClassNormalization.ParseStringStyle(stringified);
+
+        reparsed.ShouldBe(parsed);
+    }
+
+    [Fact]
+    public void Hyphenate_ConvertsCamelCase()
+    {
+        StyleAndClassNormalization.Hyphenate("backgroundColor").ShouldBe("background-color");
+        StyleAndClassNormalization.Hyphenate("color").ShouldBe("color");
+        // Upstream \B([A-Z]): no hyphen before a leading capital.
+        StyleAndClassNormalization.Hyphenate("WebkitTransition").ShouldBe("webkit-transition");
+        StyleAndClassNormalization.Hyphenate("ArrowUp").ShouldBe("arrow-up");
+    }
+
+    [Fact]
+    public void IsTruthy_FollowsJavaScriptSemantics()
+    {
+        StyleAndClassNormalization.IsTruthy(null).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(false).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(0).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(0.0).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(double.NaN).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(string.Empty).ShouldBeFalse();
+        StyleAndClassNormalization.IsTruthy(true).ShouldBeTrue();
+        StyleAndClassNormalization.IsTruthy(1).ShouldBeTrue();
+        StyleAndClassNormalization.IsTruthy("false").ShouldBeTrue(); // non-empty string is truthy
+        StyleAndClassNormalization.IsTruthy(new object()).ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Vue.Testing/Assimalign.Vue.Testing.slnx
+++ b/libraries/Assimalign.Vue.Testing/Assimalign.Vue.Testing.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.Testing.csproj" />
+	<Project Path="test/Assimalign.Vue.Testing.Tests.csproj" />
+</Solution>


### PR DESCRIPTION
## Summary

**Wave 01 closeout** — the last four W01 items across three areas: the `@vue/shared` value-normalization helpers, the frozen DOM knowledge tables with the netstandard2.0 generator-host decision, the event system with Vue's invoker pattern (zero listener churn, one `[JSExport]` dispatch, `WithModifiers`/`WithKeys`), and per-area CI with path filtering. **This PR's own checks demonstrate the CI landing**: every area workflow runs (it touches shared build files + all areas), and the path filtering/cache behavior is observable on the runs.

**519 tests green** (123 new), 0-warning build, event system verified live on WASM including the lifecycle stress returning all registries — now including .NET invokers — exactly to baseline.

## Type of change

- [x] `feat` — Shared helpers + tables, RuntimeDom event system
- [ ] `fix`
- [ ] `refactor`
- [x] `test` — 123 new tests (parity vectors, invoker instrumentation, guard suites)
- [x] `docs` — linked shared-source decision doc, RuntimeDom DESIGN/OVERVIEW event sections
- [x] `chore` — CI workflows, composite action, per-area `.slnx`

## Changes

- **Normalization helpers (V01.01.01.02):** `NormalizeClass` (string/nested-enumerable/dictionary forms under JS truthiness), `NormalizeStyle` + `ParseStringStyle` (paren-aware `;` splitting so `url(data:...)` survives; CSS comments stripped; first-colon declarations) + `StringifyStyle` (upstream `\B` hyphenation — no hyphen before a leading capital — and `--custom` passthrough), `ToDisplayString` (null→empty, invariant-culture scalars proven under a comma-decimal culture, hand-written JSON-like recursion with upstream's `Map(n)`/`Set(n)` replacer conventions, **no reflection serialization**), `LooseEqual`/`LooseIndexOf` (element-wise/key-wise/date-instant/`String(a)===String(b)` coercion) for `v-model` matching. Parity vectors ported from vuejs/core's specs; a parse→stringify→parse round-trip pins runtime/SSR determinism.
- **DOM knowledge tables (V01.01.01.03):** HTML (case-insensitive per WHATWG) / SVG / MathML (case-sensitive) tag sets, WHATWG void tags and boolean attributes, known HTML/SVG attribute sets, SSR-safe attribute-name validation (unsafe names **excluded**, never escaped), and the `propsToAttrMap` casing exceptions — all `FrozenSet`/`FrozenDictionary`. **The multi-targeting question is decided and documented: linked shared-source.** One netstandard2.0-compatible constants file (`Internal/DomKnowledgeData.cs`) is the single authoritative definition; the net10 runtime freezes it, and the new `Assimalign.Vue.Shared.GeneratorFixture` (a `$(TargetFrameworkForAnalyzers)` project linking the same file) proves the generator-host path compiles, with tests asserting both consumption paths agree member-for-member. Multi-targeting the whole assembly was rejected as a polyfill tax on every hot-path file.
- **Event system (V01.01.04.03):** `BrowserEventInvokerRegistry` — one DOM listener per (element, event, capture); **updating a handler between renders is a delegate swap with zero `addEventListener`/`removeEventListener` interop**, asserted through an instrumented bridge. `onClickOnce`/`Capture`/`Passive` (and combinations) parse to listener options; capture/bubble are independent invokers. The single `[JSExport]` entry (`DispatchBrowserEvent`) receives the whole typed payload as primitives (no per-field `JSObject` reads, no proxy per event) and returns stop/prevent flags applied to the live event; the module binds it via `getDotnetRuntime`/`getAssemblyExports` at initialize. The attach-timestamp guard runs JS-side (`e.timeStamp < attached`, upstream's exact check — guarded events cost zero interop). `BrowserEvents.WithModifiers` (`.stop`/`.prevent` as `BrowserEvent` intents, `.self`, system modifiers, mouse buttons, `.exact`) and `.WithKeys` (Vue key aliases over hyphenated `event.key`). Handler exceptions route to an error-sink seam — a debug trace until the [V01.01.03.12] app pipeline replaces it (#28, named dependency) — and never escape into the JS listener.
- **CI (V01.01.12.02):** `.github/actions/setup-dotnet-wasm` composite (SDK pinned by `global.json`, NuGet cache keyed on the central package targets — workload packs ride the same cache — opt-in `wasm-tools`); five path-filtered area workflows building the new per-area `.slnx` files with `-warnaserror` + `dotnet test --no-build`, plus a `webapp` workflow building the WASM example with `wasm-tools`. Shared-build-file changes trigger every area; single-area PRs run one. Two wording deviations, both documented in-file: **checkout lives in each workflow** (a local composite can't run before the repo holding it is checked out), and downstream areas don't run on upstream-only PRs (the criterion's explicit independent-jobs rule; project references still compile upstream code inside each area build).

## Work items resolved

Closes #4
Closes #5
Closes #41
Closes #91

> **Reviewer notes:** (1) For #91, "required status checks" is a branch-protection setting only a repo admin can flip — suggested required checks: `build+test Shared`, `build+test Reactivity`, `build+test RuntimeCore`, `build+test RuntimeDom`, `build+test Testing`, `build WASM example`. The warm-vs-cold cache comparison is visible across this PR's first and subsequent runs. (2) For #41, the error-routing criterion names the app error pipeline, which is [V01.01.03.12] (#28, W02) — the seam is in place and tested; #28 plugs into it.

### Discovered (out-of-scope) work

None filed as new items; sequenced follow-ups are named on existing backlog items (#28 error pipeline, #43 command buffer, #87/#91-adjacent WASM-hosted test automation).

## Testing & verification

- [x] `dotnet build Assimalign.Vuecs.slnx` — 0 warnings/errors; **519/519 tests green** (196 Shared, 61 Reactivity, 69 RuntimeCore, 61 RuntimeDom, 9 Testing, plus the ns2.0 fixture compiling as its own proof).
- [x] Per-area `.slnx` files build locally (CI/local lockstep verified before the workflows reference them).
- [x] Event system verified **live on WASM**: clicks flow JS listener → `[JSExport]` dispatch → invoker → reactive re-render; the 100-cycle mount/unmount stress passes with nodes, JS listener maps, and .NET invokers exactly at baseline.
- [x] One upstream-parity bug caught by my own cross-checking during this batch: `Hyphenate` initially hyphenated leading capitals; upstream's `\B([A-Z])` does not (`WebkitTransition` → `webkit-transition`) — fixed and pinned, which also keeps `WithKeys` aliases (`ArrowUp` → `arrow-up`) correct.
- This PR's own workflow runs demonstrate the #91 acceptance behavior (all areas trigger here because shared build files changed).

## Checklist

- [x] Each resolved work item has its own `Closes #` line; area epics V01.01.01/V01.01.04/V01.01.12 stay open (later-wave sub-items remain).
- [x] Public APIs have XML docs with upstream links; the shared-source decision is documented at the data-file seam; RuntimeDom DESIGN/OVERVIEW updated in the same change.
- [x] Trimming/WASM-AOT-safe: no reflection serialization (`ToDisplayString` recursion is explicit; the one interface probe for set detection is per-type-cached with an `UnconditionalSuppressMessage` justifying graceful display-only degradation); `[GeneratedRegex]` for the style patterns; frozen tables from constant arrays.
- [x] JS-interop boundary: the event path is one listener per (element,event,capture) + one dispatch export; handle/listener/invoker cleanup verified by the stress harness.
- [x] Tests added and passing; the GeneratorFixture and per-area slnx files are wired into the root slnx/CI.
- [x] No dangling references; the old callback-based event plumbing is fully removed.
