### PR TITLE
feat(runtime-core): unmount blocks through the DynamicChildren fast path

### DIFF
--- a/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Internal/BlockStack.cs
@@ -30,6 +30,11 @@ internal static class BlockStack
     // disable-tracking block (v-once content, upstream openBlock(true)).
     private static readonly List<List<VirtualNode>?> Stack = [];
 
+    // Parallel to Stack: whether each open block has had a v-once bracket suspend collection inside it
+    // (upstream: the hasOnce flag carried on currentBlock / dynamicChildren). Kept as a separate list
+    // rather than a property on the pooled accumulator so pooling stays a plain clear-and-reuse.
+    private static readonly List<bool> StackHasOnce = [];
+
     // A free-list of accumulator lists: rented on OpenBlock, returned once the block is closed and
     // its children copied out, so collection reuses lists instead of allocating per render.
     private static readonly Stack<List<VirtualNode>> Pool = new();
@@ -51,17 +56,29 @@ internal static class BlockStack
     {
         var block = disableTracking ? null : Rent();
         Stack.Add(block);
+        StackHasOnce.Add(false);
         current = block;
     }
 
     /// <summary>
-    /// Adjusts block-tree tracking (upstream: <c>setBlockTracking</c>). The upstream <c>hasOnce</c>
-    /// marking is intentionally omitted: Vuecs unmount always walks the full children rather than
-    /// the <c>DynamicChildren</c> fast path, so nested components inside v-once content are always
-    /// torn down and the guard it protects is not reachable.
+    /// Adjusts block-tree tracking (upstream: <c>setBlockTracking</c>). When
+    /// <paramref name="inVOnce"/> suspends collection (<paramref name="value"/> &lt; 0) inside an open
+    /// block, that block is marked so unmount skips the <see cref="VirtualNode.DynamicChildren"/> fast
+    /// path (upstream #5154: <c>currentBlock.hasOnce = true</c>) — otherwise a component nested in the
+    /// v-once content, absent from the block's collected descendants, would never be torn down.
     /// </summary>
     /// <param name="value">-1 suspends collection; +1 resumes it.</param>
-    internal static void SetBlockTracking(int value) => enabled += value;
+    /// <param name="inVOnce">True when the suspension brackets v-once content (marks the block).</param>
+    internal static void SetBlockTracking(int value, bool inVOnce = false)
+    {
+        enabled += value;
+        if (value < 0 && inVOnce && current is not null)
+        {
+            // Mark the innermost open (tracking) block; a disable-tracking block has current == null
+            // and is intentionally not marked (upstream: the `currentBlock &&` guard).
+            StackHasOnce[^1] = true;
+        }
+    }
 
     /// <summary>
     /// Closes the current block and stamps its collected dynamic descendants onto
@@ -76,6 +93,9 @@ internal static class BlockStack
         var accumulator = current;
         // Upstream: dynamicChildren = isBlockTreeEnabled > 0 ? currentBlock || EMPTY_ARR : null.
         block.DynamicChildren = enabled > 0 ? Materialize(accumulator) : null;
+        // Carry the v-once mark from the open block onto the vnode (upstream: dynamicChildren.hasOnce),
+        // read before CloseBlock pops the frame.
+        block.HasOnce = StackHasOnce.Count > 0 && StackHasOnce[^1];
         Recycle(accumulator);
         CloseBlock();
         if (enabled > 0 && current is not null)
@@ -115,6 +135,7 @@ internal static class BlockStack
     internal static void ClearAfterRenderFailure()
     {
         Stack.Clear();
+        StackHasOnce.Clear();
         current = null;
         enabled = 1;
     }
@@ -126,6 +147,7 @@ internal static class BlockStack
     internal static void Reset()
     {
         Stack.Clear();
+        StackHasOnce.Clear();
         Pool.Clear();
         current = null;
         enabled = 1;
@@ -135,6 +157,7 @@ internal static class BlockStack
     {
         // Upstream closeBlock: pop the stack and restore the parent block as current.
         Stack.RemoveAt(Stack.Count - 1);
+        StackHasOnce.RemoveAt(StackHasOnce.Count - 1);
         current = Stack.Count > 0 ? Stack[^1] : null;
     }
 

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Renderer{TNode}.cs
@@ -39,6 +39,14 @@ public sealed class Renderer<TNode>
     /// </summary>
     internal static int PatchVisitCount;
 
+    /// <summary>
+    /// Test seam: counts every <see cref="Unmount"/> entry so a block-unmount test can pin that
+    /// tearing down a tree of N static nodes with K dynamic descendants visits O(K) vnodes, not O(N) —
+    /// the dynamicChildren fast path (issue [V01.01.03.15.01]). Reset it before the unmount under test.
+    /// Ambient static, single-threaded.
+    /// </summary>
+    internal static int UnmountVisitCount;
+
     private readonly RendererOptions<TNode> _options;
     private readonly Dictionary<TNode, VirtualNode> _containerRoots = new(NodeComparer);
 
@@ -63,7 +71,8 @@ public sealed class Renderer<TNode>
         {
             if (current is not null)
             {
-                Unmount(current, doRemove: true);
+                // Root unmount: no owning component instance for error routing (upstream: null).
+                Unmount(current, parentComponent: null, doRemove: true);
                 _containerRoots.Remove(container);
             }
         }
@@ -122,7 +131,7 @@ public sealed class Renderer<TNode>
         {
             // Mismatched type: unmount and remount in place (upstream parity).
             anchor = GetNextHostNode(current);
-            Unmount(current, doRemove: true);
+            Unmount(current, parentComponent, doRemove: true);
             current = null;
         }
         switch (next.Type)
@@ -808,7 +817,8 @@ public sealed class Renderer<TNode>
         instance.Scope.Stop();
         if (instance.Subtree is not null)
         {
-            Unmount(instance.Subtree, doRemove);
+            // The subtree's owner is this instance (upstream: unmount(subTree, instance, ...)).
+            Unmount(instance.Subtree, instance, doRemove);
         }
         instance.IsUnmounted = true;
         QueueInstanceHooks(instance, LifecycleHookKind.Unmounted);
@@ -841,7 +851,7 @@ public sealed class Renderer<TNode>
         {
             if ((previousShape & ShapeFlags.ArrayChildren) != 0)
             {
-                UnmountChildren(current.ArrayChildren!, doRemove: true);
+                UnmountChildren(current.ArrayChildren!, parentComponent, doRemove: true);
             }
             if ((previousShape & ShapeFlags.TextChildren) == 0
                 || !string.Equals(current.TextChildren, next.TextChildren, StringComparison.Ordinal))
@@ -867,7 +877,7 @@ public sealed class Renderer<TNode>
             }
             else
             {
-                UnmountChildren(current.ArrayChildren!, doRemove: true);
+                UnmountChildren(current.ArrayChildren!, parentComponent, doRemove: true);
             }
         }
         else
@@ -902,7 +912,7 @@ public sealed class Renderer<TNode>
         }
         if (previousChildren.Length > nextChildren.Length)
         {
-            UnmountChildren(previousChildren, doRemove: true, startIndex: commonLength);
+            UnmountChildren(previousChildren, parentComponent, doRemove: true, startIndex: commonLength);
         }
         else
         {
@@ -975,7 +985,7 @@ public sealed class Renderer<TNode>
             // 4. common sequence + unmount: the new run is exhausted, so unmount the extra old nodes.
             while (i <= e1)
             {
-                Unmount(previousChildren[i], doRemove: true);
+                Unmount(previousChildren[i], parentComponent, doRemove: true);
                 i++;
             }
         }
@@ -1049,7 +1059,7 @@ public sealed class Renderer<TNode>
                 if (patched >= toBePatched)
                 {
                     // Every new node is already matched, so any remaining old node is a removal.
-                    Unmount(previousChild, doRemove: true);
+                    Unmount(previousChild, parentComponent, doRemove: true);
                     continue;
                 }
                 var newIndex = -1;
@@ -1074,7 +1084,7 @@ public sealed class Renderer<TNode>
                 }
                 if (newIndex < 0)
                 {
-                    Unmount(previousChild, doRemove: true);
+                    Unmount(previousChild, parentComponent, doRemove: true);
                 }
                 else
                 {
@@ -1263,23 +1273,37 @@ public sealed class Renderer<TNode>
         }
     }
 
-    private void UnmountChildren(VirtualNode[] children, bool doRemove, int startIndex = 0)
+    private void UnmountChildren(
+        IReadOnlyList<VirtualNode> children,
+        ComponentInstance? parentComponent,
+        bool doRemove,
+        bool optimized = false,
+        int startIndex = 0)
     {
-        for (var index = startIndex; index < children.Length; index++)
+        // The C# port of unmountChildren (renderer.ts): tear down each child, threading the owner so a
+        // throwing function template-ref routes through its error-capture chain, and the optimized flag
+        // so a block's dynamic descendants do not re-walk their own static children.
+        for (var index = startIndex; index < children.Count; index++)
         {
-            Unmount(children[index], doRemove);
+            Unmount(children[index], parentComponent, doRemove, optimized);
         }
     }
 
-    private void Unmount(VirtualNode node, bool doRemove)
+    private void Unmount(VirtualNode node, ComponentInstance? parentComponent, bool doRemove, bool optimized = false)
     {
+        UnmountVisitCount++;
+        // A Bail vnode forces the full, unoptimized children walk on teardown (upstream unmount:
+        // `if (patchFlag === PatchFlags.BAIL) optimized = false`).
+        if (node.PatchFlag == PatchFlags.Bail)
+        {
+            optimized = false;
+        }
         // Unset any template ref first (upstream unmount order: setRef with isUnmount before the
-        // node's teardown hooks). No owner instance is threaded through unmount, so a throwing
-        // function ref surfaces to the host — an acceptable simplification, since clearing sets null
-        // or drops from a collection and does not normally throw.
+        // node's teardown hooks). parentComponent is the owner, so a throwing function ref routes
+        // through its error-capture chain instead of surfacing to the host ([V01.01.03.15.01]).
         if (node.Reference is { } reference)
         {
-            SetReference(reference, oldReference: null, node, isUnmount: true, owner: null);
+            SetReference(reference, oldReference: null, node, isUnmount: true, parentComponent);
         }
         // Cleanup order (upstream parity): hooks and child teardown run before node removal.
         InvokeHook(node, null, "onVnodeBeforeUnmount");
@@ -1289,38 +1313,58 @@ public sealed class Renderer<TNode>
         {
             InvokeDirectiveHooks(node, null, DirectiveHookKind.BeforeUnmount);
         }
-        switch (node.Type)
+        if (node.Type == VirtualNodeType.Component)
         {
-            case VirtualNodeType.Component:
-                UnmountComponent(node, doRemove);
-                break;
-            case VirtualNodeType.Fragment:
-                // Children tear down without individual removals; the fragment range removal
-                // below takes their nodes out in one anchored walk.
-                UnmountChildren(node.ArrayChildren ?? [], doRemove: false);
-                if (doRemove)
+            UnmountComponent(node, doRemove);
+        }
+        else
+        {
+            var dynamicChildren = node.DynamicChildren;
+            if (dynamicChildren is not null
+                && !node.HasOnce
+                && (node.Type != VirtualNodeType.Fragment
+                    || ((int)node.PatchFlag > 0 && (node.PatchFlag & PatchFlags.StableFragment) != 0)))
+            {
+                // Fast path for block nodes: tear down only the collected dynamic descendants — the
+                // static subtree leaves with the host removal below, so on WASM every skipped visit is
+                // a skipped interop round-trip. Their own static children are not re-walked
+                // (optimized: true). A v-once block (HasOnce) and a non-stable (v-for) fragment are
+                // excluded because their teardown-relevant descendants are absent from DynamicChildren
+                // (upstream #5154 / #1153).
+                UnmountChildren(dynamicChildren, parentComponent, doRemove: false, optimized: true);
+            }
+            else if ((node.Type == VirtualNodeType.Fragment
+                    && (int)node.PatchFlag > 0
+                    && (node.PatchFlag & (PatchFlags.KeyedFragment | PatchFlags.UnkeyedFragment)) != 0)
+                || (!optimized && (node.ShapeFlag & ShapeFlags.ArrayChildren) != 0))
+            {
+                // Full walk: a keyed/unkeyed v-for fragment, or any unoptimized array-children vnode,
+                // visits every child so their teardown hooks and refs fire. Their platform nodes leave
+                // with the range/host removal below (doRemove: false here). The `> 0` gate keeps the
+                // fragment test off the negative Bail/Cached sentinels (repo PatchFlags convention).
+                UnmountChildren(node.ArrayChildren ?? [], parentComponent, doRemove: false);
+            }
+            if (doRemove)
+            {
+                switch (node.Type)
                 {
-                    RemoveFragment(node);
+                    case VirtualNodeType.Fragment:
+                        // One anchored walk removes the fragment's whole owned range.
+                        RemoveFragment(node);
+                        break;
+                    case VirtualNodeType.Static:
+                        RemoveStaticNode(node);
+                        break;
+                    default:
+                        // Element/Text/Comment: a single host removal takes the node and, for an
+                        // element, its descendants' platform nodes with it.
+                        if (node.El is not null)
+                        {
+                            _options.Remove((TNode)node.El);
+                        }
+                        break;
                 }
-                break;
-            case VirtualNodeType.Static:
-                if (doRemove)
-                {
-                    RemoveStaticNode(node);
-                }
-                break;
-            default:
-                if (node.Type == VirtualNodeType.Element && node.ArrayChildren is not null)
-                {
-                    // Walk children for their teardown hooks; their platform nodes leave with
-                    // this element's single removal.
-                    UnmountChildren(node.ArrayChildren, doRemove: false);
-                }
-                if (doRemove && node.El is not null)
-                {
-                    _options.Remove((TNode)node.El);
-                }
-                break;
+            }
         }
         QueuePostHook(node, null, "onVnodeUnmounted");
         if (node.Type == VirtualNodeType.Element)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNode.cs
@@ -106,6 +106,16 @@ public sealed class VirtualNode
     public IReadOnlyList<VirtualNode>? DynamicChildren { get; internal set; }
 
     /// <summary>
+    /// Whether this block wraps <c>v-once</c> content whose descendants were <b>not</b> collected into
+    /// <see cref="DynamicChildren"/> (upstream: <c>dynamicChildren.hasOnce</c>, set when
+    /// <c>setBlockTracking(-1, true)</c> marks <c>currentBlock.hasOnce</c> — vuejs/core#5154). When set,
+    /// the renderer must <b>not</b> take the block unmount fast path: a component nested in the
+    /// suspended-collection content is absent from <see cref="DynamicChildren"/> and would otherwise
+    /// never be torn down (<see cref="Renderer{TNode}"/>'s <c>Unmount</c>, [V01.01.03.15.01]).
+    /// </summary>
+    internal bool HasOnce { get; set; }
+
+    /// <summary>
     /// The platform node this vnode is mounted to (upstream: <c>el</c>). Renderer-owned; the
     /// boxed <c>TNode</c> of the active renderer.
     /// </summary>

--- a/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/VirtualNodeFactory.cs
@@ -152,11 +152,15 @@ public static class VirtualNodeFactory
 
     /// <summary>
     /// Suspends or resumes block-tree tracking (upstream: <c>setBlockTracking</c>): a v-once
-    /// expression brackets its cached content with <c>SetBlockTracking(-1)</c> then
-    /// <c>SetBlockTracking(1)</c> so the content is not collected as a dynamic child.
+    /// expression brackets its cached content with <c>SetBlockTracking(-1, inVOnce: true)</c> then
+    /// <c>SetBlockTracking(1)</c> so the content is not collected as a dynamic child. Passing
+    /// <paramref name="inVOnce"/> on the suspending call also marks the enclosing block so unmount
+    /// skips the fast path and still tears down components nested in the v-once content
+    /// (upstream #5154; see <see cref="VirtualNode.HasOnce"/>).
     /// </summary>
     /// <param name="value">-1 suspends collection; +1 resumes it.</param>
-    public static void SetBlockTracking(int value) => BlockStack.SetBlockTracking(value);
+    /// <param name="inVOnce">True when the suspension brackets v-once content (marks the block).</param>
+    public static void SetBlockTracking(int value, bool inVOnce = false) => BlockStack.SetBlockTracking(value, inVOnce);
 
     /// <summary>
     /// Creates a block element vnode whose <see cref="VirtualNode.DynamicChildren"/> are the dynamic
@@ -478,6 +482,7 @@ public static class VirtualNodeFactory
             PatchFlag = node.PatchFlag,
             DynamicProperties = node.DynamicProperties,
             DynamicChildren = node.DynamicChildren,
+            HasOnce = node.HasOnce,
             Directives = node.Directives,
             AppContext = node.AppContext,
             El = node.El,

--- a/libraries/Assimalign.Vue.RuntimeCore/test/BlockUnmountTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/BlockUnmountTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.Shared;
+using Assimalign.Vue.Testing;
+
+namespace Assimalign.Vue.RuntimeCore.Tests;
+
+// Pins the block unmount fast path against @vue/runtime-core's unmount / unmountChildren
+// (packages/runtime-core/src/renderer.ts): a block vnode tears down only the dynamic descendants it
+// collected — static content leaves with the host subtree removal — while a v-once block (#5154) and a
+// non-stable fragment (#1153) fall back to the full children walk. Skipping a static teardown visit is
+// skipping marshaled node-op work on WASM, so the O(K) claim is pinned with the internal unmount-visit
+// counter, and the differential tests prove buffered content is torn down identically to the full walk
+// (lifecycle hooks fire, refs null, directives' beforeUnmount/unmounted fire) ([V01.01.03.15.01]).
+public class BlockUnmountTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public BlockUnmountTests()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        Renderer<TestNode>.PatchVisitCount = 0;
+        Renderer<TestNode>.UnmountVisitCount = 0;
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        _pump.Dispose();
+    }
+
+    [Fact]
+    public void UnmountBlock_VisitsOnlyDynamicNodes_SkippingTheStaticSubtree()
+    {
+        VirtualNode Build(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("header", "static-1"),
+                    VirtualNodeFactory.Element("nav", "static-2"),
+                    VirtualNodeFactory.Element("footer", "static-3"),
+                    VirtualNodeFactory.Element("span", null, message, PatchFlags.Text),
+                });
+        }
+
+        _renderer.Render(Build("a"), _container);
+        _renderer.OperationLog.Reset();
+        Renderer<TestNode>.UnmountVisitCount = 0;
+
+        _renderer.Render(null, _container);
+
+        // O(K): only the block root and the single dynamic <span> are visited on teardown; the three
+        // static children are never passed to unmount. Their platform nodes leave in the block's one
+        // host removal (upstream unmount fast path for block nodes).
+        Renderer<TestNode>.UnmountVisitCount.ShouldBe(2);
+        _renderer.OperationLog.Count(TestNodeOperationType.Remove).ShouldBe(1);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void UnmountBlock_DoesNotReWalkTheStaticChildrenOfADynamicElement()
+    {
+        VirtualNode Build(string cls)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                null,
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element(
+                        "section",
+                        VirtualNodeFactory.Properties(("class", cls)),
+                        new VirtualNode?[]
+                        {
+                            VirtualNodeFactory.Element("span", "a"),
+                            VirtualNodeFactory.Element("span", "b"),
+                        },
+                        PatchFlags.Class),
+                });
+        }
+
+        _renderer.Render(Build("red"), _container);
+        Renderer<TestNode>.UnmountVisitCount = 0;
+
+        _renderer.Render(null, _container);
+
+        // The dynamic <section> is torn down, but its two static <span> grandchildren are not: upstream
+        // threads `optimized` through the fast-path recursion so a collected element does not re-walk
+        // its own static children. Without that threading the count would be 4, not 2.
+        Renderer<TestNode>.UnmountVisitCount.ShouldBe(2);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void UnmountStableFragmentBlock_TearsDownDynamicChildrenOnly_SkippingStaticSiblings()
+    {
+        VirtualNode Build(string message)
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.FragmentBlock(
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("hr", "static"),
+                    VirtualNodeFactory.Element("span", null, message, PatchFlags.Text),
+                },
+                key: null,
+                PatchFlags.StableFragment);
+        }
+
+        _renderer.Render(Build("a"), _container);
+        Renderer<TestNode>.UnmountVisitCount = 0;
+
+        _renderer.Render(null, _container);
+
+        // A stable fragment carrying a block tree takes the fast path (upstream: type !== Fragment ||
+        // STABLE_FRAGMENT): only the fragment block and its one dynamic <span> are visited; the static
+        // <hr> is not. The fragment's whole owned host range still leaves in one anchored removal walk.
+        Renderer<TestNode>.UnmountVisitCount.ShouldBe(2);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void UnmountBlock_FiresLifecycleRefsAndDirectives_ForDynamicDescendants()
+    {
+        var events = new List<string>();
+        var elementRef = new Reference<object?>(null);
+        var directive = new Directive
+        {
+            BeforeUnmount = (_, _, _, _) => events.Add("dir:beforeUnmount"),
+            Unmounted = (_, _, _, _) => events.Add("dir:unmounted"),
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnUnmounted(() => events.Add("child:unmounted"));
+                return static () => VirtualNodeFactory.Element("i", "child");
+            },
+        };
+        var host = new TestComponent
+        {
+            // The block is produced inside a render (WithDirectives needs the active instance); its
+            // dynamic descendants are the directive-bearing <span> (NeedPatch), the ref, and the child
+            // component. The static <header> is not collected.
+            SetupFunction = (_, _) => () =>
+            {
+                VirtualNodeFactory.OpenBlock();
+                return VirtualNodeFactory.ElementBlock(
+                    "div",
+                    null,
+                    new VirtualNode?[]
+                    {
+                        VirtualNodeFactory.Element("header", "static"),
+                        Directives.WithDirectives(
+                            VirtualNodeFactory.Element(
+                                "span",
+                                VirtualNodeFactory.Properties(("ref", elementRef)),
+                                "x",
+                                PatchFlags.NeedPatch),
+                            directive),
+                        VirtualNodeFactory.Component(child),
+                    });
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(host), _container);
+        elementRef.Value.ShouldNotBeNull();
+
+        _renderer.Render(null, _container);
+
+        // The fast path visits only the dynamic descendants, but tears each down completely — a
+        // component's unmounted hook, a directive's beforeUnmount and unmounted, and a template ref all
+        // fire exactly as the full walk would (upstream unmount parity).
+        events.ShouldContain("dir:beforeUnmount");
+        events.ShouldContain("dir:unmounted");
+        events.ShouldContain("child:unmounted");
+        elementRef.Value.ShouldBeNull();
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void UnmountVOnceBlock_TakesTheFullWalk_TearingDownAComponentNestedInVOnceContent()
+    {
+        // Upstream #5154: a component created under setBlockTracking(-1, true) is absent from the
+        // block's DynamicChildren, so the block must NOT take the unmount fast path — the fast path
+        // would skip (leak) the component. The v-once mark (HasOnce) forces the full children walk that
+        // reaches and tears it down.
+        var events = new List<string>();
+        var onceChild = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnUnmounted(() => events.Add("once:unmounted"));
+                return static () => VirtualNodeFactory.Element("i", "once");
+            },
+        };
+
+        VirtualNodeFactory.OpenBlock();
+        var liveSpan = VirtualNodeFactory.Element("span", null, "live", PatchFlags.Text); // collected
+        VirtualNodeFactory.SetBlockTracking(-1, inVOnce: true);
+        var onceComponent = VirtualNodeFactory.Component(onceChild); // NOT collected; marks HasOnce
+        VirtualNodeFactory.SetBlockTracking(1);
+        var block = VirtualNodeFactory.ElementBlock("div", null, new VirtualNode?[] { liveSpan, onceComponent });
+
+        block.HasOnce.ShouldBeTrue();                       // the block carries the v-once mark
+        block.DynamicChildren.ShouldNotBeNull();
+        block.DynamicChildren!.Count.ShouldBe(1);           // only the live <span>, not the component
+
+        _renderer.Render(block, _container);
+        _renderer.Render(null, _container);
+
+        // Full walk (fast path skipped) reaches the uncollected component and tears it down.
+        events.ShouldBe(["once:unmounted"]);
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void SetBlockTracking_MarksHasOnceOnlyForAVOnceSuspension_NotAPlainOne()
+    {
+        // Upstream setBlockTracking(value, inVOnce): only a v-once suspension marks the block (#5154);
+        // a plain -1/+1 bracket suspends collection without setting hasOnce.
+        VirtualNodeFactory.OpenBlock();
+        VirtualNodeFactory.SetBlockTracking(-1);
+        VirtualNodeFactory.SetBlockTracking(1);
+        var plain = VirtualNodeFactory.ElementBlock("div", null, (VirtualNode?[]?)null);
+        plain.HasOnce.ShouldBeFalse();
+
+        VirtualNodeFactory.OpenBlock();
+        VirtualNodeFactory.SetBlockTracking(-1, inVOnce: true);
+        VirtualNodeFactory.SetBlockTracking(1);
+        var once = VirtualNodeFactory.ElementBlock("div", null, (VirtualNode?[]?)null);
+        once.HasOnce.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void UnmountBlock_RemovesTheHostSubtree_IdenticallyToABailedFullWalk()
+    {
+        // A block (optimized teardown) and the equivalent bailed tree (full-walk teardown) must leave
+        // the container in the same state — the fast path changes which vnodes are visited, never the
+        // host result (upstream parity).
+        var bailedRenderer = new TestRenderer();
+        var bailedContainer = bailedRenderer.CreateContainer();
+
+        VirtualNode Optimized()
+        {
+            VirtualNodeFactory.OpenBlock();
+            return VirtualNodeFactory.ElementBlock(
+                "div",
+                VirtualNodeFactory.Properties(("id", "root")),
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("p", "static"),
+                    VirtualNodeFactory.Element("span", null, "a", PatchFlags.Text),
+                });
+        }
+
+        VirtualNode Bailed() => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("id", "root")),
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Element("p", "static"),
+                VirtualNodeFactory.Element("span", "a"),
+            },
+            PatchFlags.Bail);
+
+        _renderer.Render(Optimized(), _container);
+        bailedRenderer.Render(Bailed(), bailedContainer);
+        _renderer.Render(null, _container);
+        bailedRenderer.Render(null, bailedContainer);
+
+        TestNodeSerializer.Serialize(_container).ShouldBe("<root></root>");
+        TestNodeSerializer.Serialize(bailedContainer).ShouldBe("<root></root>");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeCore/test/TemplateReferenceTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/TemplateReferenceTests.cs
@@ -256,4 +256,49 @@ public class TemplateReferenceTests : IDisposable
         node.Reference.ShouldBeNull();
         warnings.Messages.ShouldContain(message => message.Contains("Invalid template ref"));
     }
+
+    [Fact]
+    public void FunctionRefThrowingOnUnmount_RoutesThroughTheOwnersErrorChain()
+    {
+        // Upstream setRef routes a throwing function ref through callWithErrorHandling with the owning
+        // component as context. Vuecs now threads parentComponent through unmount, so an unmount-time
+        // throw reaches the owner's OnErrorCaptured chain instead of surfacing to the host — previously
+        // the unmount path passed owner: null and the throw escaped ([V01.01.03.15.01]).
+        Exception? captured = null;
+        string? capturedInfo = null;
+        Action<object?> throwingRef = value =>
+        {
+            if (value is null)
+            {
+                throw new InvalidOperationException("ref teardown boom");
+            }
+        };
+        var child = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element(
+                "div", VirtualNodeFactory.Properties(("ref", throwingRef)), "x"),
+        };
+        var parent = new TestComponent
+        {
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnErrorCaptured((exception, _, info) =>
+                {
+                    captured = exception;
+                    capturedInfo = info;
+                    return false; // handled
+                });
+                return () => VirtualNodeFactory.Element("section", VirtualNodeFactory.Component(child));
+            },
+        };
+
+        _renderer.Render(VirtualNodeFactory.Component(parent), _container); // mount: ref(element), no throw
+
+        // Unmount invokes the function ref with null (synchronous doSet); it throws and must be captured.
+        Should.NotThrow(() => _renderer.Render(null, _container));
+
+        captured.ShouldBeOfType<InvalidOperationException>().Message.ShouldBe("ref teardown boom");
+        capturedInfo.ShouldNotBeNull();
+        capturedInfo.ShouldContain("template ref");
+    }
 }


### PR DESCRIPTION
Batch 8C — delegated implementation (Opus 4.8 agent) with design/functionality review; no review fixes needed. Renderer-only; independent of the other in-flight batch-8 branches.

## What landed

**Block unmount fast path [V01.01.03.15.01, #116]** — the remaining half of upstream `unmount`'s block optimization, guards ported verbatim from vuejs/core v3.5 `renderer.ts`: a block vnode tears down only its collected `DynamicChildren` (with `optimized: true` recursion so nested blocks don't re-walk static children, and `doRemove: false` since the static subtree leaves with the block root's single host removal) — excluded exactly where upstream excludes it: `hasOnce` blocks (v-once content whose components are absent from the collection, upstream #5154), non-stable fragments (upstream #1153), and `PatchFlags.Bail` forcing the unoptimized walk. The `hasOnce` machinery this required (a per-block flag stack in `BlockStack`, `VirtualNode.HasOnce`, the `SetBlockTracking(value, inVOnce)` overload) replaces the previous documented omission, whose "unreachable" rationale this change invalidated.

**`parentComponent` threading through `Unmount`/`UnmountChildren`** — all nine call sites, so a throwing function template-ref during unmount now routes through its owner's `OnErrorCaptured` chain instead of surfacing ownerless (pinned by a test that fails without the threading). Component subtrees pass their instance as owner (upstream `unmount(subTree, instance, …)`).

## Review notes

- Guard conditions verified against the upstream source the agent quoted verbatim in its report — the port is exact, including the fast path's `doRemove: false`/`optimized: true` pair.
- Teardown is differentially proven: the fast path fires the same component `OnUnmounted`, directive `beforeUnmount`/`unmounted`, and ref-nulling as the full walk, with an `UnmountVisitCount` seam pinning O(K) visits (K dynamic descendants in an N-node static tree).
- One agent deviation I explicitly endorse: `RemoveFragment` was *not* given a `parentComponent` parameter, pushing back on my brief's paraphrase in favor of the issue body and upstream's `removeFragment(cur, end)` signature — it has no ref/hook/error surface, so the parameter would be dead code.
- The `(int)flag > 0` gate on the keyed/unkeyed-fragment test is the repo's established negative-sentinel-safe idiom (Bail/Cached protection), functionally equivalent to upstream for all reachable cases — documented at the site.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors.
- **837 tests green**: RuntimeCore 207 (8 new), Compiler 148, Shared 227, Reactivity 113, RuntimeDom 108, Testing 18, Generators 9. No existing tests modified.
- `?diagnostics=1` stress — 100 tree-teardown cycles + 25 app mount/unmount cycles through the changed paths: all handle registries return to baseline, zero console errors.
- WASM AOT publish of this branch: **0 IL/trim/AOT warnings**.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)