### PR TITLE
The component era: instance + Setup model, props, emits, lifecycle hooks, and CreateApp bootstrap

### DIFF
--- a/examples/Assimalign.Vue.WebApp/Program.cs
+++ b/examples/Assimalign.Vue.WebApp/Program.cs
@@ -1,143 +1,31 @@
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices.JavaScript;
+using System.Threading;
 using System.Threading.Tasks;
 
-using Assimalign.Vue.Reactivity;
-using Assimalign.Vue.RuntimeCore;
 using Assimalign.Vue.RuntimeDom;
 
-// The production DOM bridge ([V01.01.04.01]/[V01.01.04.02]) ships with
-// Assimalign.Vue.RuntimeDom; the app just initializes it and mounts reactively.
+// A Vuecs WASM app's whole bootstrap ([V01.01.04.04]): initialize the bridge, create the app,
+// mount by selector. The component tree owns its own state and timers from here on.
 await BrowserRuntime.InitializeAsync();
 
-var rootHandle = BrowserRuntime.QuerySelector("#app");
-
-// ?diagnostics=1 runs the handle-lifecycle stress check and the marshaling-strategy
-// benchmark behind the [V01.01.04.01] ADR instead of the stopwatch.
+// ?diagnostics=1 runs the handle-lifecycle stress checks and the marshaling benchmark
+// behind the [V01.01.04.01] ADR instead of the demo.
 await JSHost.ImportAsync("benchmark", "/benchmark.js");
 if (DiagnosticsInterop.GetQuery().Contains("diagnostics", StringComparison.Ordinal))
 {
     try
     {
-        await VuecsDiagnostics.RunAsync(rootHandle);
+        await VuecsDiagnostics.RunAsync(BrowserRuntime.QuerySelector("#app"));
     }
     catch (Exception exception)
     {
         DiagnosticsInterop.ReportCrash(exception.ToString());
     }
-    return;
+    await Task.Delay(Timeout.Infinite);
 }
 
-var app = new VuecsApp(rootHandle);
+BrowserRuntime.CreateApp(new StopwatchApplication()).Mount("#app");
 
-// Advance the stopwatch STATE on a timer; rendering is driven purely by reactivity
-// ([V01.01.03.05] — no polling, no manual render loop).
-await app.RunAsync();
-
-internal sealed class VuecsApp
-{
-    private readonly Reference<bool> _isRunning = Reactive.Reference(false);
-    private readonly Reference<string> _elapsedText = Reactive.Reference("00:00:00");
-    private readonly Stopwatch _stopwatch = new();
-    private readonly Action _toggleHandler;
-    private readonly Action _resetHandler;
-#pragma warning disable IDE0052 // Held for the app's lifetime: the effect keeps the UI reactive.
-    private readonly RenderEffect<int> _renderEffect;
-#pragma warning restore IDE0052
-
-    public VuecsApp(int rootHandle)
-    {
-        _toggleHandler = Toggle;
-        _resetHandler = Reset;
-        var renderer = BrowserRuntime.CreateRenderer();
-        // Mounts immediately and re-renders whenever _isRunning or _elapsedText changes.
-        _renderEffect = renderer.CreateRenderEffect(BuildView, rootHandle);
-    }
-
-    public async Task RunAsync()
-    {
-        while (true)
-        {
-            await Task.Delay(100);
-            if (_stopwatch.IsRunning)
-            {
-                // Equal-value writes do not notify (Vue ref semantics), so ten ticks per
-                // second yield at most one re-render per displayed second.
-                _elapsedText.Value = FormatElapsed();
-            }
-        }
-    }
-
-    private VirtualNode BuildView()
-    {
-        var stateLabel = _isRunning.Value ? "Running" : "Paused";
-        var buttonLabel = _isRunning.Value ? "Pause" : "Start";
-
-        return VirtualNodeFactory.Element(
-            "section",
-            VirtualNodeFactory.Properties(("class", "shell")),
-            VirtualNodeFactory.Element(
-                "article",
-                VirtualNodeFactory.Properties(("class", "card")),
-                VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "eyebrow")), VirtualNodeFactory.Text("Vuecs Reactive Rendering")),
-                VirtualNodeFactory.Element("h1", VirtualNodeFactory.Text("Stopwatch rendered from C#")),
-                VirtualNodeFactory.Element(
-                    "p",
-                    VirtualNodeFactory.Properties(("class", "lead")),
-                    VirtualNodeFactory.Text("State mutations drive the render effect — the DOM below patches through the production RuntimeDom bridge.")),
-                VirtualNodeFactory.Element(
-                    "div",
-                    VirtualNodeFactory.Properties(("class", "meter")),
-                    VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "meter-label")), VirtualNodeFactory.Text("Elapsed")),
-                    VirtualNodeFactory.Element("strong", VirtualNodeFactory.Properties(("class", "meter-value")), VirtualNodeFactory.Text(_elapsedText.Value))),
-                VirtualNodeFactory.Element(
-                    "div",
-                    VirtualNodeFactory.Properties(("class", "status-row")),
-                    VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "status-pill")), VirtualNodeFactory.Text(stateLabel)),
-                    VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "status-hint")), VirtualNodeFactory.Text("Re-rendered reactively — no polling"))),
-                VirtualNodeFactory.Element(
-                    "div",
-                    VirtualNodeFactory.Properties(("class", "actions")),
-                    VirtualNodeFactory.Element(
-                        "button",
-                        VirtualNodeFactory.Properties(("class", "primary"), ("onClick", _toggleHandler), ("type", "button")),
-                        VirtualNodeFactory.Text(buttonLabel)),
-                    VirtualNodeFactory.Element(
-                        "button",
-                        VirtualNodeFactory.Properties(("class", "secondary"), ("onClick", _resetHandler), ("type", "button")),
-                        VirtualNodeFactory.Text("Reset")))));
-    }
-
-    private string FormatElapsed() => _stopwatch.Elapsed.ToString(@"hh\:mm\:ss");
-
-    private void Toggle()
-    {
-        if (_stopwatch.IsRunning)
-        {
-            _stopwatch.Stop();
-        }
-        else
-        {
-            _stopwatch.Start();
-        }
-
-        // State only — the render effect reacts.
-        _isRunning.Value = _stopwatch.IsRunning;
-    }
-
-    private void Reset()
-    {
-        if (_stopwatch.IsRunning)
-        {
-            _stopwatch.Restart();
-        }
-        else
-        {
-            _stopwatch.Reset();
-        }
-
-        _elapsedText.Value = FormatElapsed();
-        _isRunning.Value = _stopwatch.IsRunning;
-    }
-}
+// Keep the WASM main loop alive; rendering is reactive from here.
+await Task.Delay(Timeout.Infinite);

--- a/examples/Assimalign.Vue.WebApp/StopwatchApplication.cs
+++ b/examples/Assimalign.Vue.WebApp/StopwatchApplication.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+// The root component of the demo ([V01.01.03.06]): Setup runs once, closes over refs, and
+// returns the render function. The timer starts OnMounted and stops OnUnmounted, so unmounting
+// the app tears everything down. The elapsed display is a child component exercising props and
+// emits ([V01.01.03.07]/[V01.01.03.08]) live.
+internal sealed class StopwatchApplication : IComponentDefinition
+{
+    public string? Name => "StopwatchApplication";
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var stopwatch = new Stopwatch();
+        var isRunning = Reactive.Reference(false);
+        var elapsedText = Reactive.Reference("00:00:00");
+        var display = new ElapsedDisplay();
+        CancellationTokenSource? ticking = null;
+
+        void Toggle()
+        {
+            if (stopwatch.IsRunning)
+            {
+                stopwatch.Stop();
+            }
+            else
+            {
+                stopwatch.Start();
+            }
+            isRunning.Value = stopwatch.IsRunning;
+        }
+
+        void Reset()
+        {
+            if (stopwatch.IsRunning)
+            {
+                stopwatch.Restart();
+            }
+            else
+            {
+                stopwatch.Reset();
+            }
+            elapsedText.Value = stopwatch.Elapsed.ToString(@"hh\:mm\:ss");
+        }
+
+        Lifecycle.OnMounted(() =>
+        {
+            ticking = new CancellationTokenSource();
+            _ = TickAsync(ticking.Token);
+        });
+        Lifecycle.OnUnmounted(() =>
+        {
+            ticking?.Cancel();
+            ticking = null;
+        });
+
+        async Task TickAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(100, CancellationToken.None);
+                if (stopwatch.IsRunning)
+                {
+                    // Equal-value writes do not notify: ten ticks a second coalesce to one
+                    // re-render per displayed second.
+                    elapsedText.Value = stopwatch.Elapsed.ToString(@"hh\:mm\:ss");
+                }
+            }
+        }
+
+        return () => VirtualNodeFactory.Element(
+            "section",
+            VirtualNodeFactory.Properties(("class", "shell")),
+            VirtualNodeFactory.Element(
+                "article",
+                VirtualNodeFactory.Properties(("class", "card")),
+                VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "eyebrow")), VirtualNodeFactory.Text("Vuecs Components")),
+                VirtualNodeFactory.Element("h1", VirtualNodeFactory.Text("Stopwatch rendered from C#")),
+                VirtualNodeFactory.Element(
+                    "p",
+                    VirtualNodeFactory.Properties(("class", "lead")),
+                    VirtualNodeFactory.Text("A component tree: the display below is a child component fed by props, emitting reset back to its parent.")),
+                VirtualNodeFactory.Component(display, VirtualNodeFactory.Properties(
+                    ("text", elapsedText.Value),
+                    ("running", isRunning.Value),
+                    ("onReset", (Action)Reset))),
+                VirtualNodeFactory.Element(
+                    "div",
+                    VirtualNodeFactory.Properties(("class", "actions")),
+                    VirtualNodeFactory.Element(
+                        "button",
+                        VirtualNodeFactory.Properties(("class", "primary"), ("onClick", (Action)Toggle), ("type", "button")),
+                        VirtualNodeFactory.Text(isRunning.Value ? "Pause" : "Start")))));
+    }
+}
+
+// The child component: declared props with a default and a validator, a declared emit, and
+// lifecycle hooks — the whole W02 contract in one small component.
+internal sealed class ElapsedDisplay : IComponentDefinition
+{
+    public string? Name => "ElapsedDisplay";
+
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties { get; } =
+    [
+        new ComponentPropertyDefinition("text") { DefaultValue = "00:00:00" },
+        new ComponentPropertyDefinition("running") { DefaultValue = false },
+    ];
+
+    public IReadOnlyList<ComponentEmitDefinition>? Emits { get; } =
+    [
+        new ComponentEmitDefinition("reset"),
+    ];
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("class", "meter")),
+            VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "meter-label")), VirtualNodeFactory.Text("Elapsed")),
+            VirtualNodeFactory.Element(
+                "strong",
+                VirtualNodeFactory.Properties(("class", "meter-value")),
+                VirtualNodeFactory.Text(properties.Get<string>("text") ?? "00:00:00")),
+            VirtualNodeFactory.Element(
+                "span",
+                VirtualNodeFactory.Properties(("class", "status-pill")),
+                VirtualNodeFactory.Text(properties.Get<bool>("running") ? "Running" : "Paused")),
+            VirtualNodeFactory.Element(
+                "button",
+                VirtualNodeFactory.Properties(
+                    ("class", "secondary"),
+                    ("type", "button"),
+                    ("onClick", (Action)(() => context.Emit("reset")))),
+                VirtualNodeFactory.Text("Reset")));
+}

--- a/examples/Assimalign.Vue.WebApp/VuecsDiagnostics.cs
+++ b/examples/Assimalign.Vue.WebApp/VuecsDiagnostics.cs
@@ -34,6 +34,7 @@ internal static class VuecsDiagnostics
         report.AppendLine();
 
         RunHandleLifecycleStress(renderer, rootHandle, report);
+        RunApplicationLifecycleStress(rootHandle, report);
         RunMarshalingBenchmark(report);
 
         renderer.Render(
@@ -65,6 +66,32 @@ internal static class VuecsDiagnostics
         report.AppendLine($"  peak:     nodes={peakNodes}");
         report.AppendLine($"  after:    nodes={after.JsNodes} listenerMaps={after.JsListenerMaps} dotnetListeners={after.DotnetListeners}");
         report.AppendLine($"  result:   {(passed ? "PASS - registries returned to baseline" : "FAIL - leak detected")}");
+        report.AppendLine();
+    }
+
+    private static void RunApplicationLifecycleStress(int rootHandle, StringBuilder report)
+    {
+        // The [V01.01.04.04] criterion: CreateApp/Mount/Unmount cycles — with component
+        // lifecycles, props, emits, and timers — return the bridge registry to its pre-mount
+        // baseline.
+        var baseline = BrowserRuntime.GetRegistryDiagnostics();
+        var peakNodes = 0;
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            var application = BrowserRuntime.CreateApp(new StopwatchApplication());
+            application.Mount(rootHandle);
+            var during = BrowserRuntime.GetRegistryDiagnostics();
+            peakNodes = Math.Max(peakNodes, during.JsNodes);
+            application.Unmount();
+        }
+        var after = BrowserRuntime.GetRegistryDiagnostics();
+        var passed = after == baseline;
+        report.AppendLine("APPLICATION LIFECYCLE STRESS (CreateApp/Mount/Unmount)");
+        report.AppendLine($"  cycles: 25 x component tree (root + child, listeners, timers)");
+        report.AppendLine($"  baseline: nodes={baseline.JsNodes} listenerMaps={baseline.JsListenerMaps} dotnetListeners={baseline.DotnetListeners}");
+        report.AppendLine($"  peak:     nodes={peakNodes}");
+        report.AppendLine($"  after:    nodes={after.JsNodes} listenerMaps={after.JsListenerMaps} dotnetListeners={after.DotnetListeners}");
+        report.AppendLine($"  result:   {(passed ? "PASS - registry returned to pre-mount baseline" : "FAIL - leak detected")}");
         report.AppendLine();
     }
 

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Abstraction/IComponentDefinition.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Abstraction/IComponentDefinition.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A Vuecs component — the C# port of the component options + Composition API <c>setup()</c>
+/// contract (<c>packages/runtime-core/src/component.ts</c>,
+/// https://vuejs.org/api/composition-api-setup.html). C# has no <c>Proxy</c>, so there is no
+/// <c>this</c>-proxy: <see cref="Setup"/> runs exactly once per instance and returns the
+/// render function, with state held as refs/computeds the render function closes over — the
+/// closure IS the proxy-free realization of upstream's "state object" form. Definitions are
+/// plain objects instantiated by user code or source-generated factories — never activated
+/// reflectively (AOT/trimming contract).
+/// </summary>
+public interface IComponentDefinition
+{
+    /// <summary>The component's display name for warnings and devtools, or null.</summary>
+    string? Name => null;
+
+    /// <summary>
+    /// The declared props (upstream: the <c>props</c> option), as precomputed metadata —
+    /// emitted by the source generator or written explicitly, never discovered via reflection.
+    /// Null declares no props: every vnode prop falls through as an attribute.
+    /// </summary>
+    IReadOnlyList<ComponentPropertyDefinition>? Properties => null;
+
+    /// <summary>
+    /// The declared emitted events (upstream: the <c>emits</c> option). Declared events'
+    /// handler props are excluded from attribute fallthrough.
+    /// </summary>
+    IReadOnlyList<ComponentEmitDefinition>? Emits => null;
+
+    /// <summary>
+    /// Whether undeclared attributes fall through to a single element root (upstream:
+    /// <c>inheritAttrs</c>, default true).
+    /// </summary>
+    bool InheritAttributes => true;
+
+    /// <summary>
+    /// The Composition API entry point (upstream: <c>setup(props, context)</c>): runs once per
+    /// instance with the instance current, and returns the render function that re-executes
+    /// per update.
+    /// </summary>
+    /// <param name="properties">The instance's shallow-reactive props.</param>
+    /// <param name="context">Attrs, Emit, Expose, and Slots.</param>
+    /// <returns>The render function producing the component's subtree.</returns>
+    Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context);
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentAttributes.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentAttributes.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The instance's fallthrough attributes — undeclared vnode props minus declared emits'
+/// handler props (upstream: <c>instance.attrs</c>, https://vuejs.org/guide/components/attrs.html).
+/// A live view: the owner replaces the content on every parent patch, so reads always see the
+/// latest values. Consumed by <see cref="ComponentSetupContext.Attributes"/> and by the
+/// renderer's single-root fallthrough merge.
+/// </summary>
+public sealed class ComponentAttributes
+{
+    private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+
+    internal ComponentAttributes()
+    {
+    }
+
+    /// <summary>The number of fallthrough attributes.</summary>
+    public int Count => _values.Count;
+
+    /// <summary>Reads an attribute, or null when absent.</summary>
+    /// <param name="name">The attribute name.</param>
+    public object? this[string name]
+    {
+        get
+        {
+            _values.TryGetValue(name, out var value);
+            return value;
+        }
+    }
+
+    /// <summary>Whether the attribute is present.</summary>
+    /// <param name="name">The attribute name.</param>
+    public bool Contains(string name) => _values.ContainsKey(name);
+
+    /// <summary>Enumerates the current name/value pairs.</summary>
+    public Dictionary<string, object?>.Enumerator GetEnumerator() => _values.GetEnumerator();
+
+    internal void ReplaceFrom(List<KeyValuePair<string, object?>>? entries)
+    {
+        _values.Clear();
+        if (entries is null)
+        {
+            return;
+        }
+        foreach (var (name, value) in entries)
+        {
+            _values[name] = value;
+        }
+    }
+
+    internal VirtualNodeProperties? ToProperties()
+    {
+        if (_values.Count == 0)
+        {
+            return null;
+        }
+        var properties = new VirtualNodeProperties(_values.Count);
+        foreach (var (name, value) in _values)
+        {
+            properties.Set(name, value);
+        }
+        return properties;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentEmitDefinition.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentEmitDefinition.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Metadata for one declared emitted event — an entry of upstream's normalized <c>emits</c>
+/// option (<c>packages/runtime-core/src/componentEmits.ts</c>,
+/// https://vuejs.org/guide/components/events.html). Declared events' handler props are
+/// excluded from attribute fallthrough.
+/// </summary>
+public sealed class ComponentEmitDefinition
+{
+    /// <summary>Creates the metadata for <paramref name="name"/>.</summary>
+    /// <param name="name">The event name as emitted (e.g. <c>"change"</c>, <c>"update:modelValue"</c>).</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public ComponentEmitDefinition(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        Name = name;
+    }
+
+    /// <summary>The event name as emitted.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// An optional payload validator; returning false produces a dev warning (upstream:
+    /// emits-option validators).
+    /// </summary>
+    public Func<object?[], bool>? Validator { get; init; }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Reactivity;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A mounted component's runtime state — the C# port of upstream's
+/// <c>ComponentInternalInstance</c> (<c>packages/runtime-core/src/component.ts</c>,
+/// https://vuejs.org/api/composition-api-setup.html). Carries the identity the rest of the
+/// area depends on: <see cref="Uid"/> for scheduler ordering, <see cref="Parent"/>/<see cref="Root"/>
+/// links, the provides table, per-kind lifecycle hook lists, the owning vnode and rendered
+/// subtree back-pointers, and mount state. <see cref="Current"/> is the active-instance stack
+/// (correct across nested setups, restored on exception).
+/// Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+public sealed class ComponentInstance
+{
+    private static int _nextUid;
+    private static readonly List<ComponentInstance> InstanceStack = [];
+    private static readonly Dictionary<string, string> HandlerNameCache = new(StringComparer.Ordinal);
+    private static readonly Dictionary<string, string> CamelizeCache = new(StringComparer.Ordinal);
+
+    private readonly List<Delegate>?[] _hooks = new List<Delegate>?[10];
+    private readonly Dictionary<string, ComponentEmitDefinition>? _declaredEmits;
+    private HashSet<string>? _emittedOnceEvents;
+
+    internal ComponentInstance(IComponentDefinition definition, VirtualNode virtualNode, ComponentInstance? parent)
+    {
+        Uid = _nextUid++;
+        Definition = definition;
+        VirtualNode = virtualNode;
+        Parent = parent;
+        Root = parent?.Root ?? this;
+        Scope = new EffectScope(detached: true);
+        Properties = new ComponentProperties(DisplayName);
+        Attributes = new ComponentAttributes();
+        if (definition.Properties is { Count: > 0 } declaredProperties)
+        {
+            // camelCase and kebab-case both resolve to the declaration (upstream parity).
+            DeclaredProperties = new Dictionary<string, ComponentPropertyDefinition>(StringComparer.Ordinal);
+            foreach (var property in declaredProperties)
+            {
+                DeclaredProperties[property.Name] = property;
+                if (property.KebabName is not null)
+                {
+                    DeclaredProperties[property.KebabName] = property;
+                }
+            }
+        }
+        if (definition.Emits is { Count: > 0 } emits)
+        {
+            _declaredEmits = new Dictionary<string, ComponentEmitDefinition>(emits.Count, StringComparer.Ordinal);
+            foreach (var emit in emits)
+            {
+                _declaredEmits[emit.Name] = emit;
+            }
+        }
+    }
+
+    /// <summary>Declared-prop lookup by camelCase AND kebab-case name; null when none declared.</summary>
+    internal Dictionary<string, ComponentPropertyDefinition>? DeclaredProperties { get; }
+
+    /// <summary>The declared prop names the parent explicitly provided in the last resolve pass.</summary>
+    internal HashSet<string>? LastProvidedNames { get; set; }
+
+    /// <summary>
+    /// The instance whose <c>Setup</c>, render, or lifecycle hook is executing — upstream's
+    /// <c>getCurrentInstance()</c>. Null outside those windows.
+    /// </summary>
+    public static ComponentInstance? Current
+        => InstanceStack.Count > 0 ? InstanceStack[^1] : null;
+
+    /// <summary>The creation-ordered uid; parents have lower uids, which orders scheduler jobs.</summary>
+    public int Uid { get; }
+
+    /// <summary>The component definition this instance runs.</summary>
+    public IComponentDefinition Definition { get; }
+
+    /// <summary>The parent instance, or null at the root.</summary>
+    public ComponentInstance? Parent { get; }
+
+    /// <summary>The root instance of this component tree.</summary>
+    public ComponentInstance Root { get; }
+
+    /// <summary>The effect scope every setup-created effect/computed registers with.</summary>
+    public EffectScope Scope { get; }
+
+    /// <summary>The shallow-reactive props (upstream: <c>instance.props</c>).</summary>
+    public ComponentProperties Properties { get; }
+
+    /// <summary>The live fallthrough attributes (upstream: <c>instance.attrs</c>).</summary>
+    public ComponentAttributes Attributes { get; }
+
+    /// <summary>The slots object; typed when slots land ([V01.01.03.09]).</summary>
+    public object? Slots { get; internal set; }
+
+    /// <summary>The state surfaced to parent refs via <c>Expose</c>, or null.</summary>
+    public object? Exposed { get; private set; }
+
+    /// <summary>The vnode this instance is mounted for (upstream: <c>instance.vnode</c>).</summary>
+    public VirtualNode VirtualNode { get; internal set; }
+
+    /// <summary>The rendered subtree (upstream: <c>instance.subTree</c>).</summary>
+    public VirtualNode? Subtree { get; internal set; }
+
+    /// <summary>Whether the first mount completed.</summary>
+    public bool IsMounted { get; internal set; }
+
+    /// <summary>Whether the instance was torn down.</summary>
+    public bool IsUnmounted { get; internal set; }
+
+    /// <summary>The provides table ([V01.01.03.10] consumes it; parents chain).</summary>
+    internal Dictionary<object, object?>? Provides { get; set; }
+
+    internal Func<VirtualNode?>? RenderFunction { get; set; }
+
+    internal ReactiveEffect? Effect { get; set; }
+
+    internal SchedulerJob? UpdateJob { get; set; }
+
+    /// <summary>A pending vnode from a parent-driven update (upstream: <c>instance.next</c>).</summary>
+    internal VirtualNode? NextVirtualNode { get; set; }
+
+    internal string DisplayName => Definition.Name ?? Definition.GetType().Name;
+
+    /// <summary>
+    /// Upstream <c>toggleRecurse</c>: self-triggering is disabled while props resolve and
+    /// before-hooks run (a props write during the effect's own run must not requeue it), and
+    /// re-enabled for render/patch.
+    /// </summary>
+    internal void ToggleRecurse(bool allowed)
+    {
+        Effect!.AllowRecurse = allowed;
+        UpdateJob!.AllowRecurse = allowed;
+    }
+
+    internal void SetExposed(object? exposed) => Exposed = exposed;
+
+    // --- current-instance stack ------------------------------------------------------------
+
+    internal void PushCurrent() => InstanceStack.Add(this);
+
+    internal void PopCurrent()
+    {
+        if (InstanceStack.Count > 0 && ReferenceEquals(InstanceStack[^1], this))
+        {
+            InstanceStack.RemoveAt(InstanceStack.Count - 1);
+        }
+    }
+
+    // --- lifecycle hooks ---------------------------------------------------------------------
+
+    internal void RegisterHook(LifecycleHookKind kind, Delegate hook)
+        => (_hooks[(int)kind] ??= []).Add(hook);
+
+    internal bool HasHooks(LifecycleHookKind kind) => _hooks[(int)kind] is { Count: > 0 };
+
+    /// <summary>Runs the instance's hooks of one kind, in registration order, with this instance current.</summary>
+    internal void InvokeHooks(LifecycleHookKind kind)
+    {
+        var hooks = _hooks[(int)kind];
+        if (hooks is null || IsUnmounted && kind is not LifecycleHookKind.Unmounted)
+        {
+            return;
+        }
+        PushCurrent();
+        try
+        {
+            foreach (var hook in hooks)
+            {
+                try
+                {
+                    ((Action)hook)();
+                }
+                catch (Exception exception)
+                {
+                    ComponentErrorHandling.Handle(exception, this, $"{kind} hook");
+                }
+            }
+        }
+        finally
+        {
+            PopCurrent();
+        }
+    }
+
+    internal IReadOnlyList<Delegate>? GetHooks(LifecycleHookKind kind) => _hooks[(int)kind];
+
+    // --- emits -------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Dispatches a component event to its handler prop (upstream: <c>emit</c> in
+    /// <c>componentEmits.ts</c>): validates against the declaration, honors casing rules and
+    /// <c>Once</c> handlers, and forms the <c>update:modelValue</c> runtime contract.
+    /// </summary>
+    /// <param name="eventName">The event name as emitted.</param>
+    /// <param name="arguments">The event payload.</param>
+    internal void EmitEvent(string eventName, object?[] arguments)
+    {
+        if (_declaredEmits is not null)
+        {
+            if (!_declaredEmits.TryGetValue(eventName, out var declaration))
+            {
+                RuntimeWarnings.Warn(
+                    $"Component <{DisplayName}> emitted event \"{eventName}\" but it is not declared in the "
+                    + "Emits option.");
+            }
+            else if (declaration.Validator is not null && !declaration.Validator(arguments))
+            {
+                RuntimeWarnings.Warn($"Invalid event arguments: event validation failed for event \"{eventName}\".");
+            }
+        }
+        var properties = VirtualNode.Properties;
+        if (properties is null)
+        {
+            return;
+        }
+        var handlerName = ToHandlerPropertyName(eventName);
+        if (!properties.TryGetValue(handlerName, out var handler) || handler is null)
+        {
+            // Kebab-case emit matches a camelCase handler (upstream parity).
+            var camelizedHandlerName = ToHandlerPropertyName(Camelize(eventName));
+            properties.TryGetValue(camelizedHandlerName, out handler);
+            handlerName = camelizedHandlerName;
+        }
+        if (handler is Delegate liveHandler)
+        {
+            InvokeEmitHandler(liveHandler, arguments, eventName);
+        }
+        // Once semantics: fires exactly once per instance across re-renders (upstream
+        // instance.emitted tracking).
+        var onceName = handlerName + "Once";
+        if (properties.TryGetValue(onceName, out var onceHandler) && onceHandler is Delegate onceDelegate)
+        {
+            _emittedOnceEvents ??= new HashSet<string>(StringComparer.Ordinal);
+            if (_emittedOnceEvents.Add(onceName))
+            {
+                InvokeEmitHandler(onceDelegate, arguments, eventName);
+            }
+        }
+    }
+
+    /// <summary>Whether <paramref name="propertyName"/> is a declared emit's handler prop (attrs exclusion).</summary>
+    internal bool IsDeclaredEmitHandlerName(string propertyName)
+    {
+        if (_declaredEmits is null || !VirtualNodeFactory.IsEventListenerName(propertyName))
+        {
+            return false;
+        }
+        foreach (var name in _declaredEmits.Keys)
+        {
+            var handlerName = ToHandlerPropertyName(name);
+            if (string.Equals(propertyName, handlerName, StringComparison.Ordinal)
+                || (propertyName.EndsWith("Once", StringComparison.Ordinal)
+                    && string.Equals(propertyName[..^4], handlerName, StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void InvokeEmitHandler(Delegate handler, object?[] arguments, string eventName)
+    {
+        try
+        {
+            switch (handler)
+            {
+                case Action action:
+                    action();
+                    break;
+                case Action<object?> single:
+                    single(arguments.Length > 0 ? arguments[0] : null);
+                    break;
+                case Action<object?[]> spread:
+                    spread(arguments);
+                    break;
+                default:
+                    RuntimeWarnings.Warn(
+                        $"Handler for event \"{eventName}\" on <{DisplayName}> is a {handler.GetType().Name}; "
+                        + "supported shapes are Action, Action<object?>, and Action<object?[]>.");
+                    break;
+            }
+        }
+        catch (Exception exception)
+        {
+            ComponentErrorHandling.Handle(exception, this, $"event handler for \"{eventName}\"");
+        }
+    }
+
+    /// <summary>Cached <c>toHandlerKey</c>: <c>"change"</c> → <c>"onChange"</c>, <c>"update:modelValue"</c> → <c>"onUpdate:modelValue"</c>.</summary>
+    internal static string ToHandlerPropertyName(string eventName)
+    {
+        if (HandlerNameCache.TryGetValue(eventName, out var cached))
+        {
+            return cached;
+        }
+        var handlerName = eventName.Length == 0
+            ? "on"
+            : $"on{char.ToUpperInvariant(eventName[0])}{eventName[1..]}";
+        HandlerNameCache[eventName] = handlerName;
+        return handlerName;
+    }
+
+    /// <summary>Cached <c>camelize</c>: <c>"my-event"</c> → <c>"myEvent"</c>.</summary>
+    internal static string Camelize(string name)
+    {
+        if (CamelizeCache.TryGetValue(name, out var cached))
+        {
+            return cached;
+        }
+        var camelized = name;
+        var hyphenIndex = name.IndexOf('-', StringComparison.Ordinal);
+        if (hyphenIndex >= 0)
+        {
+            var builder = new System.Text.StringBuilder(name.Length);
+            var upperNext = false;
+            foreach (var character in name)
+            {
+                if (character == '-')
+                {
+                    upperNext = true;
+                    continue;
+                }
+                builder.Append(upperNext ? char.ToUpperInvariant(character) : character);
+                upperNext = false;
+            }
+            camelized = builder.ToString();
+        }
+        CamelizeCache[name] = camelized;
+        return camelized;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentProperties.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentProperties.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Reactivity;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The instance's shallow-reactive props object — the C# port of upstream's
+/// <c>shallowReactive</c> props (<c>packages/runtime-core/src/componentProps.ts</c>,
+/// https://vuejs.org/guide/components/props.html). Reads inside an effect track per prop name
+/// (one <see cref="Dependency"/> per read name), and a parent patch that actually changes a
+/// value triggers exactly the effects that read it — a child re-renders only when a prop it
+/// used changed. Writes from the child produce the one-way-data-flow dev warning and are
+/// ignored (upstream parity). Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+public sealed class ComponentProperties
+{
+    private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dependency> _dependencies = new(StringComparer.Ordinal);
+    private readonly string _componentName;
+
+    internal ComponentProperties(string componentName)
+    {
+        _componentName = componentName;
+    }
+
+    /// <summary>Reads a prop, tracking it in the active effect (shallow: the value itself is not wrapped).</summary>
+    /// <param name="name">The camelCase prop name.</param>
+    public object? this[string name]
+    {
+        get
+        {
+            GetDependency(name).Track();
+            _values.TryGetValue(name, out var value);
+            return value;
+        }
+    }
+
+    /// <summary>Reads a prop as <typeparamref name="T"/>, tracking it in the active effect.</summary>
+    /// <typeparam name="T">The expected value type.</typeparam>
+    /// <param name="name">The camelCase prop name.</param>
+    /// <returns>The value, or <c>default</c> when absent or of another type.</returns>
+    public T? Get<T>(string name) => this[name] is T typed ? typed : default;
+
+    /// <summary>Whether the prop currently has a value (tracked).</summary>
+    /// <param name="name">The camelCase prop name.</param>
+    public bool Contains(string name)
+    {
+        GetDependency(name).Track();
+        return _values.ContainsKey(name);
+    }
+
+    /// <summary>
+    /// Rejected with a dev warning: props are one-way data flow — the parent owns them
+    /// (upstream parity: the dev-mode props proxy blocks writes).
+    /// </summary>
+    /// <param name="name">The prop name.</param>
+    /// <param name="value">Ignored.</param>
+    public void Set(string name, object? value)
+        => RuntimeWarnings.Warn(
+            $"Attempting to mutate prop \"{name}\" on component <{_componentName}>. Props are readonly — "
+            + "use an emit to ask the owner to change it.");
+
+    internal void SetFromOwner(string name, object? value)
+    {
+        if (_values.TryGetValue(name, out var existing) && Equals(existing, value))
+        {
+            return;
+        }
+        _values[name] = value;
+        if (_dependencies.TryGetValue(name, out var dependency))
+        {
+            dependency.Trigger();
+        }
+    }
+
+    internal void RemoveFromOwner(string name)
+    {
+        if (_values.Remove(name) && _dependencies.TryGetValue(name, out var dependency))
+        {
+            dependency.Trigger();
+        }
+    }
+
+    internal IReadOnlyDictionary<string, object?> Snapshot => _values;
+
+    private Dependency GetDependency(string name)
+    {
+        if (!_dependencies.TryGetValue(name, out var dependency))
+        {
+            dependency = new Dependency();
+            _dependencies[name] = dependency;
+        }
+        return dependency;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentPropertyDefinition.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentPropertyDefinition.cs
@@ -1,0 +1,57 @@
+using System;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Precomputed metadata for one declared prop — the C# stand-in for an entry of upstream's
+/// normalized <c>props</c> option (<c>packages/runtime-core/src/componentProps.ts</c>,
+/// https://vuejs.org/guide/components/props.html). Produced by the source generator or written
+/// explicitly; the runtime never discovers props reflectively.
+/// </summary>
+public sealed class ComponentPropertyDefinition
+{
+    private readonly string? _kebabName;
+
+    /// <summary>Creates the metadata for <paramref name="name"/>.</summary>
+    /// <param name="name">The camelCase prop name (e.g. <c>"modelValue"</c>).</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public ComponentPropertyDefinition(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        Name = name;
+        var kebab = StyleAndClassNormalization.Hyphenate(name);
+        _kebabName = string.Equals(kebab, name, StringComparison.Ordinal) ? null : kebab;
+    }
+
+    /// <summary>The camelCase prop name.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The kebab-case equivalent when it differs (vnode props may use either casing,
+    /// upstream parity), or null when the name has no casing variant.
+    /// </summary>
+    public string? KebabName => _kebabName;
+
+    /// <summary>The default value applied when the prop is absent.</summary>
+    public object? DefaultValue { get; init; }
+
+    /// <summary>
+    /// A factory for the default, for reference/collection defaults that must not be shared
+    /// across instances (upstream: function defaults). Wins over <see cref="DefaultValue"/>.
+    /// </summary>
+    public Func<object?>? DefaultFactory { get; init; }
+
+    /// <summary>Whether omitting the prop produces a dev warning (upstream: <c>required</c>).</summary>
+    public bool Required { get; init; }
+
+    /// <summary>
+    /// An optional validator; returning false produces a dev warning naming the component and
+    /// prop (upstream: <c>validator</c>).
+    /// </summary>
+    public Func<object?, bool>? Validator { get; init; }
+
+    internal object? ResolveDefault()
+        => DefaultFactory is not null ? DefaultFactory() : DefaultValue;
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSetupContext.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSetupContext.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The second argument to <see cref="IComponentDefinition.Setup"/> — the C# port of upstream's
+/// <c>SetupContext</c> (<c>packages/runtime-core/src/component.ts</c>,
+/// https://vuejs.org/api/composition-api-setup.html#setup-context): the live fallthrough
+/// attributes, the emit function, <see cref="Expose"/>, and the slots object (typed once
+/// [V01.01.03.09] lands).
+/// </summary>
+public sealed class ComponentSetupContext
+{
+    private readonly ComponentInstance _instance;
+
+    internal ComponentSetupContext(ComponentInstance instance)
+    {
+        _instance = instance;
+    }
+
+    /// <summary>The live fallthrough attributes (upstream: <c>context.attrs</c>).</summary>
+    public ComponentAttributes Attributes => _instance.Attributes;
+
+    /// <summary>The slots object; typed when slots land ([V01.01.03.09]).</summary>
+    public object? Slots => _instance.Slots;
+
+    /// <summary>
+    /// Emits a component event to the matching handler prop (upstream: <c>context.emit</c>;
+    /// see https://vuejs.org/guide/components/events.html).
+    /// </summary>
+    /// <param name="eventName">The event name as declared (e.g. <c>"change"</c>, <c>"update:modelValue"</c>).</param>
+    /// <param name="arguments">The event payload.</param>
+    public void Emit(string eventName, params object?[] arguments)
+        => _instance.EmitEvent(eventName, arguments);
+
+    /// <summary>
+    /// Restricts what a parent template ref sees on this instance (upstream:
+    /// <c>context.expose</c>): after exposing, <see cref="ComponentInstance.Exposed"/> is the
+    /// only surfaced state.
+    /// </summary>
+    /// <param name="exposed">The object to surface, or null to expose nothing.</param>
+    public void Expose(object? exposed) => _instance.SetExposed(exposed);
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/ComponentErrorHandling.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/ComponentErrorHandling.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.ExceptionServices;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Routes component errors up the <c>OnErrorCaptured</c> chain — the C# port of
+/// <c>handleError</c> in <c>packages/runtime-core/src/errorHandling.ts</c>. Each ancestor's
+/// captured hooks receive <c>(exception, instance, info)</c>; returning false stops
+/// propagation. An unhandled error rethrows to the host until the app-level handler lands
+/// ([V01.01.03.12]).
+/// </summary>
+internal static class ComponentErrorHandling
+{
+    internal static void Handle(Exception exception, ComponentInstance? instance, string info)
+    {
+        for (var ancestor = instance?.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            var hooks = ancestor.GetHooks(LifecycleHookKind.ErrorCaptured);
+            if (hooks is null)
+            {
+                continue;
+            }
+            foreach (var hook in hooks)
+            {
+                if (hook is Func<Exception, ComponentInstance?, string, bool> capture
+                    && !capture(exception, instance, info))
+                {
+                    return; // false stops propagation (upstream parity)
+                }
+            }
+        }
+        // No app-level handler yet ([V01.01.03.12]); surface the failure with its original
+        // stack intact.
+        ExceptionDispatchInfo.Capture(exception).Throw();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/ComponentPropertyResolution.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/ComponentPropertyResolution.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Splits a component vnode's props into declared props and fallthrough attrs and applies them
+/// to the instance — the C# port of <c>initProps</c>/<c>updateProps</c> in
+/// <c>packages/runtime-core/src/componentProps.ts</c>
+/// (https://vuejs.org/guide/components/props.html): camelCase/kebab-case equivalence, defaults
+/// (factory defaults per instance), required/validator dev warnings naming the component and
+/// prop, declared-emit handler exclusion from attrs, and change-only application so the child
+/// re-renders only when a value it reads actually changed.
+/// </summary>
+internal static class ComponentPropertyResolution
+{
+    internal static void Resolve(ComponentInstance instance, VirtualNode virtualNode)
+    {
+        var declared = instance.DeclaredProperties;
+        HashSet<string>? providedNames = null;
+        List<KeyValuePair<string, object?>>? attributes = null;
+        if (virtualNode.Properties is not null)
+        {
+            foreach (var (name, value) in virtualNode.Properties)
+            {
+                if (IsReservedProperty(name))
+                {
+                    continue;
+                }
+                if (declared is not null && declared.TryGetValue(name, out var declaration))
+                {
+                    (providedNames ??= new HashSet<string>(StringComparer.Ordinal)).Add(declaration.Name);
+                    if (declaration.Validator is not null && !declaration.Validator(value))
+                    {
+                        RuntimeWarnings.Warn(
+                            $"Invalid prop: custom validator check failed for prop \"{declaration.Name}\" on "
+                            + $"component <{instance.DisplayName}>.");
+                    }
+                    instance.Properties.SetFromOwner(declaration.Name, value);
+                }
+                else if (!instance.IsDeclaredEmitHandlerName(name))
+                {
+                    (attributes ??= []).Add(new KeyValuePair<string, object?>(name, value));
+                }
+            }
+        }
+        if (declared is not null)
+        {
+            foreach (var declaration in declared.Values)
+            {
+                if (providedNames?.Contains(declaration.Name) == true)
+                {
+                    continue;
+                }
+                var wasProvided = instance.LastProvidedNames?.Contains(declaration.Name) == true;
+                var hasValue = instance.Properties.Snapshot.ContainsKey(declaration.Name);
+                if (declaration.Required)
+                {
+                    RuntimeWarnings.Warn(
+                        $"Missing required prop: \"{declaration.Name}\" on component <{instance.DisplayName}>.");
+                }
+                if (declaration.DefaultFactory is not null || declaration.DefaultValue is not null)
+                {
+                    // Apply the default on first resolve or when the parent just withdrew the
+                    // prop — never re-run a factory while its default is already in place
+                    // (a fresh instance per pass would spuriously re-render the child).
+                    if (!hasValue || wasProvided)
+                    {
+                        instance.Properties.SetFromOwner(declaration.Name, declaration.ResolveDefault());
+                    }
+                }
+                else if (wasProvided)
+                {
+                    instance.Properties.RemoveFromOwner(declaration.Name);
+                }
+            }
+        }
+        instance.LastProvidedNames = providedNames;
+        instance.Attributes.ReplaceFrom(attributes);
+    }
+
+    private static bool IsReservedProperty(string name)
+        => string.Equals(name, "key", StringComparison.Ordinal)
+            || string.Equals(name, "ref", StringComparison.Ordinal)
+            || name.StartsWith("onVnode", StringComparison.Ordinal);
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/LifecycleHookKind.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/LifecycleHookKind.cs
@@ -1,0 +1,38 @@
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The lifecycle hook slots an instance stores (upstream: the <c>LifecycleHooks</c> enum in
+/// <c>packages/runtime-core/src/component.ts</c>).
+/// </summary>
+internal enum LifecycleHookKind
+{
+    /// <summary>Before the first render is patched in.</summary>
+    BeforeMount,
+
+    /// <summary>After the instance's tree is in the host (post-flush).</summary>
+    Mounted,
+
+    /// <summary>Before a re-render patches (pre-patch subtree state observable).</summary>
+    BeforeUpdate,
+
+    /// <summary>After a re-render's patches applied (post-flush).</summary>
+    Updated,
+
+    /// <summary>Before teardown starts (parent-first).</summary>
+    BeforeUnmount,
+
+    /// <summary>After teardown (post-flush, child-first).</summary>
+    Unmounted,
+
+    /// <summary>Captures descendant errors (upstream: <c>errorCaptured</c>).</summary>
+    ErrorCaptured,
+
+    /// <summary>Awaited by the server renderer before serialization ([V01.01.07.01]).</summary>
+    ServerPrefetch,
+
+    /// <summary>Stored for KeepAlive activation ([V01.01.03.18]).</summary>
+    Activated,
+
+    /// <summary>Stored for KeepAlive deactivation ([V01.01.03.18]).</summary>
+    Deactivated,
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/RuntimeWarnings.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/RuntimeWarnings.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The dev-warning seam (upstream: <c>warn()</c> in <c>@vue/runtime-core</c>): props
+/// validation, emit validation, and lifecycle misuse report here. Defaults to a debug trace;
+/// tests capture it, and the app-level configuration ([V01.01.03.12]) will route it.
+/// </summary>
+internal static class RuntimeWarnings
+{
+    /// <summary>The warning sink; never null.</summary>
+    internal static Action<string> Sink { get; set; } = static message => Debug.WriteLine($"[Vue warn] {message}");
+
+    /// <summary>Emits a dev warning.</summary>
+    /// <param name="message">The warning text.</param>
+    internal static void Warn(string message) => Sink(message);
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Lifecycle.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Lifecycle.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Composition API lifecycle registration — the C# port of
+/// <c>packages/runtime-core/src/apiLifecycle.ts</c>
+/// (https://vuejs.org/api/composition-api-lifecycle.html). Hooks bind to
+/// <see cref="ComponentInstance.Current"/> at registration time (so they must be called during
+/// <c>Setup</c>), run in registration order, and are wrapped in error handling that routes
+/// through the <c>OnErrorCaptured</c> chain. Registering with no active instance produces the
+/// upstream dev warning and is otherwise ignored.
+/// </summary>
+public static class Lifecycle
+{
+    /// <summary>Runs before the instance's first render is patched in (parent before child).</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnBeforeMount(Action hook) => Register(LifecycleHookKind.BeforeMount, hook, nameof(OnBeforeMount));
+
+    /// <summary>Runs after the instance's tree is in the host — post-flush, child before parent.</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnMounted(Action hook) => Register(LifecycleHookKind.Mounted, hook, nameof(OnMounted));
+
+    /// <summary>Runs before a re-render patches; the pre-patch subtree is still observable.</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnBeforeUpdate(Action hook) => Register(LifecycleHookKind.BeforeUpdate, hook, nameof(OnBeforeUpdate));
+
+    /// <summary>Runs after a re-render's patches applied (post-flush).</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnUpdated(Action hook) => Register(LifecycleHookKind.Updated, hook, nameof(OnUpdated));
+
+    /// <summary>Runs before teardown starts (parent before child).</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnBeforeUnmount(Action hook) => Register(LifecycleHookKind.BeforeUnmount, hook, nameof(OnBeforeUnmount));
+
+    /// <summary>Runs after teardown (post-flush, child before parent); the last hooks an instance fires.</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnUnmounted(Action hook) => Register(LifecycleHookKind.Unmounted, hook, nameof(OnUnmounted));
+
+    /// <summary>
+    /// Captures descendant errors as <c>(exception, source instance, info)</c>; return false to
+    /// stop propagation to ancestors and the app-level handler.
+    /// </summary>
+    /// <param name="hook">The capture hook.</param>
+    public static void OnErrorCaptured(Func<Exception, ComponentInstance?, string, bool> hook)
+        => Register(LifecycleHookKind.ErrorCaptured, hook, nameof(OnErrorCaptured));
+
+    /// <summary>
+    /// Registered for the server renderer to await before serializing ([V01.01.07.01]);
+    /// a no-op in client-only rendering.
+    /// </summary>
+    /// <param name="hook">The prefetch task factory.</param>
+    public static void OnServerPrefetch(Func<Task> hook) => Register(LifecycleHookKind.ServerPrefetch, hook, nameof(OnServerPrefetch));
+
+    /// <summary>Stored for KeepAlive activation ([V01.01.03.18]); a no-op without a KeepAlive parent.</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnActivated(Action hook) => Register(LifecycleHookKind.Activated, hook, nameof(OnActivated));
+
+    /// <summary>Stored for KeepAlive deactivation ([V01.01.03.18]); a no-op without a KeepAlive parent.</summary>
+    /// <param name="hook">The hook.</param>
+    public static void OnDeactivated(Action hook) => Register(LifecycleHookKind.Deactivated, hook, nameof(OnDeactivated));
+
+    private static void Register(LifecycleHookKind kind, Delegate hook, string apiName)
+    {
+        ArgumentNullException.ThrowIfNull(hook);
+        var instance = ComponentInstance.Current;
+        if (instance is null)
+        {
+            RuntimeWarnings.Warn(
+                $"{apiName}() is called when there is no active component instance to be associated with. "
+                + "Lifecycle hooks can only be registered during Setup().");
+            return;
+        }
+        instance.RegisterHook(kind, hook);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using Assimalign.Vue.Reactivity;
 using Assimalign.Vue.Shared;
 
 namespace Assimalign.Vue.RuntimeCore;
@@ -12,11 +13,13 @@ namespace Assimalign.Vue.RuntimeCore;
 /// The patch dispatcher routes by <see cref="VirtualNode.Type"/> and
 /// <see cref="VirtualNode.ShapeFlag"/> to element, text, comment, static, fragment, and
 /// component paths; mismatched node types unmount and remount; fragments mount between
-/// start/end anchors; insertion honors the anchor throughout. A positive
+/// start/end anchors; insertion honors the anchor throughout. Components mount through
+/// <see cref="ComponentInstance"/>s with per-instance render effects whose scheduler jobs
+/// carry the instance uid, so parents update before children ([V01.01.03.06]). A positive
 /// <see cref="VirtualNode.PatchFlag"/> follows the compiled patch contract (targeted
 /// class/style/props/text updates); unflagged vnodes take the full diff. Array children patch
 /// positionally for now — keyed longest-increasing-subsequence reordering lands with
-/// [V01.01.03.03]; the component path lands with [V01.01.03.06].
+/// [V01.01.03.03]; slots land with [V01.01.03.09].
 /// Created through <see cref="RendererFactory.CreateRenderer{TNode}"/>.
 /// Not thread-safe (single-threaded JS event-loop model).
 /// </summary>
@@ -56,7 +59,7 @@ public sealed class Renderer<TNode>
         }
         else
         {
-            Patch(current, node, container, default, null);
+            Patch(current, node, container, default, null, null);
             _containerRoots[container] = node;
         }
         Scheduler.FlushAfterSynchronousRender();
@@ -78,7 +81,27 @@ public sealed class Renderer<TNode>
         return new RenderEffect<TNode>(this, renderFunction, container);
     }
 
-    private void Patch(VirtualNode? current, VirtualNode next, TNode container, TNode? anchor, string? elementNamespace)
+    /// <summary>
+    /// Creates the minimal application shell over this renderer (upstream:
+    /// <c>createAppAPI(render)</c>; see <see cref="VueApplication{TNode}"/>).
+    /// </summary>
+    /// <param name="rootComponent">The root component definition.</param>
+    /// <param name="rootProperties">Props for the root component, or null.</param>
+    /// <returns>The app; mount it into a container.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rootComponent"/> is null.</exception>
+    public VueApplication<TNode> CreateApplication(IComponentDefinition rootComponent, VirtualNodeProperties? rootProperties = null)
+    {
+        ArgumentNullException.ThrowIfNull(rootComponent);
+        return new VueApplication<TNode>(this, rootComponent, rootProperties);
+    }
+
+    private void Patch(
+        VirtualNode? current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
     {
         if (ReferenceEquals(current, next))
         {
@@ -103,14 +126,14 @@ public sealed class Renderer<TNode>
                 ProcessStatic(current, next, container, anchor, elementNamespace);
                 break;
             case VirtualNodeType.Fragment:
-                ProcessFragment(current, next, container, anchor, elementNamespace);
+                ProcessFragment(current, next, container, anchor, elementNamespace, parentComponent);
                 break;
             case VirtualNodeType.Element:
-                ProcessElement(current, next, container, anchor, elementNamespace);
+                ProcessElement(current, next, container, anchor, elementNamespace, parentComponent);
                 break;
             case VirtualNodeType.Component:
-                throw new NotSupportedException(
-                    "Component vnodes are not renderable yet — the component instance model lands with [V01.01.03.06].");
+                ProcessComponent(current, next, container, anchor, elementNamespace, parentComponent);
+                break;
             default:
                 throw new InvalidOperationException($"Unknown vnode type: {next.Type}.");
         }
@@ -120,7 +143,11 @@ public sealed class Renderer<TNode>
         => current.Type == next.Type
             && Equals(current.Key, next.Key)
             && (next.Type != VirtualNodeType.Element
-                || string.Equals(current.ElementTag, next.ElementTag, StringComparison.Ordinal));
+                || string.Equals(current.ElementTag, next.ElementTag, StringComparison.Ordinal))
+            && (next.Type != VirtualNodeType.Component
+                || ReferenceEquals(current.ComponentType, next.ComponentType));
+
+    // --- text / comment / static ---------------------------------------------------------------
 
     private void ProcessText(VirtualNode? current, VirtualNode next, TNode container, TNode? anchor)
     {
@@ -177,7 +204,15 @@ public sealed class Renderer<TNode>
         }
     }
 
-    private void ProcessFragment(VirtualNode? current, VirtualNode next, TNode container, TNode? anchor, string? elementNamespace)
+    // --- fragments -----------------------------------------------------------------------------
+
+    private void ProcessFragment(
+        VirtualNode? current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
     {
         if (current is null)
         {
@@ -188,17 +223,25 @@ public sealed class Renderer<TNode>
             next.Anchor = end;
             _options.Insert(start, container, anchor);
             _options.Insert(end, container, anchor);
-            MountChildren(next.ArrayChildren ?? [], container, end, elementNamespace);
+            MountChildren(next.ArrayChildren ?? [], container, end, elementNamespace, parentComponent);
         }
         else
         {
             next.El = current.El;
             next.Anchor = current.Anchor;
-            PatchChildren(current, next, container, (TNode)next.Anchor!, elementNamespace);
+            PatchChildren(current, next, container, (TNode)next.Anchor!, elementNamespace, parentComponent);
         }
     }
 
-    private void ProcessElement(VirtualNode? current, VirtualNode next, TNode container, TNode? anchor, string? elementNamespace)
+    // --- elements ------------------------------------------------------------------------------
+
+    private void ProcessElement(
+        VirtualNode? current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
     {
         // Namespace switching per upstream mountElement: an <svg>/<math> subtree switches
         // namespace; <foreignObject> children return to HTML (resolveChildrenNamespace).
@@ -213,15 +256,15 @@ public sealed class Renderer<TNode>
         }
         if (current is null)
         {
-            MountElement(next, container, anchor, elementNamespace);
+            MountElement(next, container, anchor, elementNamespace, parentComponent);
         }
         else
         {
-            PatchElement(current, next, elementNamespace);
+            PatchElement(current, next, elementNamespace, parentComponent);
         }
     }
 
-    private void MountElement(VirtualNode node, TNode container, TNode? anchor, string? elementNamespace)
+    private void MountElement(VirtualNode node, TNode container, TNode? anchor, string? elementNamespace, ComponentInstance? parentComponent)
     {
         var element = _options.CreateElement(node.ElementTag!, elementNamespace);
         node.El = element;
@@ -232,7 +275,7 @@ public sealed class Renderer<TNode>
         }
         else if ((node.ShapeFlag & ShapeFlags.ArrayChildren) != 0)
         {
-            MountChildren(node.ArrayChildren!, element, default, ChildrenNamespace(node, elementNamespace));
+            MountChildren(node.ArrayChildren!, element, default, ChildrenNamespace(node, elementNamespace), parentComponent);
         }
         if (node.Properties is not null)
         {
@@ -256,7 +299,7 @@ public sealed class Renderer<TNode>
         QueuePostHook(node, null, "onVnodeMounted");
     }
 
-    private void PatchElement(VirtualNode current, VirtualNode next, string? elementNamespace)
+    private void PatchElement(VirtualNode current, VirtualNode next, string? elementNamespace, ComponentInstance? parentComponent)
     {
         next.El = current.El;
         var element = (TNode)next.El!;
@@ -318,7 +361,7 @@ public sealed class Renderer<TNode>
         {
             // Unoptimized (or Bail): full props diff and full children diff.
             PatchProperties(element, next.ElementTag!, current.Properties, next.Properties, elementNamespace);
-            PatchChildren(current, next, element, default, ChildrenNamespace(next, elementNamespace));
+            PatchChildren(current, next, element, default, ChildrenNamespace(next, elementNamespace), parentComponent);
         }
         QueuePostHook(next, current, "onVnodeUpdated");
     }
@@ -365,7 +408,270 @@ public sealed class Renderer<TNode>
         }
     }
 
-    private void PatchChildren(VirtualNode current, VirtualNode next, TNode container, TNode? anchor, string? elementNamespace)
+    // --- components ([V01.01.03.06]) -----------------------------------------------------------
+
+    private void ProcessComponent(
+        VirtualNode? current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
+    {
+        if (current is null)
+        {
+            MountComponent(next, container, anchor, elementNamespace, parentComponent);
+        }
+        else
+        {
+            UpdateComponent(current, next);
+        }
+    }
+
+    private void MountComponent(VirtualNode next, TNode container, TNode? anchor, string? elementNamespace, ComponentInstance? parentComponent)
+    {
+        var definition = (IComponentDefinition)next.ComponentType!;
+        var instance = new ComponentInstance(definition, next, parentComponent);
+        next.Component = instance;
+        ComponentPropertyResolution.Resolve(instance, next);
+        SetupComponent(instance);
+        SetupComponentRenderEffect(instance, container, anchor, elementNamespace);
+    }
+
+    private static void SetupComponent(ComponentInstance instance)
+    {
+        // Setup runs exactly once per instance, with the instance current and inside its
+        // effect scope so created effects/computeds stop with the component (upstream parity).
+        var context = new ComponentSetupContext(instance);
+        instance.PushCurrent();
+        try
+        {
+            instance.RenderFunction = instance.Scope.Run(() => instance.Definition.Setup(instance.Properties, context));
+        }
+        catch (Exception exception)
+        {
+            ComponentErrorHandling.Handle(exception, instance, "setup function");
+        }
+        finally
+        {
+            instance.PopCurrent();
+        }
+        instance.RenderFunction ??= static () => null;
+    }
+
+    private void SetupComponentRenderEffect(ComponentInstance instance, TNode container, TNode? anchor, string? elementNamespace)
+    {
+        // The per-instance render effect (upstream: setupRenderEffect): invalidation enqueues
+        // a job carrying the instance uid, so parents flush before children; the effect
+        // registers with the instance scope so teardown stops it.
+        var job = new SchedulerJob(() => instance.Effect!.Run())
+        {
+            Identifier = instance.Uid,
+            AllowRecurse = true,
+            Name = instance.DisplayName,
+        };
+        instance.UpdateJob = job;
+        instance.Scope.Run(() =>
+        {
+            instance.Effect = new ReactiveEffect(() => ComponentUpdateFunction(instance, container, anchor, elementNamespace))
+            {
+                AllowRecurse = true,
+                Scheduler = () =>
+                {
+                    if (!instance.IsUnmounted)
+                    {
+                        Scheduler.QueueJob(job);
+                    }
+                },
+            };
+        });
+        instance.Effect!.Run();
+    }
+
+    private void ComponentUpdateFunction(ComponentInstance instance, TNode container, TNode? anchor, string? elementNamespace)
+    {
+        if (instance.IsUnmounted)
+        {
+            return;
+        }
+        if (!instance.IsMounted)
+        {
+            // Upstream toggleRecurse: hooks run with self-triggering off, render with it on.
+            instance.ToggleRecurse(false);
+            instance.InvokeHooks(LifecycleHookKind.BeforeMount);
+            instance.ToggleRecurse(true);
+            var subtree = RenderComponentRoot(instance);
+            instance.Subtree = subtree;
+            Patch(null, subtree, container, anchor, elementNamespace, instance);
+            instance.VirtualNode.El = subtree.El;
+            instance.VirtualNode.Anchor = subtree.Anchor;
+            instance.IsMounted = true;
+            QueueInstanceHooks(instance, LifecycleHookKind.Mounted);
+        }
+        else
+        {
+            // A parent-driven update carries the pending vnode; props re-resolve with
+            // self-triggering off so the write cannot requeue the running effect
+            // (upstream: toggleRecurse(false) around updateComponentPreRender + beforeUpdate).
+            instance.ToggleRecurse(false);
+            var pending = instance.NextVirtualNode;
+            if (pending is not null)
+            {
+                instance.NextVirtualNode = null;
+                pending.Component = instance;
+                instance.VirtualNode = pending;
+                ComponentPropertyResolution.Resolve(instance, pending);
+            }
+            instance.InvokeHooks(LifecycleHookKind.BeforeUpdate);
+            instance.ToggleRecurse(true);
+            var previous = instance.Subtree!;
+            var nextTree = RenderComponentRoot(instance);
+            instance.Subtree = nextTree;
+            var hostParent = _options.ParentNode((TNode)previous.El!);
+            Patch(previous, nextTree, hostParent!, GetNextHostNode(previous), elementNamespace, instance);
+            instance.VirtualNode.El = nextTree.El;
+            instance.VirtualNode.Anchor = nextTree.Anchor;
+            QueueInstanceHooks(instance, LifecycleHookKind.Updated);
+        }
+    }
+
+    private static VirtualNode RenderComponentRoot(ComponentInstance instance)
+    {
+        // Upstream renderComponentRoot: run the render function with the instance current,
+        // normalize, and apply single-element-root attrs fallthrough via mergeProps.
+        VirtualNode? root = null;
+        instance.PushCurrent();
+        try
+        {
+            root = instance.RenderFunction!();
+        }
+        catch (Exception exception)
+        {
+            ComponentErrorHandling.Handle(exception, instance, "render function");
+        }
+        finally
+        {
+            instance.PopCurrent();
+        }
+        var normalized = VirtualNodeFactory.Normalize(root);
+        if (instance.Definition.InheritAttributes
+            && instance.Attributes.Count > 0
+            && normalized.Type == VirtualNodeType.Element)
+        {
+            normalized = VirtualNodeFactory.Clone(normalized, instance.Attributes.ToProperties());
+        }
+        return normalized;
+    }
+
+    private void UpdateComponent(VirtualNode current, VirtualNode next)
+    {
+        var instance = (ComponentInstance)current.Component!;
+        if (ShouldUpdateComponent(current, next))
+        {
+            // Cancel any queued reactive update and re-render synchronously with the pending
+            // vnode (upstream: invalidateJob + instance.update()).
+            instance.NextVirtualNode = next;
+            Scheduler.InvalidateJob(instance.UpdateJob!);
+            instance.Effect!.Run();
+        }
+        else
+        {
+            // Nothing relevant changed: adopt the new vnode without re-rendering.
+            next.El = current.El;
+            next.Anchor = current.Anchor;
+            next.Component = instance;
+            instance.VirtualNode = next;
+        }
+    }
+
+    private static bool ShouldUpdateComponent(VirtualNode current, VirtualNode next)
+    {
+        // Upstream shouldUpdateComponent, minus slots (which land with [V01.01.03.09]).
+        var previousProperties = current.Properties;
+        var nextProperties = next.Properties;
+        if (ReferenceEquals(previousProperties, nextProperties))
+        {
+            return false;
+        }
+        if ((int)next.PatchFlag > 0
+            && (next.PatchFlag & PatchFlags.Props) != 0
+            && next.DynamicProperties is not null)
+        {
+            foreach (var name in next.DynamicProperties)
+            {
+                object? previousValue = null;
+                object? nextValue = null;
+                previousProperties?.TryGetValue(name, out previousValue);
+                nextProperties?.TryGetValue(name, out nextValue);
+                if (!Equals(previousValue, nextValue))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (previousProperties is null)
+        {
+            return nextProperties is not null && nextProperties.Count > 0;
+        }
+        if (nextProperties is null)
+        {
+            return true;
+        }
+        if (previousProperties.Count != nextProperties.Count)
+        {
+            return true;
+        }
+        foreach (var (name, nextValue) in nextProperties)
+        {
+            if (!previousProperties.TryGetValue(name, out var previousValue) || !Equals(previousValue, nextValue))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void UnmountComponent(VirtualNode node, bool doRemove)
+    {
+        var instance = (ComponentInstance)node.Component!;
+        // Teardown order (upstream parity): BeforeUnmount parent-first, then effects/scope,
+        // then the subtree, then Unmounted queued post-flush (children queue theirs first, so
+        // the stable post-flush order runs them child-first).
+        instance.InvokeHooks(LifecycleHookKind.BeforeUnmount);
+        if (instance.UpdateJob is not null)
+        {
+            instance.UpdateJob.IsDisposed = true;
+        }
+        instance.Scope.Stop();
+        if (instance.Subtree is not null)
+        {
+            Unmount(instance.Subtree, doRemove);
+        }
+        instance.IsUnmounted = true;
+        QueueInstanceHooks(instance, LifecycleHookKind.Unmounted);
+    }
+
+    private static void QueueInstanceHooks(ComponentInstance instance, LifecycleHookKind kind)
+    {
+        if (!instance.HasHooks(kind))
+        {
+            return;
+        }
+        // Post-flush phase (upstream: queuePostRenderEffect); stable ordering keeps
+        // child-before-parent for Mounted/Unmounted.
+        Scheduler.QueuePostFlushCallback(new SchedulerJob(() => instance.InvokeHooks(kind)));
+    }
+
+    // --- children ------------------------------------------------------------------------------
+
+    private void PatchChildren(
+        VirtualNode current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
     {
         var previousShape = current.ShapeFlag;
         var nextShape = next.ShapeFlag;
@@ -385,7 +691,7 @@ public sealed class Renderer<TNode>
         {
             if ((nextShape & ShapeFlags.ArrayChildren) != 0)
             {
-                PatchUnkeyedChildren(current.ArrayChildren!, next.ArrayChildren!, container, anchor, elementNamespace);
+                PatchUnkeyedChildren(current.ArrayChildren!, next.ArrayChildren!, container, anchor, elementNamespace, parentComponent);
             }
             else
             {
@@ -400,12 +706,18 @@ public sealed class Renderer<TNode>
             }
             if ((nextShape & ShapeFlags.ArrayChildren) != 0)
             {
-                MountChildren(next.ArrayChildren!, container, anchor, elementNamespace);
+                MountChildren(next.ArrayChildren!, container, anchor, elementNamespace, parentComponent);
             }
         }
     }
 
-    private void PatchUnkeyedChildren(VirtualNode[] previousChildren, VirtualNode[] nextChildren, TNode container, TNode? anchor, string? elementNamespace)
+    private void PatchUnkeyedChildren(
+        VirtualNode[] previousChildren,
+        VirtualNode[] nextChildren,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
     {
         // Positional diff (upstream patchUnkeyedChildren). Keyed minimal-move reordering lands
         // with [V01.01.03.03]; a positional key mismatch still replaces correctly via the
@@ -414,7 +726,7 @@ public sealed class Renderer<TNode>
         for (var index = 0; index < commonLength; index++)
         {
             var nextChild = nextChildren[index] = VirtualNodeFactory.Normalize(nextChildren[index]);
-            Patch(previousChildren[index], nextChild, container, anchor, elementNamespace);
+            Patch(previousChildren[index], nextChild, container, anchor, elementNamespace, parentComponent);
         }
         if (previousChildren.Length > nextChildren.Length)
         {
@@ -422,18 +734,24 @@ public sealed class Renderer<TNode>
         }
         else
         {
-            MountChildren(nextChildren, container, anchor, elementNamespace, startIndex: commonLength);
+            MountChildren(nextChildren, container, anchor, elementNamespace, parentComponent, startIndex: commonLength);
         }
     }
 
-    private void MountChildren(VirtualNode[] children, TNode container, TNode? anchor, string? elementNamespace, int startIndex = 0)
+    private void MountChildren(
+        VirtualNode[] children,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent,
+        int startIndex = 0)
     {
         for (var index = startIndex; index < children.Length; index++)
         {
             // Normalized in place so the array holds the mounted instances (upstream write-back
             // in mountChildren; cloning protects an already-mounted reused vnode's El).
             var child = children[index] = VirtualNodeFactory.Normalize(children[index]);
-            Patch(null, child, container, anchor, elementNamespace);
+            Patch(null, child, container, anchor, elementNamespace, parentComponent);
         }
     }
 
@@ -451,6 +769,9 @@ public sealed class Renderer<TNode>
         InvokeHook(node, null, "onVnodeBeforeUnmount");
         switch (node.Type)
         {
+            case VirtualNodeType.Component:
+                UnmountComponent(node, doRemove);
+                break;
             case VirtualNodeType.Fragment:
                 // Children tear down without individual removals; the fragment range removal
                 // below takes their nodes out in one anchored walk.
@@ -512,6 +833,11 @@ public sealed class Renderer<TNode>
 
     private TNode? GetNextHostNode(VirtualNode node)
     {
+        if (node.Type == VirtualNodeType.Component)
+        {
+            var instance = (ComponentInstance)node.Component!;
+            return instance.Subtree is null ? default : GetNextHostNode(instance.Subtree);
+        }
         if (node.Type is VirtualNodeType.Fragment or VirtualNodeType.Static)
         {
             return node.Anchor is null ? default : _options.NextSibling((TNode)node.Anchor);

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
@@ -33,6 +33,7 @@ public static class Scheduler
     private static bool _isFlushing;
     private static bool _isFlushPending;
     private static TaskCompletionSource? _flushCompletion;
+    private static long _nextInsertionSequence;
 
     /// <summary>
     /// Test seam: when set, scheduled flushes are handed to this dispatcher instead of the
@@ -81,6 +82,7 @@ public static class Scheduler
         {
             return;
         }
+        callback.InsertionSequence = _nextInsertionSequence++;
         _pendingPostFlushCallbacks.Add(callback);
         callback.Flags |= SchedulerJobFlags.Queued;
         ScheduleFlush();
@@ -93,6 +95,22 @@ public static class Scheduler
     /// </summary>
     public static Task NextTick()
         => _flushCompletion?.Task ?? Task.CompletedTask;
+
+    /// <summary>
+    /// Removes a not-yet-flushed job from the queue (upstream: <c>invalidateJob</c>) — a
+    /// parent-driven component update runs the effect synchronously and must cancel the
+    /// reactive update queued for the same instance.
+    /// </summary>
+    /// <param name="job">The job to remove.</param>
+    internal static void InvalidateJob(SchedulerJob job)
+    {
+        var index = _queue.IndexOf(job);
+        if (index > _flushIndex)
+        {
+            _queue.RemoveAt(index);
+            job.Flags &= ~SchedulerJobFlags.Queued;
+        }
+    }
 
     /// <summary>
     /// Runs queued pre-flush jobs immediately, in queue order (upstream:
@@ -136,7 +154,13 @@ public static class Scheduler
                 return;
             }
             _activePostFlushCallbacks = callbacks;
-            callbacks.Sort(static (left, right) => left.OrderKey.CompareTo(right.OrderKey));
+            // Stable id ordering (JS sort is spec-stable; List<T>.Sort is not): equal-id
+            // callbacks keep insertion order, which is what makes Mounted fire child-first.
+            callbacks.Sort(static (left, right) =>
+            {
+                var byOrder = left.OrderKey.CompareTo(right.OrderKey);
+                return byOrder != 0 ? byOrder : left.InsertionSequence.CompareTo(right.InsertionSequence);
+            });
             try
             {
                 for (_postFlushIndex = 0; _postFlushIndex < _activePostFlushCallbacks.Count; _postFlushIndex++)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/SchedulerJob.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/SchedulerJob.cs
@@ -50,7 +50,7 @@ public sealed class SchedulerJob
     public bool AllowRecurse
     {
         get => (Flags & SchedulerJobFlags.AllowRecurse) != 0;
-        init => Flags = value ? Flags | SchedulerJobFlags.AllowRecurse : Flags & ~SchedulerJobFlags.AllowRecurse;
+        set => Flags = value ? Flags | SchedulerJobFlags.AllowRecurse : Flags & ~SchedulerJobFlags.AllowRecurse;
     }
 
     /// <summary>
@@ -66,6 +66,11 @@ public sealed class SchedulerJob
     internal SchedulerJobFlags Flags;
 
     internal int ExecutionsInCurrentFlushCycle;
+
+    // Queue-assigned tiebreak so equal-id post-flush callbacks keep insertion order (JS array
+    // sort is spec-stable; List<T>.Sort is not — child-before-parent Mounted ordering depends
+    // on this).
+    internal long InsertionSequence;
 
     /// <summary>
     /// The sort key: <see cref="Identifier"/> (null last) with pre-flush jobs ordered before

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -148,6 +148,46 @@ public static class VirtualNodeFactory
         };
     }
 
+    /// <summary>
+    /// Creates a component vnode (upstream: <c>createVNode(Component, props)</c>). The
+    /// renderer instantiates a <see cref="ComponentInstance"/> for it on mount; declared props
+    /// resolve from <paramref name="properties"/> and the rest falls through as attrs
+    /// ([V01.01.03.07]).
+    /// </summary>
+    /// <param name="definition">The component definition.</param>
+    /// <param name="properties">The props passed by the parent, or null.</param>
+    public static VirtualNode Component(IComponentDefinition definition, VirtualNodeProperties? properties = null)
+        => Component(definition, properties, default, null);
+
+    /// <summary>
+    /// Creates a compiler-shaped component vnode carrying patch hints: with
+    /// <see cref="PatchFlags.Props"/> and <paramref name="dynamicProperties"/>, the parent
+    /// update compares only the listed props to decide whether the child re-renders
+    /// (upstream: <c>shouldUpdateComponent</c>'s optimized path).
+    /// </summary>
+    /// <param name="definition">The component definition.</param>
+    /// <param name="properties">The props passed by the parent, or null.</param>
+    /// <param name="patchFlag">The compiler patch hint.</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode Component(
+        IComponentDefinition definition,
+        VirtualNodeProperties? properties,
+        PatchFlags patchFlag,
+        string[]? dynamicProperties)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        return new VirtualNode(VirtualNodeType.Component)
+        {
+            ComponentType = definition,
+            Properties = properties,
+            Key = ExtractKey(properties),
+            Reference = ExtractReference(properties),
+            ShapeFlag = ShapeFlags.StatefulComponent,
+            PatchFlag = patchFlag,
+            DynamicProperties = dynamicProperties,
+        };
+    }
+
     /// <summary>Creates a fragment vnode wrapping multiple root nodes.</summary>
     /// <param name="children">The children; null entries become comment placeholders.</param>
     public static VirtualNode Fragment(params VirtualNode?[]? children)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VueApplication{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VueApplication{TNode}.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The minimal application shell — the C# port of the app object produced by
+/// <c>createAppAPI(render)</c> in <c>@vue/runtime-core</c>
+/// (<c>packages/runtime-core/src/apiCreateApp.ts</c>, https://vuejs.org/api/application.html):
+/// one root component mounted into one container, unmounted as a whole. Plugins, app-level
+/// provides, and error-handler configuration land with [V01.01.03.12]. Platform packages wrap
+/// this with container resolution (the browser's <c>CreateApp(...).Mount("#app")</c> is
+/// [V01.01.04.04]). Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+/// <typeparam name="TNode">The platform node type.</typeparam>
+public sealed class VueApplication<TNode>
+    where TNode : notnull
+{
+    private readonly Renderer<TNode> _renderer;
+    private readonly IComponentDefinition _rootComponent;
+    private readonly VirtualNodeProperties? _rootProperties;
+    private VirtualNode? _rootVirtualNode;
+    private TNode? _container;
+
+    internal VueApplication(Renderer<TNode> renderer, IComponentDefinition rootComponent, VirtualNodeProperties? rootProperties)
+    {
+        _renderer = renderer;
+        _rootComponent = rootComponent;
+        _rootProperties = rootProperties;
+    }
+
+    /// <summary>Whether the app is currently mounted.</summary>
+    public bool IsMounted { get; private set; }
+
+    /// <summary>The root component instance after mounting, or null.</summary>
+    public ComponentInstance? RootInstance => _rootVirtualNode?.Component as ComponentInstance;
+
+    /// <summary>
+    /// Mounts the root component into <paramref name="container"/> (upstream:
+    /// <c>app.mount</c>). A second call warns and no-ops, returning the existing instance
+    /// (upstream parity).
+    /// </summary>
+    /// <param name="container">The platform container node.</param>
+    /// <returns>The root component instance.</returns>
+    public ComponentInstance? Mount(TNode container)
+    {
+        if (IsMounted)
+        {
+            RuntimeWarnings.Warn(
+                "App has already been mounted. Create a new app instance to mount again, or call Unmount() first.");
+            return RootInstance;
+        }
+        _rootVirtualNode = VirtualNodeFactory.Component(_rootComponent, _rootProperties);
+        _renderer.Render(_rootVirtualNode, container);
+        _container = container;
+        IsMounted = true;
+        return RootInstance;
+    }
+
+    /// <summary>
+    /// Unmounts the app (upstream: <c>app.unmount</c>): runs the component teardown
+    /// lifecycles and removes the rendered tree from the container.
+    /// </summary>
+    public void Unmount()
+    {
+        if (!IsMounted)
+        {
+            return;
+        }
+        _renderer.Render(null, _container!);
+        _rootVirtualNode = null;
+        _container = default;
+        IsMounted = false;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/ComponentEmitTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/ComponentEmitTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the component event contract of @vue/runtime-core's componentEmits.ts —
+// https://vuejs.org/guide/components/events.html and /guide/components/v-model.html.
+public class ComponentEmitTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public ComponentEmitTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private ComponentSetupContext MountAndCaptureContext(TestComponent component, VirtualNodeProperties? componentProperties)
+    {
+        ComponentSetupContext? context = null;
+        var capturing = new TestComponent
+        {
+            Name = component.Name,
+            Properties = component.Properties,
+            Emits = component.Emits,
+            SetupFunction = (properties, setupContext) =>
+            {
+                context = setupContext;
+                return component.SetupFunction(properties, setupContext);
+            },
+        };
+        _renderer.Render(
+            VirtualNodeFactory.Element("main", VirtualNodeFactory.Component(capturing, componentProperties)),
+            _container);
+        return context!;
+    }
+
+    [Fact]
+    public void Emit_InvokesTheMatchingHandlerProp_WithArguments()
+    {
+        object? received = null;
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("change")],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var context = MountAndCaptureContext(child, VirtualNodeFactory.Properties(
+            ("onChange", (Action<object?>)(value => received = value))));
+
+        context.Emit("change", 42);
+
+        received.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Emit_KebabCaseEventMatchesCamelCaseHandler()
+    {
+        var calls = 0;
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("item-selected")],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var context = MountAndCaptureContext(child, VirtualNodeFactory.Properties(
+            ("onItemSelected", (Action)(() => calls++))));
+
+        context.Emit("item-selected");
+
+        calls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Emit_SupportsSpreadArgumentHandlers()
+    {
+        object?[]? received = null;
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("move")],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var context = MountAndCaptureContext(child, VirtualNodeFactory.Properties(
+            ("onMove", (Action<object?[]>)(arguments => received = arguments))));
+
+        context.Emit("move", 3, 4);
+
+        received.ShouldBe(new object?[] { 3, 4 });
+    }
+
+    [Fact]
+    public void UpdateModelValue_RoundTrips_TheVModelContract()
+    {
+        // The runtime half of v-model: emitting update:modelValue invokes onUpdate:modelValue.
+        object? updated = null;
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("update:modelValue")],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var context = MountAndCaptureContext(child, VirtualNodeFactory.Properties(
+            ("onUpdate:modelValue", (Action<object?>)(value => updated = value))));
+
+        context.Emit("update:modelValue", "typed");
+
+        updated.ShouldBe("typed");
+    }
+
+    [Fact]
+    public void OnceHandlers_FireExactlyOncePerInstance_AcrossReRenders()
+    {
+        var onceCalls = 0;
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("save")],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var revision = Reactive.Reference(0);
+        ComponentSetupContext? context = null;
+        var capturing = new TestComponent
+        {
+            Emits = child.Emits,
+            SetupFunction = (properties, setupContext) =>
+            {
+                context = setupContext;
+                return static () => VirtualNodeFactory.Text("child");
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Text(revision.Value.ToString()),
+                VirtualNodeFactory.Component(capturing, VirtualNodeFactory.Properties(
+                    ("onSaveOnce", (Action)(() => onceCalls++)),
+                    ("revision", revision.Value)))),
+        };
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+
+        context!.Emit("save");
+        context.Emit("save");
+        onceCalls.ShouldBe(1);
+
+        // Re-render the parent (new handler prop instance) — once-tracking is per component
+        // instance, not per render (upstream emitted-tracking parity).
+        revision.Value = 1;
+        _pump.RunUntilIdle();
+        context.Emit("save");
+
+        onceCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UndeclaredEmit_Warns_AndValidatorFailuresWarn()
+    {
+        using var warnings = new WarningCapture();
+        var child = new TestComponent
+        {
+            Name = "Emitter",
+            Emits =
+            [
+                new ComponentEmitDefinition("valid") { Validator = arguments => arguments.Length == 1 },
+            ],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+        var context = MountAndCaptureContext(child, null);
+
+        context.Emit("undeclared");
+        context.Emit("valid"); // zero args → validator false
+
+        warnings.Messages.ShouldContain(message =>
+            message.Contains("undeclared") && message.Contains("Emitter"));
+        warnings.Messages.ShouldContain(message =>
+            message.Contains("event validation failed") && message.Contains("valid"));
+    }
+
+    [Fact]
+    public void DeclaredEmitHandlers_AreExcludedFromAttrsFallthrough()
+    {
+        var child = new TestComponent
+        {
+            Emits = [new ComponentEmitDefinition("save")],
+            SetupFunction = static (_, _) => static () =>
+                VirtualNodeFactory.Element("button", "press"),
+        };
+
+        _renderer.Render(
+            VirtualNodeFactory.Element(
+                "main",
+                VirtualNodeFactory.Component(child, VirtualNodeFactory.Properties(
+                    ("onSave", (Action)(() => { })),
+                    ("onSaveOnce", (Action)(() => { })),
+                    ("data-keep", "yes")))),
+            _container);
+
+        var main = (TestElement)_container.Children[0];
+        var button = (TestElement)main.Children[0];
+        // The declared emit's handlers did NOT fall through; the plain attribute did.
+        button.Properties.ContainsKey("onSave").ShouldBeFalse();
+        button.Properties.ContainsKey("onSaveOnce").ShouldBeFalse();
+        button.Properties["data-keep"].ShouldBe("yes");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/ComponentInstanceTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/ComponentInstanceTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the component instance + Setup contract of @vue/runtime-core's component.ts —
+// https://vuejs.org/api/composition-api-setup.html. Run counts asserted throughout: Setup runs
+// once per instance; the returned render function re-executes per update.
+public class ComponentInstanceTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public ComponentInstanceTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void Component_MountsThroughTheRenderer_AndSetupRunsExactlyOnce()
+    {
+        var setupRuns = 0;
+        var renderRuns = 0;
+        var message = Reactive.Reference("first");
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                setupRuns++;
+                return () =>
+                {
+                    renderRuns++;
+                    return VirtualNodeFactory.Element("div", message.Value);
+                };
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>first</div></root>");
+        setupRuns.ShouldBe(1);
+        renderRuns.ShouldBe(1);
+
+        message.Value = "second";
+        _pump.RunUntilIdle();
+
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>second</div></root>");
+        setupRuns.ShouldBe(1); // never re-runs
+        renderRuns.ShouldBe(2); // the render function re-executes per update
+    }
+
+    [Fact]
+    public void CurrentInstance_IsCorrectDuringNestedSetups_AndNullOutside()
+    {
+        ComponentInstance? parentDuringSetup = null;
+        ComponentInstance? childDuringSetup = null;
+        ComponentInstance? parentAfterChildMount = null;
+
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                childDuringSetup = ComponentInstance.Current;
+                return static () => VirtualNodeFactory.Element("span", "child");
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                parentDuringSetup = ComponentInstance.Current;
+                return () =>
+                {
+                    var tree = VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(child));
+                    parentAfterChildMount = ComponentInstance.Current;
+                    return tree;
+                };
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+
+        parentDuringSetup.ShouldNotBeNull();
+        childDuringSetup.ShouldNotBeNull();
+        childDuringSetup.ShouldNotBeSameAs(parentDuringSetup);
+        childDuringSetup.Parent.ShouldBeSameAs(parentDuringSetup);
+        childDuringSetup.Root.ShouldBeSameAs(parentDuringSetup);
+        parentAfterChildMount.ShouldBeSameAs(parentDuringSetup); // stack restored around child
+        ComponentInstance.Current.ShouldBeNull(); // null outside setup/lifecycle
+    }
+
+    [Fact]
+    public void CurrentInstance_IsRestoredWhenSetupThrows()
+    {
+        var throwing = new TestComponent
+        {
+            SetupFunction = (_, _) => throw new InvalidOperationException("setup boom"),
+        };
+
+        Should.Throw<InvalidOperationException>(
+            () => _renderer.Render(VirtualNodeFactory.Component(throwing), _container));
+
+        ComponentInstance.Current.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Uids_AreCreationOrdered_ParentBeforeChild()
+    {
+        ComponentInstance? parentInstance = null;
+        ComponentInstance? childInstance = null;
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                childInstance = ComponentInstance.Current;
+                return static () => VirtualNodeFactory.Text("child");
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                parentInstance = ComponentInstance.Current;
+                return () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(child));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+
+        parentInstance!.Uid.ShouldBeLessThan(childInstance!.Uid);
+    }
+
+    [Fact]
+    public void Expose_RestrictsWhatTheInstanceSurfaces()
+    {
+        var exposed = new Dictionary<string, object?> { ["focus"] = (Action)(() => { }) };
+        ComponentInstance? instance = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, context) =>
+            {
+                context.Expose(exposed);
+                instance = ComponentInstance.Current;
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        instance!.Exposed.ShouldBeSameAs(exposed);
+    }
+
+    [Fact]
+    public void InstanceState_TracksMountAndUnmount()
+    {
+        ComponentInstance? instance = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                instance = ComponentInstance.Current;
+                return static () => VirtualNodeFactory.Element("div", "content");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        instance!.IsMounted.ShouldBeTrue();
+        instance.IsUnmounted.ShouldBeFalse();
+        instance.Subtree.ShouldNotBeNull();
+        instance.VirtualNode.El.ShouldNotBeNull(); // vnode el points at the subtree root
+
+        _renderer.Render(null, _container);
+        instance.IsUnmounted.ShouldBeTrue();
+        _container.Children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void UnmountingAComponent_StopsItsSetupEffects()
+    {
+        var source = Reactive.Reference(0);
+        var effectRuns = 0;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Reactive.Effect(() =>
+                {
+                    _ = source.Value;
+                    effectRuns++;
+                });
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        effectRuns.ShouldBe(1);
+
+        _renderer.Render(null, _container);
+        source.Value = 42;
+        _pump.RunUntilIdle();
+
+        effectRuns.ShouldBe(1); // the instance scope stopped the setup effect
+    }
+
+    [Fact]
+    public void ParentDrivenUpdate_ReusesTheInstance_AndSkipsWhenPropsUnchanged()
+    {
+        var setupRuns = 0;
+        var childRenderRuns = 0;
+        var child = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("label")],
+            SetupFunction = (properties, _) =>
+            {
+                setupRuns++;
+                return () =>
+                {
+                    childRenderRuns++;
+                    return VirtualNodeFactory.Element("span", (string?)properties["label"] ?? "none");
+                };
+            },
+        };
+        var parentMessage = Reactive.Reference("a");
+        var childLabel = Reactive.Reference("one");
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Text(parentMessage.Value),
+                VirtualNodeFactory.Component(child, VirtualNodeFactory.Properties(("label", childLabel.Value)))),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>a<span>one</span></div></root>");
+        childRenderRuns.ShouldBe(1);
+
+        // Parent re-renders with an UNCHANGED child prop: the child must not re-render.
+        parentMessage.Value = "b";
+        _pump.RunUntilIdle();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>b<span>one</span></div></root>");
+        setupRuns.ShouldBe(1);
+        childRenderRuns.ShouldBe(1);
+
+        // Parent re-renders with a CHANGED child prop: the child re-renders once.
+        childLabel.Value = "two";
+        _pump.RunUntilIdle();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>b<span>two</span></div></root>");
+        setupRuns.ShouldBe(1);
+        childRenderRuns.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ComponentRoots_CanBeFragments()
+    {
+        var component = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Fragment(
+                VirtualNodeFactory.Element("span", "a"),
+                VirtualNodeFactory.Element("span", "b")),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><span>a</span><span>b</span></root>");
+
+        _renderer.Render(null, _container);
+        _container.Children.ShouldBeEmpty(); // fragment range + anchors fully removed
+    }
+
+    [Fact]
+    public void SiblingReplacement_KeepsComponentPosition()
+    {
+        var componentA = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Element("span", "A"),
+        };
+        var componentB = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Element("span", "B"),
+        };
+
+        _renderer.Render(
+            VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Text("start"),
+                VirtualNodeFactory.Component(componentA),
+                VirtualNodeFactory.Text("end")),
+            _container);
+        _renderer.Render(
+            VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Text("start"),
+                VirtualNodeFactory.Component(componentB),
+                VirtualNodeFactory.Text("end")),
+            _container);
+
+        // A different component definition replaces in place, between its siblings.
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>start<span>B</span>end</div></root>");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/ComponentLifecycleTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/ComponentLifecycleTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the Composition API lifecycle contract of @vue/runtime-core's apiLifecycle.ts and
+// errorHandling.ts — https://vuejs.org/api/composition-api-lifecycle.html. Ordering matrices
+// asserted as event lists.
+public class ComponentLifecycleTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+    private readonly List<string> _events = [];
+
+    public ComponentLifecycleTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private TestComponent HookedComponent(string name, Func<VirtualNode?> render, TestComponent? childToRender = null)
+        => new()
+        {
+            Name = name,
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnBeforeMount(() => _events.Add($"{name}:beforeMount"));
+                Lifecycle.OnMounted(() => _events.Add($"{name}:mounted"));
+                Lifecycle.OnBeforeUpdate(() => _events.Add($"{name}:beforeUpdate"));
+                Lifecycle.OnUpdated(() => _events.Add($"{name}:updated"));
+                Lifecycle.OnBeforeUnmount(() => _events.Add($"{name}:beforeUnmount"));
+                Lifecycle.OnUnmounted(() => _events.Add($"{name}:unmounted"));
+                return childToRender is null
+                    ? render
+                    : () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(childToRender));
+            },
+        };
+
+    [Fact]
+    public void MountOrdering_BeforeMountParentFirst_MountedChildFirst()
+    {
+        var child = HookedComponent("child", static () => VirtualNodeFactory.Element("span", "c"));
+        var parent = HookedComponent("parent", static () => null, child);
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+
+        _events.ShouldBe(
+        [
+            "parent:beforeMount",
+            "child:beforeMount",
+            "child:mounted",   // post-flush, child before parent (stable queue order)
+            "parent:mounted",
+        ]);
+    }
+
+    [Fact]
+    public void UnmountOrdering_BeforeUnmountParentFirst_UnmountedChildFirst()
+    {
+        var child = HookedComponent("child", static () => VirtualNodeFactory.Element("span", "c"));
+        var parent = HookedComponent("parent", static () => null, child);
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        _events.Clear();
+
+        _renderer.Render(null, _container);
+
+        _events.ShouldBe(
+        [
+            "parent:beforeUnmount",
+            "child:beforeUnmount",
+            "child:unmounted",
+            "parent:unmounted",
+        ]);
+    }
+
+    [Fact]
+    public void UpdateHooks_WrapThePatch_BeforeUpdateSeesPrePatchState()
+    {
+        var message = Reactive.Reference("one");
+        string? subtreeTextDuringBeforeUpdate = null;
+        TestElement? rootElement = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnBeforeUpdate(() =>
+                {
+                    // Pre-patch: the host still shows the previous render's content.
+                    subtreeTextDuringBeforeUpdate = ((TestText)rootElement!.Children[0]).Text;
+                    _events.Add("beforeUpdate");
+                });
+                Lifecycle.OnUpdated(() =>
+                {
+                    _events.Add($"updated:{((TestText)rootElement!.Children[0]).Text}");
+                });
+                return () => VirtualNodeFactory.Element("div", message.Value);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        rootElement = (TestElement)_container.Children[0];
+
+        message.Value = "two";
+        _pump.RunUntilIdle();
+
+        subtreeTextDuringBeforeUpdate.ShouldBe("one");
+        _events.ShouldBe(["beforeUpdate", "updated:two"]); // Updated observes the patched host
+    }
+
+    [Fact]
+    public void MultipleRegistrations_RunInRegistrationOrder()
+    {
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnMounted(() => _events.Add("first"));
+                Lifecycle.OnMounted(() => _events.Add("second"));
+                Lifecycle.OnMounted(() => _events.Add("third"));
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        _events.ShouldBe(["first", "second", "third"]);
+    }
+
+    [Fact]
+    public void RegisteringOutsideAnActiveInstance_WarnsAndIgnores()
+    {
+        using var warnings = new WarningCapture();
+
+        Lifecycle.OnMounted(() => _events.Add("never"));
+
+        warnings.Messages.ShouldContain(message => message.Contains("no active component instance"));
+        _events.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void UnmountedInstances_NeverFireFurtherUpdateHooks()
+    {
+        var message = Reactive.Reference("alive");
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnBeforeUpdate(() => _events.Add("beforeUpdate"));
+                Lifecycle.OnUpdated(() => _events.Add("updated"));
+                return () => VirtualNodeFactory.Element("div", message.Value);
+            },
+        };
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+        _renderer.Render(null, _container);
+
+        message.Value = "after-unmount";
+        _pump.RunUntilIdle();
+
+        _events.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void OnErrorCaptured_ReceivesDescendantErrors_UpTheChain()
+    {
+        Exception? seen = null;
+        ComponentInstance? seenSource = null;
+        string? seenInfo = null;
+        ComponentInstance? childInstance = null;
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                childInstance = ComponentInstance.Current;
+                Lifecycle.OnMounted(static () => throw new InvalidOperationException("hook boom"));
+                return static () => VirtualNodeFactory.Text("c");
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnErrorCaptured((exception, source, info) =>
+                {
+                    seen = exception;
+                    seenSource = source;
+                    seenInfo = info;
+                    return false; // stop propagation
+                });
+                return () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(child));
+            },
+        };
+
+        Should.NotThrow(() => _renderer.Render(VirtualNodeFactory.Component(parent), _container));
+
+        seen.ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("hook boom");
+        seenSource.ShouldBeSameAs(childInstance);
+        seenInfo.ShouldNotBeNull();
+        seenInfo.ShouldContain("Mounted");
+    }
+
+    [Fact]
+    public void OnErrorCaptured_ReturningTrue_PropagatesToTheNextAncestor()
+    {
+        var order = new List<string>();
+        var child = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => throw new InvalidOperationException("render boom"),
+        };
+        var middle = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnErrorCaptured((_, _, _) =>
+                {
+                    order.Add("middle");
+                    return true; // keep propagating
+                });
+                return () => VirtualNodeFactory.Element("section", VirtualNodeFactory.Component(child));
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnErrorCaptured((_, _, _) =>
+                {
+                    order.Add("root");
+                    return false;
+                });
+                return () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(middle));
+            },
+        };
+
+        Should.NotThrow(() => _renderer.Render(VirtualNodeFactory.Component(root), _container));
+
+        order.ShouldBe(["middle", "root"]);
+    }
+
+    [Fact]
+    public void UnhandledDescendantErrors_SurfaceToTheHost()
+    {
+        var child = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => throw new InvalidOperationException("unhandled boom"),
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(child)),
+        };
+
+        Should.Throw<InvalidOperationException>(
+                () => _renderer.Render(VirtualNodeFactory.Component(parent), _container))
+            .Message.ShouldBe("unhandled boom");
+    }
+
+    [Fact]
+    public void ActivatedDeactivatedAndServerPrefetch_RegisterOnTheInstance()
+    {
+        ComponentInstance? instance = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                instance = ComponentInstance.Current;
+                Lifecycle.OnActivated(() => { });
+                Lifecycle.OnDeactivated(() => { });
+                Lifecycle.OnServerPrefetch(static () => System.Threading.Tasks.Task.CompletedTask);
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        // Stored for KeepAlive ([V01.01.03.18]) and the server renderer ([V01.01.07.01]);
+        // client-only rendering never invokes them.
+        instance!.HasHooks(LifecycleHookKind.Activated).ShouldBeTrue();
+        instance.HasHooks(LifecycleHookKind.Deactivated).ShouldBeTrue();
+        instance.HasHooks(LifecycleHookKind.ServerPrefetch).ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/ComponentPropertiesTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/ComponentPropertiesTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the props subsystem of @vue/runtime-core's componentProps.ts —
+// https://vuejs.org/guide/components/props.html and /guide/components/attrs.html.
+public class ComponentPropertiesTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public ComponentPropertiesTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private void Mount(IComponentDefinition component, VirtualNodeProperties? properties = null)
+        => _renderer.Render(VirtualNodeFactory.Component(component, properties), _container);
+
+    [Fact]
+    public void DeclaredProps_ResolveWithCamelAndKebabCaseEquivalence()
+    {
+        string? camelSeen = null;
+        string? kebabSeen = null;
+        var component = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("modelValue"), new ComponentPropertyDefinition("itemCount")],
+            SetupFunction = (properties, _) => () =>
+            {
+                camelSeen = (string?)properties["modelValue"];
+                kebabSeen = (string?)properties["itemCount"];
+                return VirtualNodeFactory.Text("x");
+            },
+        };
+
+        // One prop passed camelCase, the other kebab-case: both resolve to the declaration.
+        Mount(component, VirtualNodeFactory.Properties(("modelValue", "camel"), ("item-count", "kebab")));
+
+        camelSeen.ShouldBe("camel");
+        kebabSeen.ShouldBe("kebab");
+    }
+
+    [Fact]
+    public void UndeclaredProps_LandInAttrs_AndFallThroughToASingleElementRoot()
+    {
+        var component = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("declared")],
+            SetupFunction = static (_, _) => static () =>
+                VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "own")), "content"),
+        };
+
+        Mount(component, VirtualNodeFactory.Properties(
+            ("declared", "value"),
+            ("data-testid", "widget"),
+            ("class", "extra")));
+
+        // data-testid and class fall through; class merges with the root's own class.
+        var root = (TestElement)_container.Children[0];
+        root.Properties["data-testid"].ShouldBe("widget");
+        root.Properties["class"].ShouldBe("own extra");
+        root.Properties.ContainsKey("declared").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InheritAttributesFalse_DisablesFallthrough_ButKeepsContextAttrs()
+    {
+        ComponentAttributes? seenAttributes = null;
+        var component = new TestComponent
+        {
+            InheritAttributes = false,
+            SetupFunction = (_, context) =>
+            {
+                seenAttributes = context.Attributes;
+                return static () => VirtualNodeFactory.Element("div", "content");
+            },
+        };
+
+        Mount(component, VirtualNodeFactory.Properties(("data-x", "1")));
+
+        ((TestElement)_container.Children[0]).Properties.ContainsKey("data-x").ShouldBeFalse();
+        seenAttributes!["data-x"].ShouldBe("1"); // still visible on context.Attributes
+    }
+
+    [Fact]
+    public void Attrs_AreLive_UpdatedOnParentPatch()
+    {
+        ComponentAttributes? attributes = null;
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) =>
+            {
+                attributes = context.Attributes;
+                return static () => VirtualNodeFactory.Element("div", "x");
+            },
+        };
+        var toggle = Reactive.Reference("a");
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "section",
+                VirtualNodeFactory.Component(child, VirtualNodeFactory.Properties(("data-mode", toggle.Value)))),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        attributes!["data-mode"].ShouldBe("a");
+
+        toggle.Value = "b";
+        _pump.RunUntilIdle();
+
+        attributes["data-mode"].ShouldBe("b"); // the same live object reflects the patch
+    }
+
+    [Fact]
+    public void Defaults_Apply_WithFactoryDefaultsPerInstance()
+    {
+        var factoryRuns = 0;
+        List<string>? firstList = null;
+        List<string>? secondList = null;
+        var component = new TestComponent
+        {
+            Properties =
+            [
+                new ComponentPropertyDefinition("label") { DefaultValue = "fallback" },
+                new ComponentPropertyDefinition("items")
+                {
+                    DefaultFactory = () =>
+                    {
+                        factoryRuns++;
+                        return new List<string>();
+                    },
+                },
+            ],
+            SetupFunction = (properties, _) => () =>
+            {
+                var list = (List<string>?)properties["items"];
+                if (firstList is null)
+                {
+                    firstList = list;
+                }
+                else
+                {
+                    secondList ??= list;
+                }
+                return VirtualNodeFactory.Element("div", (string?)properties["label"] ?? string.Empty);
+            },
+        };
+
+        Mount(component);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>fallback</div></root>");
+        factoryRuns.ShouldBe(1);
+
+        var secondContainer = _renderer.CreateContainer();
+        _renderer.Render(VirtualNodeFactory.Component(component), secondContainer);
+
+        factoryRuns.ShouldBe(2); // one fresh default instance per component instance
+        secondList.ShouldNotBeSameAs(firstList);
+    }
+
+    [Fact]
+    public void RequiredAndValidatorViolations_WarnNamingComponentAndProp()
+    {
+        using var warnings = new WarningCapture();
+        var component = new TestComponent
+        {
+            Name = "PriceTag",
+            Properties =
+            [
+                new ComponentPropertyDefinition("amount") { Required = true },
+                new ComponentPropertyDefinition("currency") { Validator = value => value is "USD" or "EUR" },
+            ],
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Text("x"),
+        };
+
+        Mount(component, VirtualNodeFactory.Properties(("currency", "XYZ")));
+
+        warnings.Messages.ShouldContain(message =>
+            message.Contains("Missing required prop") && message.Contains("amount") && message.Contains("PriceTag"));
+        warnings.Messages.ShouldContain(message =>
+            message.Contains("custom validator") && message.Contains("currency") && message.Contains("PriceTag"));
+    }
+
+    [Fact]
+    public void MutatingAPropFromTheChild_WarnsOneWayDataFlow()
+    {
+        using var warnings = new WarningCapture();
+        ComponentProperties? captured = null;
+        var component = new TestComponent
+        {
+            Name = "Readonly",
+            Properties = [new ComponentPropertyDefinition("value")],
+            SetupFunction = (properties, _) =>
+            {
+                captured = properties;
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        Mount(component, VirtualNodeFactory.Properties(("value", 1)));
+        captured!.Set("value", 2);
+
+        warnings.Messages.ShouldContain(message =>
+            message.Contains("mutate prop") && message.Contains("value") && message.Contains("Readonly"));
+        captured["value"].ShouldBe(1); // the write was ignored
+    }
+
+    [Fact]
+    public void PropReads_AreShallowReactive_OnlyReadersReRender()
+    {
+        var renders = 0;
+        var child = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("used"), new ComponentPropertyDefinition("unused")],
+            SetupFunction = (properties, _) => () =>
+            {
+                renders++;
+                return VirtualNodeFactory.Element("span", (string?)properties["used"] ?? string.Empty);
+            },
+        };
+        var used = Reactive.Reference("u1");
+        var unused = Reactive.Reference("x1");
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Component(child, VirtualNodeFactory.Properties(
+                    ("used", used.Value),
+                    ("unused", unused.Value)))),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        renders.ShouldBe(1);
+
+        // The child re-renders because the parent-driven update carries a changed prop the
+        // child reads...
+        used.Value = "u2";
+        _pump.RunUntilIdle();
+        renders.ShouldBe(2);
+
+        // ...and re-renders for the unread prop only through the parent-driven path, which
+        // compares props: value changed → update. (Fine-grained skip of unread props is the
+        // dynamicProps-optimized path.)
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>u2</span></div></root>");
+    }
+
+    [Fact]
+    public void OptimizedPropsUpdate_HonorsDynamicPropsAndSkipsUnlistedChanges()
+    {
+        var renders = 0;
+        var child = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("tracked"), new ComponentPropertyDefinition("stable")],
+            SetupFunction = (properties, _) => () =>
+            {
+                renders++;
+                return VirtualNodeFactory.Element("span", (string?)properties["tracked"] ?? string.Empty);
+            },
+        };
+        VirtualNode Compiled(string tracked, string stable) => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Component(
+                child,
+                VirtualNodeFactory.Properties(("tracked", tracked), ("stable", stable)),
+                Shared.PatchFlags.Props,
+                ["tracked"]));
+
+        _renderer.Render(Compiled("a", "constant"), _container);
+        renders.ShouldBe(1);
+
+        _renderer.Render(Compiled("a", "constant"), _container);
+        renders.ShouldBe(1); // no listed prop changed: shouldUpdateComponent skips
+
+        // A change to an UNLISTED prop is invisible to the optimized comparison — the
+        // compiled contract (upstream parity).
+        _renderer.Render(Compiled("a", "drifted"), _container);
+        renders.ShouldBe(1);
+
+        _renderer.Render(Compiled("b", "drifted"), _container);
+        renders.ShouldBe(2);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>b</span></div></root>");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/ComponentTestSupport.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/ComponentTestSupport.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+/// <summary>A configurable component definition for tests.</summary>
+internal sealed class TestComponent : IComponentDefinition
+{
+    public string? Name { get; init; }
+
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties { get; init; }
+
+    public IReadOnlyList<ComponentEmitDefinition>? Emits { get; init; }
+
+    public bool InheritAttributes { get; init; } = true;
+
+    public required Func<ComponentProperties, ComponentSetupContext, Func<VirtualNode?>> SetupFunction { get; init; }
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => SetupFunction(properties, context);
+}
+
+/// <summary>Captures RuntimeWarnings for assertion; restores the sink on dispose.</summary>
+internal sealed class WarningCapture : IDisposable
+{
+    private readonly Action<string> _previous;
+
+    public WarningCapture()
+    {
+        _previous = RuntimeWarnings.Sink;
+        RuntimeWarnings.Sink = Messages.Add;
+    }
+
+    public List<string> Messages { get; } = [];
+
+    public void Dispose() => RuntimeWarnings.Sink = _previous;
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/RendererTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/RendererTests.cs
@@ -477,13 +477,4 @@ public class RendererTests : IDisposable
         TestNodeSerializer.Serialize(secondContainer).ShouldBe("<root><div><span>shared</span></div></root>");
     }
 
-    [Fact]
-    public void ComponentVnodes_ReportTheirPendingWorkItem()
-    {
-        // The component path exists in the dispatcher but lands with [V01.01.03.06].
-        var component = new VirtualNode(VirtualNodeType.Component);
-
-        Should.Throw<NotSupportedException>(() => _renderer.Render(component, _container))
-            .Message.ShouldContain("V01.01.03.06");
-    }
 }

--- a/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
@@ -268,6 +268,23 @@ public class SchedulerTests : IDisposable
     }
 
     [Fact]
+    public void PostFlushCallbacks_WithEqualIds_KeepInsertionOrder()
+    {
+        // JS array sort is spec-stable; List<T>.Sort is not — the scheduler's explicit
+        // insertion-sequence tiebreak is what keeps Mounted hooks child-before-parent.
+        var order = new List<string>();
+        for (var index = 0; index < 8; index++)
+        {
+            var name = $"cb{index}";
+            Scheduler.QueuePostFlushCallback(new SchedulerJob(() => order.Add(name)));
+        }
+
+        _pump.RunUntilIdle();
+
+        order.ShouldBe(["cb0", "cb1", "cb2", "cb3", "cb4", "cb5", "cb6", "cb7"]);
+    }
+
+    [Fact]
     public void FlushPreFlushCallbacks_RunsOnlyPreJobsImmediately()
     {
         var order = new List<string>();

--- a/libraries/Assimalign.Vue.RuntimeCore/test/VueApplicationTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/VueApplicationTests.cs
@@ -1,0 +1,105 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the minimal application shell of @vue/runtime-core's apiCreateApp.ts —
+// https://vuejs.org/api/application.html (plugins/config land with [V01.01.03.12]).
+public class VueApplicationTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public VueApplicationTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private static TestComponent Root(string text = "app") => new()
+    {
+        SetupFunction = (_, _) => () => VirtualNodeFactory.Element("div", text),
+    };
+
+    [Fact]
+    public void Mount_RendersTheRootComponent_AndReturnsItsInstance()
+    {
+        var application = _renderer.Renderer.CreateApplication(Root());
+
+        var instance = application.Mount(_container);
+
+        application.IsMounted.ShouldBeTrue();
+        instance.ShouldNotBeNull();
+        instance.ShouldBeSameAs(application.RootInstance);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>app</div></root>");
+    }
+
+    [Fact]
+    public void SecondMount_WarnsAndNoOps_ReturningTheExistingInstance()
+    {
+        using var warnings = new WarningCapture();
+        var application = _renderer.Renderer.CreateApplication(Root());
+        var first = application.Mount(_container);
+
+        var second = application.Mount(_renderer.CreateContainer());
+
+        warnings.Messages.ShouldContain(message => message.Contains("already been mounted"));
+        second.ShouldBeSameAs(first);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div>app</div></root>");
+    }
+
+    [Fact]
+    public void Unmount_RunsTeardownLifecycles_AndClearsTheContainer()
+    {
+        var unmounted = false;
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnUnmounted(() => unmounted = true);
+                return static () => VirtualNodeFactory.Element("div", "app");
+            },
+        };
+        var application = _renderer.Renderer.CreateApplication(root);
+        application.Mount(_container);
+
+        application.Unmount();
+
+        application.IsMounted.ShouldBeFalse();
+        unmounted.ShouldBeTrue();
+        _container.Children.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RootProperties_FlowToTheRootComponent()
+    {
+        string? seen = null;
+        var root = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("greeting")],
+            SetupFunction = (properties, _) => () =>
+            {
+                seen = (string?)properties["greeting"];
+                return VirtualNodeFactory.Element("div", seen ?? string.Empty);
+            },
+        };
+        var application = _renderer.Renderer.CreateApplication(
+            root, VirtualNodeFactory.Properties(("greeting", "hello")));
+
+        application.Mount(_container);
+
+        seen.ShouldBe("hello");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
@@ -8,9 +8,12 @@ node-ops and prop patching that the platform-agnostic renderer
 ## What it contains
 
 - **`BrowserRuntime`** (public entry): `InitializeAsync()` loads the package's JS bridge module;
+  `CreateApp(rootComponent).Mount("#app")` is a whole app bootstrap ([V01.01.04.04]);
   `CreateRenderer()` returns a `Renderer<int>` over the browser node-ops; `QuerySelector()`
   resolves mount containers; `GetRegistryDiagnostics()` exposes handle-registry sizes for leak
   checks.
+- **`BrowserApplication`** (public): the mounted app — selector or handle mounting with
+  clear-before-mount, and `Unmount()` returning the bridge registry to its pre-mount baseline.
 - **`BrowserDomException`** (public): typed interop failure carrying the operation name and the
   node handle.
 - **`vuecs-dom.js`** (`src/wwwroot/`, shipped with the package): the JS half — the handle
@@ -29,9 +32,7 @@ node-ops and prop patching that the platform-agnostic renderer
 
 ```csharp
 await BrowserRuntime.InitializeAsync();
-var renderer = BrowserRuntime.CreateRenderer();
-var container = BrowserRuntime.QuerySelector("#app");
-renderer.CreateRenderEffect(BuildView, container); // reactive mount
+BrowserRuntime.CreateApp(new RootComponent()).Mount("#app");
 ```
 
 The example app (`examples/Assimalign.Vue.WebApp`) is the living usage sample; its

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.Versioning;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// A browser-mounted Vuecs application — the C# port of the app object
+/// <c>createApp</c> returns in <c>@vue/runtime-dom</c>
+/// (https://vuejs.org/api/application.html, <c>packages/runtime-dom/src/index.ts</c>). Wraps
+/// the platform-agnostic <see cref="VueApplication{TNode}"/> with browser container concerns:
+/// selector resolution, clearing existing content before a non-hydrating client mount
+/// (upstream parity), and full interop cleanup on <see cref="Unmount"/> — the bridge registry
+/// returns to its pre-mount baseline. Create through
+/// <see cref="BrowserRuntime.CreateApp"/>. Not thread-safe (browser main thread only).
+/// </summary>
+[SupportedOSPlatform("browser")]
+public sealed class BrowserApplication
+{
+    private readonly VueApplication<int> _application;
+
+    internal BrowserApplication(VueApplication<int> application)
+    {
+        _application = application;
+    }
+
+    /// <summary>Whether the app is currently mounted.</summary>
+    public bool IsMounted => _application.IsMounted;
+
+    /// <summary>The root component instance after mounting, or null.</summary>
+    public ComponentInstance? RootInstance => _application.RootInstance;
+
+    /// <summary>
+    /// Resolves <paramref name="selector"/> and mounts there (upstream:
+    /// <c>app.mount('#app')</c>). A selector matching nothing throws a
+    /// <see cref="BrowserDomException"/> naming the selector.
+    /// </summary>
+    /// <param name="selector">The CSS selector of the container.</param>
+    /// <returns>The root component instance.</returns>
+    /// <exception cref="BrowserDomException">No element matches <paramref name="selector"/>.</exception>
+    public ComponentInstance? Mount(string selector)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(selector);
+        return Mount(BrowserRuntime.QuerySelector(selector));
+    }
+
+    /// <summary>Mounts into an already-resolved container handle.</summary>
+    /// <param name="containerHandle">The container's node handle.</param>
+    /// <returns>The root component instance.</returns>
+    public ComponentInstance? Mount(int containerHandle)
+    {
+        if (!_application.IsMounted)
+        {
+            // Non-hydrating client mount clears existing container content (upstream parity);
+            // one interop call that also releases any registered child handles.
+            BrowserRuntime.ClearContainer(containerHandle);
+        }
+        return _application.Mount(containerHandle);
+    }
+
+    /// <summary>
+    /// Unmounts the app (upstream: <c>app.unmount()</c>): runs component teardown lifecycles,
+    /// removes the rendered DOM, and releases every JS-side handle and listener the app
+    /// created.
+    /// </summary>
+    public void Unmount() => _application.Unmount();
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
@@ -29,8 +29,7 @@ public static class BrowserRuntime
         => _initialization ??= InitializeCoreAsync(cancellationToken);
 
     /// <summary>
-    /// Creates a renderer over the browser node-ops (the <c>createApp</c>-less equivalent of
-    /// upstream's DOM renderer; app bootstrap lands with [V01.01.04.04]).
+    /// Creates a renderer over the browser node-ops (upstream: <c>ensureRenderer()</c>).
     /// </summary>
     /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
     public static Renderer<int> CreateRenderer()
@@ -38,6 +37,30 @@ public static class BrowserRuntime
         EnsureInitialized();
         return RendererFactory.CreateRenderer(BrowserNodeOperations.Create());
     }
+
+    /// <summary>
+    /// Creates a browser application for <paramref name="rootComponent"/> (upstream:
+    /// <c>createApp(rootComponent)</c>, https://vuejs.org/api/application.html) —
+    /// <c>BrowserRuntime.CreateApp(root).Mount("#app")</c> is a Vuecs WASM app's whole
+    /// bootstrap ([V01.01.04.04]).
+    /// </summary>
+    /// <param name="rootComponent">The root component definition.</param>
+    /// <param name="rootProperties">Props for the root component, or null.</param>
+    /// <returns>The app; mount it by selector or handle.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rootComponent"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
+    public static BrowserApplication CreateApp(IComponentDefinition rootComponent, VirtualNodeProperties? rootProperties = null)
+    {
+        ArgumentNullException.ThrowIfNull(rootComponent);
+        EnsureInitialized();
+        var renderer = RendererFactory.CreateRenderer(BrowserNodeOperations.Create());
+        return new BrowserApplication(renderer.CreateApplication(rootComponent, rootProperties));
+    }
+
+    /// <summary>Clears a container's content in one interop call, releasing registered child handles.</summary>
+    /// <param name="containerHandle">The container's node handle.</param>
+    internal static void ClearContainer(int containerHandle)
+        => BrowserNodeOperations.ClearElement(containerHandle);
 
     /// <summary>Resolves a selector to a node handle (e.g. the mount container).</summary>
     /// <param name="selector">The CSS selector.</param>

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -66,6 +66,10 @@ internal static class BrowserNodeOperations
     internal static int DispatchEvent(int nodeHandle, bool capture, BrowserEvent browserEvent)
         => Invokers.Dispatch(nodeHandle, capture, browserEvent);
 
+    /// <summary>Clears an element's content (pre-mount container reset), purging released handles.</summary>
+    internal static void ClearElement(int nodeHandle)
+        => Invokers.PurgeReleasedHandles(BrowserDomBridge.SetElementText(nodeHandle, string.Empty));
+
     /// <summary>Registry sizes for leak diagnostics: JS nodes, JS listener maps, .NET invokers.</summary>
     internal static (int JsNodes, int JsListenerMaps, int DotnetListeners) GetRegistryDiagnostics()
     {


### PR DESCRIPTION
## Summary

**The component era** — the five P001/W02 items that turn Vuecs from a renderer into a component framework: the proxy-free component instance + `Setup` model, the props subsystem with attrs fallthrough, emits with the `v-model` runtime contract, the full Composition API lifecycle, and the `CreateApp().Mount("#app")` browser bootstrap. The renderer's component stub is now the real `processComponent` pipeline with per-instance render effects ordered by uid.

**440 tests green** (54 new), 0-warning build, and the whole stack verified **live on WASM**: a real component tree (root + child) with parent-driven prop updates, a child→parent emit round-trip, lifecycle-managed timers, and two live stress harnesses passing — including 25 `CreateApp`/`Mount`/`Unmount` cycles returning the bridge registry exactly to its pre-mount baseline.

## Type of change

- [x] `feat` — component model (RuntimeCore), app bootstrap (RuntimeDom)
- [ ] `fix`
- [ ] `refactor`
- [x] `test` — 54 new tests (run counts, ordering matrices, warning texts, instrumented registries)
- [x] `docs` — RuntimeDom OVERVIEW bootstrap section
- [ ] `chore`

## Changes

- **Component instance + Setup (V01.01.03.06):** `IComponentDefinition.Setup(props, context)` runs exactly once per instance inside a detached `EffectScope`, with `ComponentInstance.Current` correct across nested setups and restored on exception. C# has no `Proxy`, so there is no `this`-proxy: the returned render function closes over refs/computeds — documented as the proxy-free realization of upstream's state-object form. Instances carry uid (scheduler ordering — parents flush before children), parent/root links, the provides table (for #26), per-kind hook lists, vnode/subtree back-pointers, and mount state. `SetupContext` exposes live `Attributes`, `Emit`, `Expose` (restricting what parent refs see), and the slots placeholder (#25). Component activation is factory-based — no `Activator.CreateInstance`, nothing reflective.
- **Renderer component pipeline:** `parentComponent` threaded through every patch path; `mountComponent`/`updateComponent`/`unmountComponent` with `shouldUpdateComponent` (dynamicProps-optimized and full comparisons), `InvalidateJob` + synchronous re-render for parent-driven updates, and **upstream `toggleRecurse` parity** — props writes during the effect's own run must not requeue it, a bug my run-count tests caught as a triple render and the fix pins.
- **Props (V01.01.03.07):** precomputed `ComponentPropertyDefinition` metadata (source-generator-shaped, zero reflection), camelCase/kebab-case equivalence, defaults with per-instance factories (never shared, never spuriously re-run — pinned), `Required`/`Validator` dev warnings naming component and prop, a **shallow-reactive props store built on Reactivity's public `Dependency`** (per-name track/trigger; a child re-renders only when a prop actually changed), attrs split with single-element-root fallthrough merged via `MergeProperties` (class/style merge for free), `InheritAttributes = false`, declared-emit `onX`/`onXOnce` exclusion from attrs, and the one-way-data-flow write warning.
- **Emits (V01.01.03.08):** cached `toHandlerKey`/`camelize` transforms (no per-emit string churn), kebab emit → camelCase handler, `Action`/`Action<object?>`/`Action<object?[]>` handler shapes, **`update:modelValue` round-trip** (the runtime half of the v-model contract for the compiler), `onXOnce` fired-once-per-instance across re-renders, undeclared-event and validator dev warnings.
- **Lifecycle (V01.01.03.11):** all ten registrations; binding at registration time with the upstream no-active-instance warning; ordering parity pinned as event lists (`BeforeMount` parent-first, `Mounted` child-first post-flush, `BeforeUpdate` observing pre-patch host state, unmount parent-first/child-first); `OnErrorCaptured` chain receiving `(exception, source instance, info)` with false-stops-propagation and unhandled errors surfacing via `ExceptionDispatchInfo` (app-level handler is #28); `Activated`/`Deactivated`/`ServerPrefetch` stored for KeepAlive (#34-era) and the server renderer. **Supporting fix:** the scheduler's post-flush sort gains a stable insertion-sequence tiebreak — `List<T>.Sort` is unstable, which would have scrambled equal-id Mounted ordering (JS sort is spec-stable); pinned by its own test.
- **Browser bootstrap (V01.01.04.04):** `BrowserRuntime.CreateApp(root).Mount("#app")` over the new platform-agnostic `VueApplication` shell (`createAppAPI` parity — plugins/config stay #28): selector resolution surfaces the bridge's actionable no-match error, mount **clears existing container content in one interop call** (releasing registered child handles), double-mount warns and no-ops, and `Unmount` runs teardown lifecycles and returns the registry to baseline. The example app is now a real component tree — `StopwatchApplication` owning refs and an `OnMounted`/`OnUnmounted`-managed timer, `ElapsedDisplay` (declared props with defaults + a declared emit) receiving parent-driven updates and emitting `reset` back up — and `Program.cs` is initialize + CreateApp + Mount + keep-alive.

## Work items resolved

Closes #22
Closes #23
Closes #24
Closes #27
Closes #42

> **Reviewer notes:** (1) #22's "state access requires no reflection — verified by trimming analysis" rides on the 0-warning build with trim analyzers enabled (`IsAotCompatible`) over the whole solution including the example component assembly; a dedicated published-trimmed-app assertion would belong to the e2e harness (#87). (2) #27's `OnServerPrefetch` is registration + storage per the criterion — awaiting it is [V01.01.07.01]'s job. (3) Slots references in `SetupContext`/`ShouldUpdateComponent` are explicit placeholders for #25.

### Discovered (out-of-scope) work

None filed as new items; named forward references: #25 (slots), #26 (provide/inject — the provides table exists), #28 (App API/plugins/error handler — `VueApplication` + `RuntimeWarnings` + the error-sink seams are its integration points), #19 (keyed diffing).

## Testing & verification

- [x] `dotnet build Assimalign.Vuecs.slnx` — 0 warnings/errors; **440/440 tests green** (54 new: instance/props/emits/lifecycle/application suites + the scheduler stable-order pin).
- [x] Verified **live on WASM end-to-end**: the component tree mounts through `CreateApp().Mount("#app")`; clicking Start flips root state and the child re-renders from changed props (Running + ticking elapsed); clicking the child's Reset **emits** to the root, which restarts the stopwatch (elapsed observed dropping 00:00:40 → 00:00:07 while still Running); zero console errors.
- [x] Two live stress harnesses PASS in `?diagnostics=1`: the existing 100-cycle render stress, and the new **application-lifecycle stress** — 25 `CreateApp`/`Mount`/`Unmount` cycles of the full component tree (listeners, timers) with nodes 1 → 21 peak → 1 and zero leaked listeners on either side, proving `OnUnmounted` timer cancellation and two-sided handle cleanup through the app path.
- Two upstream-parity bugs were caught by tests during the batch and fixed with pins: the `toggleRecurse` triple-render and the unstable post-flush sort.

## Checklist

- [x] Each resolved work item has its own `Closes #` line; area epics stay open (W02 P002 items #12–#14, #19, #25, #26, #28, #29, #37, #86 remain).
- [x] Public APIs have XML docs with upstream links (composition-api-setup, componentProps, componentEmits, apiLifecycle, application API); the proxy-free divergences are documented at the contract site.
- [x] Trimming/WASM-AOT-safe: factory-based activation, precomputed prop metadata, delegate-shape event dispatch — no reflection anywhere in the component path.
- [x] JS-interop: no new surface beyond one `ClearElement` reuse of `setElementText`; app teardown verified registry-clean.
- [x] Tests added and passing; the stale component-stub renderer test was replaced by the real component suites.
- [x] No dangling references; `RenderEffect` (root-level, [V01.01.03.05]) remains supported alongside the component pipeline.
