### PR TITLE
feat(runtime-dom): v-model and v-show runtime directives; application API on BrowserApplication

### DIFF
--- a/libraries/Assimalign.Vue.RuntimeCore/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Properties/AssemblyInfo.cs
@@ -2,3 +2,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assimalign.Vue.RuntimeCore.Tests")]
 [assembly: InternalsVisibleTo("Assimalign.Vue.Testing")]
+// The RuntimeDom directive tests drive the RuntimeCore scheduler directly (v-model/v-show run
+// through the real renderer + post-flush pipeline), so they reset it between tests just as the
+// Testing library does per mount ([V01.01.04.06]).
+[assembly: InternalsVisibleTo("Assimalign.Vue.RuntimeDom.Tests")]

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
@@ -32,6 +32,118 @@ public sealed class BrowserApplication
     public ComponentInstance? RootInstance => _application.RootInstance;
 
     /// <summary>
+    /// The app-level configuration (upstream: <c>app.config</c>,
+    /// https://vuejs.org/api/application.html#app-config) — the
+    /// <see cref="ApplicationConfiguration.ErrorHandler"/> and
+    /// <see cref="ApplicationConfiguration.WarnHandler"/>. Set its handlers before
+    /// <see cref="Mount(string)"/>. Delegates to the wrapped <see cref="VueApplication{TNode}.Config"/>.
+    /// </summary>
+    public ApplicationConfiguration Config => _application.Config;
+
+    /// <summary>
+    /// Registers a component under <paramref name="name"/> so descendants of the root resolve it by
+    /// name — including <c>&lt;component :is="name"&gt;</c> (upstream:
+    /// <c>app.component(name, definition)</c>, https://vuejs.org/api/application.html#app-component).
+    /// Registering a duplicate name, or registering after mount, warns in dev. Delegates to the
+    /// wrapped <see cref="VueApplication{TNode}"/>.
+    /// </summary>
+    /// <param name="name">The component name (resolved case-insensitively at render).</param>
+    /// <param name="definition">The component definition.</param>
+    /// <returns>This application, for chaining.</returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="definition"/> is null.</exception>
+    public BrowserApplication Component(string name, IComponentDefinition definition)
+    {
+        _application.Component(name, definition);
+        return this;
+    }
+
+    /// <summary>
+    /// Returns the component registered under <paramref name="name"/>, or null (upstream:
+    /// <c>app.component(name)</c> getter — an exact-name lookup).
+    /// </summary>
+    /// <param name="name">The registered name.</param>
+    /// <returns>The registered definition, or null.</returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public IComponentDefinition? Component(string name) => _application.Component(name);
+
+    /// <summary>
+    /// Registers a directive under <paramref name="name"/> so descendants resolve it by name through
+    /// <see cref="Directives.ResolveDirective"/> (upstream: <c>app.directive(name, directive)</c>,
+    /// https://vuejs.org/api/application.html#app-directive). Registering a duplicate name, or
+    /// registering after mount, warns in dev. Delegates to the wrapped
+    /// <see cref="VueApplication{TNode}"/>.
+    /// </summary>
+    /// <param name="name">The directive name (resolved case-insensitively at render).</param>
+    /// <param name="directive">The directive definition.</param>
+    /// <returns>This application, for chaining.</returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="directive"/> is null.</exception>
+    public BrowserApplication Directive(string name, IDirective directive)
+    {
+        _application.Directive(name, directive);
+        return this;
+    }
+
+    /// <summary>
+    /// Returns the directive registered under <paramref name="name"/>, or null (upstream:
+    /// <c>app.directive(name)</c> getter — an exact-name lookup).
+    /// </summary>
+    /// <param name="name">The registered name.</param>
+    /// <returns>The registered directive, or null.</returns>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    public IDirective? Directive(string name) => _application.Directive(name);
+
+    /// <summary>
+    /// Provides <paramref name="value"/> app-wide under the typed <paramref name="key"/> (upstream:
+    /// <c>app.provide(key, value)</c>, https://vuejs.org/api/application.html#app-provide) — the
+    /// final fallback in the inject lookup chain. Providing a duplicate key, or providing after
+    /// mount, warns in dev. Delegates to the wrapped <see cref="VueApplication{TNode}"/>.
+    /// </summary>
+    /// <typeparam name="T">The provided value type.</typeparam>
+    /// <param name="key">The identity-based key descendants inject with.</param>
+    /// <param name="value">The value to provide.</param>
+    /// <returns>This application, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    public BrowserApplication Provide<T>(InjectionKey<T> key, T value)
+    {
+        _application.Provide(key, value);
+        return this;
+    }
+
+    /// <summary>
+    /// Provides <paramref name="value"/> app-wide under a string <paramref name="key"/> (upstream:
+    /// <c>app.provide</c> with a string key). Delegates to the wrapped
+    /// <see cref="VueApplication{TNode}"/>.
+    /// </summary>
+    /// <param name="key">The string key descendants inject with.</param>
+    /// <param name="value">The value to provide.</param>
+    /// <returns>This application, for chaining.</returns>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is null or empty.</exception>
+    public BrowserApplication Provide(string key, object? value)
+    {
+        _application.Provide(key, value);
+        return this;
+    }
+
+    /// <summary>
+    /// Installs <paramref name="plugin"/> exactly once (upstream: <c>app.use(plugin, options)</c>,
+    /// https://vuejs.org/api/application.html#app-use). A repeat <c>Use</c> of the same plugin
+    /// instance is deduplicated with a dev warning; a plugin installed after mount warns. The
+    /// plugin's <see cref="IVuePlugin{TNode}.Install"/> receives the wrapped
+    /// <see cref="VueApplication{TNode}"/>. Delegates to the wrapped application.
+    /// </summary>
+    /// <param name="plugin">The plugin to install (over the browser's <see cref="int"/> node handles).</param>
+    /// <param name="options">Options passed to the plugin's install, or null.</param>
+    /// <returns>This application, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="plugin"/> is null.</exception>
+    public BrowserApplication Use(IVuePlugin<int> plugin, object? options = null)
+    {
+        _application.Use(plugin, options);
+        return this;
+    }
+
+    /// <summary>
     /// Resolves <paramref name="selector"/> and mounts there (upstream:
     /// <c>app.mount('#app')</c>). A selector matching nothing throws a
     /// <see cref="BrowserDomException"/> naming the selector.

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvent.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Assimalign.Vue.RuntimeDom;
 
@@ -9,6 +10,11 @@ namespace Assimalign.Vue.RuntimeDom;
 /// <c>JSObject</c> property reads and no proxy retained per event.
 /// <see cref="StopPropagation"/>/<see cref="PreventDefault"/> record intents the bridge applies
 /// to the live JS event when the synchronous dispatch returns.
+/// <para>
+/// <see cref="TargetValue"/>, <see cref="TargetChecked"/>, and <see cref="SelectedValues"/> carry
+/// the form-control state <c>v-model</c> ([V01.01.04.06]) reads, so the directive never issues a
+/// follow-up interop read per event (the issue's interop-boundary requirement).
+/// </para>
 /// </summary>
 public sealed class BrowserEvent
 {
@@ -25,7 +31,8 @@ public sealed class BrowserEvent
         int detail,
         bool isSelfTarget,
         string? targetValue,
-        bool targetChecked)
+        bool targetChecked,
+        string[]? selectedValues = null)
     {
         EventName = eventName;
         TimeStamp = timeStamp;
@@ -40,6 +47,7 @@ public sealed class BrowserEvent
         IsSelfTarget = isSelfTarget;
         TargetValue = targetValue;
         TargetChecked = targetChecked;
+        SelectedValues = selectedValues;
     }
 
     /// <summary>The DOM event type (e.g. <c>"click"</c>, <c>"keydown"</c>).</summary>
@@ -83,6 +91,14 @@ public sealed class BrowserEvent
 
     /// <summary>The target element's <c>checked</c> state at dispatch, when it has one.</summary>
     public bool TargetChecked { get; }
+
+    /// <summary>
+    /// The values of the selected <c>&lt;option&gt;</c>s when the target is a <c>&lt;select
+    /// multiple&gt;</c> (upstream reads <c>el.selectedOptions</c>), or null for every other event.
+    /// Carried so <c>VModelSelect</c> maps a multi-select change to its bound list or set without a
+    /// follow-up interop read.
+    /// </summary>
+    public IReadOnlyList<string>? SelectedValues { get; }
 
     /// <summary>Whether <see cref="StopPropagation"/> was requested.</summary>
     public bool PropagationStopped { get; private set; }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDirectiveOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDirectiveOperations.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The small operation surface the DOM <c>v-model</c>/<c>v-show</c> directives write through, plus
+/// the per-element <see cref="BrowserModelState"/> store they keep between renders. The directive
+/// types (<see cref="VModelText"/>, <see cref="VShow"/>, …) are stateless singletons the compiler
+/// references, so they resolve this ambient instance at hook time rather than capturing operations
+/// at construction: <see cref="BrowserNodeOperations"/> installs the bridge-backed instance for a
+/// real app, and tests install a recording instance to exercise the whole directive pipeline with
+/// no browser.
+/// <para>
+/// Every write maps 1:1 to a <see cref="BrowserPropertyLeafOperations"/> leaf and, for listeners,
+/// the model channel of <see cref="BrowserEventInvokerRegistry"/> — the same batched, cleanup-safe
+/// paths the patch engine uses. Single-threaded ambient state (browser main thread only).
+/// </para>
+/// </summary>
+internal sealed class BrowserDirectiveOperations
+{
+    private readonly Dictionary<int, BrowserModelState> _states = [];
+
+    /// <summary>
+    /// The ambient instance the directives resolve. Installed by <see cref="BrowserNodeOperations"/>
+    /// (bridge-backed) or a test harness (recording); never resolved off the main thread.
+    /// </summary>
+    public static BrowserDirectiveOperations? Current { get; set; }
+
+    /// <summary>Registers, swaps, or removes (null) a model-channel event listener (upstream: v-model's raw <c>addEventListener</c>).</summary>
+    public required Action<int, string, Delegate?> SetModelListener { get; init; }
+
+    /// <summary>Writes <c>el.value</c> through the guarded compare-and-set leaf (caret/IME safe).</summary>
+    public required Action<int, string> SetValueGuarded { get; init; }
+
+    /// <summary>Writes a boolean DOM property — <c>checked</c> on inputs, <c>selected</c> on options.</summary>
+    public required Action<int, string, bool> SetBooleanProperty { get; init; }
+
+    /// <summary>Sets one inline style property (name, value, important) — <c>v-show</c> toggles <c>display</c>.</summary>
+    public required Action<int, string, string, bool> SetStyleProperty { get; init; }
+
+    /// <summary>Removes one inline style property — <c>v-show</c> uses it to restore an empty original <c>display</c>.</summary>
+    public required Action<int, string> RemoveStyleProperty { get; init; }
+
+    /// <summary>The ambient instance, or a thrown <see cref="InvalidOperationException"/> when none is installed.</summary>
+    public static BrowserDirectiveOperations Require()
+        => Current ?? throw new InvalidOperationException(
+            "No BrowserDirectiveOperations installed. BrowserRuntime.CreateApp installs the "
+            + "browser-backed operations; a v-model/v-show directive ran before it.");
+
+    /// <summary>Gets (creating on first use) the model state for <paramref name="handle"/>.</summary>
+    /// <param name="handle">The element handle.</param>
+    public BrowserModelState GetState(int handle)
+        => _states.TryGetValue(handle, out var state) ? state : _states[handle] = new BrowserModelState();
+
+    /// <summary>Releases the model state for <paramref name="handle"/> when its element unmounts.</summary>
+    /// <param name="handle">The element handle.</param>
+    public void ReleaseState(int handle) => _states.Remove(handle);
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventDispatch.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventDispatch.cs
@@ -8,7 +8,9 @@ namespace Assimalign.Vue.RuntimeDom;
 /// bridge's one JS listener per (element, event, options) forwards the complete typed payload
 /// as primitives in this one call — no per-field <c>JSObject</c> reads, no proxy retained per
 /// event — and applies the returned flags (bit 0 <c>stopPropagation</c>, bit 1
-/// <c>preventDefault</c>) to the live event.
+/// <c>preventDefault</c>) to the live event. <paramref name="selectedValues"/> rides the same
+/// call for <c>&lt;select multiple&gt;</c> so <c>v-model</c> ([V01.01.04.06]) never issues a
+/// per-event follow-up read; it is null for every non-multi-select event.
 /// </summary>
 [SupportedOSPlatform("browser")]
 internal static partial class BrowserEventDispatch
@@ -29,7 +31,8 @@ internal static partial class BrowserEventDispatch
         int detail,
         bool isSelfTarget,
         string? targetValue,
-        bool targetChecked)
+        bool targetChecked,
+        [JSMarshalAs<JSType.Array<JSType.String>>] string[]? selectedValues)
     {
         var browserEvent = new BrowserEvent(
             eventName,
@@ -44,7 +47,8 @@ internal static partial class BrowserEventDispatch
             detail,
             isSelfTarget,
             targetValue,
-            targetChecked);
+            targetChecked,
+            selectedValues);
         return BrowserNodeOperations.DispatchEvent(nodeHandle, capture, browserEvent);
     }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventInvokerRegistry.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserEventInvokerRegistry.cs
@@ -14,6 +14,14 @@ namespace Assimalign.Vue.RuntimeDom;
 /// Bridge calls are injected delegates so the registry is unit-testable with no browser.
 /// Handler exceptions route to <see cref="ErrorSink"/> instead of escaping into the JS
 /// listener (the app-level pipeline plugs in with [V01.01.03.12]).
+/// <para>
+/// Each invoker carries two independent handler channels for the same DOM event: the
+/// <em>property</em> channel (a template <c>@event</c> / <c>onX</c> prop) and the <em>model</em>
+/// channel (a <c>v-model</c> directive listener, [V01.01.04.06]). Upstream adds the directive's
+/// listener with a separate raw <c>addEventListener</c>; a single shared DOM listener plus two
+/// .NET channels reproduces that coexistence without a second interop listener — both fire, in
+/// property-then-model order.
+/// </para>
 /// Not thread-safe (single-threaded JS event-loop model).
 /// </summary>
 internal sealed class BrowserEventInvokerRegistry
@@ -41,36 +49,71 @@ internal sealed class BrowserEventInvokerRegistry
     internal int InvokerCount => _invokers.Count;
 
     /// <summary>
-    /// Sets, swaps, or removes the handler for a raw event prop (upstream: <c>patchEvent</c>).
+    /// Sets, swaps, or removes the property-channel handler for a raw event prop (upstream:
+    /// <c>patchEvent</c>).
     /// </summary>
     /// <param name="nodeHandle">The element handle.</param>
     /// <param name="rawPropertyName">The full prop name (e.g. <c>"onClickCaptureOnce"</c>).</param>
     /// <param name="handler">The handler delegate, or null to remove.</param>
     internal void SetListener(int nodeHandle, string rawPropertyName, Delegate? handler)
+        => SetChannel(nodeHandle, rawPropertyName, handler, model: false);
+
+    /// <summary>
+    /// Sets, swaps, or removes the model-channel handler for a raw event prop — the listener a
+    /// <c>v-model</c> directive attaches ([V01.01.04.06]). Independent of the property channel, so
+    /// a directive listener and a template <c>@event</c> handler on the same element coexist
+    /// (upstream: v-model uses a separate raw listener).
+    /// </summary>
+    /// <param name="nodeHandle">The element handle.</param>
+    /// <param name="rawPropertyName">The full prop name (e.g. <c>"onInput"</c>, <c>"onChange"</c>).</param>
+    /// <param name="handler">The handler delegate, or null to remove.</param>
+    internal void SetModelListener(int nodeHandle, string rawPropertyName, Delegate? handler)
+        => SetChannel(nodeHandle, rawPropertyName, handler, model: true);
+
+    private void SetChannel(int nodeHandle, string rawPropertyName, Delegate? handler, bool model)
     {
         var (eventName, once, capture, passive) = ParseEventName(rawPropertyName);
         var key = (nodeHandle, eventName, capture);
-        if (handler is null)
+        if (_invokers.TryGetValue(key, out var invoker))
         {
-            if (_invokers.Remove(key))
+            // The whole point of the pattern: a re-rendered handler is a delegate swap only.
+            if (model)
             {
+                invoker.ModelHandler = handler;
+            }
+            else
+            {
+                invoker.PropertyHandler = handler;
+            }
+            // Once both channels are empty the shared DOM listener has no reason to exist.
+            if (invoker.PropertyHandler is null && invoker.ModelHandler is null)
+            {
+                _invokers.Remove(key);
                 _removeListener(nodeHandle, eventName, capture);
             }
             return;
         }
-        if (_invokers.TryGetValue(key, out var invoker))
+        if (handler is null)
         {
-            // The whole point of the pattern: a re-rendered handler is a delegate swap only.
-            invoker.Handler = handler;
             return;
         }
-        _invokers[key] = new BrowserEventInvoker { Handler = handler };
+        var created = new BrowserEventInvoker();
+        if (model)
+        {
+            created.ModelHandler = handler;
+        }
+        else
+        {
+            created.PropertyHandler = handler;
+        }
+        _invokers[key] = created;
         _addListener(nodeHandle, eventName, once, capture, passive);
     }
 
     /// <summary>
     /// Routes one dispatched event to its invoker, returning the response flags
     /// (bit 0: stopPropagation, bit 1: preventDefault) the bridge applies to the live event.
+    /// Both channels fire in property-then-model order.
     /// </summary>
     /// <param name="nodeHandle">The element handle the listener is attached to.</param>
     /// <param name="capture">Whether the capture-phase listener fired.</param>
@@ -81,11 +124,22 @@ internal sealed class BrowserEventInvokerRegistry
         {
             return 0;
         }
+        Invoke(invoker.PropertyHandler, browserEvent);
+        Invoke(invoker.ModelHandler, browserEvent);
+        return browserEvent.ToResponseFlags();
+    }
+
+    private void Invoke(Delegate? handler, BrowserEvent browserEvent)
+    {
+        if (handler is null)
+        {
+            return;
+        }
         try
         {
             // Reflection-free dispatch; a multicast delegate of either shape invokes every
             // merged target natively (MergeProperties chains same-typed handlers).
-            switch (invoker.Handler)
+            switch (handler)
             {
                 case Action<BrowserEvent> typedHandler:
                     typedHandler(browserEvent);
@@ -96,7 +150,7 @@ internal sealed class BrowserEventInvokerRegistry
                 default:
                     throw new NotSupportedException(
                         $"Event handler for '{browserEvent.EventName}' is a "
-                        + $"{invoker.Handler.GetType().Name}; handlers must be Action or Action<BrowserEvent>.");
+                        + $"{handler.GetType().Name}; handlers must be Action or Action<BrowserEvent>.");
             }
         }
         catch (Exception exception)
@@ -104,7 +158,6 @@ internal sealed class BrowserEventInvokerRegistry
             // Never escape into the JS listener; route to the error seam ([V01.01.03.12]).
             ErrorSink(exception);
         }
-        return browserEvent.ToResponseFlags();
     }
 
     /// <summary>Drops the invokers of released node handles (bridge removal already detached DOM listeners).</summary>
@@ -173,6 +226,10 @@ internal sealed class BrowserEventInvokerRegistry
 
     private sealed class BrowserEventInvoker
     {
-        internal required Delegate Handler { get; set; }
+        /// <summary>The template <c>@event</c> / <c>onX</c> prop handler, or null.</summary>
+        internal Delegate? PropertyHandler { get; set; }
+
+        /// <summary>The <c>v-model</c> directive handler, or null.</summary>
+        internal Delegate? ModelHandler { get; set; }
     }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserModelDirective.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserModelDirective.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// Shared helpers for the DOM <c>v-model</c> directives — unboxing the element handle, reading the
+/// <see cref="VueModelBinding"/> carrier and the directive modifiers, and formatting values for the
+/// DOM the same invariant way the patch engine does. Keeps <see cref="VModelText"/> and its
+/// siblings free of duplicated boilerplate; every operation is reflection-free.
+/// </summary>
+internal static class BrowserModelDirective
+{
+    /// <summary>Unboxes the directive element argument to its int node handle.</summary>
+    /// <param name="element">The boxed platform node from the directive hook.</param>
+    /// <exception cref="InvalidOperationException"><paramref name="element"/> is not a boxed int handle.</exception>
+    public static int Handle(object? element)
+        => element is int handle
+            ? handle
+            : throw new InvalidOperationException(
+                "A DOM v-model/v-show directive ran against a non-DOM node; the element handle must be an int.");
+
+    /// <summary>Whether a directive modifier (the <c>bar</c> in <c>v-model.bar</c>) is present.</summary>
+    /// <param name="binding">The directive binding.</param>
+    /// <param name="name">The modifier name.</param>
+    public static bool HasModifier(DirectiveBinding binding, string name)
+        => binding.Modifiers.TryGetValue(name, out var present) && present;
+
+    /// <summary>The <see cref="VueModelBinding"/> carried by the binding value, or null.</summary>
+    /// <param name="binding">The directive binding.</param>
+    public static VueModelBinding? Carrier(DirectiveBinding binding) => binding.Value as VueModelBinding;
+
+    /// <summary>The model value from a binding's carrier, or null when the carrier is absent.</summary>
+    /// <param name="binding">The directive binding (its <see cref="DirectiveBinding.Value"/> or <see cref="DirectiveBinding.OldValue"/>).</param>
+    public static object? ModelValue(object? binding) => (binding as VueModelBinding)?.Value;
+
+    /// <summary>Formats a value for the DOM (null → empty; invariant scalar otherwise), matching the patch engine.</summary>
+    /// <param name="value">The value to format.</param>
+    public static string FormatValue(object? value)
+        => value is null ? string.Empty : DisplayStringFormatter.FormatScalar(value);
+
+    /// <summary>Reads a raw vnode property (the bound <c>:value</c>, <c>true-value</c>, …), preserving object identity.</summary>
+    /// <param name="node">The element vnode.</param>
+    /// <param name="name">The property name.</param>
+    public static object? Property(VirtualNode node, string name) => node.Properties?[name];
+
+    /// <summary>Whether the vnode declares <c>type="number"</c> (upstream: <c>vnode.props.type === 'number'</c>).</summary>
+    /// <param name="node">The element vnode.</param>
+    public static bool IsNumberType(VirtualNode node)
+        => string.Equals(FormatValue(Property(node, "type")), "number", StringComparison.Ordinal);
+
+    /// <summary>Whether a model value is an ordered list (upstream: <c>isArray</c>) — array/set checkbox and multi-select semantics branch here first.</summary>
+    /// <param name="value">The model value.</param>
+    public static bool IsList([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? value)
+        => value is IList; // string does not implement IList, so no explicit exclusion is needed.
+
+    /// <summary>
+    /// Whether a model value is a set (upstream: <c>isSet</c>). Reflection-free: after
+    /// <see cref="IsList(object?)"/> has been ruled out, any non-string, non-dictionary enumerable
+    /// is treated as a set — matching the <c>IList</c>-or-<c>ISet</c> model contract for
+    /// checkbox/select <c>v-model</c>.
+    /// </summary>
+    /// <param name="value">The model value (already known not to be a list).</param>
+    public static bool IsSet([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? value)
+        => value is IEnumerable and not string and not IDictionary and not IList;
+
+    /// <summary>Copies an enumerable model collection into a fresh <see cref="List{T}"/> so a reassign triggers reactivity (upstream: <c>modelValue.concat</c> / <c>[...modelValue]</c>).</summary>
+    /// <param name="values">The source collection.</param>
+    public static List<object?> CopyToList(IEnumerable values)
+    {
+        var copy = new List<object?>();
+        foreach (var item in values)
+        {
+            copy.Add(item);
+        }
+        return copy;
+    }
+
+    /// <summary>Copies an enumerable model set into a fresh <see cref="HashSet{T}"/> (upstream: <c>new Set(modelValue)</c>).</summary>
+    /// <param name="values">The source set.</param>
+    public static HashSet<object?> CopyToSet(IEnumerable values)
+    {
+        var copy = new HashSet<object?>();
+        foreach (var item in values)
+        {
+            copy.Add(item);
+        }
+        return copy;
+    }
+
+    /// <summary>Whether a set contains a value by strict equality (upstream: <c>Set.has</c> — SameValueZero, not looseEqual).</summary>
+    /// <param name="values">The set.</param>
+    /// <param name="value">The value to test.</param>
+    public static bool SetContains(IEnumerable values, object? value)
+    {
+        foreach (var item in values)
+        {
+            if (Equals(item, value))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserModelState.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserModelState.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The per-element mutable state a <c>v-model</c> (or <c>v-show</c>) directive keeps between renders
+/// and events — the C# stand-in for the ad-hoc fields upstream stashes on the DOM element itself
+/// (<c>el._assign</c>, <c>el._modelValue</c>, <c>el._value</c>, <c>el.composing</c>,
+/// <c>el._assigning</c>, <c>el[vShowOriginalDisplay]</c>;
+/// https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts and
+/// <c>vShow.ts</c>). A handle-based bridge cannot hang arbitrary .NET objects off a JS node, so this
+/// state lives on the .NET side keyed by the element's int handle
+/// (<see cref="BrowserDirectiveOperations.GetState(int)"/>) and is released when the element
+/// unmounts. Not thread-safe (single-threaded browser main thread).
+/// </summary>
+internal sealed class BrowserModelState
+{
+    /// <summary>
+    /// The model setter to invoke on element input (upstream: <c>el[assignKey]</c>), refreshed each
+    /// render from the binding's <see cref="VueModelBinding.Setter"/>.
+    /// </summary>
+    public Action<object?>? Assign { get; set; }
+
+    /// <summary>Whether an IME composition is in progress (upstream: <c>el.composing</c>) — input updates are suppressed while true.</summary>
+    public bool Composing { get; set; }
+
+    /// <summary>Whether the element currently holds focus (tracked from focus/blur), gating the lazy/trim write guards.</summary>
+    public bool Focused { get; set; }
+
+    /// <summary>The last-known DOM string value (from input events and directive writes), for the "already equal" write guard.</summary>
+    public string CurrentValue { get; set; } = string.Empty;
+
+    /// <summary>The element's bound <c>:value</c> (checkbox/radio), refreshed each render — the raw object, so identity round-trips (upstream: <c>el._value</c>).</summary>
+    public object? ElementValue { get; set; }
+
+    /// <summary>The checkbox <c>true-value</c>, refreshed each render (upstream: <c>el._trueValue</c>).</summary>
+    public object? TrueValue { get; set; }
+
+    /// <summary>The checkbox <c>false-value</c>, refreshed each render (upstream: <c>el._falseValue</c>).</summary>
+    public object? FalseValue { get; set; }
+
+    /// <summary>The bound model collection/value last reflected onto the checkbox (upstream: <c>el._modelValue</c>), so the change handler knows whether it is a list, set, or scalar.</summary>
+    public object? ModelValue { get; set; }
+
+    /// <summary>
+    /// Set true by a select change while it writes the model back, so the directive's <c>updated</c>
+    /// pass skips re-reflecting the value it just read (upstream: <c>el._assigning</c>).
+    /// </summary>
+    public bool Assigning { get; set; }
+
+    /// <summary>
+    /// The current <c>&lt;option&gt;</c> values in document order (formatted string paired with the
+    /// raw object), refreshed each render — lets a select change map DOM string selections back to
+    /// their raw (possibly object) values, so object option values round-trip.
+    /// </summary>
+    public List<KeyValuePair<string, object?>>? OptionValues { get; set; }
+
+    /// <summary>
+    /// The element's original inline <c>display</c>, saved by <c>v-show</c> at mount and restored
+    /// when the binding becomes truthy (upstream: <c>el[vShowOriginalDisplay]</c>). Empty means "no
+    /// inline display" — restoring removes the inline property so a stylesheet value wins.
+    /// </summary>
+    public string? OriginalDisplay { get; set; }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -42,6 +42,22 @@ internal static class BrowserNodeOperations
             Invokers.SetListener(element, rawPropertyName, listener),
     };
 
+    // Installs the ambient operations the DOM v-model/v-show directives ([V01.01.04.06]) write
+    // through: model listeners ride the invoker registry's model channel, DOM writes reuse the same
+    // leaf ops as the patch engine. Runs once on first touch of this type (which precedes any render).
+    static BrowserNodeOperations()
+    {
+        BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
+        {
+            SetModelListener = static (element, rawPropertyName, handler) =>
+                Invokers.SetModelListener(element, rawPropertyName, handler),
+            SetValueGuarded = LeafOperations.SetValueGuarded,
+            SetBooleanProperty = LeafOperations.SetBooleanProperty,
+            SetStyleProperty = LeafOperations.SetStyleProperty,
+            RemoveStyleProperty = LeafOperations.RemoveStyleProperty,
+        };
+    }
+
     internal static RendererOptions<int> Create() => new()
     {
         Insert = static (child, parent, anchor) => BrowserDomBridge.Insert(parent, child, anchor),

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VModelCheckbox.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VModelCheckbox.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-model</c> directive for checkboxes — the C# port of upstream's <c>vModelCheckbox</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+/// https://vuejs.org/guide/essentials/forms.html#checkbox). Binds a boolean (honoring
+/// <c>true-value</c>/<c>false-value</c>), or adds/removes the element's bound <c>:value</c> in a
+/// model <see cref="IList"/> (loose-equality membership, upstream <c>looseIndexOf</c>) or
+/// <see cref="ISet{T}"/> (strict membership, upstream <c>Set.has</c>). The bound <c>:value</c>,
+/// <c>true-value</c>, and <c>false-value</c> are read as raw vnode props, so object values
+/// round-trip. Reads <c>checked</c> from the dispatched <see cref="BrowserEvent"/> payload, never a
+/// follow-up interop read. Stateless singleton (<see cref="Instance"/>); per-element state lives in
+/// <see cref="BrowserModelState"/>.
+/// </summary>
+public sealed class VModelCheckbox : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VModelCheckbox Instance = new();
+
+    private static readonly object BoxedTrue = true;
+    private static readonly object BoxedFalse = false;
+
+    private VModelCheckbox()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? Created => OnCreated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Mounted => OnMounted;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUpdate => OnBeforeUpdate;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnCreated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        operations.GetState(handle).Assign = BrowserModelDirective.Carrier(binding)?.Setter;
+        operations.SetModelListener(handle, "onChange", (Action<BrowserEvent>)(browserEvent => OnChange(operations, handle, browserEvent)));
+    }
+
+    private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => SetChecked(BrowserDirectiveOperations.Require(), BrowserModelDirective.Handle(element), binding, node);
+
+    private static void OnBeforeUpdate(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        operations.GetState(handle).Assign = BrowserModelDirective.Carrier(binding)?.Setter; // refresh assigner
+        SetChecked(operations, handle, binding, node);
+    }
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => BrowserDirectiveOperations.Require().ReleaseState(BrowserModelDirective.Handle(element));
+
+    private static void OnChange(BrowserDirectiveOperations operations, int handle, BrowserEvent browserEvent)
+    {
+        var state = operations.GetState(handle);
+        var assign = state.Assign;
+        if (assign is null)
+        {
+            return;
+        }
+        var model = state.ModelValue;
+        var elementValue = state.ElementValue;
+        var isChecked = browserEvent.TargetChecked;
+        if (BrowserModelDirective.IsList(model))
+        {
+            var list = (IList)model!;
+            var index = LooseEquality.LooseIndexOf(list, elementValue);
+            var found = index != -1;
+            if (isChecked && !found)
+            {
+                var next = BrowserModelDirective.CopyToList(list);
+                next.Add(elementValue);
+                assign(next);
+            }
+            else if (!isChecked && found)
+            {
+                var next = BrowserModelDirective.CopyToList(list);
+                next.RemoveAt(index);
+                assign(next);
+            }
+        }
+        else if (BrowserModelDirective.IsSet(model))
+        {
+            var next = BrowserModelDirective.CopyToSet((IEnumerable)model!);
+            if (isChecked)
+            {
+                next.Add(elementValue);
+            }
+            else
+            {
+                next.Remove(elementValue);
+            }
+            assign(next);
+        }
+        else
+        {
+            // Boolean binding: checked -> true-value (or true), unchecked -> false-value (or false).
+            assign(isChecked ? state.TrueValue : state.FalseValue);
+        }
+    }
+
+    // Reflect the model onto el.checked and refresh the change handler's inputs (upstream setChecked).
+    private static void SetChecked(BrowserDirectiveOperations operations, int handle, DirectiveBinding binding, VirtualNode node)
+    {
+        var state = operations.GetState(handle);
+        var value = BrowserModelDirective.Carrier(binding)?.Value;
+        state.ElementValue = BrowserModelDirective.Property(node, "value");
+        state.TrueValue = node.Properties?.ContainsName("true-value") == true
+            ? BrowserModelDirective.Property(node, "true-value")
+            : BoxedTrue;
+        state.FalseValue = node.Properties?.ContainsName("false-value") == true
+            ? BrowserModelDirective.Property(node, "false-value")
+            : BoxedFalse;
+        state.ModelValue = value;
+
+        bool isChecked;
+        if (BrowserModelDirective.IsList(value))
+        {
+            isChecked = LooseEquality.LooseIndexOf((IList)value!, state.ElementValue) > -1;
+        }
+        else if (BrowserModelDirective.IsSet(value))
+        {
+            isChecked = BrowserModelDirective.SetContains((IEnumerable)value!, state.ElementValue);
+        }
+        else
+        {
+            // Upstream: if (value === oldValue) return — no change to reflect.
+            var oldValue = BrowserModelDirective.ModelValue(binding.OldValue);
+            if (Equals(value, oldValue))
+            {
+                return;
+            }
+            isChecked = LooseEquality.LooseEqual(value, state.TrueValue);
+        }
+        operations.SetBooleanProperty(handle, "checked", isChecked);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VModelDynamic.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VModelDynamic.cs
@@ -1,0 +1,74 @@
+using System;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-model</c> directive for elements whose kind is only known at runtime — the C# port of
+/// upstream's <c>vModelDynamic</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts). Each
+/// hook resolves the concrete directive from the element's current tag and <c>type</c> and forwards
+/// to it, so <c>&lt;input :type="t"&gt;</c> switches between text, checkbox, and radio behavior when
+/// <c>t</c> changes at runtime; <c>&lt;select&gt;</c> and <c>&lt;textarea&gt;</c> resolve by tag.
+/// Emitted by the compiler when the <c>v-model</c> element's type is dynamic
+/// ([V01.01.05.03]). Stateless singleton (<see cref="Instance"/>).
+/// </summary>
+public sealed class VModelDynamic : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VModelDynamic Instance = new();
+
+    private VModelDynamic()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? Created => OnCreated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Mounted => OnMounted;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUpdate => OnBeforeUpdate;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Updated => OnUpdated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnCreated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => Resolve(node).Created?.Invoke(element, binding, node, previousNode);
+
+    private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => Resolve(node).Mounted?.Invoke(element, binding, node, previousNode);
+
+    private static void OnBeforeUpdate(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => Resolve(node).BeforeUpdate?.Invoke(element, binding, node, previousNode);
+
+    private static void OnUpdated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => Resolve(node).Updated?.Invoke(element, binding, node, previousNode);
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => Resolve(node).BeforeUnmount?.Invoke(element, binding, node, previousNode);
+
+    // Upstream resolveDynamicModel: SELECT/TEXTAREA by tag, otherwise by input type.
+    private static IDirective Resolve(VirtualNode node)
+    {
+        if (string.Equals(node.ElementTag, "select", StringComparison.Ordinal))
+        {
+            return VModelSelect.Instance;
+        }
+        if (string.Equals(node.ElementTag, "textarea", StringComparison.Ordinal))
+        {
+            return VModelText.Instance;
+        }
+        return BrowserModelDirective.FormatValue(BrowserModelDirective.Property(node, "type")) switch
+        {
+            "checkbox" => VModelCheckbox.Instance,
+            "radio" => VModelRadio.Instance,
+            _ => VModelText.Instance,
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VModelRadio.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VModelRadio.cs
@@ -1,0 +1,66 @@
+using System;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-model</c> directive for radio buttons — the C# port of upstream's <c>vModelRadio</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+/// https://vuejs.org/guide/essentials/forms.html#radio). The element is <c>checked</c> when the
+/// model loosely equals the radio's bound <c>:value</c> (upstream <c>looseEqual</c>), so object
+/// values round-trip without string coercion; on change the model is assigned the radio's raw
+/// <c>:value</c>. Stateless singleton (<see cref="Instance"/>); per-element state lives in
+/// <see cref="BrowserModelState"/>.
+/// </summary>
+public sealed class VModelRadio : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VModelRadio Instance = new();
+
+    private VModelRadio()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? Created => OnCreated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUpdate => OnBeforeUpdate;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnCreated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        var state = operations.GetState(handle);
+        state.ElementValue = BrowserModelDirective.Property(node, "value");
+        state.Assign = BrowserModelDirective.Carrier(binding)?.Setter;
+        // Upstream: el.checked = looseEqual(value, vnode.props.value).
+        operations.SetBooleanProperty(handle, "checked",
+            LooseEquality.LooseEqual(BrowserModelDirective.Carrier(binding)?.Value, state.ElementValue));
+        operations.SetModelListener(handle, "onChange",
+            (Action)(() => operations.GetState(handle).Assign?.Invoke(operations.GetState(handle).ElementValue)));
+    }
+
+    private static void OnBeforeUpdate(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        var state = operations.GetState(handle);
+        state.Assign = BrowserModelDirective.Carrier(binding)?.Setter; // refresh assigner
+        state.ElementValue = BrowserModelDirective.Property(node, "value");
+        var value = BrowserModelDirective.Carrier(binding)?.Value;
+        // Upstream: if (value !== oldValue) el.checked = looseEqual(value, vnode.props.value).
+        if (!Equals(value, BrowserModelDirective.ModelValue(binding.OldValue)))
+        {
+            operations.SetBooleanProperty(handle, "checked", LooseEquality.LooseEqual(value, state.ElementValue));
+        }
+    }
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => BrowserDirectiveOperations.Require().ReleaseState(BrowserModelDirective.Handle(element));
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VModelSelect.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VModelSelect.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-model</c> directive for <c>&lt;select&gt;</c> — the C# port of upstream's
+/// <c>vModelSelect</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+/// https://vuejs.org/guide/essentials/forms.html#select). Reflects the model onto the options'
+/// selected state and, on change, assigns the selected value(s) back: a single select assigns one
+/// value, a <c>multiple</c> select assigns a list or (when the model is a set) a set. Option values
+/// compare by loose equality (upstream <c>looseEqual</c>). Object option values round-trip: the
+/// directive snapshots each option's raw <c>:value</c> and maps the dispatched selection strings
+/// (single: <see cref="BrowserEvent.TargetValue"/>; multiple: <see cref="BrowserEvent.SelectedValues"/>)
+/// back to the raw value — never a follow-up interop read. Stateless singleton
+/// (<see cref="Instance"/>); per-element state lives in <see cref="BrowserModelState"/>.
+/// </summary>
+public sealed class VModelSelect : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VModelSelect Instance = new();
+
+    private VModelSelect()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? Created => OnCreated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Mounted => OnMounted;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUpdate => OnBeforeUpdate;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Updated => OnUpdated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnCreated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        operations.GetState(handle).Assign = BrowserModelDirective.Carrier(binding)?.Setter;
+        // Upstream captures isSetModel and reads number once at created; multiple is captured here
+        // (a runtime :multiple toggle is uncommon and deferred).
+        var multiple = IsMultiple(node);
+        var isSetModel = BrowserModelDirective.IsSet(BrowserModelDirective.Carrier(binding)?.Value);
+        var castToNumber = BrowserModelDirective.HasModifier(binding, "number");
+        operations.SetModelListener(handle, "onChange",
+            (Action<BrowserEvent>)(browserEvent => OnChange(operations, handle, browserEvent, multiple, isSetModel, castToNumber)));
+    }
+
+    private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => SetSelected(BrowserDirectiveOperations.Require(), BrowserModelDirective.Handle(element), node, BrowserModelDirective.Carrier(binding)?.Value);
+
+    private static void OnBeforeUpdate(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => BrowserDirectiveOperations.Require().GetState(BrowserModelDirective.Handle(element)).Assign
+            = BrowserModelDirective.Carrier(binding)?.Setter;
+
+    private static void OnUpdated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        var state = operations.GetState(handle);
+        // Upstream: if (!el._assigning) setSelected(...). Skip the reflect that would re-run right
+        // after the user's own change; consume the flag (a faithful simplification of the nextTick
+        // clear — see BrowserModelState).
+        if (state.Assigning)
+        {
+            state.Assigning = false;
+            return;
+        }
+        SetSelected(operations, handle, node, BrowserModelDirective.Carrier(binding)?.Value);
+    }
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => BrowserDirectiveOperations.Require().ReleaseState(BrowserModelDirective.Handle(element));
+
+    private static void OnChange(BrowserDirectiveOperations operations, int handle, BrowserEvent browserEvent, bool multiple, bool isSetModel, bool castToNumber)
+    {
+        var state = operations.GetState(handle);
+        var assign = state.Assign;
+        if (assign is null)
+        {
+            return;
+        }
+        if (multiple)
+        {
+            var selected = new List<object?>();
+            if (browserEvent.SelectedValues is { } selectedValues)
+            {
+                foreach (var domValue in selectedValues)
+                {
+                    selected.Add(MapSelected(state.OptionValues, domValue, castToNumber));
+                }
+            }
+            if (isSetModel)
+            {
+                var set = new HashSet<object?>();
+                foreach (var value in selected)
+                {
+                    set.Add(value);
+                }
+                assign(set);
+            }
+            else
+            {
+                assign(selected);
+            }
+        }
+        else
+        {
+            assign(MapSelected(state.OptionValues, browserEvent.TargetValue ?? string.Empty, castToNumber));
+        }
+        state.Assigning = true;
+    }
+
+    // Reflect the model onto the options' selected state and refresh the option-value snapshot
+    // (upstream setSelected).
+    private static void SetSelected(BrowserDirectiveOperations operations, int handle, VirtualNode node, object? value)
+    {
+        var options = new List<(int Handle, object? RawValue)>();
+        CollectOptions(node, options);
+
+        var snapshot = new List<KeyValuePair<string, object?>>(options.Count);
+        foreach (var (_, rawValue) in options)
+        {
+            snapshot.Add(new KeyValuePair<string, object?>(BrowserModelDirective.FormatValue(rawValue), rawValue));
+        }
+        operations.GetState(handle).OptionValues = snapshot;
+
+        var multiple = IsMultiple(node);
+        var isArrayValue = BrowserModelDirective.IsList(value);
+        var isSetValue = BrowserModelDirective.IsSet(value);
+        if (multiple && !isArrayValue && !isSetValue)
+        {
+            // Upstream warns and bails when a multi-select is not bound to an Array or Set.
+            Debug.WriteLine("[Vue warn] <select multiple v-model> expects an Array or Set value for its binding.");
+            return;
+        }
+        foreach (var (optionHandle, rawValue) in options)
+        {
+            bool selected;
+            if (multiple)
+            {
+                selected = isArrayValue
+                    ? LooseEquality.LooseIndexOf((IList)value!, rawValue) > -1
+                    : BrowserModelDirective.SetContains((IEnumerable)value!, rawValue);
+            }
+            else
+            {
+                selected = LooseEquality.LooseEqual(rawValue, value);
+            }
+            operations.SetBooleanProperty(optionHandle, "selected", selected);
+        }
+    }
+
+    // Map a dispatched selection string back to its raw (possibly object) option value via the
+    // snapshot, applying .number coercion (upstream getValue + optional looseToNumber).
+    private static object? MapSelected(List<KeyValuePair<string, object?>>? optionValues, string domValue, bool castToNumber)
+    {
+        object? raw = domValue;
+        if (optionValues is not null)
+        {
+            foreach (var pair in optionValues)
+            {
+                if (string.Equals(pair.Key, domValue, StringComparison.Ordinal))
+                {
+                    raw = pair.Value;
+                    break;
+                }
+            }
+        }
+        return castToNumber ? NumberCoercion.LooseToNumber(raw) : raw;
+    }
+
+    // Collect option vnodes (with their handles) in document order, recursing through optgroups and
+    // v-for fragments (upstream reads the flat el.options collection).
+    private static void CollectOptions(VirtualNode? node, List<(int Handle, object? RawValue)> options)
+    {
+        if (node?.ArrayChildren is null)
+        {
+            return;
+        }
+        foreach (var child in node.ArrayChildren)
+        {
+            if (child is null)
+            {
+                continue;
+            }
+            if (string.Equals(child.ElementTag, "option", StringComparison.Ordinal) && child.El is int handle)
+            {
+                options.Add((handle, OptionRawValue(child)));
+            }
+            else
+            {
+                CollectOptions(child, options);
+            }
+        }
+    }
+
+    // An option's raw value: its :value prop when present, else its text content (HTML option.value
+    // defaults to option.text).
+    private static object? OptionRawValue(VirtualNode option)
+        => option.Properties?.ContainsName("value") == true
+            ? BrowserModelDirective.Property(option, "value")
+            : option.TextChildren;
+
+    private static bool IsMultiple(VirtualNode node)
+        => node.Properties?["multiple"] is bool multiple
+            ? multiple
+            : node.Properties?.ContainsName("multiple") == true;
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VModelText.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VModelText.cs
@@ -1,0 +1,176 @@
+using System;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-model</c> directive for text inputs and <c>&lt;textarea&gt;</c> — the C# port of
+/// upstream's <c>vModelText</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+/// https://vuejs.org/guide/essentials/forms.html). Reflects the model onto <c>el.value</c> and
+/// writes user edits back through the binding's <see cref="VueModelBinding.Setter"/>. IME safety:
+/// input updates are suppressed between <c>compositionstart</c> and <c>compositionend</c>. Modifiers:
+/// <c>.lazy</c> listens on <c>change</c> instead of <c>input</c>; <c>.number</c> coerces via
+/// <see cref="NumberCoercion.LooseToNumber(object?)"/> (non-numeric input is left untouched);
+/// <c>.trim</c> trims the bound value and re-syncs the element on <c>change</c> (blur). Reads the DOM
+/// value from the dispatched <see cref="BrowserEvent"/> payload, never a follow-up interop read.
+/// Stateless singleton (<see cref="Instance"/>) referenced by the compiled <c>v-model</c> transform
+/// ([V01.01.05.03]); per-element state lives in <see cref="BrowserModelState"/>.
+/// </summary>
+public sealed class VModelText : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VModelText Instance = new();
+
+    private VModelText()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? Created => OnCreated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Mounted => OnMounted;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUpdate => OnBeforeUpdate;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnCreated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        operations.GetState(handle).Assign = BrowserModelDirective.Carrier(binding)?.Setter;
+
+        var lazy = BrowserModelDirective.HasModifier(binding, "lazy");
+        var trim = BrowserModelDirective.HasModifier(binding, "trim");
+        var castToNumber = BrowserModelDirective.HasModifier(binding, "number")
+            || BrowserModelDirective.IsNumberType(node);
+
+        if (lazy)
+        {
+            operations.SetModelListener(handle, "onChange",
+                (Action<BrowserEvent>)(browserEvent => OnChange(operations, handle, browserEvent, lazy: true, trim, castToNumber)));
+        }
+        else
+        {
+            operations.SetModelListener(handle, "onInput",
+                (Action<BrowserEvent>)(browserEvent => Commit(operations, handle, browserEvent, trim, castToNumber)));
+            operations.SetModelListener(handle, "onCompositionstart",
+                (Action<BrowserEvent>)(_ => operations.GetState(handle).Composing = true));
+            operations.SetModelListener(handle, "onCompositionend",
+                (Action<BrowserEvent>)(browserEvent => OnCompositionEnd(operations, handle, browserEvent, trim, castToNumber)));
+            // Upstream also binds onCompositionEnd (and the trim re-sync) to 'change'.
+            operations.SetModelListener(handle, "onChange",
+                (Action<BrowserEvent>)(browserEvent => OnChange(operations, handle, browserEvent, lazy: false, trim, castToNumber)));
+        }
+
+        // Focus tracking gates the lazy/trim write guards below without an activeElement interop
+        // read. A listener on the element fires for its own (non-bubbling) focus/blur in the target
+        // phase; real browser focus is exercised by the e2e harness ([V01.01.11.03]).
+        operations.SetModelListener(handle, "onFocus", (Action)(() => operations.GetState(handle).Focused = true));
+        operations.SetModelListener(handle, "onBlur", (Action)(() => operations.GetState(handle).Focused = false));
+    }
+
+    private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        // Upstream: el.value = value == null ? '' : value.
+        var formatted = BrowserModelDirective.FormatValue(BrowserModelDirective.Carrier(binding)?.Value);
+        operations.SetValueGuarded(handle, formatted);
+        operations.GetState(handle).CurrentValue = formatted;
+    }
+
+    private static void OnBeforeUpdate(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        var state = operations.GetState(handle);
+        state.Assign = BrowserModelDirective.Carrier(binding)?.Setter; // refresh the assigner (upstream)
+        if (state.Composing)
+        {
+            return; // never clobber an in-progress composition
+        }
+        var model = BrowserModelDirective.Carrier(binding)?.Value;
+        var newValue = BrowserModelDirective.FormatValue(model);
+        // Primary guard: the DOM already shows the model (also protects a focused caret).
+        if (string.Equals(state.CurrentValue, newValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+        if (state.Focused)
+        {
+            // Upstream gates these on document.activeElement === el && el.type !== 'range'; a range
+            // input's guard nuance is deferred (uncommon; e2e harness [V01.01.11.03]).
+            var lazy = BrowserModelDirective.HasModifier(binding, "lazy");
+            var trim = BrowserModelDirective.HasModifier(binding, "trim");
+            if (lazy && LooseEquality.LooseEqual(model, BrowserModelDirective.ModelValue(binding.OldValue)))
+            {
+                return;
+            }
+            if (trim && string.Equals(state.CurrentValue.Trim(), newValue, StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+        operations.SetValueGuarded(handle, newValue);
+        state.CurrentValue = newValue;
+    }
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+        => BrowserDirectiveOperations.Require().ReleaseState(BrowserModelDirective.Handle(element));
+
+    // The DOM value -> model commit shared by input/change/compositionend (upstream: the shared
+    // listener body). trim then number, matching upstream order.
+    private static void Commit(BrowserDirectiveOperations operations, int handle, BrowserEvent browserEvent, bool trim, bool castToNumber)
+    {
+        var state = operations.GetState(handle);
+        if (state.Composing)
+        {
+            return;
+        }
+        var domValue = browserEvent.TargetValue ?? string.Empty;
+        state.CurrentValue = domValue;
+        var candidate = trim ? domValue.Trim() : domValue;
+        var modelValue = castToNumber ? NumberCoercion.LooseToNumber(candidate) : candidate;
+        state.Assign?.Invoke(modelValue);
+    }
+
+    private static void OnChange(BrowserDirectiveOperations operations, int handle, BrowserEvent browserEvent, bool lazy, bool trim, bool castToNumber)
+    {
+        var state = operations.GetState(handle);
+        if (lazy)
+        {
+            Commit(operations, handle, browserEvent, trim, castToNumber); // .lazy commits on change
+        }
+        else if (state.Composing)
+        {
+            // A composition can be ended by 'change' too (upstream binds onCompositionEnd here).
+            state.Composing = false;
+            Commit(operations, handle, browserEvent, trim, castToNumber);
+        }
+        if (trim)
+        {
+            // Re-sync the element to the trimmed value on blur/change (upstream trim 'change' hook).
+            var trimmed = (browserEvent.TargetValue ?? string.Empty).Trim();
+            state.CurrentValue = trimmed;
+            operations.SetValueGuarded(handle, trimmed);
+        }
+    }
+
+    private static void OnCompositionEnd(BrowserDirectiveOperations operations, int handle, BrowserEvent browserEvent, bool trim, bool castToNumber)
+    {
+        var state = operations.GetState(handle);
+        if (!state.Composing)
+        {
+            return;
+        }
+        state.Composing = false;
+        Commit(operations, handle, browserEvent, trim, castToNumber);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VShow.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VShow.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>v-show</c> directive — the C# port of upstream's <c>vShow</c>
+/// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vShow.ts,
+/// https://vuejs.org/guide/essentials/conditional.html#v-show). Toggles an element's inline
+/// <c>display</c> from a truthy/falsy binding while preserving its original value: the original
+/// inline <c>display</c> is saved at mount, a falsy binding sets <c>display: none</c>, and a truthy
+/// binding restores the saved value (removing the inline property when there was none, so a
+/// stylesheet value wins). Because <see cref="IDirective.BeforeMount"/> runs before insertion, an
+/// initially-falsy element is hidden from the first paint (no flash of visible content). Truthiness
+/// follows JavaScript coercion (<see cref="StyleAndClassNormalization.IsTruthy(object?)"/>).
+/// <para>
+/// The saved display is derived from the vnode's <c>style</c> prop rather than an interop read of
+/// <c>el.style.display</c> — equivalent for inline styles and one fewer boundary crossing. The
+/// <c>&lt;Transition&gt;</c> coordination clause of the acceptance criteria is a
+/// <b>documented-inert seam</b>: the hook shape is present, but there is no transition object to
+/// coordinate with until <c>&lt;Transition&gt;</c> lands ([V01.01.04.07]).
+/// </para>
+/// Stateless singleton (<see cref="Instance"/>); the saved display lives in
+/// <see cref="BrowserModelState.OriginalDisplay"/>.
+/// </summary>
+public sealed class VShow : IDirective
+{
+    /// <summary>The shared directive instance the compiler references.</summary>
+    public static readonly VShow Instance = new();
+
+    private VShow()
+    {
+    }
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeMount => OnBeforeMount;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Mounted => OnMounted;
+
+    /// <inheritdoc/>
+    public DirectiveHook? Updated => OnUpdated;
+
+    /// <inheritdoc/>
+    public DirectiveHook? BeforeUnmount => OnBeforeUnmount;
+
+    private static void OnBeforeMount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        var original = OriginalDisplay(node);
+        operations.GetState(handle).OriginalDisplay = original;
+        // Transition seam is inert until [V01.01.04.07]; upstream would defer to transition.beforeEnter
+        // when a transition and truthy value are present. beforeMount timing means an initially-falsy
+        // element is hidden before its first paint.
+        SetDisplay(operations, handle, StyleAndClassNormalization.IsTruthy(binding.Value), original);
+    }
+
+    private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        // Deferred-inert transition seam: upstream runs transition.enter here when a transition and
+        // truthy value are present ([V01.01.04.07]). No transition object exists yet, so this is a
+        // no-op placeholder that keeps the hook shape.
+    }
+
+    private static void OnUpdated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var value = StyleAndClassNormalization.IsTruthy(binding.Value);
+        // Upstream: if (!value === !oldValue) return — nothing to toggle when the truthiness is unchanged.
+        if (value == StyleAndClassNormalization.IsTruthy(binding.OldValue))
+        {
+            return;
+        }
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        // Deferred-inert transition seam ([V01.01.04.07]); upstream coordinates enter/leave here.
+        SetDisplay(operations, handle, value, operations.GetState(handle).OriginalDisplay ?? string.Empty);
+    }
+
+    private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
+    {
+        var operations = BrowserDirectiveOperations.Require();
+        var handle = BrowserModelDirective.Handle(element);
+        // Upstream restores the binding's display before teardown (matters for a leave transition).
+        SetDisplay(operations, handle, StyleAndClassNormalization.IsTruthy(binding.Value), operations.GetState(handle).OriginalDisplay ?? string.Empty);
+        operations.ReleaseState(handle);
+    }
+
+    // Upstream setDisplay: el.style.display = value ? original : 'none'. An empty original removes
+    // the inline property so a stylesheet-supplied display is not clobbered.
+    private static void SetDisplay(BrowserDirectiveOperations operations, int handle, bool value, string original)
+    {
+        if (!value)
+        {
+            operations.SetStyleProperty(handle, "display", "none", false);
+        }
+        else if (original.Length == 0)
+        {
+            operations.RemoveStyleProperty(handle, "display");
+        }
+        else
+        {
+            operations.SetStyleProperty(handle, "display", original, false);
+        }
+    }
+
+    // Derive the original inline display from the vnode's style prop (upstream reads el.style.display,
+    // equivalent for inline styles); 'none' is normalized to empty so restoring reveals the element.
+    private static string OriginalDisplay(VirtualNode node)
+    {
+        var style = BrowserModelDirective.Property(node, "style");
+        if (style is null)
+        {
+            return string.Empty;
+        }
+        string? display = null;
+        var normalized = StyleAndClassNormalization.NormalizeStyle(style);
+        if (normalized is string css)
+        {
+            StyleAndClassNormalization.ParseStringStyle(css).TryGetValue("display", out var parsed);
+            display = parsed as string;
+        }
+        else if (normalized is IReadOnlyDictionary<string, object?> readOnlyMap)
+        {
+            if (readOnlyMap.TryGetValue("display", out var mapped))
+            {
+                display = BrowserModelDirective.FormatValue(mapped);
+            }
+        }
+        else if (normalized is IDictionary<string, object?> map)
+        {
+            if (map.TryGetValue("display", out var mapped))
+            {
+                display = BrowserModelDirective.FormatValue(mapped);
+            }
+        }
+        display ??= string.Empty;
+        return string.Equals(display, "none", StringComparison.OrdinalIgnoreCase) ? string.Empty : display;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/VueModelBinding.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/VueModelBinding.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The bound value a <c>v-model</c> directive carries — a snapshot of the current model value paired
+/// with the setter that writes it back. This is the C# stand-in for how upstream threads the model
+/// through a directive: Vue reads the value from <c>binding.value</c> and the setter from
+/// <c>vnode.props['onUpdate:modelValue']</c> (<c>getModelAssigner</c>,
+/// https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts). Vuecs has
+/// no <c>this</c>-proxy and no reflection, so the compiler cannot stash a magic prop; instead the
+/// <c>v-model</c> transform ([V01.01.05.03]) emits, per render,
+/// <c>Directives.WithDirectives(vnode, VModelText.Instance, new VueModelBinding(model, v =&gt; model = v))</c>
+/// — the getter is the value already read into <see cref="Value"/>, the setter is the write-back
+/// delegate. Both are plain delegates, never reflection over component members (AOT/trimming
+/// contract).
+/// <para>
+/// The directive reads <see cref="Value"/> where upstream reads <c>binding.value</c>, calls
+/// <see cref="Setter"/> where upstream calls <c>el[assignKey](v)</c>, and reads the previous
+/// binding's <see cref="Value"/> where upstream reads <c>binding.oldValue</c>.
+/// </para>
+/// </summary>
+public sealed class VueModelBinding
+{
+    /// <summary>Creates a binding carrying the current model <paramref name="value"/> and its <paramref name="setter"/>.</summary>
+    /// <param name="value">The current model value this render (upstream: <c>binding.value</c>).</param>
+    /// <param name="setter">The write-back delegate invoked on element input (upstream: the model assigner).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="setter"/> is null.</exception>
+    public VueModelBinding(object? value, Action<object?> setter)
+    {
+        ArgumentNullException.ThrowIfNull(setter);
+        Value = value;
+        Setter = setter;
+    }
+
+    /// <summary>The current model value this render (upstream: <c>binding.value</c>).</summary>
+    public object? Value { get; }
+
+    /// <summary>The setter that writes a new value back to the model (upstream: the model assigner from <c>onUpdate:modelValue</c>).</summary>
+    public Action<object?> Setter { get; }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
@@ -292,6 +292,11 @@ export const dom = {
 
             const target = event.target
             const hasValue = target && typeof target.value !== 'undefined'
+            // <select multiple> v-model reads the selected option values here rather than issuing
+            // a follow-up interop read per change ([V01.01.04.06]); null for every other target.
+            const selectedValues = (target && target.multiple && target.options)
+                ? Array.prototype.filter.call(target.options, option => option.selected).map(option => option.value)
+                : null
             const flags = dispatchEvent(
                 nodeHandle,
                 eventName,
@@ -307,7 +312,8 @@ export const dom = {
                 event.detail ?? 0,
                 target === event.currentTarget,
                 hasValue ? String(target.value) : null,
-                !!(target && target.checked))
+                !!(target && target.checked),
+                selectedValues)
             if (flags & 1) {
                 event.stopPropagation()
             }

--- a/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.Tests.csproj
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.Tests.csproj
@@ -11,5 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <VuecsProjectReference Include="Assimalign.Vue.RuntimeDom" />
+    <VuecsProjectReference Include="Assimalign.Vue.RuntimeCore" />
+    <VuecsProjectReference Include="Assimalign.Vue.Reactivity" />
+    <VuecsProjectReference Include="Assimalign.Vue.Shared" />
+    <VuecsProjectReference Include="Assimalign.Vue.Testing" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserApplicationTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserApplicationTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins the [V01.01.04.04.01] application API surface on BrowserApplication against Vue's app object
+// (https://vuejs.org/api/application.html): chainable Component/Directive/Provide/Use/Config, each
+// delegating to the wrapped VueApplication<int>. Registration and config need no browser — the
+// wrapper is constructed over an inert int renderer (its interop members Mount/Unmount are the
+// browser-dependent remainder, verified through the demo app). The platform annotation mirrors the
+// type under test; nothing here crosses the interop boundary.
+[SupportedOSPlatform("browser")]
+public sealed class BrowserApplicationTests
+{
+    private static BrowserApplication CreateApp(out VueApplication<int> wrapped)
+    {
+        // An inert int-handle renderer: the registration surface never invokes node operations.
+        var renderer = RendererFactory.CreateRenderer(new RendererOptions<int>
+        {
+            Insert = static (_, _, _) => { },
+            Remove = static _ => { },
+            CreateElement = static (_, _) => 1,
+            CreateText = static _ => 1,
+            CreateComment = static _ => 1,
+            SetText = static (_, _) => { },
+            SetElementText = static (_, _) => { },
+            ParentNode = static _ => 0,
+            NextSibling = static _ => 0,
+            PatchProperty = static (_, _, _, _, _, _) => { },
+        });
+        wrapped = renderer.CreateApplication(new RenderComponent(static () => VirtualNodeFactory.Element("div")));
+        return new BrowserApplication(wrapped);
+    }
+
+    [Fact]
+    public void Component_RegistersAndResolves_ThroughTheWrappedApplication()
+    {
+        var app = CreateApp(out var wrapped);
+        var child = new RenderComponent(static () => VirtualNodeFactory.Element("span"));
+
+        var returned = app.Component("MyChild", child);
+
+        returned.ShouldBeSameAs(app); // chainable, returns BrowserApplication
+        app.Component("MyChild").ShouldBeSameAs(child);
+        wrapped.Component("MyChild").ShouldBeSameAs(child); // delegated to the wrapped app
+        app.Component("Unknown").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Directive_RegistersAndResolves_ThroughTheWrappedApplication()
+    {
+        var app = CreateApp(out var wrapped);
+        var focus = new Directive { Mounted = static (_, _, _, _) => { } };
+
+        var returned = app.Directive("focus", focus);
+
+        returned.ShouldBeSameAs(app);
+        app.Directive("focus").ShouldBeSameAs(focus);
+        wrapped.Directive("focus").ShouldBeSameAs(focus);
+        app.Directive("missing").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Provide_TypedAndString_DelegateToTheWrappedApplication()
+    {
+        var app = CreateApp(out _);
+        var key = new InjectionKey<string>("theme");
+        var warnings = new List<string>();
+        var previousSink = RuntimeWarnings.Sink;
+        RuntimeWarnings.Sink = warnings.Add;
+        try
+        {
+            app.Provide(key, "dark").ShouldBeSameAs(app);
+            app.Provide("locale", "en-US").ShouldBeSameAs(app);
+
+            // Re-providing the same key warns through the wrapped app — proof the provide landed in
+            // the shared ApplicationContext (upstream: "App already provides property with key").
+            app.Provide(key, "light");
+            warnings.ShouldContain(message => message.Contains("already provides"));
+        }
+        finally
+        {
+            RuntimeWarnings.Sink = previousSink;
+        }
+    }
+
+    [Fact]
+    public void Use_InstallsThePluginOnce_AgainstTheWrappedApplication()
+    {
+        var app = CreateApp(out var wrapped);
+        var plugin = new CountingPlugin();
+
+        app.Use(plugin, options: "options").ShouldBeSameAs(app);
+        app.Use(plugin).ShouldBeSameAs(app); // repeat Use of the same instance is deduplicated
+
+        plugin.InstallCount.ShouldBe(1);
+        plugin.SeenApplication.ShouldBeSameAs(wrapped); // the plugin receives the wrapped VueApplication<int>
+        plugin.SeenOptions.ShouldBe("options");
+    }
+
+    [Fact]
+    public void Config_IsTheWrappedApplicationsConfiguration()
+    {
+        var app = CreateApp(out var wrapped);
+
+        app.Config.ShouldBeSameAs(wrapped.Config); // one shared ApplicationConfiguration
+
+        Action<string> warnHandler = static _ => { };
+        app.Config.WarnHandler = warnHandler;
+        wrapped.Config.WarnHandler.ShouldBeSameAs(warnHandler);
+    }
+
+    [Fact]
+    public void RegistrationSurface_ChainsFluently()
+    {
+        var app = CreateApp(out _);
+        var child = new RenderComponent(static () => VirtualNodeFactory.Element("span"));
+        var focus = new Directive { Mounted = static (_, _, _, _) => { } };
+
+        var returned = app
+            .Component("Child", child)
+            .Directive("focus", focus)
+            .Provide("locale", "en-US")
+            .Use(new CountingPlugin());
+
+        returned.ShouldBeSameAs(app);
+    }
+
+    private sealed class CountingPlugin : IVuePlugin<int>
+    {
+        public int InstallCount { get; private set; }
+
+        public VueApplication<int>? SeenApplication { get; private set; }
+
+        public object? SeenOptions { get; private set; }
+
+        public void Install(VueApplication<int> application, object? options)
+        {
+            InstallCount++;
+            SeenApplication = application;
+            SeenOptions = options;
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserDirectiveTestHarness.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserDirectiveTestHarness.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// A DOM-free harness that drives the real RuntimeCore renderer + directive pipeline over int node
+// handles (as the browser does), recording element state in memory and routing events through the
+// real BrowserEventInvokerRegistry. It installs a recording BrowserDirectiveOperations so v-model /
+// v-show exercise their whole production path with no browser, WASM toolchain, or JS interop. The
+// browser-only remainder (real IME composition, real focus, actual selectedOptions reads) is
+// deferred to the e2e harness ([V01.01.11.03]).
+internal sealed class BrowserDirectiveTestHarness : IDisposable
+{
+    private readonly Dictionary<int, RecordingNode> _nodes = [];
+    private readonly Dictionary<int, List<int>> _children = [];
+    private readonly BrowserEventInvokerRegistry _registry;
+    private readonly BrowserDirectiveOperations? _previousOperations;
+    private readonly TestSchedulerPump _pump;
+    private readonly Renderer<int> _renderer;
+    private int _nextHandle = 1;
+
+    public BrowserDirectiveTestHarness()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _registry = new BrowserEventInvokerRegistry(
+            static (_, _, _, _, _) => { },
+            static (_, _, _) => { });
+
+        Leaf = new BrowserPropertyLeafOperations
+        {
+            SetAttribute = SetAttribute,
+            RemoveAttribute = (element, name) => Element(element).Attributes.Remove(name),
+            SetXlinkAttribute = SetAttribute,
+            RemoveXlinkAttribute = (element, name) => Element(element).Attributes.Remove(name),
+            SetClassName = (element, value) => Element(element).Attributes["class"] = value,
+            SetStringProperty = SetAttribute,
+            SetBooleanProperty = SetBooleanProperty,
+            SetValueGuarded = SetValueGuarded,
+            SetStyleText = (element, cssText) => Element(element).Attributes["style"] = cssText,
+            SetStyleProperty = (element, name, value, _) => Element(element).Style[name] = value,
+            RemoveStyleProperty = (element, name) => Element(element).Style.Remove(name),
+            SetEventListener = (element, rawPropertyName, listener) => _registry.SetListener(element, rawPropertyName, listener),
+        };
+
+        _previousOperations = BrowserDirectiveOperations.Current;
+        BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
+        {
+            SetModelListener = (element, rawPropertyName, handler) => _registry.SetModelListener(element, rawPropertyName, handler),
+            SetValueGuarded = SetValueGuarded,
+            SetBooleanProperty = SetBooleanProperty,
+            SetStyleProperty = (element, name, value, _) => Element(element).Style[name] = value,
+            RemoveStyleProperty = (element, name) => Element(element).Style.Remove(name),
+        };
+
+        _renderer = RendererFactory.CreateRenderer(new RendererOptions<int>
+        {
+            Insert = Insert,
+            Remove = Remove,
+            CreateElement = (tag, _) => Create(new RecordingNode { Tag = tag }),
+            CreateText = text => Create(new RecordingNode { Tag = "#text", Value = text }),
+            CreateComment = text => Create(new RecordingNode { Tag = "#comment", Value = text }),
+            SetText = (node, text) => Element(node).Value = text,
+            SetElementText = (node, text) => Element(node).Value = text,
+            ParentNode = node => Element(node).Parent,
+            NextSibling = _ => 0,
+            PatchProperty = (element, elementTag, propertyName, previousValue, nextValue, elementNamespace) =>
+                BrowserPropertyPatcher.Patch(Leaf, element, elementTag, propertyName, previousValue, nextValue, elementNamespace),
+        });
+
+        Container = Create(new RecordingNode { Tag = "#container" });
+    }
+
+    /// <summary>The leaf operations the renderer's patchProp records through.</summary>
+    public BrowserPropertyLeafOperations Leaf { get; }
+
+    /// <summary>The container handle to render into.</summary>
+    public int Container { get; }
+
+    /// <summary>The live invoker count (for listener-cleanup assertions).</summary>
+    public int InvokerCount => _registry.InvokerCount;
+
+    /// <summary>Renders a component's tree into the container.</summary>
+    public void Render(IComponentDefinition component)
+        => _renderer.Render(VirtualNodeFactory.Component(component), Container);
+
+    /// <summary>Unmounts everything from the container.</summary>
+    public void Unmount() => _renderer.Render(null, Container);
+
+    /// <summary>Runs captured scheduler flushes until idle (post-flush mounted/updated hooks).</summary>
+    public int RunUntilIdle() => _pump.RunUntilIdle();
+
+    /// <summary>The handle of the first recorded element with <paramref name="tag"/>, in creation order.</summary>
+    public int FindElement(string tag)
+    {
+        for (var handle = 1; handle < _nextHandle; handle++)
+        {
+            if (_nodes.TryGetValue(handle, out var node) && string.Equals(node.Tag, tag, StringComparison.Ordinal))
+            {
+                return handle;
+            }
+        }
+        throw new InvalidOperationException($"No <{tag}> was recorded.");
+    }
+
+    /// <summary>Every recorded element handle with <paramref name="tag"/>, in creation order.</summary>
+    public IReadOnlyList<int> FindElements(string tag)
+    {
+        var matches = new List<int>();
+        for (var handle = 1; handle < _nextHandle; handle++)
+        {
+            if (_nodes.TryGetValue(handle, out var node) && string.Equals(node.Tag, tag, StringComparison.Ordinal))
+            {
+                matches.Add(handle);
+            }
+        }
+        return matches;
+    }
+
+    public string Value(int handle) => Element(handle).Value;
+
+    public bool Checked(int handle) => Element(handle).Checked;
+
+    public bool Selected(int handle) => Element(handle).Selected;
+
+    public int ValueWriteCount(int handle) => Element(handle).ValueWriteCount;
+
+    /// <summary>The element's inline <c>display</c>, or null when there is no inline display.</summary>
+    public string? Display(int handle)
+        => Element(handle).Style.TryGetValue("display", out var display) ? display : null;
+
+    // --- event firing (routes through the real registry: property + model channels) ------------
+
+    public int FireInput(int handle, string value)
+    {
+        SimulateUserValue(handle, value); // the browser sets el.value before firing 'input'
+        return _registry.Dispatch(handle, capture: false, Event("input", targetValue: value));
+    }
+
+    public int FireChange(int handle, string value)
+    {
+        SimulateUserValue(handle, value);
+        return _registry.Dispatch(handle, capture: false, Event("change", targetValue: value));
+    }
+
+    public int FireCheckboxChange(int handle, bool isChecked)
+    {
+        Element(handle).Checked = isChecked; // the browser toggles el.checked before firing 'change'
+        return _registry.Dispatch(handle, capture: false, Event("change", targetChecked: isChecked));
+    }
+
+    public int FireSelectChange(int handle, string singleValue, string[]? selectedValues = null)
+    {
+        SimulateUserValue(handle, singleValue);
+        return _registry.Dispatch(handle, capture: false, Event("change", targetValue: singleValue, selectedValues: selectedValues));
+    }
+
+    public int FireCompositionStart(int handle)
+        => _registry.Dispatch(handle, capture: false, Event("compositionstart"));
+
+    public int FireCompositionEnd(int handle, string value)
+    {
+        SimulateUserValue(handle, value);
+        return _registry.Dispatch(handle, capture: false, Event("compositionend", targetValue: value));
+    }
+
+    // Simulate a user edit landing in the DOM (does not count as a directive write).
+    private void SimulateUserValue(int handle, string value) => Element(handle).Value = value;
+
+    public void FireFocus(int handle) => _registry.Dispatch(handle, capture: false, Event("focus"));
+
+    public void FireBlur(int handle) => _registry.Dispatch(handle, capture: false, Event("blur"));
+
+    private static BrowserEvent Event(string eventName, string? targetValue = null, bool targetChecked = false, string[]? selectedValues = null)
+        => new(eventName, 1000, string.Empty, string.Empty, BrowserEventModifiers.None, -1, 0, 0, 0, 0, true, targetValue, targetChecked, selectedValues);
+
+    // --- recording node-ops --------------------------------------------------------------------
+
+    private int Create(RecordingNode node)
+    {
+        var handle = _nextHandle++;
+        _nodes[handle] = node;
+        return handle;
+    }
+
+    private RecordingNode Element(int handle) => _nodes[handle];
+
+    private void Insert(int child, int parent, int anchor)
+    {
+        Element(child).Parent = parent;
+        (_children.TryGetValue(parent, out var list) ? list : _children[parent] = []).Add(child);
+    }
+
+    private void Remove(int child)
+    {
+        var parent = Element(child).Parent;
+        var released = new List<int>();
+        CollectSubtree(child, released);
+        _registry.PurgeReleasedHandles(released.ToArray());
+        foreach (var handle in released)
+        {
+            _nodes.Remove(handle);
+            _children.Remove(handle);
+        }
+        if (_children.TryGetValue(parent, out var siblings))
+        {
+            siblings.Remove(child);
+        }
+    }
+
+    private void CollectSubtree(int handle, List<int> released)
+    {
+        released.Add(handle);
+        if (_children.TryGetValue(handle, out var childHandles))
+        {
+            foreach (var child in childHandles)
+            {
+                CollectSubtree(child, released);
+            }
+        }
+    }
+
+    private void SetAttribute(int handle, string name, string value) => Element(handle).Attributes[name] = value;
+
+    private void SetBooleanProperty(int handle, string name, bool value)
+    {
+        var node = Element(handle);
+        if (string.Equals(name, "checked", StringComparison.Ordinal))
+        {
+            node.Checked = value;
+        }
+        else if (string.Equals(name, "selected", StringComparison.Ordinal))
+        {
+            node.Selected = value;
+        }
+        else
+        {
+            node.Attributes[name] = value ? "true" : "false";
+        }
+    }
+
+    private void SetValueGuarded(int handle, string value)
+    {
+        // Mirror the JS compare-and-set so tests can assert caret-safe no-writes.
+        var node = Element(handle);
+        if (!string.Equals(node.Value, value, StringComparison.Ordinal))
+        {
+            node.Value = value;
+            node.ValueWriteCount++;
+        }
+    }
+
+    public void Dispose()
+    {
+        BrowserDirectiveOperations.Current = _previousOperations;
+        _pump.Dispose();
+        Scheduler.Reset();
+    }
+
+    private sealed class RecordingNode
+    {
+        public string Tag = string.Empty;
+        public string Value = string.Empty;
+        public bool Checked;
+        public bool Selected;
+        public int Parent;
+        public int ValueWriteCount;
+        public readonly Dictionary<string, string> Attributes = new(StringComparer.Ordinal);
+        public readonly Dictionary<string, string> Style = new(StringComparer.Ordinal);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventInvokerRegistryTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserEventInvokerRegistryTests.cs
@@ -159,4 +159,64 @@ public class BrowserEventInvokerRegistryTests
 
         invoked.ShouldBe(["first", "second:click"]);
     }
+
+    // --- model channel ([V01.01.04.06]: v-model listeners coexist with template @event props;
+    // upstream attaches the directive's listener with a separate raw addEventListener) ----------
+
+    [Fact]
+    public void ModelAndPropertyChannels_ShareOneDomListener_AndBothFire()
+    {
+        var invoked = new List<string>();
+        _registry.SetListener(Element, "onInput", (Action)(() => invoked.Add("property")));
+        _registry.SetModelListener(Element, "onInput", (Action)(() => invoked.Add("model")));
+
+        _bridgeCalls.Count.ShouldBe(1); // one addEventListener for both channels
+
+        _registry.Dispatch(Element, capture: false, Event("input"));
+        invoked.ShouldBe(["property", "model"]); // property fires first, then the directive
+    }
+
+    [Fact]
+    public void RemovingThePropertyChannel_KeepsTheModelChannelListening()
+    {
+        var invoked = new List<string>();
+        _registry.SetModelListener(Element, "onInput", (Action)(() => invoked.Add("model")));
+        _registry.SetListener(Element, "onInput", (Action)(() => invoked.Add("property")));
+
+        _registry.SetListener(Element, "onInput", null); // template handler removed on re-render
+
+        _bridgeCalls.ShouldBe([$"add({Element},input,once:False,capture:False,passive:False)"]); // no remove
+        _registry.Dispatch(Element, capture: false, Event("input"));
+        invoked.ShouldBe(["model"]);
+    }
+
+    [Fact]
+    public void RemovingBothChannels_RemovesTheDomListenerOnce()
+    {
+        _registry.SetModelListener(Element, "onInput", (Action)(() => { }));
+        _registry.SetListener(Element, "onInput", (Action)(() => { }));
+
+        _registry.SetListener(Element, "onInput", null);
+        _registry.SetModelListener(Element, "onInput", null);
+
+        _bridgeCalls.ShouldBe(
+        [
+            $"add({Element},input,once:False,capture:False,passive:False)",
+            $"remove({Element},input,capture:False)",
+        ]);
+        _registry.InvokerCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SwappingTheModelHandler_MakesZeroBridgeCalls()
+    {
+        var invoked = new List<string>();
+        _registry.SetModelListener(Element, "onChange", (Action)(() => invoked.Add("first")));
+        _registry.SetModelListener(Element, "onChange", (Action)(() => invoked.Add("second")));
+
+        _bridgeCalls.Count.ShouldBe(1); // re-rendered directive handler is a delegate swap only
+
+        _registry.Dispatch(Element, capture: false, Event("change"));
+        invoked.ShouldBe(["second"]);
+    }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/test/RenderComponent.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/RenderComponent.cs
@@ -1,0 +1,19 @@
+using System;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// A minimal component definition whose setup returns a supplied render function — the RuntimeDom
+// test stand-in for the source-generated component the compiler emits.
+internal sealed class RenderComponent : IComponentDefinition
+{
+    private readonly Func<ComponentProperties, ComponentSetupContext, Func<VirtualNode?>> _setup;
+
+    public RenderComponent(Func<ComponentProperties, ComponentSetupContext, Func<VirtualNode?>> setup) => _setup = setup;
+
+    // Convenience for a render that needs no setup state.
+    public RenderComponent(Func<VirtualNode?> render) => _setup = (_, _) => render;
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context) => _setup(properties, context);
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VModelCheckboxTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VModelCheckboxTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VModelCheckbox against @vue/runtime-dom's vModelCheckbox
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+// https://vuejs.org/guide/essentials/forms.html#checkbox): boolean, array, and set bindings with
+// true-value/false-value, through the DOM-free directive pipeline.
+public sealed class VModelCheckboxTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _model = Reactive.Reference<object?>(false);
+
+    public void Dispose() => _harness.Dispose();
+
+    private RenderComponent Checkbox(object? elementValue = null, (object? True, object? False)? trueFalse = null)
+        => new((_, _) => () =>
+        {
+            var properties = new VirtualNodeProperties();
+            properties.Set("type", "checkbox");
+            if (elementValue is not null)
+            {
+                properties.Set("value", elementValue);
+            }
+            if (trueFalse is { } pair)
+            {
+                properties.Set("true-value", pair.True);
+                properties.Set("false-value", pair.False);
+            }
+            return Directives.WithDirectives(
+                VirtualNodeFactory.Element("input", properties),
+                VModelCheckbox.Instance,
+                new VueModelBinding(_model.Value, value => _model.Value = value));
+        });
+
+    [Fact]
+    public void BooleanBinding_TogglesTheModel()
+    {
+        _model.Value = false;
+        _harness.Render(Checkbox());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+        _harness.Checked(input).ShouldBeFalse();
+
+        _harness.FireCheckboxChange(input, isChecked: true);
+        _model.Value.ShouldBe(true);
+
+        _harness.FireCheckboxChange(input, isChecked: false);
+        _model.Value.ShouldBe(false);
+    }
+
+    [Fact]
+    public void TrueFalseValue_AssignsTheConfiguredValues()
+    {
+        _model.Value = "no";
+        _harness.Render(Checkbox(trueFalse: ("yes", "no")));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+        _harness.Checked(input).ShouldBeFalse(); // "no" != true-value "yes"
+
+        _harness.FireCheckboxChange(input, isChecked: true);
+        _model.Value.ShouldBe("yes");
+
+        _harness.FireCheckboxChange(input, isChecked: false);
+        _model.Value.ShouldBe("no");
+    }
+
+    [Fact]
+    public void ArrayBinding_AddsAndRemovesTheElementValue()
+    {
+        _model.Value = new List<object?>();
+        _harness.Render(Checkbox(elementValue: "a"));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireCheckboxChange(input, isChecked: true);
+        _harness.RunUntilIdle();
+        ((List<object?>)_model.Value!).ShouldBe(["a"]);
+
+        _harness.FireCheckboxChange(input, isChecked: false);
+        ((List<object?>)_model.Value!).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetBinding_AddsAndRemovesTheElementValue()
+    {
+        _model.Value = new HashSet<object?>();
+        _harness.Render(Checkbox(elementValue: "x"));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireCheckboxChange(input, isChecked: true);
+        _harness.RunUntilIdle();
+        ((HashSet<object?>)_model.Value!).ShouldContain("x");
+
+        _harness.FireCheckboxChange(input, isChecked: false);
+        ((HashSet<object?>)_model.Value!).ShouldNotContain("x");
+    }
+
+    [Fact]
+    public void ArrayBinding_ReflectsMembershipOntoCheckedAtMount()
+    {
+        _model.Value = new List<object?> { "a", "b" };
+        _harness.Render(Checkbox(elementValue: "b"));
+        _harness.RunUntilIdle();
+
+        _harness.Checked(_harness.FindElement("input")).ShouldBeTrue(); // "b" is in the bound list
+    }
+
+    [Fact]
+    public void ArrayBinding_UsesLooseEquality_ForMembership()
+    {
+        // Vue's looseEqual: numeric 1 loosely equals string "1" for array membership.
+        _model.Value = new List<object?> { 1 };
+        _harness.Render(Checkbox(elementValue: "1"));
+        _harness.RunUntilIdle();
+
+        _harness.Checked(_harness.FindElement("input")).ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VModelDynamicTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VModelDynamicTests.cs
@@ -1,0 +1,108 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VModelDynamic against @vue/runtime-dom's vModelDynamic/resolveDynamicModel
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts): each
+// hook resolves the concrete directive from the element's current tag/type, so behavior switches
+// at runtime when <input :type> changes.
+public sealed class VModelDynamicTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _model = Reactive.Reference<object?>(null);
+    private readonly Reference<string> _type = Reactive.Reference("text");
+
+    public void Dispose() => _harness.Dispose();
+
+    private RenderComponent DynamicInput()
+        => new((_, _) => () =>
+        {
+            var properties = new VirtualNodeProperties();
+            properties.Set("type", _type.Value);
+            return Directives.WithDirectives(
+                VirtualNodeFactory.Element("input", properties),
+                VModelDynamic.Instance,
+                new VueModelBinding(_model.Value, value => _model.Value = value));
+        });
+
+    private RenderComponent Tagged(string tag)
+        => new((_, _) => () => Directives.WithDirectives(
+            VirtualNodeFactory.Element(tag),
+            VModelDynamic.Instance,
+            new VueModelBinding(_model.Value, value => _model.Value = value)));
+
+    [Fact]
+    public void TextType_BehavesAsVModelText()
+    {
+        _model.Value = "typed";
+        _type.Value = "text";
+        _harness.Render(DynamicInput());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+        _harness.Value(input).ShouldBe("typed"); // text mount reflects the value
+
+        _harness.FireInput(input, "edited");
+        _model.Value.ShouldBe("edited");
+    }
+
+    [Fact]
+    public void CheckboxType_BehavesAsVModelCheckbox()
+    {
+        _model.Value = true;
+        _type.Value = "checkbox";
+        _harness.Render(DynamicInput());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+        _harness.Checked(input).ShouldBeTrue();
+
+        _harness.FireCheckboxChange(input, isChecked: false);
+        _model.Value.ShouldBe(false);
+    }
+
+    [Fact]
+    public void RadioType_BehavesAsVModelRadio()
+    {
+        _model.Value = "other";
+        _type.Value = "radio";
+        _harness.Render(DynamicInput());
+        _harness.RunUntilIdle();
+
+        // Radio created reflects looseEqual(model, :value); no :value prop -> unchecked.
+        _harness.Checked(_harness.FindElement("input")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TextareaTag_ResolvesToVModelText()
+    {
+        _model.Value = "long form";
+        _harness.Render(Tagged("textarea"));
+        _harness.RunUntilIdle();
+
+        _harness.Value(_harness.FindElement("textarea")).ShouldBe("long form");
+    }
+
+    [Fact]
+    public void RuntimeTypeSwitch_SwitchesTheResolvedBehavior()
+    {
+        // Upstream resolveDynamicModel runs per hook, so a type change re-routes the update pass.
+        _model.Value = "hello";
+        _type.Value = "text";
+        _harness.Render(DynamicInput());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+        _harness.Value(input).ShouldBe("hello");
+
+        _type.Value = "checkbox";
+        _model.Value = true;
+        _harness.RunUntilIdle();
+
+        // The beforeUpdate pass resolved VModelCheckbox and reflected checked from the model.
+        _harness.Checked(input).ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VModelRadioTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VModelRadioTests.cs
@@ -1,0 +1,90 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VModelRadio against @vue/runtime-dom's vModelRadio
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+// https://vuejs.org/guide/essentials/forms.html#radio): loose-equality checked state and object
+// value round-trip, through the DOM-free directive pipeline.
+public sealed class VModelRadioTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _model = Reactive.Reference<object?>(null);
+
+    public void Dispose() => _harness.Dispose();
+
+    private RenderComponent RadioGroup(object valueA, object valueB)
+        => new((_, _) => () =>
+        {
+            VirtualNode Radio(object value)
+            {
+                var properties = new VirtualNodeProperties();
+                properties.Set("type", "radio");
+                properties.Set("value", value);
+                return Directives.WithDirectives(
+                    VirtualNodeFactory.Element("input", properties),
+                    VModelRadio.Instance,
+                    new VueModelBinding(_model.Value, next => _model.Value = next));
+            }
+
+            return VirtualNodeFactory.Element("div", (VirtualNodeProperties?)null, Radio(valueA), Radio(valueB));
+        });
+
+    [Fact]
+    public void ChecksTheRadioMatchingTheModel()
+    {
+        _model.Value = "a";
+        _harness.Render(RadioGroup("a", "b"));
+        _harness.RunUntilIdle();
+        var radios = _harness.FindElements("input");
+
+        _harness.Checked(radios[0]).ShouldBeTrue();
+        _harness.Checked(radios[1]).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ChangeAssignsTheRadiosValueToTheModel()
+    {
+        _model.Value = "a";
+        _harness.Render(RadioGroup("a", "b"));
+        _harness.RunUntilIdle();
+        var radios = _harness.FindElements("input");
+
+        _harness.FireChange(radios[1], "b");
+
+        _model.Value.ShouldBe("b");
+    }
+
+    [Fact]
+    public void ObjectValues_RoundTripByIdentity()
+    {
+        var first = new object();
+        var second = new object();
+        _model.Value = first;
+        _harness.Render(RadioGroup(first, second));
+        _harness.RunUntilIdle();
+        var radios = _harness.FindElements("input");
+        _harness.Checked(radios[0]).ShouldBeTrue(); // identity match, no string coercion
+
+        _harness.FireChange(radios[1], string.Empty);
+
+        _model.Value.ShouldBeSameAs(second); // the raw object round-trips
+    }
+
+    [Fact]
+    public void UsesLooseEquality_ForTheCheckedComparison()
+    {
+        // Vue's looseEqual: numeric 1 loosely equals string "1".
+        _model.Value = "1";
+        _harness.Render(RadioGroup(1, 2));
+        _harness.RunUntilIdle();
+
+        _harness.Checked(_harness.FindElements("input")[0]).ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VModelSelectTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VModelSelectTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VModelSelect against @vue/runtime-dom's vModelSelect
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+// https://vuejs.org/guide/essentials/forms.html#select): single/multiple, list/set, .number, and
+// object option values, through the DOM-free directive pipeline. The real DOM selectedOptions read
+// is exercised by the e2e harness ([V01.01.11.03]); here the selection rides the event payload.
+public sealed class VModelSelectTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _model = Reactive.Reference<object?>(null);
+
+    public void Dispose() => _harness.Dispose();
+
+    private RenderComponent Select(bool multiple, bool number, params (object Value, string Text)[] options)
+        => new((_, _) => () =>
+        {
+            var selectProperties = new VirtualNodeProperties();
+            if (multiple)
+            {
+                selectProperties.Set("multiple", true);
+            }
+            var optionNodes = new VirtualNode?[options.Length];
+            for (var index = 0; index < options.Length; index++)
+            {
+                var optionProperties = new VirtualNodeProperties();
+                optionProperties.Set("value", options[index].Value);
+                optionNodes[index] = VirtualNodeFactory.Element("option", optionProperties, options[index].Text);
+            }
+            var modifiers = number
+                ? new Dictionary<string, bool>(StringComparer.Ordinal) { ["number"] = true }
+                : null;
+            return Directives.WithDirectives(
+                VirtualNodeFactory.Element("select", selectProperties, optionNodes),
+                VModelSelect.Instance,
+                new VueModelBinding(_model.Value, value => _model.Value = value),
+                argument: null,
+                modifiers);
+        });
+
+    [Fact]
+    public void SingleSelect_ReflectsTheModelOntoTheSelectedOption()
+    {
+        _model.Value = "b";
+        _harness.Render(Select(multiple: false, number: false, ("a", "A"), ("b", "B")));
+        _harness.RunUntilIdle();
+        var options = _harness.FindElements("option");
+
+        _harness.Selected(options[0]).ShouldBeFalse();
+        _harness.Selected(options[1]).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SingleSelect_ChangeAssignsTheSelectedValue()
+    {
+        _model.Value = "a";
+        _harness.Render(Select(multiple: false, number: false, ("a", "A"), ("b", "B")));
+        _harness.RunUntilIdle();
+
+        _harness.FireSelectChange(_harness.FindElement("select"), singleValue: "b");
+
+        _model.Value.ShouldBe("b");
+    }
+
+    [Fact]
+    public void MultipleSelect_AssignsAListOfSelectedValues()
+    {
+        _model.Value = new List<object?> { "a" };
+        _harness.Render(Select(multiple: true, number: false, ("a", "A"), ("b", "B"), ("c", "C")));
+        _harness.RunUntilIdle();
+
+        _harness.FireSelectChange(_harness.FindElement("select"), singleValue: string.Empty, selectedValues: ["b", "c"]);
+
+        ((List<object?>)_model.Value!).ShouldBe(["b", "c"]);
+    }
+
+    [Fact]
+    public void MultipleSelect_WithSetModel_AssignsASet()
+    {
+        _model.Value = new HashSet<object?> { "a" };
+        _harness.Render(Select(multiple: true, number: false, ("a", "A"), ("b", "B")));
+        _harness.RunUntilIdle();
+
+        _harness.FireSelectChange(_harness.FindElement("select"), singleValue: string.Empty, selectedValues: ["a", "b"]);
+
+        _model.Value.ShouldBeOfType<HashSet<object?>>();
+        ((HashSet<object?>)_model.Value!).ShouldBe(new HashSet<object?> { "a", "b" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void MultipleSelect_ReflectsModelMembershipOntoOptions()
+    {
+        _model.Value = new List<object?> { "a", "c" };
+        _harness.Render(Select(multiple: true, number: false, ("a", "A"), ("b", "B"), ("c", "C")));
+        _harness.RunUntilIdle();
+        var options = _harness.FindElements("option");
+
+        _harness.Selected(options[0]).ShouldBeTrue();
+        _harness.Selected(options[1]).ShouldBeFalse();
+        _harness.Selected(options[2]).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NumberModifier_CoercesSelectedValues()
+    {
+        _model.Value = "1";
+        _harness.Render(Select(multiple: false, number: true, ("1", "One"), ("2", "Two")));
+        _harness.RunUntilIdle();
+
+        _harness.FireSelectChange(_harness.FindElement("select"), singleValue: "2");
+
+        _model.Value.ShouldBe(2d);
+    }
+
+    [Fact]
+    public void ObjectOptionValues_RoundTripByIdentity()
+    {
+        var apple = new Fruit("apple");
+        var banana = new Fruit("banana");
+        _model.Value = apple;
+        _harness.Render(Select(multiple: false, number: false, (apple, "Apple"), (banana, "Banana")));
+        _harness.RunUntilIdle();
+
+        // The dispatched selection string maps back to the raw object via the option-value snapshot.
+        _harness.FireSelectChange(_harness.FindElement("select"), singleValue: "banana");
+
+        _model.Value.ShouldBeSameAs(banana);
+    }
+
+    private sealed record Fruit(string Name)
+    {
+        public override string ToString() => Name;
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VModelTextTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VModelTextTests.cs
@@ -1,0 +1,187 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VModelText against @vue/runtime-dom's vModelText
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vModel.ts,
+// https://vuejs.org/guide/essentials/forms.html) through the DOM-free directive pipeline. Real IME
+// composition and real focus are exercised by the e2e harness ([V01.01.11.03]); here composition and
+// focus are simulated via their events, which is what the directive actually reacts to.
+public sealed class VModelTextTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _model = Reactive.Reference<object?>(string.Empty);
+    private readonly Reference<int> _tick = Reactive.Reference(0);
+
+    public void Dispose() => _harness.Dispose();
+
+    // Forces an unrelated re-render of the same component without touching the model.
+    private void ReRender()
+    {
+        _tick.Value++;
+        _harness.RunUntilIdle();
+    }
+
+    private RenderComponent Input(string? type = null, params string[] modifiers)
+    {
+        var modifierMap = new System.Collections.Generic.Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var modifier in modifiers)
+        {
+            modifierMap[modifier] = true;
+        }
+        return new RenderComponent((_, _) => () =>
+        {
+            _ = _tick.Value; // establish a re-render dependency independent of the model
+            var properties = new VirtualNodeProperties();
+            if (type is not null)
+            {
+                properties.Set("type", type);
+            }
+            return Directives.WithDirectives(
+                VirtualNodeFactory.Element("input", properties),
+                VModelText.Instance,
+                new VueModelBinding(_model.Value, value => _model.Value = value),
+                argument: null,
+                modifierMap);
+        });
+    }
+
+    [Fact]
+    public void Mounted_WritesTheModelOntoTheElementValue()
+    {
+        _model.Value = "hello";
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+
+        _harness.Value(_harness.FindElement("input")).ShouldBe("hello");
+    }
+
+    [Fact]
+    public void Input_WritesTheDomValueBackToTheModel()
+    {
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireInput(input, "typed");
+
+        _model.Value.ShouldBe("typed");
+    }
+
+    [Fact]
+    public void NumberModifier_CoercesNumericInput_AndLeavesNonNumericUntouched()
+    {
+        _harness.Render(Input(modifiers: "number"));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireInput(input, "42");
+        _model.Value.ShouldBe(42d);
+
+        _harness.FireInput(input, "abc");
+        _model.Value.ShouldBe("abc"); // non-numeric input is left untouched (looseToNumber)
+    }
+
+    [Fact]
+    public void NumberType_CoercesEvenWithoutTheModifier()
+    {
+        _harness.Render(Input(type: "number"));
+        _harness.RunUntilIdle();
+
+        _harness.FireInput(_harness.FindElement("input"), "7");
+
+        _model.Value.ShouldBe(7d);
+    }
+
+    [Fact]
+    public void TrimModifier_TrimsTheModel_AndReSyncsTheElementOnChange()
+    {
+        _harness.Render(Input(modifiers: "trim"));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireInput(input, "  spaced  ");
+        _model.Value.ShouldBe("spaced"); // model is trimmed
+
+        _harness.FireChange(input, "  spaced  ");
+        _harness.Value(input).ShouldBe("spaced"); // element re-synced to the trimmed value on change
+    }
+
+    [Fact]
+    public void LazyModifier_CommitsOnChange_NotOnInput()
+    {
+        _harness.Render(Input(modifiers: "lazy"));
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireInput(input, "ignored"); // no 'input' listener under .lazy
+        _model.Value.ShouldBe(string.Empty);
+
+        _harness.FireChange(input, "committed");
+        _model.Value.ShouldBe("committed");
+    }
+
+    [Fact]
+    public void Composition_SuppressesInputUpdates_UntilCompositionEnd()
+    {
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireCompositionStart(input);
+        _harness.FireInput(input, "partial"); // suppressed while composing (IME safety)
+        _model.Value.ShouldBe(string.Empty);
+
+        _harness.FireCompositionEnd(input, "final"); // commits the final composed value
+        _model.Value.ShouldBe("final");
+    }
+
+    [Fact]
+    public void FocusedElement_WhoseValueEqualsTheModel_IsNotRewrittenOnReRender()
+    {
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _harness.FireFocus(input);
+        _harness.FireInput(input, "hello"); // model and element value now agree
+        var writesBefore = _harness.ValueWriteCount(input);
+
+        // An unrelated re-render must not clobber the focused element whose value already equals the model.
+        ReRender();
+
+        _harness.ValueWriteCount(input).ShouldBe(writesBefore); // no redundant write
+        _harness.Value(input).ShouldBe("hello");
+    }
+
+    [Fact]
+    public void ProgrammaticModelChange_UpdatesTheElement()
+    {
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+        var input = _harness.FindElement("input");
+
+        _model.Value = "programmatic";
+        _harness.RunUntilIdle();
+
+        _harness.Value(input).ShouldBe("programmatic");
+    }
+
+    [Fact]
+    public void Unmount_ReleasesTheDirectiveListeners()
+    {
+        _harness.Render(Input());
+        _harness.RunUntilIdle();
+        _harness.InvokerCount.ShouldBeGreaterThan(0);
+
+        _harness.Unmount();
+
+        _harness.InvokerCount.ShouldBe(0);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/VShowTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/VShowTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Pins VShow against @vue/runtime-dom's vShow
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vShow.ts,
+// https://vuejs.org/guide/essentials/conditional.html#v-show): display toggling that preserves the
+// original inline display, hidden-from-first-paint timing, and stylesheet-value restoration. The
+// <Transition> coordination clause is a documented-inert seam until [V01.01.04.07].
+public sealed class VShowTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+    private readonly Reference<object?> _condition = Reactive.Reference<object?>(true);
+
+    public void Dispose() => _harness.Dispose();
+
+    private RenderComponent Shown(string? inlineDisplay = null)
+        => new((_, _) => () =>
+        {
+            VirtualNodeProperties? properties = null;
+            if (inlineDisplay is not null)
+            {
+                properties = new VirtualNodeProperties();
+                properties.Set("style", new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["display"] = inlineDisplay,
+                });
+            }
+            return Directives.WithDirectives(
+                VirtualNodeFactory.Element("div", properties, "content"),
+                VShow.Instance,
+                _condition.Value);
+        });
+
+    [Fact]
+    public void InitiallyFalsy_IsHiddenFromTheFirstPaint()
+    {
+        _condition.Value = false;
+        _harness.Render(Shown());
+
+        // Asserted before RunUntilIdle: beforeMount (sync, pre-insert) already applied
+        // display:none — no flash of visible content while post-flush hooks are still queued.
+        _harness.Display(_harness.FindElement("div")).ShouldBe("none");
+    }
+
+    [Fact]
+    public void Toggling_HidesAndReveals()
+    {
+        _condition.Value = true;
+        _harness.Render(Shown());
+        _harness.RunUntilIdle();
+        var div = _harness.FindElement("div");
+        _harness.Display(div).ShouldBeNull(); // no inline display while shown
+
+        _condition.Value = false;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("none");
+
+        _condition.Value = true;
+        _harness.RunUntilIdle();
+        // Restoring with no author-supplied inline display removes the inline property, so a
+        // stylesheet-supplied display value wins (upstream parity).
+        _harness.Display(div).ShouldBeNull();
+    }
+
+    [Fact]
+    public void AuthorSuppliedInlineDisplay_SurvivesTheToggle()
+    {
+        _condition.Value = true;
+        _harness.Render(Shown(inlineDisplay: "flex"));
+        _harness.RunUntilIdle();
+        var div = _harness.FindElement("div");
+        _harness.Display(div).ShouldBe("flex");
+
+        _condition.Value = false;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("none");
+
+        _condition.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("flex"); // the original inline display is restored
+
+        // Repeated toggling never loses the saved original.
+        _condition.Value = false;
+        _harness.RunUntilIdle();
+        _condition.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("flex");
+    }
+
+    [Fact]
+    public void TruthinessUnchangedUpdate_DoesNotTouchDisplay()
+    {
+        _condition.Value = "first";
+        _harness.Render(Shown());
+        _harness.RunUntilIdle();
+        var div = _harness.FindElement("div");
+        _harness.Display(div).ShouldBeNull();
+
+        // truthy -> truthy: upstream's `if (!value === !oldValue) return` — nothing to toggle.
+        _condition.Value = "second";
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBeNull();
+    }
+
+    [Fact]
+    public void JavaScriptFalsyValues_Hide()
+    {
+        // JS truthiness: 0, "", null are falsy; "0" is truthy (upstream coercion semantics).
+        _condition.Value = 0;
+        _harness.Render(Shown());
+        _harness.RunUntilIdle();
+        var div = _harness.FindElement("div");
+        _harness.Display(div).ShouldBe("none");
+
+        _condition.Value = "0";
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBeNull();
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/src/NumberCoercion.cs
+++ b/libraries/Assimalign.Vue.Shared/src/NumberCoercion.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Globalization;
+
+namespace Assimalign.Vue.Shared;
+
+/// <summary>
+/// JavaScript-style numeric coercion — the C# port of <c>looseToNumber</c> and <c>toNumber</c>
+/// from <c>@vue/shared</c> (<c>packages/shared/src/general.ts</c>). The <c>.number</c> modifier
+/// on <c>v-model</c> (https://vuejs.org/guide/essentials/forms.html#lazy) runs the raw DOM string
+/// through <see cref="LooseToNumber(object?)"/>: a value whose leading portion parses as a number
+/// becomes that number, and anything else is left untouched — so <c>"12abc"</c> yields <c>12</c>
+/// but <c>"abc"</c> and <c>""</c> stay strings. Parsing is invariant-culture (mandatory so SSR and
+/// client hydration agree) with no reflection.
+/// </summary>
+public static class NumberCoercion
+{
+    /// <summary>
+    /// The C# port of upstream's <c>looseToNumber</c> — <c>parseFloat</c> semantics: the longest
+    /// leading numeric prefix (after leading whitespace, an optional sign, digits, an optional
+    /// fraction and exponent, or <c>Infinity</c>) becomes a <see cref="double"/>; a value with no
+    /// numeric prefix is returned unchanged (upstream: <c>const n = parseFloat(val); return
+    /// isNaN(n) ? val : n</c>).
+    /// </summary>
+    /// <param name="value">The raw value, typically a DOM element's string value.</param>
+    /// <returns>The parsed <see cref="double"/>, or <paramref name="value"/> unchanged when it has no numeric prefix.</returns>
+    public static object? LooseToNumber(object? value)
+    {
+        if (value is not string text)
+        {
+            // v-model always hands this a string; other shapes pass through (upstream coerces via
+            // String(val) first, but the runtime only feeds it DOM string values).
+            return value;
+        }
+        return TryParseFloatPrefix(text, out var number) ? number : value;
+    }
+
+    /// <summary>
+    /// The C# port of upstream's <c>toNumber</c> — stricter than <see cref="LooseToNumber(object?)"/>:
+    /// the <em>entire</em> string must parse as a number (upstream: <c>looseToNumber</c> uses
+    /// <c>parseFloat(val)</c>, while <c>toNumber</c> uses <c>Number(val)</c>), otherwise the value
+    /// is returned unchanged. Used where a whole-string numeric value is expected (e.g. compiled
+    /// numeric props), not the partial-prefix <c>v-model.number</c> path.
+    /// </summary>
+    /// <param name="value">The raw value.</param>
+    /// <returns>The parsed <see cref="double"/>, or <paramref name="value"/> unchanged when it is not wholly numeric.</returns>
+    public static object? ToNumber(object? value)
+    {
+        if (value is not string text)
+        {
+            return value;
+        }
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+        {
+            // Number("") === 0 in JavaScript; toNumber therefore returns 0.
+            return 0d;
+        }
+        return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
+            ? number
+            : value;
+    }
+
+    // parseFloat: skip leading whitespace, then match the longest StrDecimalLiteral prefix
+    // (optional sign, Infinity, or digits/fraction/exponent). Returns false when no numeric
+    // prefix exists (JavaScript's NaN result), matching ECMA-262 parseFloat.
+    private static bool TryParseFloatPrefix(string text, out double number)
+    {
+        number = 0d;
+        var span = text.AsSpan();
+        var index = 0;
+        while (index < span.Length && char.IsWhiteSpace(span[index]))
+        {
+            index++;
+        }
+        var start = index;
+        var negative = false;
+        if (index < span.Length && (span[index] == '+' || span[index] == '-'))
+        {
+            negative = span[index] == '-';
+            index++;
+        }
+        // parseFloat('Infinity') / parseFloat('-Infinity').
+        if (span[index..].StartsWith("Infinity".AsSpan(), StringComparison.Ordinal))
+        {
+            number = negative ? double.NegativeInfinity : double.PositiveInfinity;
+            return true;
+        }
+        var integerDigits = 0;
+        while (index < span.Length && char.IsAsciiDigit(span[index]))
+        {
+            index++;
+            integerDigits++;
+        }
+        var fractionDigits = 0;
+        if (index < span.Length && span[index] == '.')
+        {
+            index++;
+            while (index < span.Length && char.IsAsciiDigit(span[index]))
+            {
+                index++;
+                fractionDigits++;
+            }
+        }
+        if (integerDigits == 0 && fractionDigits == 0)
+        {
+            return false;
+        }
+        // Optional exponent; roll back when 'e' is not followed by (sign?) digits.
+        if (index < span.Length && (span[index] == 'e' || span[index] == 'E'))
+        {
+            var afterExponent = index + 1;
+            if (afterExponent < span.Length && (span[afterExponent] == '+' || span[afterExponent] == '-'))
+            {
+                afterExponent++;
+            }
+            var exponentDigits = 0;
+            while (afterExponent < span.Length && char.IsAsciiDigit(span[afterExponent]))
+            {
+                afterExponent++;
+                exponentDigits++;
+            }
+            if (exponentDigits > 0)
+            {
+                index = afterExponent;
+            }
+        }
+        var numeric = span[start..index];
+        // A lone trailing '.' (e.g. "5.") is valid in JavaScript but not every invariant parse;
+        // drop it so the numeric portion round-trips.
+        if (numeric[^1] == '.')
+        {
+            numeric = numeric[..^1];
+        }
+        return double.TryParse(numeric, NumberStyles.Float, CultureInfo.InvariantCulture, out number);
+    }
+}

--- a/libraries/Assimalign.Vue.Shared/test/NumberCoercionTests.cs
+++ b/libraries/Assimalign.Vue.Shared/test/NumberCoercionTests.cs
@@ -1,0 +1,70 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Shared.Tests;
+
+// Pins Vue's numeric coercion (looseToNumber/toNumber in @vue/shared general.ts) — the semantics
+// behind v-model's .number modifier (https://vuejs.org/guide/essentials/forms.html#lazy).
+public class NumberCoercionTests
+{
+    [Theory]
+    [InlineData("12", 12d)]
+    [InlineData("12.5", 12.5d)]
+    [InlineData("-0.5", -0.5d)]
+    [InlineData("+7", 7d)]
+    [InlineData(".5", 0.5d)]
+    [InlineData("5.", 5d)]
+    [InlineData("1e3", 1000d)]
+    [InlineData("2.5E2", 250d)]
+    [InlineData("  3.14  ", 3.14d)] // parseFloat skips leading whitespace, ignores the trailing tail
+    [InlineData("12abc", 12d)]      // longest numeric prefix wins
+    [InlineData("3.14.15", 3.14d)]  // stops at the second decimal point
+    [InlineData("0x10", 0d)]        // parseFloat('0x10') === 0 (stops before 'x')
+    [InlineData("1e", 1d)]          // dangling exponent is rolled back
+    public void LooseToNumber_ParsesTheLeadingNumericPrefix(string input, double expected)
+        => NumberCoercion.LooseToNumber(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("e5")]
+    [InlineData("+")]
+    [InlineData(".")]
+    public void LooseToNumber_LeavesNonNumericInputUntouched(string input)
+        // Upstream: isNaN(parseFloat(val)) ? val : n — the original string is returned unchanged.
+        => NumberCoercion.LooseToNumber(input).ShouldBe(input);
+
+    [Fact]
+    public void LooseToNumber_SupportsInfinity()
+    {
+        NumberCoercion.LooseToNumber("Infinity").ShouldBe(double.PositiveInfinity);
+        NumberCoercion.LooseToNumber("-Infinity").ShouldBe(double.NegativeInfinity);
+    }
+
+    [Fact]
+    public void LooseToNumber_PassesNonStringsThrough()
+    {
+        NumberCoercion.LooseToNumber(null).ShouldBeNull();
+        var marker = new object();
+        NumberCoercion.LooseToNumber(marker).ShouldBeSameAs(marker);
+    }
+
+    [Theory]
+    [InlineData("42", 42d)]
+    [InlineData("  42  ", 42d)]
+    [InlineData("3.5", 3.5d)]
+    public void ToNumber_ParsesWhollyNumericStrings(string input, double expected)
+        => NumberCoercion.ToNumber(input).ShouldBe(expected);
+
+    [Fact]
+    public void ToNumber_EmptyStringIsZero()
+        // Number('') === 0 in JavaScript, unlike parseFloat('') which is NaN.
+        => NumberCoercion.ToNumber("").ShouldBe(0d);
+
+    [Theory]
+    [InlineData("12abc")] // Number('12abc') is NaN — the whole string must parse, unlike looseToNumber
+    [InlineData("abc")]
+    public void ToNumber_LeavesPartialOrNonNumericInputUntouched(string input)
+        => NumberCoercion.ToNumber(input).ShouldBe(input);
+}


### PR DESCRIPTION
Batch 7B — delegated implementation (Opus 4.8 agent, resumed once after a stream stall) with design/functionality review. RuntimeDom + one Shared helper; independent of the other open batch-7 PRs.

## What landed

**v-model + v-show [V01.01.04.06, #44]** — the `vModel.ts`/`vShow.ts` port as stateless `IDirective` singletons: `VModelText` (composition-event IME guard — `compositionend` clears-and-commits, and `change` also ends a composition, both upstream behaviors; `.lazy`/`.number`/`.trim`), `VModelCheckbox` (boolean / `IList` with loose index-of / `ISet`, `true-value`/`false-value`), `VModelRadio` and `VModelSelect` (loose equality so object option values round-trip; `multiple` to list or set), `VModelDynamic` (runtime tag/type dispatch, type-switch pinned), and `VShow` (original inline `display` saved/restored, hidden-from-first-paint via beforeMount, stylesheet-supplied display preserved). Focused-element write guards match upstream so programmatic model writes never clobber in-progress input.

Interop discipline (the issue's hard boundary): element state rides the **single event dispatch** — `BrowserEvent` gained `SelectedValues` (JS + `[JSExport]` extended together, primitives/string[] only) so even `<select multiple>` costs zero follow-up interop reads per event. The invoker registry gained a **model channel** beside the property channel: one shared DOM listener per (element, event, capture), two delegate slots, property-then-model firing order — upstream's separate raw `addEventListener` coexistence with zero extra listener interop. `.number` coercion landed as Shared `NumberCoercion` (invariant-culture loose-to-number).

**Application API on BrowserApplication [V01.01.04.04.01, #114]** — chainable `Component`/`Directive`/`Provide` (typed + string)/`Use`/`Config` delegating to the wrapped `VueApplication<int>`, closing the gap flagged in PR #113.

## Review notes

- Hook usage verified against upstream (vModel: created/mounted/beforeUpdate, select adds updated; vShow: beforeMount/mounted/updated/beforeUnmount); all model directives add beforeUnmount to release per-element state — the .NET-side stand-in for upstream's element stashes (`el._assign` etc.), which an int-handle bridge cannot hang off JS nodes. Handle-registry stress confirms nothing leaks through the new channels.
- The two-channel invoker's removal logic drops the DOM listener only when both channels are empty — verified, and the live smoke confirms the extended dispatch signature binds cleanly.

## Deviations (documented at each site)

- `VueModelBinding` (value + setter delegates) is the model carrier and the [V01.01.05.03] compiler emission target — upstream's `onUpdate:modelValue` prop has no reflection-free C# analog.
- Focus tracked via the element's own focus/blur events instead of a per-update `document.activeElement` interop read.
- v-show's original display derives from the vnode's style prop rather than an `el.style.display` interop read (equivalent for inline styles; stylesheet case behaves identically since no inline value is restored).
- Transition coordination is a documented-inert seam until `<Transition>` ([V01.01.04.07]) exists, per the issue's forward reference.
- Select `multiple` captured at created; runtime `:multiple` toggling deferred (listed below).

## Deferred (explicit, not fake-passed)

Real IME sequences, browser focus/caret nuances, and live `selectedOptions` reads → the e2e harness [V01.01.11.03]. v-show + Transition → [V01.01.04.07]. Runtime `:multiple` toggle and `<option>`s rendered by child components — noted for follow-up when the e2e harness lands.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors.
- **629 tests green**: RuntimeDom 108 (47 new, driving the real renderer + directive pipeline + invoker registry over int handles), Shared 227 (27 new), RuntimeCore 175, Reactivity 93, Testing 18, Generators 8. No pre-existing tests modified.
- Live WASM smoke: demo boots and runs with the extended event-dispatch signature; zero console errors. `?diagnostics=1` stress: all handle registries return to baseline through the new model channels.
- WASM AOT publish of this branch: **0 IL/trim/AOT warnings**.

Closes #44
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)