### PR TITLE
feat(runtime-core): block-tree fast paths and template refs

### DIFF
--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
@@ -105,6 +105,21 @@ internal static class BlockStack
     }
 
     /// <summary>
+    /// Clears every open block after a throwing render function (upstream renderComponentRoot's
+    /// <c>blockStack.length = 0</c> in its catch): a render that threw between <see cref="OpenBlock"/>
+    /// and its closing block factory would otherwise leak an open accumulator, and — when an
+    /// ErrorCaptured hook or the app-level errorHandler swallows the error — corrupt every later
+    /// render's dynamic-child collection. The tracking counter is also restored (a small hardening
+    /// over upstream, which leaves an unbalanced v-once bracket broken).
+    /// </summary>
+    internal static void ClearAfterRenderFailure()
+    {
+        Stack.Clear();
+        current = null;
+        enabled = 1;
+    }
+
+    /// <summary>
     /// Test hook: clears the stack, current block, pool, and enable counter so one test's block
     /// state cannot leak into the next (ambient static state is the single-threaded design).
     /// </summary>

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// The per-render block-tree collection state — the C# port of the block machinery in
+/// <c>@vue/runtime-core</c> (<c>openBlock</c>/<c>closeBlock</c>/<c>setupBlock</c>/<c>currentBlock</c>/
+/// <c>isBlockTreeEnabled</c> in <c>packages/runtime-core/src/vnode.ts</c>,
+/// https://vuejs.org/guide/extras/rendering-mechanism.html#compiler-informed-virtual-dom). An open
+/// block accumulates the dynamic descendants created within it — flattened across static depth —
+/// into its <see cref="VirtualNode.DynamicChildren"/>, so the renderer patches only those nodes and
+/// skips static subtrees. On WASM every skipped patch visit is a skipped JS-interop call.
+/// <para>
+/// All state is ambient <c>static</c>: the runtime targets the single-threaded JS event loop, so
+/// this is <b>not thread-safe</b>. The stack is reused across renders (it never churns), and the
+/// growable accumulator lists are drawn from a free-list and returned once a block is closed and
+/// its children copied to a right-sized array — the persistent <c>DynamicChildren</c> arrays stay
+/// right-sized while collection allocates no per-render lists.
+/// </para>
+/// </summary>
+internal static class BlockStack
+{
+    // The empty accumulation result: a block with no dynamic descendants shares this (upstream
+    // EMPTY_ARR), so a static block allocates nothing.
+    private static readonly VirtualNode[] Empty = [];
+
+    // The stack of open blocks; each entry is one block's accumulator, or null for a
+    // disable-tracking block (v-once content, upstream openBlock(true)).
+    private static readonly List<List<VirtualNode>?> Stack = [];
+
+    // A free-list of accumulator lists: rented on OpenBlock, returned once the block is closed and
+    // its children copied out, so collection reuses lists instead of allocating per render.
+    private static readonly Stack<List<VirtualNode>> Pool = new();
+
+    // The innermost open block's accumulator, cached from the top of Stack (upstream currentBlock).
+    // Null when no block is open or the open block disables tracking.
+    private static List<VirtualNode>? current;
+
+    // Upstream isBlockTreeEnabled: > 0 collects dynamic children, <= 0 suspends collection (a
+    // v-once expression brackets itself with SetBlockTracking(-1) / SetBlockTracking(1)).
+    private static int enabled = 1;
+
+    /// <summary>
+    /// Opens a block (upstream: <c>openBlock</c>): pushes a fresh accumulator — or null when
+    /// <paramref name="disableTracking"/> is set — and makes it the current block.
+    /// </summary>
+    /// <param name="disableTracking">True for v-once content whose descendants are never collected.</param>
+    internal static void OpenBlock(bool disableTracking)
+    {
+        var block = disableTracking ? null : Rent();
+        Stack.Add(block);
+        current = block;
+    }
+
+    /// <summary>
+    /// Adjusts block-tree tracking (upstream: <c>setBlockTracking</c>). The upstream <c>hasOnce</c>
+    /// marking is intentionally omitted: Vuecs unmount always walks the full children rather than
+    /// the <c>DynamicChildren</c> fast path, so nested components inside v-once content are always
+    /// torn down and the guard it protects is not reachable.
+    /// </summary>
+    /// <param name="value">-1 suspends collection; +1 resumes it.</param>
+    internal static void SetBlockTracking(int value) => enabled += value;
+
+    /// <summary>
+    /// Closes the current block and stamps its collected dynamic descendants onto
+    /// <paramref name="block"/> (upstream: <c>setupBlock</c>): the block vnode is then itself
+    /// registered into the enclosing block, because a block is always patched and so must persist
+    /// as a dynamic child of its parent.
+    /// </summary>
+    /// <param name="block">The block vnode being created.</param>
+    /// <returns><paramref name="block"/>.</returns>
+    internal static VirtualNode CloseBlockAndSetup(VirtualNode block)
+    {
+        var accumulator = current;
+        // Upstream: dynamicChildren = isBlockTreeEnabled > 0 ? currentBlock || EMPTY_ARR : null.
+        block.DynamicChildren = enabled > 0 ? Materialize(accumulator) : null;
+        Recycle(accumulator);
+        CloseBlock();
+        if (enabled > 0 && current is not null)
+        {
+            current.Add(block);
+        }
+        return block;
+    }
+
+    /// <summary>
+    /// Registers a freshly created vnode as a dynamic child of the current block, per upstream
+    /// <c>createBaseVNode</c> tracking: a vnode is collected when it needs patching on updates — it
+    /// carries a positive patch flag, or it is a component (whose instance must persist across
+    /// renders). A vnode whose only flag is <see cref="PatchFlags.NeedHydration"/> is not dynamic
+    /// (handler caching), matching upstream.
+    /// </summary>
+    /// <param name="vnode">The vnode to consider for collection.</param>
+    internal static void TrackDynamicChild(VirtualNode vnode)
+    {
+        if (enabled > 0
+            && current is not null
+            && ((int)vnode.PatchFlag > 0 || (vnode.ShapeFlag & ShapeFlags.Component) != 0)
+            && vnode.PatchFlag != PatchFlags.NeedHydration)
+        {
+            current.Add(vnode);
+        }
+    }
+
+    /// <summary>
+    /// Test hook: clears the stack, current block, pool, and enable counter so one test's block
+    /// state cannot leak into the next (ambient static state is the single-threaded design).
+    /// </summary>
+    internal static void Reset()
+    {
+        Stack.Clear();
+        Pool.Clear();
+        current = null;
+        enabled = 1;
+    }
+
+    private static void CloseBlock()
+    {
+        // Upstream closeBlock: pop the stack and restore the parent block as current.
+        Stack.RemoveAt(Stack.Count - 1);
+        current = Stack.Count > 0 ? Stack[^1] : null;
+    }
+
+    private static VirtualNode[] Materialize(List<VirtualNode>? accumulator)
+        => accumulator is null || accumulator.Count == 0 ? Empty : accumulator.ToArray();
+
+    private static void Recycle(List<VirtualNode>? accumulator)
+    {
+        if (accumulator is not null)
+        {
+            accumulator.Clear();
+            Pool.Push(accumulator);
+        }
+    }
+
+    private static List<VirtualNode> Rent() => Pool.Count > 0 ? Pool.Pop() : [];
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -148,6 +148,13 @@ public sealed class Renderer<TNode>
             default:
                 throw new InvalidOperationException($"Unknown vnode type: {next.Type}.");
         }
+        // Set the template ref (upstream setRef call site: the end of patch). A mismatched-type
+        // replacement already cleared the old ref through the unmount above (current is now null),
+        // so only the new binding is applied here.
+        if (next.Reference is { } reference)
+        {
+            SetReference(reference, current?.Reference, next, isUnmount: false, parentComponent);
+        }
     }
 
     private static bool IsSameVirtualNodeType(VirtualNode current, VirtualNode next)
@@ -1262,6 +1269,14 @@ public sealed class Renderer<TNode>
 
     private void Unmount(VirtualNode node, bool doRemove)
     {
+        // Unset any template ref first (upstream unmount order: setRef with isUnmount before the
+        // node's teardown hooks). No owner instance is threaded through unmount, so a throwing
+        // function ref surfaces to the host — an acceptable simplification, since clearing sets null
+        // or drops from a collection and does not normally throw.
+        if (node.Reference is { } reference)
+        {
+            SetReference(reference, oldReference: null, node, isUnmount: true, owner: null);
+        }
         // Cleanup order (upstream parity): hooks and child teardown run before node removal.
         InvokeHook(node, null, "onVnodeBeforeUnmount");
         // Directive teardown fires only for element vnodes (upstream: shouldInvokeDirs = ELEMENT &&
@@ -1374,6 +1389,79 @@ public sealed class Renderer<TNode>
             // Lifecycle hooks fire in the post-flush phase (upstream: queuePostRenderEffect).
             Scheduler.QueuePostFlushCallback(new SchedulerJob(() => hook(node, previousNode)));
         }
+    }
+
+    // --- template refs ([V01.01.03.14]) --------------------------------------------------------
+
+    private static void SetReference(
+        TemplateReference reference,
+        TemplateReference? oldReference,
+        VirtualNode vnode,
+        bool isUnmount,
+        ComponentInstance? owner)
+    {
+        // The C# port of setRef (rendererTemplateRef.ts): the applied value is the mounted element,
+        // or a component's exposed surface, or null on unmount.
+        var value = isUnmount ? null : ResolveReferenceValue(vnode);
+        // Unset the previous ref-object when the binding changed to a different ref (upstream's
+        // "unset old ref" block): only a ref-object is nulled; a changed function old is simply
+        // dropped, never invoked with null (upstream parity).
+        if (oldReference is { } previous && previous != reference && previous.ReferenceObject is { } previousObject)
+        {
+            previousObject.Value = null;
+        }
+        if (value is not null)
+        {
+            // #1789: a non-null value is applied after render, id -1 so the ref is populated before
+            // user mounted/updated hooks observe it (upstream: doSet.id = -1; queuePostRenderEffect).
+            // Deviates from upstream Vue 3 parity per the #30 acceptance criteria: upstream invokes a
+            // function ref synchronously inside setRef, but Vuecs defers it here like a ref-object so
+            // that no template ref is ever applied synchronously mid-patch ("never synchronously
+            // mid-patch"). Both ref kinds therefore observe identical, post-flush timing.
+            var applied = value;
+            Scheduler.QueuePostFlushCallback(
+                new SchedulerJob(() => ApplyReference(reference, applied, owner)) { Identifier = -1 });
+        }
+        else
+        {
+            // Unmount (or a falsy value): applied synchronously (upstream doSet()).
+            ApplyReference(reference, null, owner);
+        }
+    }
+
+    private static void ApplyReference(TemplateReference reference, object? value, ComponentInstance? owner)
+    {
+        if (reference.ReferenceObject is { } referenceObject)
+        {
+            referenceObject.Value = value;
+        }
+        else if (reference.Function is { } function)
+        {
+            // A function ref (the v-for collection pattern) can run arbitrary user code; route its
+            // exceptions through the owner's error-capture chain (upstream: callWithErrorHandling
+            // with ErrorCodes.FUNCTION_REF) so one throwing ref cannot abandon the flush.
+            try
+            {
+                function(value);
+            }
+            catch (Exception exception)
+            {
+                ComponentErrorHandling.Handle(exception, owner, "template ref function");
+            }
+        }
+    }
+
+    private static object? ResolveReferenceValue(VirtualNode vnode)
+    {
+        // Upstream getComponentPublicInstance: a component ref receives the exposed surface, else the
+        // public instance. Vuecs has no public instance proxy, so the ComponentInstance itself stands
+        // in for instance.proxy (documented deviation: the fallback surface is the instance). An
+        // element ref receives the platform node.
+        if (vnode.Type == VirtualNodeType.Component && vnode.Component is ComponentInstance instance)
+        {
+            return instance.Exposed ?? instance;
+        }
+        return vnode.El;
     }
 
     // --- directive hooks ([V01.01.03.13]) ------------------------------------------------------

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -650,6 +650,10 @@ public sealed class Renderer<TNode>
         }
         catch (Exception exception)
         {
+            // Upstream renderComponentRoot clears the block stack in its catch (blockStack.length
+            // = 0): a render that threw mid-block must not leak its open accumulator into later
+            // renders when an ErrorCaptured hook or the app-level errorHandler swallows the error.
+            BlockStack.ClearAfterRenderFailure();
             ComponentErrorHandling.Handle(exception, instance, "render function");
         }
         finally

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -32,6 +32,13 @@ public sealed class Renderer<TNode>
 {
     private static readonly EqualityComparer<TNode> NodeComparer = EqualityComparer<TNode>.Default;
 
+    /// <summary>
+    /// Test seam: counts every <see cref="Patch"/> entry so a block-tree test can pin that a
+    /// re-render of a tree with N static nodes and K dynamic bindings visits O(K) vnodes, not O(N)
+    /// (issue [V01.01.03.15]). Reset it before the patch under test. Ambient static, single-threaded.
+    /// </summary>
+    internal static int PatchVisitCount;
+
     private readonly RendererOptions<TNode> _options;
     private readonly Dictionary<TNode, VirtualNode> _containerRoots = new(NodeComparer);
 
@@ -106,6 +113,7 @@ public sealed class Renderer<TNode>
         string? elementNamespace,
         ComponentInstance? parentComponent)
     {
+        PatchVisitCount++;
         if (ReferenceEquals(current, next))
         {
             return;
@@ -232,7 +240,21 @@ public sealed class Renderer<TNode>
         {
             next.El = current.El;
             next.Anchor = current.Anchor;
-            PatchChildren(current, next, container, (TNode)next.Anchor!, elementNamespace, parentComponent);
+            // Upstream processFragment routing: a stable fragment carrying a block tree patches only
+            // its dynamic descendants (positionally, never the keyed diff); every other fragment —
+            // keyed/unkeyed v-for, or a hand-written fragment — takes the full children diff. The
+            // block container is the fragment's parent, not its anchor (fragments own no element).
+            if ((int)next.PatchFlag > 0
+                && (next.PatchFlag & PatchFlags.StableFragment) != 0
+                && next.DynamicChildren is not null
+                && current.DynamicChildren is not null)
+            {
+                PatchBlockChildren(current.DynamicChildren, next.DynamicChildren, container, elementNamespace, parentComponent);
+            }
+            else
+            {
+                PatchChildren(current, next, container, (TNode)next.Anchor!, elementNamespace, parentComponent);
+            }
         }
     }
 
@@ -315,66 +337,121 @@ public sealed class Renderer<TNode>
         InvokeHook(next, current, "onVnodeBeforeUpdate");
         InvokeDirectiveHooks(next, current, DirectiveHookKind.BeforeUpdate);
         var patchFlag = (int)next.PatchFlag;
-        if (patchFlag > 0)
+        if (next.DynamicChildren is not null)
         {
-            // Compiled patch contract: only what the flags name can have changed. On WASM every
-            // skipped patchProp visit is a skipped interop call.
-            if ((next.PatchFlag & PatchFlags.FullProps) != 0)
-            {
-                PatchProperties(element, next.ElementTag!, current.Properties, next.Properties, elementNamespace);
-            }
-            else
-            {
-                if ((next.PatchFlag & PatchFlags.Class) != 0)
-                {
-                    var previousClass = current.Properties?["class"];
-                    var nextClass = next.Properties?["class"];
-                    if (!Equals(previousClass, nextClass))
-                    {
-                        _options.PatchProperty(element, next.ElementTag!, "class", previousClass, nextClass, elementNamespace);
-                    }
-                }
-                if ((next.PatchFlag & PatchFlags.Style) != 0)
-                {
-                    _options.PatchProperty(
-                        element,
-                        next.ElementTag!,
-                        "style",
-                        current.Properties?["style"],
-                        next.Properties?["style"],
-                        elementNamespace);
-                }
-                if ((next.PatchFlag & PatchFlags.Props) != 0 && next.DynamicProperties is not null)
-                {
-                    foreach (var name in next.DynamicProperties)
-                    {
-                        object? previousValue = null;
-                        object? nextValue = null;
-                        current.Properties?.TryGetValue(name, out previousValue);
-                        next.Properties?.TryGetValue(name, out nextValue);
-                        if (!Equals(previousValue, nextValue) || string.Equals(name, "value", StringComparison.Ordinal))
-                        {
-                            _options.PatchProperty(element, next.ElementTag!, name, previousValue, nextValue, elementNamespace);
-                        }
-                    }
-                }
-            }
-            if ((next.PatchFlag & PatchFlags.Text) != 0)
-            {
-                if (!string.Equals(current.TextChildren, next.TextChildren, StringComparison.Ordinal))
-                {
-                    _options.SetElementText(element, next.TextChildren ?? string.Empty);
-                }
-            }
+            // Block element: patch only the dynamic descendants the block collected — the static
+            // subtree is skipped entirely (on WASM every skipped node is a skipped interop call).
+            // The block still patches its OWN props through its patch flag; a flag of 0 means the
+            // props are static, so ApplyPatchFlagProperties leaves them untouched (upstream parity:
+            // the `else if (!optimized && dynamicChildren == null)` full-props branch is not taken).
+            PatchBlockChildren(current.DynamicChildren ?? [], next.DynamicChildren, element, ChildrenNamespace(next, elementNamespace), parentComponent);
+            ApplyPatchFlagProperties(element, current, next, elementNamespace);
+        }
+        else if (patchFlag > 0)
+        {
+            // Compiled leaf: only what the flags name can have changed; the children are static (or
+            // the single dynamic text handled by the TEXT flag). Every skipped patchProp visit is a
+            // skipped interop call on WASM.
+            ApplyPatchFlagProperties(element, current, next, elementNamespace);
         }
         else
         {
-            // Unoptimized (or Bail): full props diff and full children diff.
+            // Unoptimized (or Bail) and not a block: full props diff and full children diff.
             PatchProperties(element, next.ElementTag!, current.Properties, next.Properties, elementNamespace);
             PatchChildren(current, next, element, default, ChildrenNamespace(next, elementNamespace), parentComponent);
         }
         QueuePostHook(next, current, "onVnodeUpdated");
         QueuePostDirectiveHooks(next, current, DirectiveHookKind.Updated);
+    }
+
+    private void ApplyPatchFlagProperties(TNode element, VirtualNode current, VirtualNode next, string? elementNamespace)
+    {
+        // The compiled prop fast paths (upstream patchElement's patchFlag block): update only what
+        // the flag names. FULL_PROPS forces a full prop-bag diff; otherwise class, style, and the
+        // dynamicProps list are each visited independently; TEXT updates only the element text.
+        // NEED_PATCH / NEED_HYDRATION carry no prop work here — refs, directives, and vnode hooks
+        // are processed at their own call sites (documented N/A). A non-positive flag (a block with
+        // static props) falls through untouched.
+        var patchFlag = next.PatchFlag;
+        if ((int)patchFlag <= 0)
+        {
+            return;
+        }
+        if ((patchFlag & PatchFlags.FullProps) != 0)
+        {
+            PatchProperties(element, next.ElementTag!, current.Properties, next.Properties, elementNamespace);
+        }
+        else
+        {
+            if ((patchFlag & PatchFlags.Class) != 0)
+            {
+                var previousClass = current.Properties?["class"];
+                var nextClass = next.Properties?["class"];
+                if (!Equals(previousClass, nextClass))
+                {
+                    _options.PatchProperty(element, next.ElementTag!, "class", previousClass, nextClass, elementNamespace);
+                }
+            }
+            if ((patchFlag & PatchFlags.Style) != 0)
+            {
+                _options.PatchProperty(
+                    element,
+                    next.ElementTag!,
+                    "style",
+                    current.Properties?["style"],
+                    next.Properties?["style"],
+                    elementNamespace);
+            }
+            if ((patchFlag & PatchFlags.Props) != 0 && next.DynamicProperties is not null)
+            {
+                foreach (var name in next.DynamicProperties)
+                {
+                    object? previousValue = null;
+                    object? nextValue = null;
+                    current.Properties?.TryGetValue(name, out previousValue);
+                    next.Properties?.TryGetValue(name, out nextValue);
+                    if (!Equals(previousValue, nextValue) || string.Equals(name, "value", StringComparison.Ordinal))
+                    {
+                        _options.PatchProperty(element, next.ElementTag!, name, previousValue, nextValue, elementNamespace);
+                    }
+                }
+            }
+        }
+        if ((patchFlag & PatchFlags.Text) != 0)
+        {
+            if (!string.Equals(current.TextChildren, next.TextChildren, StringComparison.Ordinal))
+            {
+                _options.SetElementText(element, next.TextChildren ?? string.Empty);
+            }
+        }
+    }
+
+    private void PatchBlockChildren(
+        IReadOnlyList<VirtualNode> oldChildren,
+        IReadOnlyList<VirtualNode> newChildren,
+        TNode fallbackContainer,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
+    {
+        // The C# port of patchBlockChildren (renderer.ts): patch the paired dynamic descendants the
+        // block collected, never the static ones — so a tree of N static nodes with K dynamic
+        // bindings costs O(K) patch visits. Each pair resolves its container the way upstream does:
+        // the real host parent when the child may insert or move nodes (a fragment, a replaced type,
+        // or a component), otherwise the block element itself — which the patch never reads for an
+        // in-place prop/text update, so the parentNode call is skipped.
+        for (var index = 0; index < newChildren.Count; index++)
+        {
+            var oldChild = oldChildren[index];
+            var newChild = newChildren[index];
+            var container =
+                oldChild.El is not null
+                && (oldChild.Type == VirtualNodeType.Fragment
+                    || !IsSameVirtualNodeType(oldChild, newChild)
+                    || oldChild.Type == VirtualNodeType.Component)
+                    ? _options.ParentNode((TNode)oldChild.El)!
+                    : fallbackContainer;
+            Patch(oldChild, newChild, container, default, elementNamespace, parentComponent);
+        }
     }
 
     private void PatchProperties(TNode element, string elementTag, VirtualNodeProperties? previous, VirtualNodeProperties? next, string? elementNamespace)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/TemplateReference.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/TemplateReference.cs
@@ -1,0 +1,104 @@
+using System;
+
+using Assimalign.Vue.Reactivity;
+
+namespace Assimalign.Vue.RuntimeCore;
+
+/// <summary>
+/// A template-ref binding — the C# port of a normalized template ref in <c>@vue/runtime-core</c>
+/// (<c>packages/runtime-core/src/rendererTemplateRef.ts</c>,
+/// https://vuejs.org/guide/essentials/template-refs.html). A binding is exactly one of:
+/// <list type="bullet">
+/// <item>a reactive ref-object (<see cref="IReference{T}"/> of <see cref="object"/>) that receives
+/// the mounted element or a component's exposed surface — nulled on unmount;</item>
+/// <item>a function ref (<see cref="Action{T}"/> of <see cref="object"/>) invoked with the
+/// element/instance on mount and <c>null</c> on unmount, enabling custom collection (the v-for ref
+/// pattern).</item>
+/// </list>
+/// Vue's string-ref form — which resolves against a component instance proxy — is intentionally not
+/// ported: this model is reflection-free and has no string case. The renderer applies a binding
+/// through its <c>SetReference</c> in the post-flush phase (<see cref="Renderer{TNode}"/>).
+/// Element refs carry <see cref="object"/> at this TNode-generic layer (the boxed platform node);
+/// platform wrappers give typed access.
+/// </summary>
+public readonly struct TemplateReference : IEquatable<TemplateReference>
+{
+    private readonly IReference<object?>? _reference;
+    private readonly Action<object?>? _function;
+
+    private TemplateReference(IReference<object?>? reference, Action<object?>? function)
+    {
+        _reference = reference;
+        _function = function;
+    }
+
+    /// <summary>Creates a ref-object binding (upstream: a <c>Ref</c> template ref).</summary>
+    /// <param name="reference">The reactive ref that receives the element or exposed surface.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="reference"/> is null.</exception>
+    public static TemplateReference FromReference(IReference<object?> reference)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        return new TemplateReference(reference, null);
+    }
+
+    /// <summary>Creates a function-ref binding (upstream: a function template ref).</summary>
+    /// <param name="function">Invoked with the element/instance on mount and null on unmount.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="function"/> is null.</exception>
+    public static TemplateReference FromFunction(Action<object?> function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        return new TemplateReference(null, function);
+    }
+
+    /// <summary>Whether this binding is a ref-object (as opposed to a function ref).</summary>
+    public bool IsReferenceObject => _reference is not null;
+
+    /// <summary>The ref-object when <see cref="IsReferenceObject"/>; otherwise null.</summary>
+    internal IReference<object?>? ReferenceObject => _reference;
+
+    /// <summary>The function when this binding is a function ref; otherwise null.</summary>
+    internal Action<object?>? Function => _function;
+
+    /// <summary>
+    /// Classifies a raw <c>"ref"</c> prop value into a binding, or null when there is none. A value
+    /// that is neither an <see cref="IReference{T}"/> of <see cref="object"/> nor an
+    /// <see cref="Action{T}"/> of <see cref="object"/> is reported (upstream dev warning for an
+    /// invalid ref type) and treated as no ref.
+    /// </summary>
+    /// <param name="raw">The raw <c>"ref"</c> prop value.</param>
+    internal static TemplateReference? FromRaw(object? raw) => raw switch
+    {
+        null => null,
+        IReference<object?> reference => new TemplateReference(reference, null),
+        Action<object?> function => new TemplateReference(null, function),
+        _ => Invalid(raw),
+    };
+
+    /// <inheritdoc />
+    public bool Equals(TemplateReference other)
+        => ReferenceEquals(_reference, other._reference) && Equals(_function, other._function);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TemplateReference other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(_reference, _function);
+
+    /// <summary>Whether two bindings wrap the same ref-object or the same function.</summary>
+    /// <param name="left">The left binding.</param>
+    /// <param name="right">The right binding.</param>
+    public static bool operator ==(TemplateReference left, TemplateReference right) => left.Equals(right);
+
+    /// <summary>Whether two bindings differ.</summary>
+    /// <param name="left">The left binding.</param>
+    /// <param name="right">The right binding.</param>
+    public static bool operator !=(TemplateReference left, TemplateReference right) => !left.Equals(right);
+
+    private static TemplateReference? Invalid(object raw)
+    {
+        RuntimeWarnings.Warn(
+            $"Invalid template ref of type {raw.GetType().Name}: a template ref must be an "
+            + "IReference<object?> or an Action<object?> (string refs are not supported).");
+        return null;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
@@ -96,11 +96,13 @@ public sealed class VirtualNode
     public string[]? DynamicProperties { get; internal init; }
 
     /// <summary>
-    /// The block's dynamic descendants collected by the block tree (upstream:
-    /// <c>dynamicChildren</c>). Populated once block-tree fast paths land ([V01.01.03.15]);
-    /// the field exists now so compiled vnodes round-trip.
+    /// The block's dynamic descendants, collected by the block tree and flattened across static
+    /// depth (upstream: <c>dynamicChildren</c>, set by <c>setupBlock</c>). Non-null marks this
+    /// vnode as a block: the renderer patches only these nodes and skips the static subtree
+    /// (<see cref="Renderer{TNode}"/>'s <c>PatchBlockChildren</c>, [V01.01.03.15]). A block with
+    /// no dynamic descendants carries an empty list, not null.
     /// </summary>
-    public IList<VirtualNode>? DynamicChildren { get; set; }
+    public IReadOnlyList<VirtualNode>? DynamicChildren { get; internal set; }
 
     /// <summary>
     /// The platform node this vnode is mounted to (upstream: <c>el</c>). Renderer-owned; the

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
@@ -48,10 +48,11 @@ public sealed class VirtualNode
 
     /// <summary>
     /// The template-ref binding extracted from the <c>"ref"</c> prop at creation (upstream:
-    /// <c>ref</c>). Carried as data for now; the renderer wires refs when the component model
-    /// lands ([V01.01.03.06]).
+    /// <c>ref</c>, normalized by <c>normalizeRef</c>), or null when the vnode carries no ref. The
+    /// renderer applies it in the post-flush phase after mount/patch and clears it on unmount
+    /// (<see cref="Renderer{TNode}"/>'s <c>SetReference</c>, [V01.01.03.14]).
     /// </summary>
-    public object? Reference { get; internal init; }
+    public TemplateReference? Reference { get; internal init; }
 
     /// <summary>
     /// The text payload: element text children (<see cref="ShapeFlags.TextChildren"/>),

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -578,8 +578,10 @@ public static class VirtualNodeFactory
     private static object? ExtractKey(VirtualNodeProperties? properties)
         => properties is not null && properties.TryGetValue("key", out var key) ? key : null;
 
-    private static object? ExtractReference(VirtualNodeProperties? properties)
-        => properties is not null && properties.TryGetValue("ref", out var reference) ? reference : null;
+    private static TemplateReference? ExtractReference(VirtualNodeProperties? properties)
+        => properties is not null && properties.TryGetValue("ref", out var reference)
+            ? TemplateReference.FromRaw(reference)
+            : null;
 
     private static object? MergeClassValues(object? existing, object? incoming)
     {

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -66,6 +66,18 @@ public static class VirtualNodeFactory
         PatchFlags patchFlag,
         string[]? dynamicProperties = null)
     {
+        var vnode = BuildElement(tag, properties, textChildren, patchFlag, dynamicProperties);
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
+    }
+
+    private static VirtualNode BuildElement(
+        string tag,
+        VirtualNodeProperties? properties,
+        string textChildren,
+        PatchFlags patchFlag,
+        string[]? dynamicProperties)
+    {
         ArgumentException.ThrowIfNullOrEmpty(tag);
         return new VirtualNode(VirtualNodeType.Element)
         {
@@ -96,6 +108,18 @@ public static class VirtualNodeFactory
         PatchFlags patchFlag,
         string[]? dynamicProperties = null)
     {
+        var vnode = BuildElement(tag, properties, children, patchFlag, dynamicProperties);
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
+    }
+
+    private static VirtualNode BuildElement(
+        string tag,
+        VirtualNodeProperties? properties,
+        VirtualNode?[]? children,
+        PatchFlags patchFlag,
+        string[]? dynamicProperties)
+    {
         ArgumentException.ThrowIfNullOrEmpty(tag);
         var normalizedChildren = NormalizeArrayChildren(children);
         return new VirtualNode(VirtualNodeType.Element)
@@ -113,17 +137,79 @@ public static class VirtualNodeFactory
         };
     }
 
+    /// <summary>
+    /// Opens a block so the vnodes created until the matching block factory call are collected as
+    /// its dynamic descendants (upstream: <c>openBlock</c>,
+    /// https://vuejs.org/guide/extras/rendering-mechanism.html#compiler-informed-virtual-dom). Pair
+    /// every call with a block factory — <see cref="ElementBlock(string, VirtualNodeProperties?, VirtualNode?[]?, PatchFlags, string[]?)"/>
+    /// or <see cref="FragmentBlock"/> — that closes it. Not thread-safe (single-threaded JS
+    /// event-loop model).
+    /// </summary>
+    /// <param name="disableTracking">
+    /// True for v-once content whose descendants are created once and never collected.
+    /// </param>
+    public static void OpenBlock(bool disableTracking = false) => BlockStack.OpenBlock(disableTracking);
+
+    /// <summary>
+    /// Suspends or resumes block-tree tracking (upstream: <c>setBlockTracking</c>): a v-once
+    /// expression brackets its cached content with <c>SetBlockTracking(-1)</c> then
+    /// <c>SetBlockTracking(1)</c> so the content is not collected as a dynamic child.
+    /// </summary>
+    /// <param name="value">-1 suspends collection; +1 resumes it.</param>
+    public static void SetBlockTracking(int value) => BlockStack.SetBlockTracking(value);
+
+    /// <summary>
+    /// Creates a block element vnode whose <see cref="VirtualNode.DynamicChildren"/> are the dynamic
+    /// descendants collected since <see cref="OpenBlock"/> (upstream: <c>createElementBlock</c>); the
+    /// renderer patches only those descendants on update, skipping the static subtree.
+    /// </summary>
+    /// <param name="tag">The element tag.</param>
+    /// <param name="properties">The properties, or null.</param>
+    /// <param name="children">The children; null entries become comment placeholders.</param>
+    /// <param name="patchFlag">The compiler patch hint for this element's own props.</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode ElementBlock(
+        string tag,
+        VirtualNodeProperties? properties,
+        VirtualNode?[]? children,
+        PatchFlags patchFlag = default,
+        string[]? dynamicProperties = null)
+        => BlockStack.CloseBlockAndSetup(BuildElement(tag, properties, children, patchFlag, dynamicProperties));
+
+    /// <summary>
+    /// Creates a block element vnode with text children whose
+    /// <see cref="VirtualNode.DynamicChildren"/> are the dynamic descendants collected since
+    /// <see cref="OpenBlock"/> (upstream: <c>createElementBlock</c>).
+    /// </summary>
+    /// <param name="tag">The element tag.</param>
+    /// <param name="properties">The properties, or null.</param>
+    /// <param name="textChildren">The text content.</param>
+    /// <param name="patchFlag">The compiler patch hint for this element's own props.</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode ElementBlock(
+        string tag,
+        VirtualNodeProperties? properties,
+        string textChildren,
+        PatchFlags patchFlag = default,
+        string[]? dynamicProperties = null)
+        => BlockStack.CloseBlockAndSetup(BuildElement(tag, properties, textChildren, patchFlag, dynamicProperties));
+
     /// <summary>Creates a text vnode (upstream: <c>createTextVNode</c>).</summary>
     /// <param name="content">The text content.</param>
     /// <param name="patchFlag">
     /// The compiler hint — <see cref="PatchFlags.Text"/> when the content is a dynamic expression.
     /// </param>
     public static VirtualNode Text(string content, PatchFlags patchFlag = default)
-        => new(VirtualNodeType.Text)
+    {
+        var vnode = new VirtualNode(VirtualNodeType.Text)
         {
             TextChildren = content ?? string.Empty,
             PatchFlag = patchFlag,
         };
+        // Dynamic text (PatchFlags.Text) is a collected block child (upstream createTextVNode).
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
+    }
 
     /// <summary>Creates a comment vnode (upstream: <c>createCommentVNode</c>).</summary>
     /// <param name="content">The comment text.</param>
@@ -176,7 +262,7 @@ public static class VirtualNodeFactory
         string[]? dynamicProperties)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        return new VirtualNode(VirtualNodeType.Component)
+        var vnode = new VirtualNode(VirtualNodeType.Component)
         {
             ComponentType = definition,
             Properties = properties,
@@ -186,6 +272,10 @@ public static class VirtualNodeFactory
             PatchFlag = patchFlag,
             DynamicProperties = dynamicProperties,
         };
+        // A component is always collected into the enclosing block (upstream: shapeFlag & COMPONENT):
+        // it must persist its instance to the next vnode even when its own props do not change.
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
     }
 
     /// <summary>
@@ -217,7 +307,7 @@ public static class VirtualNodeFactory
                 ? SlotFlags.Stable
                 : SlotFlags.Dynamic;
         }
-        return new VirtualNode(VirtualNodeType.Component)
+        var vnode = new VirtualNode(VirtualNodeType.Component)
         {
             ComponentType = definition,
             Properties = properties,
@@ -230,6 +320,9 @@ public static class VirtualNodeFactory
             PatchFlag = patchFlag,
             DynamicProperties = dynamicProperties,
         };
+        // A component is always collected into the enclosing block (upstream: shapeFlag & COMPONENT).
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
     }
 
     /// <summary>
@@ -309,6 +402,27 @@ public static class VirtualNodeFactory
     /// <see cref="PatchFlags.KeyedFragment"/>, or <see cref="PatchFlags.UnkeyedFragment"/>).
     /// </param>
     public static VirtualNode Fragment(VirtualNode?[]? children, object? key, PatchFlags patchFlag = default)
+    {
+        var vnode = BuildFragment(children, key, patchFlag);
+        // A flagged fragment (keyed/unkeyed/stable v-for) is a collected block child; a plain
+        // fragment (patchFlag 0, e.g. RenderSlot's output) is not, keeping slot behavior identical.
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
+    }
+
+    /// <summary>
+    /// Creates a block fragment vnode whose <see cref="VirtualNode.DynamicChildren"/> are the
+    /// dynamic descendants collected since <see cref="OpenBlock"/> (upstream: <c>createBlock</c> over
+    /// the <c>Fragment</c> type). A stable fragment with a block tree patches only those descendants
+    /// positionally, never through the keyed diff.
+    /// </summary>
+    /// <param name="children">The children; null entries become comment placeholders.</param>
+    /// <param name="key">The diffing key, or null.</param>
+    /// <param name="patchFlag">The compiler hint (typically <see cref="PatchFlags.StableFragment"/>).</param>
+    public static VirtualNode FragmentBlock(VirtualNode?[]? children, object? key = null, PatchFlags patchFlag = default)
+        => BlockStack.CloseBlockAndSetup(BuildFragment(children, key, patchFlag));
+
+    private static VirtualNode BuildFragment(VirtualNode?[]? children, object? key, PatchFlags patchFlag)
         => new(VirtualNodeType.Fragment)
         {
             Key = key,

--- a/libraries/Assimalign.Vue.RuntimeCore/test/BlockTreeTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/BlockTreeTests.cs
@@ -1,0 +1,371 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Shared;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the block-tree fast paths against @vue/runtime-core's openBlock/setupBlock/patchBlockChildren
+// and the patchElement patch-flag matrix (packages/runtime-core/src/vnode.ts + renderer.ts) —
+// https://vuejs.org/guide/extras/rendering-mechanism.html#compiler-informed-virtual-dom. Skipping a
+// static subtree is skipping marshaled node-op calls on WASM, so the O(K) visit claim is pinned with
+// both the node-op log and the internal patch-visit counter ([V01.01.03.15]).
+public class BlockTreeTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public BlockTreeTests()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        Renderer<TestNode>.PatchVisitCount = 0;
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void OpenBlock_CollectsDynamicChildren_FlattenedAcrossStaticDepth()
+    {
+        // Upstream setupBlock: a block's dynamicChildren are the dynamic descendants created within
+        // it, flattened past static wrapper elements — the static <div> is not collected, but the
+        // dynamic <span> nested inside it is.
+        VirtualNodeFactory.OpenBlock();
+        var block = VirtualNodeFactory.ElementBlock(
+            "section",
+            null,
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Element(
+                    "div",
+                    null,
+                    new VirtualNode?[] { VirtualNodeFactory.Element("span", null, "msg", PatchFlags.Text) }),
+            });
+
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren.Count.ShouldBe(1);
+        block.DynamicChildren[0].ElementTag.ShouldBe("span");
+    }
+
+    [Fact]
+    public void PatchBlock_VisitsOnlyDynamicNodes_SkippingTheStaticSubtree()
+    {
+        VirtualNode Build(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("header", "static-1"),
+                    VirtualNodeFactory.Element("nav", "static-2"),
+                    VirtualNodeFactory.Element("footer", "static-3"),
+                    VirtualNodeFactory.Element("span", null, message, PatchFlags.Text),
+                });
+        }
+
+        _renderer.Render(Build("a"), _container);
+        _renderer.OperationLog.Reset();
+        Renderer<TestNode>.PatchVisitCount = 0;
+
+        _renderer.Render(Build("b"), _container);
+
+        // O(K): only the block root and the single dynamic <span> are visited; the three static
+        // children are never passed to patch. K = 1 dynamic binding, not N = 3 static nodes.
+        Renderer<TestNode>.PatchVisitCount.ShouldBe(2);
+        _renderer.OperationLog.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        _renderer.OperationLog.StructuralOperationCount.ShouldBe(0);
+        _renderer.OperationLog.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        TestNodeSerializer.Serialize(_container).ShouldBe(
+            "<root><div><header>static-1</header><nav>static-2</nav><footer>static-3</footer><span>b</span></div></root>");
+    }
+
+    [Fact]
+    public void PatchBlock_TrustsTheCompiler_LeavingAStaticChildUntouchedEvenIfItsContentDiffers()
+    {
+        // A block skips static children entirely (upstream parity): the compiler promised the <p> is
+        // static, so a differing value in the re-render's vnode is never applied — proof the static
+        // subtree is not walked.
+        VirtualNode Build(string staticText, string dynamicText)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("p", staticText),
+                    VirtualNodeFactory.Element("span", null, dynamicText, PatchFlags.Text),
+                });
+        }
+
+        _renderer.Render(Build("first", "a"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(Build("second", "b"), _container);
+
+        _renderer.OperationLog.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><p>first</p><span>b</span></div></root>");
+    }
+
+    [Fact]
+    public void NestedBlock_PatchesTheInnerBlockThroughTheOuter()
+    {
+        VirtualNode Inner(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[] { VirtualNodeFactory.Element("span", null, message, PatchFlags.Text) });
+        }
+
+        VirtualNode Build(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "section",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("h1", "static-title"),
+                    Inner(message),
+                });
+        }
+
+        _renderer.Render(Build("a"), _container);
+        _renderer.OperationLog.Reset();
+        Renderer<TestNode>.PatchVisitCount = 0;
+
+        _renderer.Render(Build("b"), _container);
+
+        // The outer block collects the inner block (a block is always a dynamic child of its parent);
+        // the visit chain is section -> inner div -> span, and the static <h1> is skipped.
+        Renderer<TestNode>.PatchVisitCount.ShouldBe(3);
+        _renderer.OperationLog.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        TestNodeSerializer.Serialize(_container).ShouldBe(
+            "<root><section><h1>static-title</h1><div><span>b</span></div></section></root>");
+    }
+
+    [Fact]
+    public void StableFragmentBlock_PatchesDynamicChildrenPositionally_WithoutTheKeyedDiff()
+    {
+        VirtualNode Build(string first, string second)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.FragmentBlock(
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("span", null, first, PatchFlags.Text),
+                    VirtualNodeFactory.Element("span", null, second, PatchFlags.Text),
+                },
+                key: null,
+                PatchFlags.StableFragment);
+        }
+
+        _renderer.Render(Build("a1", "b1"), _container);
+        _renderer.OperationLog.Reset();
+        Renderer<TestNode>.PatchVisitCount = 0;
+
+        _renderer.Render(Build("a2", "b2"), _container);
+
+        // A stable fragment with a block tree patches its dynamic children positionally (upstream
+        // processFragment): two targeted set-text, no structural moves and no keyed reconciliation.
+        Renderer<TestNode>.PatchVisitCount.ShouldBe(3);
+        _renderer.OperationLog.Count(TestNodeOperationType.SetElementText).ShouldBe(2);
+        _renderer.OperationLog.StructuralOperationCount.ShouldBe(0);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><span>a2</span><span>b2</span></root>");
+    }
+
+    [Fact]
+    public void Bail_ProducesIdenticalResultToTheOptimizedBlock()
+    {
+        // PatchFlags.Bail exits optimized mode into a full diff; the same scenario patched optimized
+        // versus bailed must produce identical serialized DOM (upstream parity).
+        var bailedRenderer = new TestRenderer();
+        var bailedContainer = bailedRenderer.CreateContainer();
+
+        VirtualNode Optimized(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                VirtualNodeFactory.Properties(("id", "root")),
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("p", "static"),
+                    VirtualNodeFactory.Element("span", null, message, PatchFlags.Text),
+                });
+        }
+
+        VirtualNode Bailed(string message) => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("id", "root")),
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Element("p", "static"),
+                VirtualNodeFactory.Element("span", message),
+            },
+            PatchFlags.Bail);
+
+        _renderer.Render(Optimized("a"), _container);
+        bailedRenderer.Render(Bailed("a"), bailedContainer);
+        _renderer.Render(Optimized("b"), _container);
+        bailedRenderer.Render(Bailed("b"), bailedContainer);
+
+        const string expected = "<root><div id=\"root\"><p>static</p><span>b</span></div></root>";
+        TestNodeSerializer.Serialize(_container).ShouldBe(expected);
+        TestNodeSerializer.Serialize(bailedContainer).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void OpenBlock_WithDisableTracking_DoesNotCollectDynamicChildren()
+    {
+        // Upstream openBlock(true): v-once content — a dynamic child created inside is not collected,
+        // so the block carries an empty dynamicChildren and the content re-renders only via the full
+        // walk (never the block fast path).
+        VirtualNodeFactory.OpenBlock(disableTracking: true);
+        var block = VirtualNodeFactory.ElementBlock(
+            "div",
+            null,
+            new VirtualNode?[] { VirtualNodeFactory.Element("span", null, "once", PatchFlags.Text) });
+
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetBlockTracking_SuspendsThenResumesCollection()
+    {
+        // Upstream setBlockTracking: a v-once expression brackets its cached content with -1 / +1 so
+        // it is not collected, while content created after tracking resumes is.
+        VirtualNodeFactory.OpenBlock();
+        VirtualNodeFactory.SetBlockTracking(-1);
+        var cached = VirtualNodeFactory.Element("span", null, "cached", PatchFlags.Text);
+        VirtualNodeFactory.SetBlockTracking(1);
+        var live = VirtualNodeFactory.Element("em", null, "live", PatchFlags.Text);
+        var block = VirtualNodeFactory.ElementBlock("div", null, new VirtualNode?[] { cached, live });
+
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren.Count.ShouldBe(1);
+        block.DynamicChildren[0].ElementTag.ShouldBe("em");
+    }
+
+    [Fact]
+    public void ComponentChild_IsAlwaysCollected_EvenWithoutAPatchFlag()
+    {
+        // Upstream createBaseVNode: a component is collected regardless of patch flag, because its
+        // instance must persist to the next vnode even when its own props do not change.
+        var component = new TestComponent
+        {
+            SetupFunction = static (_, _) => static () => VirtualNodeFactory.Element("i", "child"),
+        };
+        VirtualNodeFactory.OpenBlock();
+        var block = VirtualNodeFactory.ElementBlock(
+            "div",
+            null,
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Element("hr"),
+                VirtualNodeFactory.Component(component),
+            });
+
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren.Count.ShouldBe(1);
+        block.DynamicChildren[0].Type.ShouldBe(VirtualNodeType.Component);
+    }
+
+    [Fact]
+    public void PatchBlock_WithAComponentChild_UpdatesTheComponentThroughTheBlock()
+    {
+        var childRenders = 0;
+        var child = new TestComponent
+        {
+            Properties = [new ComponentPropertyDefinition("label")],
+            SetupFunction = (properties, _) => () =>
+            {
+                childRenders++;
+                return VirtualNodeFactory.Element("i", (string?)properties["label"] ?? "none");
+            },
+        };
+
+        VirtualNode Build(string label)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("hr"),
+                    VirtualNodeFactory.Component(child, VirtualNodeFactory.Properties(("label", label)), PatchFlags.Props, ["label"]),
+                });
+        }
+
+        _renderer.Render(Build("one"), _container);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><hr></hr><i>one</i></div></root>");
+        childRenders.ShouldBe(1);
+
+        _renderer.Render(Build("two"), _container);
+
+        // The block patches the component (resolving its real container via the host parent) and
+        // never the static <hr>; the child re-renders once with the changed prop.
+        childRenders.ShouldBe(2);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root><div><hr></hr><i>two</i></div></root>");
+    }
+
+    [Fact]
+    public void CompiledStyleFlag_PatchesOnlyTheStyleProperty()
+    {
+        // Upstream patchElement STYLE fast path: only the style prop is visited (the stable id is not).
+        VirtualNode Compiled(string style) => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("style", style), ("id", "stable")),
+            (VirtualNode?[]?)null,
+            PatchFlags.Style);
+
+        _renderer.Render(Compiled("color:red"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(Compiled("color:blue"), _container);
+
+        var patches = _renderer.OperationLog.OfType(TestNodeOperationType.PatchProperty);
+        patches.Count.ShouldBe(1);
+        patches[0].PropertyName.ShouldBe("style");
+        patches[0].NextValue.ShouldBe("color:blue");
+    }
+
+    [Fact]
+    public void CompiledFullPropsFlag_FullyDiffsThePropertyBag()
+    {
+        // Upstream patchElement FULL_PROPS fast path: a full prop-bag diff patches only the changed
+        // key (id), skipping the unchanged one (title).
+        VirtualNode Compiled(string id, string title) => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("id", id), ("title", title)),
+            (VirtualNode?[]?)null,
+            PatchFlags.FullProps);
+
+        _renderer.Render(Compiled("a", "stable-title"), _container);
+        _renderer.OperationLog.Reset();
+
+        _renderer.Render(Compiled("b", "stable-title"), _container);
+
+        var patches = _renderer.OperationLog.OfType(TestNodeOperationType.PatchProperty);
+        patches.Count.ShouldBe(1);
+        patches[0].PropertyName.ShouldBe("id");
+        patches[0].NextValue.ShouldBe("b");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/BlockTreeTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/BlockTreeTests.cs
@@ -368,4 +368,40 @@ public class BlockTreeTests : IDisposable
         patches[0].PropertyName.ShouldBe("id");
         patches[0].NextValue.ShouldBe("b");
     }
+
+    [Fact]
+    public void RenderFunctionThrowingMidBlock_DoesNotCorruptLaterBlockCollection()
+    {
+        // Upstream renderComponentRoot clears the block stack in its catch (blockStack.length = 0).
+        // A render that throws between OpenBlock and its closing block factory, with the error
+        // swallowed by the app-level errorHandler, must not leak its open accumulator into later
+        // renders' dynamic-child collection.
+        var failing = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                VirtualNodeFactory.OpenBlock();
+                throw new InvalidOperationException("mid-block boom");
+            },
+        };
+        var application = _renderer.Renderer.CreateApplication(failing);
+        var handled = 0;
+        application.Config.ErrorHandler = (_, _, _) => handled++;
+        application.Mount(_container);
+        handled.ShouldBe(1);
+
+        // A later, unrelated block render must collect exactly its own dynamic children.
+        VirtualNodeFactory.OpenBlock();
+        var block = VirtualNodeFactory.ElementBlock(
+            "div",
+            null,
+            [
+                VirtualNodeFactory.Element("span", null, "static", default),
+                VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("id", "x")), (VirtualNode?[]?)null, PatchFlags.Props, ["id"]),
+            ]);
+
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren!.Count.ShouldBe(1);
+        block.DynamicChildren[0].ElementTag.ShouldBe("span");
+    }
 }

--- a/libraries/Assimalign.Vue.RuntimeCore/test/TemplateReferenceTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/TemplateReferenceTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins template refs against @vue/runtime-core's rendererTemplateRef.ts setRef and the template-refs
+// guide (https://vuejs.org/guide/essentials/template-refs.html): a ref-object receives the mounted
+// element or a component's exposed surface, a function ref is invoked with the element/instance and
+// nulled on unmount, application is post-flush (before user mounted hooks observe it), and a binding
+// change unsets the old ref before setting the new. String refs are intentionally excluded
+// ([V01.01.03.14]). Direct Render drains the post-flush queue synchronously, so a ref is observable
+// immediately after Render returns.
+public class TemplateReferenceTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public TemplateReferenceTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void ElementRefObject_IsSetToThePlatformNode_AfterMount()
+    {
+        var elementRef = new Reference<object?>(null);
+
+        _renderer.Render(
+            VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", elementRef)), "content"),
+            _container);
+
+        elementRef.Value.ShouldNotBeNull();
+        elementRef.Value.ShouldBeSameAs(_container.Children[0]);
+    }
+
+    [Fact]
+    public void ElementRefObject_IsClearedToNull_OnUnmount()
+    {
+        var elementRef = new Reference<object?>(null);
+        _renderer.Render(
+            VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", elementRef)), "x"),
+            _container);
+        elementRef.Value.ShouldNotBeNull();
+
+        _renderer.Render(null, _container);
+
+        elementRef.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ComponentRefObject_ReceivesTheExposedSurface_NotTheRawInstance()
+    {
+        var exposed = new object();
+        var component = new TestComponent
+        {
+            SetupFunction = (_, context) =>
+            {
+                context.Expose(exposed);
+                return static () => VirtualNodeFactory.Element("input");
+            },
+        };
+        var componentRef = new Reference<object?>(null);
+
+        _renderer.Render(
+            VirtualNodeFactory.Component(component, VirtualNodeFactory.Properties(("ref", componentRef))),
+            _container);
+
+        // Upstream getComponentPublicInstance: an exposed component surfaces only what it exposed.
+        componentRef.Value.ShouldBeSameAs(exposed);
+    }
+
+    [Fact]
+    public void ComponentRefObject_FallsBackToTheInstance_WhenNothingIsExposed()
+    {
+        ComponentInstance? instance = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                instance = ComponentInstance.Current;
+                return static () => VirtualNodeFactory.Element("input");
+            },
+        };
+        var componentRef = new Reference<object?>(null);
+
+        _renderer.Render(
+            VirtualNodeFactory.Component(component, VirtualNodeFactory.Properties(("ref", componentRef))),
+            _container);
+
+        // No Expose: the fallback surface is the component instance (Vuecs's stand-in for the
+        // upstream public instance proxy).
+        componentRef.Value.ShouldBeSameAs(instance);
+    }
+
+    [Fact]
+    public void ComponentRefObject_IsClearedToNull_OnUnmount()
+    {
+        var exposed = new object();
+        var component = new TestComponent
+        {
+            SetupFunction = (_, context) =>
+            {
+                context.Expose(exposed);
+                return static () => VirtualNodeFactory.Element("input");
+            },
+        };
+        var componentRef = new Reference<object?>(null);
+        _renderer.Render(
+            VirtualNodeFactory.Component(component, VirtualNodeFactory.Properties(("ref", componentRef))),
+            _container);
+        componentRef.Value.ShouldBeSameAs(exposed);
+
+        _renderer.Render(null, _container);
+
+        componentRef.Value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FunctionRef_IsInvokedWithTheElementOnMount_AndNullOnUnmount()
+    {
+        var calls = new List<object?>();
+        Action<object?> functionRef = value => calls.Add(value);
+
+        _renderer.Render(
+            VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", functionRef)), "x"),
+            _container);
+
+        calls.Count.ShouldBe(1);
+        calls[0].ShouldBeSameAs(_container.Children[0]);
+
+        _renderer.Render(null, _container);
+
+        calls.Count.ShouldBe(2);
+        calls[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public void FunctionRef_IsInvokedPerElement_TheVForCollectionPattern()
+    {
+        var collected = new List<object?>();
+        Action<object?> collector = value =>
+        {
+            if (value is not null)
+            {
+                collected.Add(value);
+            }
+        };
+
+        _renderer.Render(
+            VirtualNodeFactory.Element(
+                "ul",
+                (VirtualNodeProperties?)null,
+                VirtualNodeFactory.Element("li", VirtualNodeFactory.Properties(("ref", collector)), "a"),
+                VirtualNodeFactory.Element("li", VirtualNodeFactory.Properties(("ref", collector)), "b")),
+            _container);
+
+        // The same function ref is invoked once per element, enabling v-for-style collection.
+        collected.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void PatchChangingTheBinding_UnsetsTheOldRefThenSetsTheNewInThatOrder()
+    {
+        var firstRef = new Reference<object?>(null);
+        var secondRef = new Reference<object?>(null);
+
+        _renderer.Render(
+            VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", firstRef)), "x"),
+            _container);
+        firstRef.Value.ShouldNotBeNull();
+
+        // Same element, a different ref binding: the old ref is unset and the new one set.
+        _renderer.Render(
+            VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", secondRef)), "x"),
+            _container);
+
+        firstRef.Value.ShouldBeNull();
+        secondRef.Value.ShouldBeSameAs(_container.Children[0]);
+    }
+
+    [Fact]
+    public void ElementRef_IsPopulatedBeforeTheMountedHookObservesIt()
+    {
+        var elementRef = new Reference<object?>(null);
+        object? observedInMounted = null;
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnMounted(() => observedInMounted = elementRef.Value);
+                return () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", elementRef)), "x");
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(component), _container);
+
+        // The ref (post-flush id -1) is applied before the user's OnMounted (post-flush, later id),
+        // so the hook observes a populated ref (upstream: refs set before mounted).
+        observedInMounted.ShouldNotBeNull();
+        observedInMounted.ShouldBeSameAs(elementRef.Value);
+    }
+
+    [Fact]
+    public void RefUpdate_IsScheduled_NotAppliedSynchronouslyOnMutation()
+    {
+        var swap = Reactive.Reference(false);
+        var firstRef = new Reference<object?>(null);
+        var secondRef = new Reference<object?>(null);
+
+        using var effect = _renderer.Renderer.CreateRenderEffect(
+            () => swap.Value
+                ? VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", secondRef)), "x")
+                : VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("ref", firstRef)), "x"),
+            _container);
+
+        firstRef.Value.ShouldNotBeNull();
+        secondRef.Value.ShouldBeNull();
+
+        // Mutating the binding does not apply the ref synchronously — it is scheduled for the flush.
+        swap.Value = true;
+        firstRef.Value.ShouldNotBeNull();
+        secondRef.Value.ShouldBeNull();
+
+        _pump.RunUntilIdle();
+
+        // After the flush (patch + post-flush): the old ref is cleared and the new one set.
+        firstRef.Value.ShouldBeNull();
+        secondRef.Value.ShouldBeSameAs(_container.Children[0]);
+    }
+
+    [Fact]
+    public void StringRef_IsRejectedWithAWarning_AndCarriesNoBinding()
+    {
+        // String refs need a component instance proxy and are intentionally not ported: an invalid
+        // ref value is reported (upstream dev warning) and treated as no ref.
+        using var warnings = new WarningCapture();
+
+        var node = VirtualNodeFactory.Element(
+            "div", VirtualNodeFactory.Properties(("ref", "stringRef")), "x");
+
+        node.Reference.ShouldBeNull();
+        warnings.Messages.ShouldContain(message => message.Contains("Invalid template ref"));
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/VirtualNodeTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/VirtualNodeTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Shouldly;
 using Xunit;
 
+using Assimalign.Vue.Reactivity;
 using Assimalign.Vue.Shared;
 
 namespace Assimalign.Vue.RuntimeCore.Tests;
@@ -48,13 +49,17 @@ public class VirtualNodeTests
     [Fact]
     public void Element_KeyAndReferenceAreExtractedFromPropertiesAtCreation()
     {
-        var reference = new object();
+        // The "ref" prop is classified into a TemplateReference at creation ([V01.01.03.14]): a
+        // reactive ref-object becomes a ref-object binding. String refs are intentionally excluded.
+        var reference = new Reference<object?>(null);
         var node = VirtualNodeFactory.Element(
             "div",
             VirtualNodeFactory.Properties(("key", "k1"), ("ref", reference), ("class", "c")));
 
         node.Key.ShouldBe("k1");
-        node.Reference.ShouldBeSameAs(reference);
+        node.Reference.ShouldNotBeNull();
+        node.Reference.Value.ShouldBe(TemplateReference.FromReference(reference));
+        node.Reference.Value.IsReferenceObject.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Batch 7A — delegated implementation (Opus 4.8 agent) with design/functionality review and one review fix. Renderer-only; independent of the other in-flight batch-7 branches.

## What landed

**Block-tree fast paths [V01.01.03.15, #31]** — the runtime half of Vue's compiler-informed virtual DOM (`openBlock`/`setupBlock`/`patchBlockChildren`, vnode.ts + renderer.ts): `OpenBlock`/`SetBlockTracking`/`ElementBlock`/`FragmentBlock` collect dynamic descendants (positive patch flag, or any component; `NeedHydration`-only excluded) into right-sized `DynamicChildren` arrays, flattened across static depth, with the accumulator lists pooled so collection allocates nothing per render. `PatchBlockChildren` patches only the collected pairs with upstream's per-child container resolution; `PatchElement` gets the full patch-flag matrix (TEXT/CLASS/STYLE/PROPS-with-dynamicProps/FULL_PROPS, `value` always re-patched); a stable fragment with a block tree patches through the block path, every other fragment keeps the keyed/positional diff. `Bail`/disable-tracking exit to the full diff with differentially-tested identical output. O(K) is pinned two ways — the node-op log and a patch-visit counter: N static nodes + K dynamic bindings = K visits. On WASM every skipped visit is a skipped interop call, which is why this item was the wave's priority.

**Template refs [V01.01.03.14, #30]** — the `rendererTemplateRef.ts` port: `TemplateReference` is a typed discriminated struct (`IReference<object?>` ref-object or `Action<object?>` function ref — no reflection, string refs intentionally unsupported per the issue). Set at upstream's exact sites (end of patch, start of unmount): element refs receive the platform node, component refs the `Exposed` surface, non-null values applied post-flush at id −1 so refs are populated before `OnMounted` observes them, old-ref unset before new-ref set on rebind, null applied synchronously on unmount, function-ref exceptions routed through the error-capture chain.

## Review notes

- **Review fix (610a0f0):** upstream `renderComponentRoot` clears the block stack in its catch (`blockStack.length = 0`); the port didn't. A render throwing between `OpenBlock` and its closing factory — with the error swallowed by `OnErrorCaptured` or the app-level `errorHandler` — leaked an open accumulator and corrupted every later render's dynamic-child collection. `BlockStack.ClearAfterRenderFailure()` now runs in the render catch (also restoring the tracking counter, a small hardening over upstream's unbalanced v-once bracket), pinned by a swallowed-mid-block-throw test.
- The upstream `!isBlockNode` double-registration guard is solved structurally: block factories build through non-tracking private builders, and only `CloseBlockAndSetup` registers the block into its parent.
- `PatchBlockChildren` container resolution verified against upstream (fragment/replaced-type/component → real host parent; otherwise the block element, never read for in-place updates).
- The one issue↔upstream conflict is documented at the site: function refs apply post-flush like ref-objects (upstream invokes them synchronously inside `setRef`) — #30's "never synchronously mid-patch" AC wins, giving both ref kinds identical timing.

## Deviations (per repo protocol)

- Function-ref post-flush timing (above, issue-mandated).
- Component-ref fallback returns the `ComponentInstance` when nothing is exposed — no public instance proxy exists yet (upstream returns `instance.proxy`); noted as a follow-up for when a proxy surface lands.
- `SetBlockTracking` omits upstream's `hasOnce` marking — unreachable here because Vuecs unmount walks full children (see #116 for the unmount fast path that will revisit this).
- `VirtualNode.DynamicChildren`/`Reference` placeholder properties retyped; one existing test updated for the `Reference` retype (legitimately changed shape).

## Discovered scope (filed, not implemented)

- **#116 [V01.01.03.15.01]** — unmount blocks through the `DynamicChildren` fast path + thread `parentComponent` through `Unmount` (owner for unmount-time function-ref errors).
- `ComponentBlock` factory (upstream `createBlock` over a component type) noted on #53, whose codegen will need it.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors.
- **579 tests green**: RuntimeCore 199 (24 new), Shared 200, Reactivity 93, RuntimeDom 61, Testing 18, Generators 8. One pre-existing test updated (justified above).
- Live WASM smoke: demo boots, timer runs, zero console errors. `?diagnostics=1` stress: 100 tree cycles + 25 app mount/unmount cycles — all handle registries return to baseline.
- WASM AOT publish of this branch: **0 IL/trim/AOT warnings**.

Closes #31
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)