### PR TITLE
feat(runtime-core): keyed LIS children diff, component slots, provide/inject

### DIFF
--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
@@ -33,6 +33,10 @@ public sealed class ComponentInstance
         VirtualNode = virtualNode;
         Parent = parent;
         Root = parent?.Root ?? this;
+        // Inherit the parent's provides table by reference (upstream: instance.provides =
+        // parent.provides). DependencyInjection.Provide forks a layered copy on this instance's
+        // first own provide; until then the reference is shared with every non-providing ancestor.
+        Provides = parent?.Provides;
         Scope = new EffectScope(detached: true);
         Properties = new ComponentProperties(DisplayName);
         Attributes = new ComponentAttributes();
@@ -111,7 +115,12 @@ public sealed class ComponentInstance
     /// <summary>Whether the instance was torn down.</summary>
     public bool IsUnmounted { get; internal set; }
 
-    /// <summary>The provides table ([V01.01.03.10] consumes it; parents chain).</summary>
+    /// <summary>
+    /// The dependency-injection provides table (upstream: <c>instance.provides</c>), consumed by
+    /// <see cref="DependencyInjection"/>. Inherited from the parent by reference and forked into a
+    /// layered copy on this instance's first own provide (copy-on-first-provide); null when neither
+    /// this instance nor any ancestor has provided anything.
+    /// </summary>
     internal Dictionary<object, object?>? Provides { get; set; }
 
     internal Func<VirtualNode?>? RenderFunction { get; set; }

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentInstance.cs
@@ -97,8 +97,12 @@ public sealed class ComponentInstance
     /// <summary>The live fallthrough attributes (upstream: <c>instance.attrs</c>).</summary>
     public ComponentAttributes Attributes { get; }
 
-    /// <summary>The slots object; typed when slots land ([V01.01.03.09]).</summary>
-    public object? Slots { get; internal set; }
+    /// <summary>
+    /// The instance's slots object (upstream: <c>instance.slots</c>), rendered through
+    /// <see cref="VirtualNodeFactory.RenderSlot"/>. Installed at mount and refreshed on a
+    /// slot-affecting parent update; null when the parent passed no slot content.
+    /// </summary>
+    public ComponentSlots? Slots { get; internal set; }
 
     /// <summary>The state surfaced to parent refs via <c>Expose</c>, or null.</summary>
     public object? Exposed { get; private set; }

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSetupContext.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSetupContext.cs
@@ -21,8 +21,11 @@ public sealed class ComponentSetupContext
     /// <summary>The live fallthrough attributes (upstream: <c>context.attrs</c>).</summary>
     public ComponentAttributes Attributes => _instance.Attributes;
 
-    /// <summary>The slots object; typed when slots land ([V01.01.03.09]).</summary>
-    public object? Slots => _instance.Slots;
+    /// <summary>
+    /// The slots passed by the parent (upstream: <c>context.slots</c>), rendered through
+    /// <see cref="VirtualNodeFactory.RenderSlot"/>; null when the parent passed no slot content.
+    /// </summary>
+    public ComponentSlots? Slots => _instance.Slots;
 
     /// <summary>
     /// Emits a component event to the matching handler prop (upstream: <c>context.emit</c>;

--- a/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSlots.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/ComponentSlots.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A component's slots object — the C# port of upstream's <c>Slots</c>/<c>InternalSlots</c>
+/// (<c>packages/runtime-core/src/componentSlots.ts</c>,
+/// https://vuejs.org/guide/components/slots.html): a name to <see cref="Slot"/> map plus the
+/// <see cref="Shared.SlotFlags"/> stability marker upstream stores on the hidden <c>_</c> property.
+/// Passed on a component vnode via <see cref="VirtualNode.SlotChildren"/> and surfaced on the
+/// mounted instance as <see cref="ComponentInstance.Slots"/> / <see cref="ComponentSetupContext.Slots"/>.
+/// The <see cref="Flag"/> drives how aggressively a parent re-render forces the child to re-render
+/// (see <see cref="Shared.SlotFlags"/>) — on WASM a skipped forced update is skipped patch-and-interop
+/// work. Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+public sealed class ComponentSlots
+{
+    private readonly Dictionary<string, Slot> _slots;
+
+    /// <summary>Creates an empty <see cref="Shared.SlotFlags.Stable"/> slots object.</summary>
+    public ComponentSlots()
+        : this(SlotFlags.Stable)
+    {
+    }
+
+    /// <summary>Creates an empty slots object with the given stability <paramref name="flag"/>.</summary>
+    /// <param name="flag">The slot stability classification.</param>
+    public ComponentSlots(SlotFlags flag)
+    {
+        _slots = new Dictionary<string, Slot>(StringComparer.Ordinal);
+        Flag = flag;
+    }
+
+    /// <summary>
+    /// The stability classification (upstream: the slots object's <c>_</c> marker). Defaults to
+    /// <see cref="Shared.SlotFlags.Stable"/> — the compiler's default for structurally stable slots,
+    /// and safe because a slot's reactive reads are still tracked by the consuming child regardless
+    /// of this flag; only structural changes (<c>v-if</c>/<c>v-for</c>/dynamic names) need
+    /// <see cref="Shared.SlotFlags.Dynamic"/>. A <see cref="Shared.SlotFlags.Forwarded"/> value is
+    /// resolved to Stable or Dynamic at vnode creation
+    /// (<see cref="VirtualNodeFactory.Component(IComponentDefinition, VirtualNodeProperties?, ComponentSlots?, Shared.PatchFlags, string[]?)"/>).
+    /// </summary>
+    public SlotFlags Flag { get; set; }
+
+    /// <summary>The number of named slots.</summary>
+    public int Count => _slots.Count;
+
+    /// <summary>
+    /// Gets or sets the slot registered under <paramref name="name"/> (upstream: <c>slots[name]</c>).
+    /// Setting null removes the slot.
+    /// </summary>
+    /// <param name="name">The slot name (<c>"default"</c> for the default slot).</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public Slot? this[string name]
+    {
+        get => _slots.TryGetValue(name, out var slot) ? slot : null;
+        set
+        {
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            if (value is null)
+            {
+                _slots.Remove(name);
+            }
+            else
+            {
+                _slots[name] = value;
+            }
+        }
+    }
+
+    /// <summary>Whether a slot named <paramref name="name"/> is present.</summary>
+    /// <param name="name">The slot name.</param>
+    public bool Contains(string name) => _slots.ContainsKey(name);
+
+    /// <summary>Looks up the slot named <paramref name="name"/>.</summary>
+    /// <param name="name">The slot name.</param>
+    /// <param name="slot">The slot when present; null otherwise.</param>
+    /// <returns>Whether a slot named <paramref name="name"/> is present.</returns>
+    public bool TryGetSlot(string name, [NotNullWhen(true)] out Slot? slot) => _slots.TryGetValue(name, out slot);
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/DependencyInjection.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/DependencyInjection.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// Composition API dependency injection — the C# port of <c>provide()</c> and <c>inject()</c>
+/// from <c>packages/runtime-core/src/apiInject.ts</c>
+/// (https://vuejs.org/guide/components/provide-inject.html). A value provided by an ancestor is
+/// injectable by any descendant regardless of depth; a nearer provider shadows a farther one.
+/// Both APIs bind to <see cref="ComponentInstance.Current"/> and must be called during
+/// <c>Setup</c>; calling them with no active instance produces the upstream dev warning and is
+/// otherwise inert.
+/// <para>
+/// <b>Provides representation.</b> Upstream gives each instance a provides object whose prototype
+/// is the parent's, so <c>inject</c> reads are O(1) via the prototype chain. C# has no prototype
+/// chain, so this uses <b>copy-on-first-provide</b>: an instance inherits its parent's provides
+/// table <i>by reference</i> until it provides a value of its own, at which point it forks a flat
+/// dictionary seeded with a copy of the parent's entries (see
+/// <see cref="ComponentInstance.Provides"/>). The trade-off: a provide costs O(n) in the ancestor
+/// provide-count on first fork, but every <c>inject</c> is an O(1) dictionary probe with no
+/// allocation on the hit path — the right bias, since injects vastly outnumber provides and run on
+/// the render hot path. Because <c>Setup</c> runs parent-before-child, an ancestor's table is
+/// always complete before a descendant copies it, so the flat copy stays correct.
+/// </para>
+/// </summary>
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Provides <paramref name="value"/> under the typed <paramref name="key"/> for all
+    /// descendants (upstream: <c>provide</c>). Overwrites any value this instance already provided
+    /// under the same key.
+    /// </summary>
+    /// <typeparam name="T">The provided value type.</typeparam>
+    /// <param name="key">The identity-based key descendants inject with.</param>
+    /// <param name="value">The value to provide.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    public static void Provide<T>(InjectionKey<T> key, T value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ProvideCore(key, value);
+    }
+
+    /// <summary>
+    /// Provides <paramref name="value"/> under a string <paramref name="key"/> for all descendants
+    /// (upstream: <c>provide</c> with a string key). String keys are matched by value; prefer
+    /// <see cref="InjectionKey{T}"/> for type safety and collision resistance.
+    /// </summary>
+    /// <param name="key">The string key descendants inject with.</param>
+    /// <param name="value">The value to provide.</param>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+    public static void Provide(string key, object? value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ProvideCore(key, value);
+    }
+
+    /// <summary>
+    /// Injects the value provided under the typed <paramref name="key"/> by an ancestor (upstream:
+    /// <c>inject</c>). Missing key with no default: a dev warning fires and <c>default</c> is
+    /// returned.
+    /// </summary>
+    /// <typeparam name="T">The injected value type.</typeparam>
+    /// <param name="key">The key an ancestor provided under.</param>
+    /// <returns>The provided value, or <c>default</c> when absent.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    public static T? Inject<T>(InjectionKey<T> key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return Lookup(key, out var value) switch
+        {
+            InjectionLookup.Found => (T?)value,
+            InjectionLookup.NoInstance => WarnOutsideSetup<T?>(default),
+            _ => WarnNotFound<T?>(key, default),
+        };
+    }
+
+    /// <summary>
+    /// Injects the value provided under the typed <paramref name="key"/>, falling back to
+    /// <paramref name="defaultValue"/> when no ancestor provided it (upstream: <c>inject</c> with a
+    /// default value). No "not found" warning fires when a default is supplied.
+    /// </summary>
+    /// <typeparam name="T">The injected value type.</typeparam>
+    /// <param name="key">The key an ancestor provided under.</param>
+    /// <param name="defaultValue">The value returned when the key is absent.</param>
+    /// <returns>The provided value, or <paramref name="defaultValue"/> when absent.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    public static T Inject<T>(InjectionKey<T> key, T defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return Lookup(key, out var value) switch
+        {
+            InjectionLookup.Found => (T)value!,
+            InjectionLookup.NoInstance => WarnOutsideSetup(defaultValue),
+            _ => defaultValue,
+        };
+    }
+
+    /// <summary>
+    /// Injects the value provided under the typed <paramref name="key"/>, invoking
+    /// <paramref name="defaultFactory"/> for the fallback when no ancestor provided it (upstream:
+    /// <c>inject</c> with <c>treatDefaultAsFactory: true</c> — choosing the factory overload is the
+    /// idiomatic C# form of that flag). The factory runs only on a miss.
+    /// </summary>
+    /// <typeparam name="T">The injected value type.</typeparam>
+    /// <param name="key">The key an ancestor provided under.</param>
+    /// <param name="defaultFactory">Produces the fallback when the key is absent.</param>
+    /// <returns>The provided value, or <paramref name="defaultFactory"/>'s result when absent.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="defaultFactory"/> is null.</exception>
+    public static T Inject<T>(InjectionKey<T> key, Func<T> defaultFactory)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(defaultFactory);
+        return Lookup(key, out var value) switch
+        {
+            InjectionLookup.Found => (T)value!,
+            InjectionLookup.NoInstance => WarnOutsideSetup(defaultFactory()),
+            _ => defaultFactory(),
+        };
+    }
+
+    /// <summary>
+    /// Injects the value provided under a string <paramref name="key"/> (upstream: <c>inject</c>
+    /// with a string key). Missing key with no default: a dev warning fires and null is returned.
+    /// </summary>
+    /// <param name="key">The string key an ancestor provided under.</param>
+    /// <returns>The provided value, or null when absent.</returns>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+    public static object? Inject(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        return Lookup(key, out var value) switch
+        {
+            InjectionLookup.Found => value,
+            InjectionLookup.NoInstance => WarnOutsideSetup<object?>(null),
+            _ => WarnNotFound<object?>(key, null),
+        };
+    }
+
+    /// <summary>
+    /// Injects the value provided under a string <paramref name="key"/>, falling back to
+    /// <paramref name="defaultValue"/> when absent (upstream: <c>inject(key, default,
+    /// treatDefaultAsFactory)</c>). When <paramref name="treatDefaultAsFactory"/> is true and
+    /// <paramref name="defaultValue"/> is a parameterless delegate, the delegate is invoked for the
+    /// fallback; otherwise <paramref name="defaultValue"/> is returned as-is.
+    /// </summary>
+    /// <param name="key">The string key an ancestor provided under.</param>
+    /// <param name="defaultValue">The fallback value, or a factory when <paramref name="treatDefaultAsFactory"/> is true.</param>
+    /// <param name="treatDefaultAsFactory">Whether a delegate <paramref name="defaultValue"/> is invoked to produce the fallback.</param>
+    /// <returns>The provided value, or the resolved default when absent.</returns>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+    public static object? Inject(string key, object? defaultValue, bool treatDefaultAsFactory = false)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        return Lookup(key, out var value) switch
+        {
+            InjectionLookup.Found => value,
+            InjectionLookup.NoInstance => WarnOutsideSetup(ResolveDefault(defaultValue, treatDefaultAsFactory)),
+            _ => ResolveDefault(defaultValue, treatDefaultAsFactory),
+        };
+    }
+
+    private static object? ResolveDefault(object? defaultValue, bool treatDefaultAsFactory)
+        => treatDefaultAsFactory && defaultValue is Func<object?> factory ? factory() : defaultValue;
+
+    private static void ProvideCore(object key, object? value)
+    {
+        var instance = ComponentInstance.Current;
+        if (instance is null)
+        {
+            RuntimeWarnings.Warn("provide() can only be used inside Setup().");
+            return;
+        }
+        var parentProvides = instance.Parent?.Provides;
+        if (ReferenceEquals(instance.Provides, parentProvides))
+        {
+            // First own provide: fork a flat table layered over the inherited one (upstream:
+            // provides = Object.create(parentProvides)). Setup runs parent-before-child, so the
+            // parent's table is already complete and the copy is a correct snapshot.
+            instance.Provides = parentProvides is null
+                ? new Dictionary<object, object?>()
+                : new Dictionary<object, object?>(parentProvides);
+        }
+        instance.Provides![key] = value;
+    }
+
+    private static InjectionLookup Lookup(object key, out object? value)
+    {
+        value = null;
+        var instance = ComponentInstance.Current;
+        if (instance is null)
+        {
+            return InjectionLookup.NoInstance;
+        }
+        // Upstream reads from the parent's provides, never the instance's own: a component that
+        // both provides and injects the same key sees the ancestor value, not the one it just
+        // provided for its descendants. At the root, the parent chain ends and app-level provides
+        // ([V01.01.03.12]) are the documented final-fallback seam (null until that lands).
+        var provides = instance.Parent?.Provides;
+        if (provides is not null && provides.TryGetValue(key, out value))
+        {
+            return InjectionLookup.Found;
+        }
+        return InjectionLookup.NotFound;
+    }
+
+    private static TValue WarnOutsideSetup<TValue>(TValue fallback)
+    {
+        RuntimeWarnings.Warn("inject() can only be used inside Setup().");
+        return fallback;
+    }
+
+    private static TValue WarnNotFound<TValue>(object key, TValue fallback)
+    {
+        RuntimeWarnings.Warn($"injection \"{key}\" not found.");
+        return fallback;
+    }
+
+    private enum InjectionLookup
+    {
+        Found,
+        NotFound,
+        NoInstance,
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/InjectionKey{T}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/InjectionKey{T}.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A typed, identity-based provide/inject key — the C# port of upstream's
+/// <c>InjectionKey&lt;T&gt;</c> (<c>packages/runtime-core/src/apiInject.ts</c>,
+/// https://vuejs.org/api/composition-api-dependency-injection.html#injectionkey). Upstream keys
+/// are ES <c>Symbol</c>s carrying a phantom value type; C# has no <c>Symbol</c>, so this stands in
+/// with <b>reference identity</b> (two distinct instances are distinct keys, even with the same
+/// <see cref="Name"/>) and a phantom <typeparamref name="T"/> that lets
+/// <see cref="DependencyInjection.Provide{T}(InjectionKey{T}, T)"/> and
+/// <see cref="DependencyInjection.Inject{T}(InjectionKey{T})"/> round-trip strongly typed with no
+/// cast at the call site. Declare keys as <c>static readonly</c> singletons and share them between
+/// the provider and the injector.
+/// <para>
+/// Deliberately a <c>class</c>, not a <c>record</c>: a record's value equality would make every
+/// same-typed key collide, breaking the <c>Symbol</c> identity contract. Trimming-safe — the type
+/// argument is phantom and never activated reflectively.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The type of the value provided under this key.</typeparam>
+public sealed class InjectionKey<T>
+{
+    /// <summary>Creates an anonymous key whose identity is the instance itself.</summary>
+    public InjectionKey()
+    {
+    }
+
+    /// <summary>Creates a key with a diagnostic <paramref name="name"/> (identity is still the instance).</summary>
+    /// <param name="name">A description used in warnings and <see cref="ToString"/>; not part of key identity.</param>
+    public InjectionKey(string? name)
+    {
+        Name = name;
+    }
+
+    /// <summary>The diagnostic description, or null. Does not participate in key identity.</summary>
+    public string? Name { get; }
+
+    /// <summary>Returns <see cref="Name"/> when set, otherwise a type-qualified placeholder.</summary>
+    public override string ToString() => Name ?? $"InjectionKey<{typeof(T).Name}>";
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 using Assimalign.Vue.Reactivity;
@@ -17,9 +18,10 @@ namespace Assimalign.Vue.RuntimeCore;
 /// <see cref="ComponentInstance"/>s with per-instance render effects whose scheduler jobs
 /// carry the instance uid, so parents update before children ([V01.01.03.06]). A positive
 /// <see cref="VirtualNode.PatchFlag"/> follows the compiled patch contract (targeted
-/// class/style/props/text updates); unflagged vnodes take the full diff. Array children patch
-/// positionally for now — keyed longest-increasing-subsequence reordering lands with
-/// [V01.01.03.03]. Component slots ([V01.01.03.09]) are installed on the instance and their
+/// class/style/props/text updates); unflagged vnodes take the full diff. Array children take the
+/// keyed diff by default (head/tail sync then longest-increasing-subsequence minimal moves,
+/// [V01.01.03.03]); an <see cref="PatchFlags.UnkeyedFragment"/> keeps the positional fast path.
+/// Component slots ([V01.01.03.09]) are installed on the instance and their
 /// <see cref="Shared.SlotFlags"/> stability drives whether a parent re-render forces the child.
 /// Created through <see cref="RendererFactory.CreateRenderer{TNode}"/>.
 /// Not thread-safe (single-threaded JS event-loop model).
@@ -721,7 +723,17 @@ public sealed class Renderer<TNode>
         {
             if ((nextShape & ShapeFlags.ArrayChildren) != 0)
             {
-                PatchUnkeyedChildren(current.ArrayChildren!, next.ArrayChildren!, container, anchor, elementNamespace, parentComponent);
+                // Upstream patchChildren routing: only an explicit UnkeyedFragment flag keeps the
+                // positional fast path; every other array-vs-array case takes the keyed diff
+                // (upstream's default), which reconciles keyed and keyless children alike.
+                if ((int)next.PatchFlag > 0 && (next.PatchFlag & PatchFlags.UnkeyedFragment) != 0)
+                {
+                    PatchUnkeyedChildren(current.ArrayChildren!, next.ArrayChildren!, container, anchor, elementNamespace, parentComponent);
+                }
+                else
+                {
+                    PatchKeyedChildren(current.ArrayChildren!, next.ArrayChildren!, container, anchor, elementNamespace, parentComponent);
+                }
             }
             else
             {
@@ -767,6 +779,342 @@ public sealed class Renderer<TNode>
             MountChildren(nextChildren, container, anchor, elementNamespace, parentComponent, startIndex: commonLength);
         }
     }
+
+    private void PatchKeyedChildren(
+        VirtualNode[] previousChildren,
+        VirtualNode[] nextChildren,
+        TNode container,
+        TNode? parentAnchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
+    {
+        // The C# port of patchKeyedChildren in @vue/runtime-core renderer.ts
+        // (https://github.com/vuejs/core/blob/main/packages/runtime-core/src/renderer.ts): head
+        // sync, tail sync, common-sequence mount/unmount, then a key->new-index map plus a
+        // longest-increasing-subsequence over the middle so the reorder issues the fewest host
+        // moves — each avoided move is an avoided insert interop call on WASM.
+        var i = 0;
+        var l2 = nextChildren.Length;
+        var e1 = previousChildren.Length - 1;
+        var e2 = l2 - 1;
+
+        // 1. sync from start: (a b) c / (a b) d e
+        while (i <= e1 && i <= e2)
+        {
+            var n1 = previousChildren[i];
+            var n2 = nextChildren[i] = VirtualNodeFactory.Normalize(nextChildren[i]);
+            if (!IsSameVirtualNodeType(n1, n2))
+            {
+                break;
+            }
+            Patch(n1, n2, container, default, elementNamespace, parentComponent);
+            i++;
+        }
+
+        // 2. sync from end: a (b c) / d e (b c)
+        while (i <= e1 && i <= e2)
+        {
+            var n1 = previousChildren[e1];
+            var n2 = nextChildren[e2] = VirtualNodeFactory.Normalize(nextChildren[e2]);
+            if (!IsSameVirtualNodeType(n1, n2))
+            {
+                break;
+            }
+            Patch(n1, n2, container, default, elementNamespace, parentComponent);
+            e1--;
+            e2--;
+        }
+
+        if (i > e1)
+        {
+            // 3. common sequence + mount: the old run is exhausted, so mount the extra new nodes.
+            if (i <= e2)
+            {
+                var nextPosition = e2 + 1;
+                var anchor = nextPosition < l2 ? AsHostNode(nextChildren[nextPosition].El) : parentAnchor;
+                while (i <= e2)
+                {
+                    var n2 = nextChildren[i] = VirtualNodeFactory.Normalize(nextChildren[i]);
+                    Patch(null, n2, container, anchor, elementNamespace, parentComponent);
+                    i++;
+                }
+            }
+        }
+        else if (i > e2)
+        {
+            // 4. common sequence + unmount: the new run is exhausted, so unmount the extra old nodes.
+            while (i <= e1)
+            {
+                Unmount(previousChildren[i], doRemove: true);
+                i++;
+            }
+        }
+        else
+        {
+            // 5. unknown sequence: a b [c d e] f g -> a b [e d c h] f g.
+            PatchUnknownSequence(
+                previousChildren, nextChildren, container, parentAnchor, elementNamespace, parentComponent, i, l2, e1, e2);
+        }
+    }
+
+    private void PatchUnknownSequence(
+        VirtualNode[] previousChildren,
+        VirtualNode[] nextChildren,
+        TNode container,
+        TNode? parentAnchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent,
+        int start,
+        int l2,
+        int e1,
+        int e2)
+    {
+        var s1 = start;
+        var s2 = start;
+
+        // 5.1 build a key->new-index map for the new-children middle, warning on duplicate keys
+        // and on a keyed/keyless mix (both upstream dev warnings; the sink compiles out in release).
+        var keyToNewIndexMap = new Dictionary<object, int>();
+        var hasKeyed = false;
+        var hasKeyless = false;
+        for (var index = s2; index <= e2; index++)
+        {
+            var nextChild = nextChildren[index] = VirtualNodeFactory.Normalize(nextChildren[index]);
+            if (nextChild.Key is not null)
+            {
+                hasKeyed = true;
+                if (keyToNewIndexMap.ContainsKey(nextChild.Key))
+                {
+                    RuntimeWarnings.Warn(
+                        $"Duplicate keys found during update: \"{nextChild.Key}\". Make sure keys are unique.");
+                }
+                keyToNewIndexMap[nextChild.Key] = index;
+            }
+            else if (nextChild.Type != VirtualNodeType.Comment)
+            {
+                hasKeyless = true;
+            }
+        }
+        if (hasKeyed && hasKeyless)
+        {
+            RuntimeWarnings.Warn(
+                "Mixed keyed and unkeyed children detected during update. Give every iterated child a "
+                + "key (or none) so the keyed diff can track them reliably.");
+        }
+
+        // 5.2 patch matched old children, unmount the ones with no new counterpart, and record each
+        // matched new slot's old index (offset by +1; 0 marks a brand-new node).
+        var toBePatched = e2 - s2 + 1;
+        var newIndexToOldIndexMap = ArrayPool<int>.Shared.Rent(toBePatched);
+        int[]? sequence = null;
+        try
+        {
+            Array.Clear(newIndexToOldIndexMap, 0, toBePatched);
+            var patched = 0;
+            var moved = false;
+            var maxNewIndexSoFar = 0;
+            for (var index = s1; index <= e1; index++)
+            {
+                var previousChild = previousChildren[index];
+                if (patched >= toBePatched)
+                {
+                    // Every new node is already matched, so any remaining old node is a removal.
+                    Unmount(previousChild, doRemove: true);
+                    continue;
+                }
+                var newIndex = -1;
+                if (previousChild.Key is not null)
+                {
+                    if (keyToNewIndexMap.TryGetValue(previousChild.Key, out var mapped))
+                    {
+                        newIndex = mapped;
+                    }
+                }
+                else
+                {
+                    // Keyless: match the first same-type new node not already claimed.
+                    for (var j = s2; j <= e2; j++)
+                    {
+                        if (newIndexToOldIndexMap[j - s2] == 0 && IsSameVirtualNodeType(previousChild, nextChildren[j]))
+                        {
+                            newIndex = j;
+                            break;
+                        }
+                    }
+                }
+                if (newIndex < 0)
+                {
+                    Unmount(previousChild, doRemove: true);
+                }
+                else
+                {
+                    newIndexToOldIndexMap[newIndex - s2] = index + 1;
+                    if (newIndex >= maxNewIndexSoFar)
+                    {
+                        maxNewIndexSoFar = newIndex;
+                    }
+                    else
+                    {
+                        moved = true;
+                    }
+                    Patch(previousChild, nextChildren[newIndex], container, default, elementNamespace, parentComponent);
+                    patched++;
+                }
+            }
+
+            // 5.3 walk the middle back-to-front, mounting new nodes and moving only the reused nodes
+            // that fall outside the longest increasing subsequence — the minimal set of host moves.
+            var sequenceLength = 0;
+            if (moved)
+            {
+                sequence = ArrayPool<int>.Shared.Rent(toBePatched);
+                sequenceLength = GetSequence(newIndexToOldIndexMap, toBePatched, sequence);
+            }
+            var stableCursor = sequenceLength - 1;
+            for (var index = toBePatched - 1; index >= 0; index--)
+            {
+                var nextChildIndex = s2 + index;
+                var nextChild = nextChildren[nextChildIndex];
+                var anchor = nextChildIndex + 1 < l2 ? AsHostNode(nextChildren[nextChildIndex + 1].El) : parentAnchor;
+                if (newIndexToOldIndexMap[index] == 0)
+                {
+                    // A new node: mount it before the next child's host node.
+                    Patch(null, nextChild, container, anchor, elementNamespace, parentComponent);
+                }
+                else if (moved)
+                {
+                    // No stable subsequence (e.g. a full reverse) or this node is not part of it →
+                    // move it; otherwise it is already in place, so advance the stable cursor.
+                    if (stableCursor < 0 || index != sequence![stableCursor])
+                    {
+                        Move(nextChild, container, anchor);
+                    }
+                    else
+                    {
+                        stableCursor--;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<int>.Shared.Return(newIndexToOldIndexMap);
+            if (sequence is not null)
+            {
+                ArrayPool<int>.Shared.Return(sequence);
+            }
+        }
+    }
+
+    private void Move(VirtualNode node, TNode container, TNode? anchor)
+    {
+        // The C# port of move() in renderer.ts: relocate an already-mounted vnode's host node(s)
+        // before `anchor`. Components move their subtree; fragments and static nodes move their
+        // whole owned range; element/text/comment nodes move as a single host node (descendants
+        // travel with them).
+        switch (node.Type)
+        {
+            case VirtualNodeType.Component:
+                Move(((ComponentInstance)node.Component!).Subtree!, container, anchor);
+                return;
+            case VirtualNodeType.Fragment:
+                _options.Insert((TNode)node.El!, container, anchor);
+                var fragmentChildren = node.ArrayChildren!;
+                for (var index = 0; index < fragmentChildren.Length; index++)
+                {
+                    Move(fragmentChildren[index], container, anchor);
+                }
+                _options.Insert((TNode)node.Anchor!, container, anchor);
+                return;
+            case VirtualNodeType.Static:
+                MoveStaticNode(node, container, anchor);
+                return;
+            default:
+                _options.Insert((TNode)node.El!, container, anchor);
+                return;
+        }
+    }
+
+    private void MoveStaticNode(VirtualNode node, TNode container, TNode? anchor)
+    {
+        // Move every host node from the start through the end anchor inclusive (upstream:
+        // moveStaticNode); the next sibling is captured before each move mutates the sibling links.
+        var currentNode = (TNode)node.El!;
+        var endNode = (TNode)node.Anchor!;
+        while (!NodeComparer.Equals(currentNode, endNode))
+        {
+            var nextNode = _options.NextSibling(currentNode);
+            _options.Insert(currentNode, container, anchor);
+            currentNode = nextNode!;
+        }
+        _options.Insert(endNode, container, anchor);
+    }
+
+    private static int GetSequence(int[] source, int length, int[] result)
+    {
+        // Longest increasing subsequence — the C# port of getSequence in renderer.ts. Fills
+        // `result[0..count)` with indices into `source` (0..length) forming an increasing
+        // subsequence of maximal length, skipping zero entries (brand-new nodes). `result` must
+        // have length >= `length`; `predecessors` is a rented scratch buffer (upstream's `p`).
+        var predecessors = ArrayPool<int>.Shared.Rent(length);
+        try
+        {
+            Array.Copy(source, predecessors, length);
+            result[0] = 0;
+            var resultLength = 1;
+            for (var i = 0; i < length; i++)
+            {
+                var value = source[i];
+                if (value == 0)
+                {
+                    continue;
+                }
+                var last = result[resultLength - 1];
+                if (source[last] < value)
+                {
+                    predecessors[i] = last;
+                    result[resultLength++] = i;
+                    continue;
+                }
+                var low = 0;
+                var high = resultLength - 1;
+                while (low < high)
+                {
+                    var middle = (low + high) >> 1;
+                    if (source[result[middle]] < value)
+                    {
+                        low = middle + 1;
+                    }
+                    else
+                    {
+                        high = middle;
+                    }
+                }
+                if (value < source[result[low]])
+                {
+                    if (low > 0)
+                    {
+                        predecessors[i] = result[low - 1];
+                    }
+                    result[low] = i;
+                }
+            }
+            var cursor = resultLength;
+            var predecessor = result[cursor - 1];
+            while (cursor-- > 0)
+            {
+                result[cursor] = predecessor;
+                predecessor = predecessors[predecessor];
+            }
+            return resultLength;
+        }
+        finally
+        {
+            ArrayPool<int>.Shared.Return(predecessors);
+        }
+    }
+
+    private static TNode? AsHostNode(object? node) => node is null ? default : (TNode)node;
 
     private void MountChildren(
         VirtualNode[] children,

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -19,7 +19,8 @@ namespace Assimalign.Vue.RuntimeCore;
 /// <see cref="VirtualNode.PatchFlag"/> follows the compiled patch contract (targeted
 /// class/style/props/text updates); unflagged vnodes take the full diff. Array children patch
 /// positionally for now — keyed longest-increasing-subsequence reordering lands with
-/// [V01.01.03.03]; slots land with [V01.01.03.09].
+/// [V01.01.03.03]. Component slots ([V01.01.03.09]) are installed on the instance and their
+/// <see cref="Shared.SlotFlags"/> stability drives whether a parent re-render forces the child.
 /// Created through <see cref="RendererFactory.CreateRenderer{TNode}"/>.
 /// Not thread-safe (single-threaded JS event-loop model).
 /// </summary>
@@ -434,6 +435,7 @@ public sealed class Renderer<TNode>
         var instance = new ComponentInstance(definition, next, parentComponent);
         next.Component = instance;
         ComponentPropertyResolution.Resolve(instance, next);
+        ResolveSlots(instance, next);
         SetupComponent(instance);
         SetupComponentRenderEffect(instance, container, anchor, elementNamespace);
     }
@@ -521,6 +523,7 @@ public sealed class Renderer<TNode>
                 pending.Component = instance;
                 instance.VirtualNode = pending;
                 ComponentPropertyResolution.Resolve(instance, pending);
+                ResolveSlots(instance, pending);
             }
             instance.InvokeHooks(LifecycleHookKind.BeforeUpdate);
             instance.ToggleRecurse(true);
@@ -584,9 +587,36 @@ public sealed class Renderer<TNode>
         }
     }
 
+    private static void ResolveSlots(ComponentInstance instance, VirtualNode vnode)
+    {
+        // Install the parent-provided slots on the instance (upstream: initSlots/updateSlots).
+        // Runs at mount and on every update the component actually takes; when
+        // ShouldUpdateComponent skips a stable-slots parent re-render, the child keeps its existing
+        // slots, so the delegates it re-invokes stay the parent's latest committed ones.
+        if ((vnode.ShapeFlag & ShapeFlags.SlotsChildren) != 0)
+        {
+            instance.Slots = vnode.SlotChildren;
+        }
+    }
+
     private static bool ShouldUpdateComponent(VirtualNode current, VirtualNode next)
     {
-        // Upstream shouldUpdateComponent, minus slots (which land with [V01.01.03.09]).
+        // Upstream shouldUpdateComponent (packages/runtime-core/src/componentRenderUtils.ts).
+        // Compiled dynamic slots (v-if/v-for/dynamic names in slot content) always force an update.
+        if ((int)next.PatchFlag > 0 && (next.PatchFlag & PatchFlags.DynamicSlots) != 0)
+        {
+            return true;
+        }
+        // Non-stable slot children force a child update on any parent re-render so the child
+        // reflects the parent's latest slot content (upstream: the !$stable branch). A FORWARDED
+        // flag was already resolved to Stable/Dynamic at vnode creation, so only Stable is skipped.
+        var previousSlots = current.SlotChildren;
+        var nextSlots = next.SlotChildren;
+        if ((previousSlots is not null || nextSlots is not null)
+            && (nextSlots is null || nextSlots.Flag != SlotFlags.Stable))
+        {
+            return true;
+        }
         var previousProperties = current.Properties;
         var nextProperties = next.Properties;
         if (ReferenceEquals(previousProperties, nextProperties))

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Slot.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Slot.cs
@@ -1,0 +1,16 @@
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A single named slot — the C# port of upstream's <c>Slot</c> function type
+/// (<c>packages/runtime-core/src/componentSlots.ts</c>,
+/// https://vuejs.org/guide/components/slots.html). A slot is a plain delegate that produces vnodes
+/// on demand, capturing its defining render context; the child invokes it through
+/// <see cref="VirtualNodeFactory.RenderSlot"/> when it reaches the corresponding outlet. The
+/// <paramref name="properties"/> argument carries the child-supplied scope for a scoped slot (the
+/// object passed to <c>&lt;slot :x="…"/&gt;</c>); a non-scoped slot simply ignores it. Returning
+/// null or an empty array renders nothing. No reflection or boxing beyond the caller's own
+/// arguments — the delegate is the entire slot, matching the AOT/trimming contract.
+/// </summary>
+/// <param name="properties">The scoped-slot props supplied by the child, or null.</param>
+/// <returns>The slot's vnodes, or null for empty content.</returns>
+public delegate VirtualNode?[]? Slot(object? properties);

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
@@ -69,10 +69,11 @@ public sealed class VirtualNode
     public VirtualNode[]? ArrayChildren { get; internal init; }
 
     /// <summary>
-    /// The slots object when the vnode is a component with slot children. Typed as
-    /// <see cref="object"/> until slots land ([V01.01.03.09]).
+    /// The slots object when the vnode is a component carrying <see cref="ShapeFlags.SlotsChildren"/>
+    /// (upstream: the slots-object arm of <c>children</c>). Null for components rendered without
+    /// slot content.
     /// </summary>
-    public object? SlotChildren { get; internal init; }
+    public ComponentSlots? SlotChildren { get; internal init; }
 
     /// <summary>
     /// The node-kind and children-shape bitmask (upstream: <c>shapeFlag</c>); values match

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -188,6 +188,81 @@ public static class VirtualNodeFactory
         };
     }
 
+    /// <summary>
+    /// Creates a component vnode carrying <paramref name="slots"/> (upstream:
+    /// <c>createVNode(Component, props, slots)</c>). The instance renders named slots through
+    /// <see cref="RenderSlot"/>. A <see cref="SlotFlags.Forwarded"/> slots object is resolved to
+    /// <see cref="SlotFlags.Stable"/> or <see cref="SlotFlags.Dynamic"/> here against the forwarding
+    /// component's own slot stability — exactly where upstream <c>normalizeChildren</c> resolves it,
+    /// using <see cref="ComponentInstance.Current"/> as the forwarding (currently rendering)
+    /// instance.
+    /// </summary>
+    /// <param name="definition">The component definition.</param>
+    /// <param name="properties">The props passed by the parent, or null.</param>
+    /// <param name="slots">The slot content, or null.</param>
+    /// <param name="patchFlag">The compiler patch hint (<see cref="PatchFlags.DynamicSlots"/> forces child updates).</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode Component(
+        IComponentDefinition definition,
+        VirtualNodeProperties? properties,
+        ComponentSlots? slots,
+        PatchFlags patchFlag = default,
+        string[]? dynamicProperties = null)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (slots is not null && slots.Flag == SlotFlags.Forwarded)
+        {
+            var forwardingSlots = ComponentInstance.Current?.Slots;
+            slots.Flag = forwardingSlots is not null && forwardingSlots.Flag == SlotFlags.Stable
+                ? SlotFlags.Stable
+                : SlotFlags.Dynamic;
+        }
+        return new VirtualNode(VirtualNodeType.Component)
+        {
+            ComponentType = definition,
+            Properties = properties,
+            Key = ExtractKey(properties),
+            Reference = ExtractReference(properties),
+            SlotChildren = slots,
+            ShapeFlag = slots is null
+                ? ShapeFlags.StatefulComponent
+                : ShapeFlags.StatefulComponent | ShapeFlags.SlotsChildren,
+            PatchFlag = patchFlag,
+            DynamicProperties = dynamicProperties,
+        };
+    }
+
+    /// <summary>
+    /// Renders the named slot as a fragment (upstream: <c>renderSlot</c>,
+    /// <c>packages/runtime-core/src/helpers/renderSlot.ts</c>). Invokes the slot with
+    /// <paramref name="properties"/> (the scoped-slot scope) when present; otherwise renders
+    /// <paramref name="fallback"/>'s content — upstream uses fallback only when the slot is
+    /// <b>absent</b>, not when it returns empty. The result is a keyed fragment so it patches in
+    /// place across re-renders.
+    /// </summary>
+    /// <param name="slots">The instance's slots (<see cref="ComponentInstance.Slots"/>), or null.</param>
+    /// <param name="name">The slot name (<c>"default"</c> for the default slot).</param>
+    /// <param name="properties">The scoped-slot props to pass, or null.</param>
+    /// <param name="fallback">The fallback content factory used when the slot is absent, or null.</param>
+    /// <returns>A fragment vnode wrapping the slot's (or fallback's) vnodes.</returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public static VirtualNode RenderSlot(
+        ComponentSlots? slots,
+        string name,
+        object? properties = null,
+        Func<VirtualNode?[]?>? fallback = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        // The slot delegate captures its defining (parent) render context; invoking it here runs
+        // that content as part of the child's subtree. Reactive reads therefore attribute to the
+        // child's render effect (upstream withCtx parity — reactive tracking stays live; only the
+        // block-tracking suppression is deferred to the block-tree work [V01.01.03.15]).
+        VirtualNode?[]? children = slots is not null && slots.TryGetSlot(name, out var slot)
+            ? slot(properties)
+            : fallback?.Invoke();
+        return Fragment(children, "_" + name);
+    }
+
     /// <summary>Creates a fragment vnode wrapping multiple root nodes.</summary>
     /// <param name="children">The children; null entries become comment placeholders.</param>
     public static VirtualNode Fragment(params VirtualNode?[]? children)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -235,15 +235,17 @@ public static class VirtualNodeFactory
     /// <summary>
     /// Renders the named slot as a fragment (upstream: <c>renderSlot</c>,
     /// <c>packages/runtime-core/src/helpers/renderSlot.ts</c>). Invokes the slot with
-    /// <paramref name="properties"/> (the scoped-slot scope) when present; otherwise renders
-    /// <paramref name="fallback"/>'s content — upstream uses fallback only when the slot is
-    /// <b>absent</b>, not when it returns empty. The result is a keyed fragment so it patches in
-    /// place across re-renders.
+    /// <paramref name="properties"/> (the scoped-slot scope); <paramref name="fallback"/>'s content
+    /// renders when the slot is absent <b>or</b> when its content renders empty — upstream's
+    /// <c>ensureValidVNode</c> treats comment-only and empty output as no content, and a null entry
+    /// is this model's comment-placeholder idiom. The result is a keyed fragment so it patches in
+    /// place across re-renders; the fallback branch takes a distinct <c>_fb</c>-suffixed key
+    /// (upstream parity) so slot content and fallback content never patch against each other.
     /// </summary>
     /// <param name="slots">The instance's slots (<see cref="ComponentInstance.Slots"/>), or null.</param>
     /// <param name="name">The slot name (<c>"default"</c> for the default slot).</param>
     /// <param name="properties">The scoped-slot props to pass, or null.</param>
-    /// <param name="fallback">The fallback content factory used when the slot is absent, or null.</param>
+    /// <param name="fallback">The fallback content factory, or null.</param>
     /// <returns>A fragment vnode wrapping the slot's (or fallback's) vnodes.</returns>
     /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
     public static VirtualNode RenderSlot(
@@ -257,10 +259,41 @@ public static class VirtualNodeFactory
         // that content as part of the child's subtree. Reactive reads therefore attribute to the
         // child's render effect (upstream withCtx parity — reactive tracking stays live; only the
         // block-tracking suppression is deferred to the block-tree work [V01.01.03.15]).
-        VirtualNode?[]? children = slots is not null && slots.TryGetSlot(name, out var slot)
-            ? slot(properties)
-            : fallback?.Invoke();
-        return Fragment(children, "_" + name);
+        VirtualNode?[]? children = null;
+        if (slots is not null && slots.TryGetSlot(name, out var slot))
+        {
+            children = slot(properties);
+        }
+        if (fallback is null || HasRenderableContent(children))
+        {
+            return Fragment(children, "_" + name);
+        }
+        return Fragment(fallback(), "_" + name + "_fb");
+    }
+
+    private static bool HasRenderableContent(VirtualNode?[]? children)
+    {
+        // Upstream ensureValidVNode: slot output counts as content only if some child is neither a
+        // comment nor a fragment that itself renders empty. Null entries are this model's
+        // comment-placeholder idiom (see Fragment), so they count as empty too.
+        if (children is null)
+        {
+            return false;
+        }
+        for (var index = 0; index < children.Length; index++)
+        {
+            var child = children[index];
+            if (child is null || child.Type == VirtualNodeType.Comment)
+            {
+                continue;
+            }
+            if (child.Type == VirtualNodeType.Fragment && !HasRenderableContent(child.ArrayChildren))
+            {
+                continue;
+            }
+            return true;
+        }
+        return false;
     }
 
     /// <summary>Creates a fragment vnode wrapping multiple root nodes.</summary>

--- a/libraries/Assimalign.Vue.RuntimeCore/test/DependencyInjectionTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/DependencyInjectionTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins provide/inject against @vue/runtime-core's apiInject.ts —
+// https://vuejs.org/guide/components/provide-inject.html. Exercised through the in-memory renderer
+// so provide/inject run in real Setup windows with the current-instance stack live.
+public class DependencyInjectionTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public DependencyInjectionTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void Inject_ResolvesAncestorProvidedValue_AtAnyDepth()
+    {
+        var key = new InjectionKey<string>("message");
+        string? injected = null;
+
+        var grandchild = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                injected = DependencyInjection.Inject(key);
+                return static () => VirtualNodeFactory.Text("leaf");
+            },
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Component(grandchild),
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "hello");
+                return () => VirtualNodeFactory.Component(child);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+
+        injected.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void NearerProvider_ShadowsFartherProvider()
+    {
+        var key = new InjectionKey<string>("k");
+        string? injected = null;
+
+        var leaf = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                injected = DependencyInjection.Inject(key);
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+        var middle = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "near");
+                return () => VirtualNodeFactory.Component(leaf);
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "far");
+                return () => VirtualNodeFactory.Component(middle);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        injected.ShouldBe("near");
+    }
+
+    [Fact]
+    public void Inject_ResolvesThroughADeepTree()
+    {
+        // Deep-tree injection: every level probes the same provided value in O(1) via the layered
+        // provides table (no parent-chain walk on the read path).
+        var key = new InjectionKey<int>("level");
+        var seen = new List<int?>();
+
+        IComponentDefinition Build(int depth)
+        {
+            if (depth == 0)
+            {
+                return new TestComponent
+                {
+                    SetupFunction = (_, _) =>
+                    {
+                        seen.Add(DependencyInjection.Inject(key));
+                        return static () => VirtualNodeFactory.Text("leaf");
+                    },
+                };
+            }
+            var inner = Build(depth - 1);
+            return new TestComponent
+            {
+                SetupFunction = (_, _) =>
+                {
+                    seen.Add(DependencyInjection.Inject(key));
+                    return () => VirtualNodeFactory.Component(inner);
+                },
+            };
+        }
+
+        var chain = Build(10);
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, 7);
+                return () => VirtualNodeFactory.Component(chain);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        seen.Count.ShouldBe(11);
+        seen.ShouldAllBe(value => value == 7);
+    }
+
+    [Fact]
+    public void Inject_MissingKey_UsesDefaultValueWithoutWarning()
+    {
+        using var warnings = new WarningCapture();
+        var key = new InjectionKey<int>("count");
+        var injected = -1;
+
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                injected = DependencyInjection.Inject(key, 42);
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        injected.ShouldBe(42);
+        warnings.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Inject_DefaultFactory_RunsOnlyOnMiss()
+    {
+        var key = new InjectionKey<string>("k");
+        var factoryRuns = 0;
+        string? missResult = null;
+        string? hitResult = null;
+
+        var missComponent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                missResult = DependencyInjection.Inject(key, () =>
+                {
+                    factoryRuns++;
+                    return "made";
+                });
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+        _renderer.Render(VirtualNodeFactory.Component(missComponent), _container);
+        missResult.ShouldBe("made");
+        factoryRuns.ShouldBe(1);
+
+        var hitLeaf = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                hitResult = DependencyInjection.Inject(key, () =>
+                {
+                    factoryRuns++;
+                    return "made";
+                });
+                return static () => VirtualNodeFactory.Text("y");
+            },
+        };
+        var provider = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "provided");
+                return () => VirtualNodeFactory.Component(hitLeaf);
+            },
+        };
+        _renderer.Render(VirtualNodeFactory.Component(provider), _renderer.CreateContainer());
+
+        hitResult.ShouldBe("provided");
+        factoryRuns.ShouldBe(1); // never invoked on a hit
+    }
+
+    [Fact]
+    public void Inject_MissingKeyWithNoDefault_WarnsAndReturnsDefault()
+    {
+        using var warnings = new WarningCapture();
+        var key = new InjectionKey<string>("absent");
+        var injected = "sentinel";
+
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                injected = DependencyInjection.Inject(key)!;
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        injected.ShouldBeNull();
+        warnings.Messages.ShouldContain(message => message.Contains("not found"));
+    }
+
+    [Fact]
+    public void ComponentThatProvidesAndInjectsSameKey_SeesAncestorValue()
+    {
+        // Upstream reads from the parent's provides, so a self-provide is invisible to the same
+        // component's own inject — it resolves the ancestor value instead.
+        var key = new InjectionKey<string>("k");
+        string? injected = null;
+
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "childs-own");
+                injected = DependencyInjection.Inject(key, "fallback");
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "ancestor");
+                return () => VirtualNodeFactory.Component(child);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        injected.ShouldBe("ancestor");
+    }
+
+    [Fact]
+    public void ProvideInOneChild_IsNotVisibleToSibling()
+    {
+        var key = new InjectionKey<string>("k");
+        var siblingInjected = "sentinel";
+
+        var provider = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(key, "secret");
+                return static () => VirtualNodeFactory.Text("p");
+            },
+        };
+        var sibling = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                siblingInjected = DependencyInjection.Inject(key, "none");
+                return static () => VirtualNodeFactory.Text("s");
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Component(provider),
+                VirtualNodeFactory.Component(sibling)),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        siblingInjected.ShouldBe("none");
+    }
+
+    [Fact]
+    public void StringKeys_AreSupported()
+    {
+        object? injected = null;
+
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                injected = DependencyInjection.Inject("theme");
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide("theme", "dark");
+                return () => VirtualNodeFactory.Component(child);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        injected.ShouldBe("dark");
+    }
+
+    [Fact]
+    public void StringInject_TreatDefaultAsFactory_InvokesDelegateOnlyWhenAsked()
+    {
+        object? asValue = null;
+        object? asFactory = null;
+        Func<object?> factory = () => "computed";
+
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                // Without the flag the delegate is returned verbatim (upstream: default is a value).
+                asValue = DependencyInjection.Inject("absent", factory);
+                // With the flag it is invoked (upstream: treatDefaultAsFactory).
+                asFactory = DependencyInjection.Inject("absent", factory, treatDefaultAsFactory: true);
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        asValue.ShouldBeSameAs(factory);
+        asFactory.ShouldBe("computed");
+    }
+
+    [Fact]
+    public void InjectionKeys_AreIdentityBased_NotNameBased()
+    {
+        // Parity with upstream's Symbol keys: identity, not description, distinguishes keys.
+        var keyA = new InjectionKey<string>("same-name");
+        var keyB = new InjectionKey<string>("same-name");
+        string? viaA = null;
+        var viaB = "sentinel";
+
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                viaA = DependencyInjection.Inject(keyA);
+                viaB = DependencyInjection.Inject(keyB, "fallback-b");
+                return static () => VirtualNodeFactory.Text("x");
+            },
+        };
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                DependencyInjection.Provide(keyA, "onlyA");
+                return () => VirtualNodeFactory.Component(child);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(root), _container);
+
+        viaA.ShouldBe("onlyA");
+        viaB.ShouldBe("fallback-b");
+    }
+
+    [Fact]
+    public void ProvideAndInject_OutsideSetup_Warn()
+    {
+        using var warnings = new WarningCapture();
+        ComponentInstance.Current.ShouldBeNull();
+
+        DependencyInjection.Provide("k", "v");
+        var result = DependencyInjection.Inject("k", "fallback");
+
+        result.ShouldBe("fallback");
+        warnings.Messages.ShouldContain(message => message.Contains("provide()"));
+        warnings.Messages.ShouldContain(message => message.Contains("inject()"));
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/KeyedChildrenDiffTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/KeyedChildrenDiffTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Shared;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins keyed children reconciliation against @vue/runtime-core's patchKeyedChildren + getSequence
+// (renderer.ts) — https://vuejs.org/guide/essentials/list.html#maintaining-state-with-key. Op
+// counts are asserted for the canonical scenarios: a reorder must issue the minimal host moves
+// (each move is one insert interop call), never N removes + N inserts.
+public class KeyedChildrenDiffTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public KeyedChildrenDiffTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void Reverse_ReordersWithMinimalMoves_NotRemounts()
+    {
+        _renderer.Render(KeyedList("1", "2", "3", "4", "5"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("5", "4", "3", "2", "1"), _container);
+
+        RenderedKeys(_container).ShouldBe(["5", "4", "3", "2", "1"]);
+        // Minimal: one node stays (the LIS), the other N-1 move. Never remounted.
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(4);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+    }
+
+    [Fact]
+    public void SwapTwoEnds_MovesOnlyTheTwoEnds()
+    {
+        _renderer.Render(KeyedList("a", "b", "c", "d"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("d", "b", "c", "a"), _container);
+
+        RenderedKeys(_container).ShouldBe(["d", "b", "c", "a"]);
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(2); // b, c form the stable run
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+    }
+
+    [Fact]
+    public void Rotate_MovesOnlyTheRotatedNode()
+    {
+        _renderer.Render(KeyedList("a", "b", "c", "d"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("b", "c", "d", "a"), _container);
+
+        RenderedKeys(_container).ShouldBe(["b", "c", "d", "a"]);
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(1); // b, c, d stay; only a moves
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+    }
+
+    [Fact]
+    public void ShuffleWithAddAndRemove_ConvergesWithMinimalOps()
+    {
+        _renderer.Render(KeyedList("a", "b", "c", "d"), _container);
+        _renderer.OperationLog.Reset();
+
+        // Remove c, add e, and reorder: only e is created, only c is removed, and the reused nodes
+        // move minimally (a stays as the stable run; b and d move).
+        _renderer.Render(KeyedList("d", "b", "e", "a"), _container);
+
+        RenderedKeys(_container).ShouldBe(["d", "b", "e", "a"]);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(1);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(1);
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(3); // 1 mount + 2 moves
+    }
+
+    [Fact]
+    public void PrependAndAppend_MountNewNodesWithoutMovingExisting()
+    {
+        _renderer.Render(KeyedList("b", "c"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("a", "b", "c", "d"), _container);
+
+        RenderedKeys(_container).ShouldBe(["a", "b", "c", "d"]);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(2); // only a and d
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveFromMiddle_UnmountsOnlyTheRemoved_WithNoMoves()
+    {
+        _renderer.Render(KeyedList("a", "b", "c", "d"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("a", "c", "d"), _container);
+
+        RenderedKeys(_container).ShouldBe(["a", "c", "d"]);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(1);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(0); // head/tail sync, no reorder
+    }
+
+    [Fact]
+    public void UnchangedKeyedList_ProducesNoStructuralOps()
+    {
+        _renderer.Render(KeyedList("a", "b", "c"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(KeyedList("a", "b", "c"), _container);
+
+        _renderer.OperationLog.StructuralOperationCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void KeyedComponents_Reverse_MoveSubtrees_NotRemount()
+    {
+        // Reused component definitions keyed by name so the same-type check matches across renders.
+        var definitions = new Dictionary<string, IComponentDefinition>(StringComparer.Ordinal);
+        IComponentDefinition Definition(string key)
+        {
+            if (!definitions.TryGetValue(key, out var definition))
+            {
+                definition = new TestComponent
+                {
+                    SetupFunction = (_, _) => () => VirtualNodeFactory.Element("span", key),
+                };
+                definitions[key] = definition;
+            }
+            return definition;
+        }
+        VirtualNode ComponentList(params string[] keys)
+        {
+            var children = new VirtualNode?[keys.Length];
+            for (var index = 0; index < keys.Length; index++)
+            {
+                children[index] = VirtualNodeFactory.Component(
+                    Definition(keys[index]), VirtualNodeFactory.Properties(("key", keys[index])));
+            }
+            return VirtualNodeFactory.Element("div", null, children);
+        }
+
+        _renderer.Render(ComponentList("a", "b", "c"), _container);
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><div><span>a</span><span>b</span><span>c</span></div></root>");
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(ComponentList("c", "b", "a"), _container);
+
+        // Subtrees relocate; no span is remounted, and only the minimal moves are issued.
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><div><span>c</span><span>b</span><span>a</span></div></root>");
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.Insert).ShouldBe(2);
+    }
+
+    [Fact]
+    public void KeyedFragments_Swap_MoveTheirWholeRange_NotRemount()
+    {
+        VirtualNode FragmentList(params string[] keys)
+        {
+            var children = new VirtualNode?[keys.Length];
+            for (var index = 0; index < keys.Length; index++)
+            {
+                children[index] = VirtualNodeFactory.Fragment(
+                    [VirtualNodeFactory.Element("span", keys[index])], keys[index]);
+            }
+            return VirtualNodeFactory.Element("div", null, children);
+        }
+
+        _renderer.Render(FragmentList("a", "b"), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>a</span><span>b</span></div></root>");
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(FragmentList("b", "a"), _container);
+
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>b</span><span>a</span></div></root>");
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(0);
+    }
+
+    [Fact]
+    public void UnkeyedFragmentFlag_KeepsPositionalPatching_IgnoringKeys()
+    {
+        // With the UNKEYED_FRAGMENT flag the diff patches by index, so a per-position key change
+        // remounts in place instead of moving — the contrast that proves the routing.
+        VirtualNode UnkeyedFragment(params string[] keys)
+        {
+            var children = new VirtualNode?[keys.Length];
+            for (var index = 0; index < keys.Length; index++)
+            {
+                children[index] = VirtualNodeFactory.Element(
+                    "li", VirtualNodeFactory.Properties(("key", keys[index])), keys[index]);
+            }
+            return VirtualNodeFactory.Fragment(children, null, PatchFlags.UnkeyedFragment);
+        }
+
+        _renderer.Render(UnkeyedFragment("a", "b"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(UnkeyedFragment("b", "a"), _container);
+
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><li>b</li><li>a</li></root>");
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(2);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(2);
+    }
+
+    [Fact]
+    public void DuplicateKeys_ProduceADevWarning()
+    {
+        using var warnings = new WarningCapture();
+        _renderer.Render(KeyedList("start"), _container);
+
+        _renderer.Render(KeyedList("dup", "dup"), _container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("Duplicate keys"));
+    }
+
+    [Fact]
+    public void MixedKeyedAndUnkeyedChildren_ProduceADevWarning()
+    {
+        using var warnings = new WarningCapture();
+        var keyedOnly = VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Element("li", VirtualNodeFactory.Properties(("key", "a")), "a"),
+            VirtualNodeFactory.Element("li", VirtualNodeFactory.Properties(("key", "b")), "b"));
+        _renderer.Render(keyedOnly, _container);
+
+        // The reconciled middle mixes a keyless <span> with a keyed <li>.
+        var mixed = VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Element("span", "x"),
+            VirtualNodeFactory.Element("li", VirtualNodeFactory.Properties(("key", "a")), "a"));
+        _renderer.Render(mixed, _container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("Mixed keyed and unkeyed"));
+    }
+
+    [Fact]
+    public void KeyedDiff_ConvergesForRandomPermutationsWithInsertsAndDeletes()
+    {
+        // Fuzz: any permutation with inserts and deletes must converge to the exact target order.
+        var random = new Random(20260717);
+        for (var iteration = 0; iteration < 400; iteration++)
+        {
+            var renderer = new TestRenderer();
+            var container = renderer.CreateContainer();
+            var initial = RandomDistinctKeys(random, 0, 15);
+            renderer.Render(KeyedList(initial), container);
+            RenderedKeys(container).ShouldBe(initial);
+
+            var next = RandomNextKeys(random, initial);
+            renderer.Render(KeyedList(next), container);
+            RenderedKeys(container).ShouldBe(next, $"iteration {iteration}: [{string.Join(",", initial)}] -> [{string.Join(",", next)}]");
+        }
+    }
+
+    private static VirtualNode KeyedList(params string[] keys)
+    {
+        var children = new VirtualNode?[keys.Length];
+        for (var index = 0; index < keys.Length; index++)
+        {
+            children[index] = VirtualNodeFactory.Element(
+                "li", VirtualNodeFactory.Properties(("key", keys[index])), keys[index]);
+        }
+        return VirtualNodeFactory.Element("ul", null, children);
+    }
+
+    private static string[] RenderedKeys(TestElement container)
+    {
+        var host = (TestElement)container.Children[0];
+        return host.Children
+            .OfType<TestElement>()
+            .Select(child => ((TestText)child.Children[0]).Text)
+            .ToArray();
+    }
+
+    private static string[] RandomDistinctKeys(Random random, int rangeStart, int rangeEnd)
+    {
+        var count = random.Next(1, 9);
+        return Enumerable.Range(rangeStart, rangeEnd - rangeStart)
+            .OrderBy(_ => random.Next())
+            .Take(count)
+            .Select(key => key.ToString())
+            .ToArray();
+    }
+
+    private static string[] RandomNextKeys(Random random, string[] initial)
+    {
+        // Keep a random subset of the current keys (deletes), then splice in disjoint new keys
+        // (inserts), then shuffle (reorder).
+        var kept = initial.Where(_ => random.Next(3) != 0).ToList();
+        var additions = Enumerable.Range(100, 15)
+            .Where(_ => random.Next(3) == 0)
+            .Select(key => key.ToString());
+        return kept.Concat(additions).OrderBy(_ => random.Next()).ToArray();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/SlotsTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/SlotsTests.cs
@@ -1,0 +1,343 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Shared;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins slots against @vue/runtime-core's componentSlots.ts and helpers/renderSlot.ts —
+// https://vuejs.org/guide/components/slots.html. Run counts pin the SlotFlags stability contract
+// (a stable slot must not force a child re-render on a parent-only update — an interop saver).
+public class SlotsTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public SlotsTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void RenderSlot_RendersProvidedContent_AndFallbackWhenAbsent()
+    {
+        var slots = new ComponentSlots
+        {
+            ["default"] = _ => [VirtualNodeFactory.Element("span", "provided")],
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "default", null, () => [VirtualNodeFactory.Element("em", "fb-default")]),
+                VirtualNodeFactory.RenderSlot(context.Slots, "header", null, () => [VirtualNodeFactory.Element("h1", "fb-header")])),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+
+        // Default slot provided → its content; header slot absent → its fallback.
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><div><span>provided</span><h1>fb-header</h1></div></root>");
+    }
+
+    [Fact]
+    public void ScopedSlot_ReceivesChildProvidedProps()
+    {
+        object? received = null;
+        var slots = new ComponentSlots
+        {
+            ["default"] = properties =>
+            {
+                received = properties;
+                return [VirtualNodeFactory.Element("span", (string?)properties ?? "none")];
+            },
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "default", "child-scope")),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+
+        received.ShouldBe("child-scope");
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>child-scope</span></div></root>");
+    }
+
+    [Fact]
+    public void ScopedSlot_ReRendersWithUpdatedChildScope_OnChildUpdate()
+    {
+        var count = Reactive.Reference(0);
+        var slots = new ComponentSlots
+        {
+            ["default"] = properties => [VirtualNodeFactory.Element("span", $"count:{properties}")],
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "default", count.Value)),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>count:0</span></div></root>");
+
+        // The child re-renders on its own state change and passes the new scope to the slot.
+        count.Value = 5;
+        _pump.RunUntilIdle();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>count:5</span></div></root>");
+    }
+
+    [Fact]
+    public void StableSlots_DoNotForceChildUpdate_OnParentOnlyReRender()
+    {
+        var childRenderRuns = 0;
+        var parentState = Reactive.Reference("a");
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () =>
+            {
+                childRenderRuns++;
+                return VirtualNodeFactory.Element("div", VirtualNodeFactory.RenderSlot(context.Slots, "default"));
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                var slots = new ComponentSlots(SlotFlags.Stable)
+                {
+                    ["default"] = _ => [VirtualNodeFactory.Element("span", "slot")],
+                };
+                return VirtualNodeFactory.Element(
+                    "section",
+                    VirtualNodeFactory.Text(parentState.Value),
+                    VirtualNodeFactory.Component(child, null, slots));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        childRenderRuns.ShouldBe(1);
+
+        // Parent re-renders its own text; stable slots + unchanged props must not force the child.
+        parentState.Value = "b";
+        _pump.RunUntilIdle();
+        childRenderRuns.ShouldBe(1);
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><section>b<div><span>slot</span></div></section></root>");
+    }
+
+    [Fact]
+    public void DynamicSlots_ForceChildUpdate_OnParentReRender()
+    {
+        var childRenderRuns = 0;
+        var parentState = Reactive.Reference("a");
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () =>
+            {
+                childRenderRuns++;
+                return VirtualNodeFactory.Element("div", VirtualNodeFactory.RenderSlot(context.Slots, "default"));
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                var slots = new ComponentSlots(SlotFlags.Dynamic)
+                {
+                    ["default"] = _ => [VirtualNodeFactory.Element("span", "slot")],
+                };
+                return VirtualNodeFactory.Element(
+                    "section",
+                    VirtualNodeFactory.Text(parentState.Value),
+                    VirtualNodeFactory.Component(child, null, slots));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        childRenderRuns.ShouldBe(1);
+
+        parentState.Value = "b";
+        _pump.RunUntilIdle();
+        childRenderRuns.ShouldBe(2); // dynamic slots force the child to re-render
+    }
+
+    [Fact]
+    public void DynamicSlotsPatchFlag_ForcesChildUpdate()
+    {
+        var childRenderRuns = 0;
+        var parentState = Reactive.Reference("a");
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () =>
+            {
+                childRenderRuns++;
+                return VirtualNodeFactory.Element("div", VirtualNodeFactory.RenderSlot(context.Slots, "default"));
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                // Slots object is Stable, but the compiled DYNAMIC_SLOTS patch flag forces the update.
+                var slots = new ComponentSlots(SlotFlags.Stable)
+                {
+                    ["default"] = _ => [VirtualNodeFactory.Element("span", "slot")],
+                };
+                return VirtualNodeFactory.Element(
+                    "section",
+                    VirtualNodeFactory.Text(parentState.Value),
+                    VirtualNodeFactory.Component(child, null, slots, PatchFlags.DynamicSlots));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        childRenderRuns.ShouldBe(1);
+
+        parentState.Value = "b";
+        _pump.RunUntilIdle();
+        childRenderRuns.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ForwardedSlots_FromStableParent_DoNotForceGrandchildUpdate()
+        => RunForwardingScenario(SlotFlags.Stable).ShouldBe(1);
+
+    [Fact]
+    public void ForwardedSlots_FromDynamicParent_ForceGrandchildUpdate()
+        => RunForwardingScenario(SlotFlags.Dynamic).ShouldBe(2);
+
+    [Fact]
+    public void SlotReactiveReads_AttributeToTheInvokingChild_NotTheDefiningParent()
+    {
+        // Upstream withCtx parity: a slot's reactive reads are tracked by the child effect that
+        // invokes the slot, not the parent effect that defined it. The parent never reads the dep,
+        // so a change re-renders only the child.
+        var slotDependency = Reactive.Reference("x");
+        var parentRenderRuns = 0;
+        var childRenderRuns = 0;
+
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () =>
+            {
+                childRenderRuns++;
+                return VirtualNodeFactory.Element("div", VirtualNodeFactory.RenderSlot(context.Slots, "default"));
+            },
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                parentRenderRuns++;
+                var slots = new ComponentSlots(SlotFlags.Stable)
+                {
+                    // Reads the dep only when INVOKED (in the child), never during parent render.
+                    ["default"] = _ => [VirtualNodeFactory.Element("span", slotDependency.Value)],
+                };
+                return VirtualNodeFactory.Component(child, null, slots);
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        parentRenderRuns.ShouldBe(1);
+        childRenderRuns.ShouldBe(1);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>x</span></div></root>");
+
+        slotDependency.Value = "y";
+        _pump.RunUntilIdle();
+
+        childRenderRuns.ShouldBe(2);
+        parentRenderRuns.ShouldBe(1);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>y</span></div></root>");
+    }
+
+    [Fact]
+    public void RenderSlot_InvokedOutsideAnyRenderEffect_ReturnsContentSafely()
+    {
+        var dependency = Reactive.Reference("v");
+        var slots = new ComponentSlots
+        {
+            ["default"] = _ => [VirtualNodeFactory.Element("span", dependency.Value)],
+        };
+
+        // No active render effect: invoking the slot must neither throw nor strand tracking.
+        var fragment = VirtualNodeFactory.RenderSlot(slots, "default");
+
+        fragment.Type.ShouldBe(VirtualNodeType.Fragment);
+        fragment.ArrayChildren!.Length.ShouldBe(1);
+        Should.NotThrow(() =>
+        {
+            dependency.Value = "changed";
+        });
+    }
+
+    // Parent -> Middle (forwards its slots) -> Grandchild. The forwarded slots' stability is
+    // resolved from the flag Parent passed to Middle, so it propagates the forced-update contract.
+    private int RunForwardingScenario(SlotFlags parentToMiddleFlag)
+    {
+        var grandchildRenderRuns = 0;
+        var parentState = Reactive.Reference("a");
+
+        var grandchild = new TestComponent
+        {
+            Name = "Grandchild",
+            SetupFunction = (_, context) => () =>
+            {
+                grandchildRenderRuns++;
+                return VirtualNodeFactory.Element("div", VirtualNodeFactory.RenderSlot(context.Slots, "default"));
+            },
+        };
+        var middle = new TestComponent
+        {
+            Name = "Middle",
+            SetupFunction = (_, context) => () =>
+            {
+                var forwarded = new ComponentSlots(SlotFlags.Forwarded)
+                {
+                    ["default"] = properties => context.Slots?["default"]?.Invoke(properties),
+                };
+                return VirtualNodeFactory.Component(grandchild, null, forwarded);
+            },
+        };
+        var parent = new TestComponent
+        {
+            Name = "Parent",
+            SetupFunction = (_, _) => () =>
+            {
+                var slots = new ComponentSlots(parentToMiddleFlag)
+                {
+                    ["default"] = _ => [VirtualNodeFactory.Element("span", "leaf")],
+                };
+                return VirtualNodeFactory.Element(
+                    "section",
+                    VirtualNodeFactory.Text(parentState.Value),
+                    VirtualNodeFactory.Component(middle, null, slots));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container);
+        grandchildRenderRuns.ShouldBe(1);
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><section>a<div><span>leaf</span></div></section></root>");
+
+        parentState.Value = "b";
+        _pump.RunUntilIdle();
+        return grandchildRenderRuns;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/SlotsTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/SlotsTests.cs
@@ -268,6 +268,83 @@ public class SlotsTests : IDisposable
     }
 
     [Fact]
+    public void RenderSlot_SlotRendersEmpty_UsesFallback()
+    {
+        // Upstream renderSlot: validSlotContent || fallback() — a present slot whose content
+        // renders empty (null, empty array) falls back, exactly like an absent slot
+        // (packages/runtime-core/src/helpers/renderSlot.ts, ensureValidVNode).
+        var slots = new ComponentSlots
+        {
+            ["empty"] = _ => null,
+            ["hollow"] = _ => [],
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "empty", null, () => [VirtualNodeFactory.Element("em", "fb-empty")]),
+                VirtualNodeFactory.RenderSlot(context.Slots, "hollow", null, () => [VirtualNodeFactory.Element("em", "fb-hollow")])),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><div><em>fb-empty</em><em>fb-hollow</em></div></root>");
+    }
+
+    [Fact]
+    public void RenderSlot_SlotRendersOnlyCommentPlaceholders_UsesFallback()
+    {
+        // Upstream ensureValidVNode filters comment-only content (a v-if'd-out slot body) so the
+        // fallback shows; null entries are this model's comment-placeholder idiom.
+        var slots = new ComponentSlots
+        {
+            ["default"] = _ => [null, VirtualNodeFactory.Comment("v-if")],
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "default", null, () => [VirtualNodeFactory.Element("em", "fallback")])),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+
+        TestNodeSerializer.Serialize(_container)
+            .ShouldBe("<root><div><em>fallback</em></div></root>");
+    }
+
+    [Fact]
+    public void RenderSlot_TogglingBetweenSlotContentAndFallback_PatchesCleanly()
+    {
+        // The fallback branch renders under a "_fb"-suffixed fragment key (upstream parity), so
+        // toggling between slot content and fallback replaces the fragment rather than patching
+        // one against the other.
+        var showContent = Reactive.Reference(true);
+        var slots = new ComponentSlots(SlotFlags.Dynamic)
+        {
+            ["default"] = _ => showContent.Value ? [VirtualNodeFactory.Element("span", "content")] : null,
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, context) => () => VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.RenderSlot(context.Slots, "default", null, () => [VirtualNodeFactory.Element("em", "fallback")])),
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(child, null, slots), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>content</span></div></root>");
+
+        showContent.Value = false;
+        _pump.RunUntilIdle();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><em>fallback</em></div></root>");
+
+        showContent.Value = true;
+        _pump.RunUntilIdle();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><span>content</span></div></root>");
+    }
+
+    [Fact]
     public void RenderSlot_InvokedOutsideAnyRenderEffect_ReturnsContentSafely()
     {
         var dependency = Reactive.Reference("v");


### PR DESCRIPTION
Batch 6B — delegated implementation (Opus 4.8 agent) with design/functionality review, one review fix, and independent verification in this session.

## What landed

**Keyed children diffing [V01.01.03.03]** — the C# port of `patchKeyedChildren` from `@vue/runtime-core` renderer.ts: head/tail sync, common-sequence mount/unmount, then a key→new-index map plus longest-increasing-subsequence so reorders issue the minimal set of host moves (each avoided move is an avoided interop insert on WASM). `move()` relocates components (via subtree), fragments (start..end anchor range), and static ranges. Keyed diff is now the **default** array-vs-array path (upstream parity); only an explicit `PatchFlags.UnkeyedFragment` keeps the positional fast path. Scratch arrays come from `ArrayPool<int>` and return on all paths. Pinned op counts: reverse-of-5 = 4 moves, 0 removes, 0 creates; plus a 400-iteration randomized fuzz against a positional oracle.

**Component slots [V01.01.03.09]** — typed `ComponentSlots` (name→`Slot` delegate map) with the upstream `SlotFlags` stability marker: `Stable` slots don't force a child re-render on parent-only updates (pinned by run counts), `Dynamic`/`DynamicSlots` do, and `Forwarded` resolves against the forwarding instance at vnode creation exactly where upstream `normalizeChildren` does. `RenderSlot` renders a named slot as a keyed fragment with scoped-slot props; slot reactive reads attribute to the invoking child's render effect (upstream `withCtx` parity).

**Provide/inject [V01.01.03.10]** — `DependencyInjection.Provide`/`Inject` over typed `InjectionKey<T>` (reference identity, standing in for ES `Symbol`) and string keys, with default-value and default-factory overloads. C# has no prototype chain, so provides layering is **copy-on-first-provide**: inherit the parent table by reference, fork a flat copy on the instance's first own provide — O(1) inject on the hot path, correct because Setup runs parent-before-child. Inject reads the *parent's* table (self-provides invisible, upstream parity); root-level fallback to app provides is the documented seam for #28.

## Review notes

- **Review fix (59391c5):** `RenderSlot` originally used the fallback only when the slot was *absent*; upstream `renderSlot.ts` falls back whenever `ensureValidVNode` rejects the output (empty/comment-only content) and keys the fallback branch with a `_fb` suffix so slot content and fallback never patch against each other. Fixed and pinned by three new tests.
- `GetSequence` verified line-by-line against upstream `getSequence` (binary-search + predecessor backtrack, including upstream's initial-index-0 behavior).
- Anchor validity for component middle children verified: component vnodes carry `El` from their subtree at mount/update, so keyed-diff anchors and `Move` recursion are sound.
- Forwarded-dynamic resolution omits or-ing `DynamicSlots` into the patch flag (upstream does both); behavior is identical because `ShouldUpdateComponent` also checks slot stability directly.

## Deviations (per repo protocol)

- `InjectionKey<T>` is a sealed **class**, not a record — record value equality would collide all same-typed keys; the `Symbol` contract requires reference identity. Documented in XML docs.
- Mixed keyed/unkeyed children emit a dev warning (mandated by the #19 acceptance criteria; comment placeholders exempt).
- Provides layering is a flat copy-on-first-provide rather than a chain walk — trade-off documented in `DependencyInjection` XML docs.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors.
- 478 tests green: RuntimeCore 147, Shared 200, Reactivity 61, RuntimeDom 61, Testing 9. No pre-existing tests modified.
- Live WASM smoke: stopwatch demo boots, ticks, pause/reset emits work, zero console errors.
- `?diagnostics=1` stress: 100 tree cycles + 25 CreateApp/Mount/Unmount cycles — all registries return to baseline (no handle/listener leaks through the new move/unmount paths).

Closes #19
Closes #25
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)