### PR TITLE
feat(sfc): the .viu file format (@-block syntax) and block parser

### DIFF
--- a/.github/workflows/area-sfc.yml
+++ b/.github/workflows/area-sfc.yml
@@ -1,0 +1,47 @@
+# Area build+test for Assimalign.Vue.Sfc ([V01.01.12.02]): path-filtered so a PR only runs the areas
+# it touches; shared build files trigger every area. The build scope is the per-area slnx, keeping CI
+# and local builds in lockstep. Jobs are independent by design — cross-area contracts are enforced by
+# project references at build time, not workflow ordering. The Sfc library references nothing but the
+# BCL, so only its own tree (and the shared build files) gate this area.
+name: area-sfc
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Sfc/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-sfc.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Vue.Sfc/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-sfc.yml'
+
+jobs:
+  build-test:
+    name: build+test Sfc
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Vue.Sfc/Assimalign.Vue.Sfc.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Vue.Sfc/Assimalign.Vue.Sfc.slnx --configuration Release --no-build

--- a/Assimalign.Vuecs.slnx
+++ b/Assimalign.Vuecs.slnx
@@ -132,6 +132,18 @@
 	<Folder Name="/vuecs/libraries/Assimalign.Vue.RuntimeDom/test/">
 		<Project Path="libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.Tests.csproj" />
 	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Sfc/">
+		<File Path="libraries/Assimalign.Vue.Sfc/Assimalign.Vue.Sfc.slnx" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Sfc/docs/">
+		<File Path="libraries/Assimalign.Vue.Sfc/docs/FORMAT.md" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Sfc/src/">
+		<Project Path="libraries/Assimalign.Vue.Sfc/src/Assimalign.Vue.Sfc.csproj" />
+	</Folder>
+	<Folder Name="/vuecs/libraries/Assimalign.Vue.Sfc/test/">
+		<Project Path="libraries/Assimalign.Vue.Sfc/test/Assimalign.Vue.Sfc.Tests.csproj" />
+	</Folder>
 	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/" />
 	<Folder Name="/vuecs/libraries/Assimalign.Vue.Shared/src/">
 		<Project Path="libraries/Assimalign.Vue.Shared/src/Assimalign.Vue.Shared.csproj" />

--- a/libraries/Assimalign.Vue.Sfc/Assimalign.Vue.Sfc.slnx
+++ b/libraries/Assimalign.Vue.Sfc/Assimalign.Vue.Sfc.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Vue.Sfc.csproj" />
+	<Project Path="test/Assimalign.Vue.Sfc.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Vue.Sfc/docs/FORMAT.md
+++ b/libraries/Assimalign.Vue.Sfc/docs/FORMAT.md
@@ -1,0 +1,245 @@
+# The `.viu` single-file component format
+
+`Assimalign.Vue.Sfc` defines and parses the `.viu` single-file component (SFC) format — the Vuecs
+counterpart to Vue's `.vue` files. This document is the authoritative specification for the container
+syntax and the block parser (`SfcParser.Parse`). It matches the parser's behavior exactly; the test
+suite (`libraries/Assimalign.Vue.Sfc/test/`) pins every rule stated here.
+
+Work item: **[V01.01.06.01]**. Block semantics mirror the Vue SFC specification
+(<https://vuejs.org/api/sfc-spec.html>); descriptor shape mirrors `parse()` in `@vue/compiler-sfc`
+(vuejs/core, `packages/compiler-sfc/src/parse.ts`).
+
+## 1. The @-block container is a documented Vuecs divergence
+
+Vue wraps SFC blocks in HTML-like tags — `<template>…</template>`, `<script>…</script>`,
+`<style>…</style>`. Vuecs deliberately diverges (design decision, 2026-07-17): a `.viu` file uses
+**@-block container syntax** instead.
+
+```
+@template {
+    <!-- Vue template markup: directives, {{ }} interpolation -->
+    <div>{{ message }}</div>
+}
+
+@script {
+    // C# — the component's partial-class body
+    public string Message = "Hello";
+}
+
+@style scoped {
+    /* CSS */
+    .box { color: red; }
+}
+```
+
+Only the **container** is different. The block *semantics* — what `template`/`script`/`style`/custom
+blocks mean, and what their options mean — follow the Vue SFC spec unchanged. In particular, the markup
+inside `@template` is **standard Vue template syntax**; the block parser does not parse it. It only
+slices the file into blocks and records their source spans. The template markup is parsed later by the
+template compiler (`Assimalign.Vue.Compiler`, [V01.01.05.01]); the C# in `@script` is analysed by
+[V01.01.06.03].
+
+### Upstream-semantics mapping
+
+| `.viu`                         | Vue SFC                          | Meaning (per the Vue SFC spec)                    |
+| ------------------------------ | -------------------------------- | ------------------------------------------------- |
+| `@template { … }`              | `<template> … </template>`       | The component's markup.                            |
+| `@template lang="html" { … }`  | `<template lang="html">`         | Markup pre-processor language.                     |
+| `@script { … }`                | `<script> … </script>`           | The component's script body.                       |
+| `@script lang="csharp" { … }`  | `<script lang="…">`              | Script language.                                   |
+| `@style { … }`                 | `<style> … </style>`             | Component CSS (a file may have several).           |
+| `@style scoped { … }`          | `<style scoped>`                 | [Scoped CSS](https://vuejs.org/api/sfc-css-features.html#scoped-css). |
+| `@style module { … }`          | `<style module>`                 | [CSS Modules](https://vuejs.org/api/sfc-css-features.html#css-modules) (default name). |
+| `@style module="classes" { … }`| `<style module="classes">`       | CSS Modules bound to a named object.              |
+| `@style lang="scss" { … }`     | `<style lang="scss">`            | CSS pre-processor language.                        |
+| `@docs { … }` (any other name) | `<docs>` (custom block)          | [Custom block](https://vuejs.org/api/sfc-spec.html#custom-blocks), preserved verbatim. |
+
+> The Vue `<script setup>` distinction is script *analysis*, deferred to [V01.01.06.03]. This parser
+> treats every `@script` block uniformly and allows at most one per file.
+
+## 2. Block headers
+
+A block is introduced by a **header line**:
+
+```
+@<name> <options>? {
+```
+
+- The header line's **first column must be `@`** (see §4 — column 0 is structural). A header that is
+  indented is not recognised as a header.
+- `<name>` immediately follows the `@` and matches `[A-Za-z_][A-Za-z0-9_-]*` (a letter or `_`, then
+  letters, digits, `_`, or `-`).
+- The three well-known names `template`, `script`, and `style` are matched **case-sensitively and in
+  lowercase**. Any other name (including a different casing such as `@Template`) is a **custom block**.
+- The opening `{` must be the **last non-whitespace character on the header line**. Content begins on
+  the next line.
+
+### 2.1 Options
+
+Options replace Vue's block attributes and are written between the name and the `{`, separated by
+whitespace:
+
+```
+@<name> option option="value" {
+```
+
+- An option is either a **valueless flag** (`scoped`) or a **key with a double-quoted value**
+  (`lang="scss"`).
+- An option name matches `[A-Za-z_][A-Za-z0-9_-]*`.
+- A value is written as `name="value"` with **no whitespace around `=`**. The value is any run of
+  characters except `"` — values are simple tokens (language names, identifiers); there is no escape
+  syntax, so a value cannot itself contain a double quote.
+- Options are preserved on every block, in source order, each with its own source span. Unknown options
+  on any block, and any options on custom blocks, are preserved rather than rejected.
+
+Honored (typed) options, per the Vue SFC spec:
+
+| Option              | Blocks                    | Surfaced as                                        |
+| ------------------- | ------------------------- | -------------------------------------------------- |
+| `scoped`            | `@style`                  | `SfcStyleBlock.Scoped` (`bool`)                    |
+| `module`            | `@style`                  | `SfcStyleBlock.IsModule` (`bool`)                  |
+| `module="name"`     | `@style`                  | `SfcStyleBlock.IsModule` + `SfcStyleBlock.ModuleName` |
+| `lang="…"`          | `@style`/`@script`/`@template` (and custom) | `SfcBlock.Lang` (`string?`)      |
+
+All other options remain available through `SfcBlock.HasOption(name)` and
+`SfcBlock.GetOptionValue(name)`.
+
+## 3. Block content
+
+A block's content is the **exact raw source** between the header line and the closing brace:
+
+- It starts at the first character of the line *after* the header line.
+- It ends at the first character of the closing-brace line (see §4).
+- It is never re-parsed, trimmed, or normalised. Interior indentation and the trailing newline that
+  precedes the closing brace are preserved verbatim. An empty body yields an empty string.
+
+`SfcBlock.Content` equals `SfcBlock.ContentLocation.Source`, and every span the parser emits satisfies
+`Location.Source == source.Substring(Start.Offset, End.Offset - Start.Offset)`. Positions carry a
+zero-based `Offset`, a one-based `Line`, and a one-based `Column` — suitable for `#line` mapping
+([V01.01.06.03]) and IDE diagnostics.
+
+## 4. The termination rule — column 0 is structural
+
+This is the core rule. It is deterministic, language-agnostic, and requires no knowledge of C#, CSS, or
+HTML syntax:
+
+> **A block opened by a header line closes at the first later line whose first column is `}`.**
+
+Restated as a single principle: **column 0 is structural.**
+
+- At the **top level** (outside any block), a line whose first column is `@` begins a block header.
+- **Inside a block**, a line whose first column is `}` closes the block. Nothing else is examined — the
+  parser scans line starts only.
+- Every other line is **content** (inside a block) or **stray content** (at the top level).
+
+The immediate consequence is the one requirement the format places on authors:
+
+> **Block content must be indented.** No content line may begin at column 0 with `}`.
+
+Because the parser only inspects the first column of each line, unbalanced or literal braces *inside*
+content never terminate a block, as long as content is indented:
+
+```
+@script {
+    var json = "{ \"a\": 1 }";   // literal { and } inside a C# string — fine
+    var closing = "}";           // the } is not at column 0 — fine
+}
+```
+
+```
+@style {
+    .a {
+        color: red;
+    }                            // the CSS rule's own } is indented — fine
+    .b { color: blue; }
+}
+```
+
+```
+@template {
+    <p>Use { and } carefully</p> <!-- braces in text — fine -->
+    @template {                  <!-- even a line that looks like a header is just content -->
+}
+```
+
+### 4.1 The indentation requirement, made concrete
+
+If CSS (or any content) is written flush against column 0, the content's own `}` closes the block
+early. This is the documented flip side of the rule, not a bug:
+
+```
+@style {
+.a {
+    color: red;
+}          ← this column-0 } closes the @style block early
+}          ← this } is now stray top-level content → StrayTopLevelContent
+```
+
+Authors avoid this simply by indenting block bodies (as every example here does).
+
+### 4.2 Closing-brace line details
+
+- Recognition is purely "first column is `}`". Any characters after the `}` on that line are ignored,
+  so `} // closes the block` is a valid closer. The block's whole-span `Location` ends immediately
+  after the `}`.
+- A block that is never closed (end of file is reached with no column-0 `}`) is reported as
+  `UnterminatedBlock`; for recovery the block's content is taken to end of file and the block still
+  appears in the descriptor.
+
+### 4.3 Between and around blocks
+
+- Blank lines (empty or whitespace-only) at the top level are ignored; they may separate blocks.
+- Any non-blank top-level line that is not a valid header is reported as `StrayTopLevelContent` and
+  skipped; parsing continues with the next line.
+
+## 5. The descriptor
+
+`SfcParser.Parse(string source)` returns an `SfcParseResult` — an `SfcDescriptor` plus the diagnostics.
+Both the descriptor and the blocks are **immutable records with structural (value) equality**: parsing
+identical file content twice yields equal (and equal-hashing) descriptors, and any content or location
+difference makes them unequal. This is the prerequisite for incremental-generator caching
+([V01.01.06.02]).
+
+`SfcDescriptor` exposes, mirroring Vue's `SFCDescriptor`:
+
+- `Template` — the single `@template` block, or `null`.
+- `Script` — the single `@script` block, or `null`.
+- `Styles` — the `@style` blocks, in source order (Vue allows several).
+- `CustomBlocks` — all other blocks (e.g. `@docs`), in source order.
+- `Source` — the full original file text.
+
+A file may contain **at most one** `@template` and **at most one** `@script`; a second of either is
+reported (`DuplicateTemplateBlock` / `DuplicateScriptBlock`) and ignored — the **first** is kept.
+
+## 6. Diagnostics
+
+Parsing is **recoverable**: malformed input is reported through `SfcParseResult.Errors` and the parser
+never throws for bad content (a `null` source argument throws `ArgumentNullException` — that is API
+misuse, not input). Multiple problems are reported in a single pass, each with a code, a message, and a
+source location.
+
+The diagnostic codes (`SfcErrorCode`) are **Vuecs-defined**. Unlike `Assimalign.Vue.Compiler`'s
+`CompilerErrorCode`, which mirrors vuejs/core's numbering, the `@`-block container is a Vuecs divergence
+and has no upstream vuejs/core codes to align to. Values start at 1000 to stay visibly distinct from any
+upstream-aligned catalog.
+
+| Code                          | Value | Raised when                                                              |
+| ----------------------------- | ----- | ----------------------------------------------------------------------- |
+| `StrayTopLevelContent`        | 1001  | Non-whitespace text appears at the top level, outside any block.        |
+| `MalformedBlockHeader`        | 1002  | A top-level line begins with `@` but no valid block name follows.       |
+| `MissingOpeningBrace`         | 1003  | A header names a block but has no opening `{` on its line.              |
+| `ContentAfterOpeningBrace`    | 1004  | Non-whitespace follows the opening `{` on a header line.                |
+| `MalformedOptionValue`        | 1005  | An option value is not a well-formed double-quoted string.              |
+| `DuplicateTemplateBlock`      | 1006  | A file declares more than one `@template`.                              |
+| `DuplicateScriptBlock`        | 1007  | A file declares more than one `@script`.                                |
+| `UnterminatedBlock`           | 1008  | A block is opened but end of file is reached with no column-0 `}`.      |
+
+### Recovery policy
+
+- A structurally openable header (`@<name> … {`) **always opens the block**; option problems
+  (`MalformedOptionValue`) and trailing content (`ContentAfterOpeningBrace`) are reported but do not
+  suppress the block, so its content is still sliced.
+- A header only fails to open when it has **no valid name** (`MalformedBlockHeader`) or **no `{`**
+  (`MissingOpeningBrace`); the header line is then skipped.
+- `UnterminatedBlock` still yields the block (content to end of file), so downstream tooling has
+  something to work with.

--- a/libraries/Assimalign.Vue.Sfc/src/Assimalign.Vue.Sfc.csproj
+++ b/libraries/Assimalign.Vue.Sfc/src/Assimalign.Vue.Sfc.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Deviates from the repo build-system rule (libraries use $(TargetFrameworkForLibraries) = net10.0)
+         per the reviewer's architectural steer: the .viu block parser runs INSIDE the Roslyn SFC
+         generator ([V01.01.06.02]), which is a netstandard2.0 analyzer host. It therefore targets the
+         analyzer TFM alias — the same central property the template compiler and generators projects use
+         — never a hardcoded string. Its net10.0 test project references it normally. -->
+    <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
+    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
+         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
+         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the Compiler csproj. -->
+    <EnablePreviewFeatures>false</EnablePreviewFeatures>
+    <!-- Deviates from the checklist rule "shipping libraries set IsAotCompatible=true": the AOT analyzers
+         require net7.0+, so the switch is inert (and warns) on netstandard2.0. This library is consumed at
+         build time by the generator, not shipped into the WASM app, so AOT-compat analysis does not apply.
+         The runtime AOT boundary is enforced on the generator's OUTPUT, which is ordinary net10.0 code. -->
+  </PropertyGroup>
+</Project>

--- a/libraries/Assimalign.Vue.Sfc/src/BlockOption.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/BlockOption.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A single option on a block header, written between the block name and the opening brace, e.g.
+/// <c>@style scoped module="classes" lang="scss" {</c>. The <c>.viu</c> equivalent of a Vue SFC block
+/// attribute (https://vuejs.org/api/sfc-spec.html): <c>scoped</c> is a valueless flag and
+/// <c>lang="scss"</c> a double-quoted key/value. Immutable and value-equatable so identical headers
+/// compare equal.
+/// </summary>
+/// <param name="Name">The option name (e.g. <c>scoped</c>, <c>lang</c>, <c>module</c>).</param>
+/// <param name="Value">The double-quoted value, or <see langword="null"/> for a valueless flag.</param>
+/// <param name="Location">The source range covering the whole option token.</param>
+public sealed record BlockOption(string Name, string? Value, SourceLocation Location);

--- a/libraries/Assimalign.Vue.Sfc/src/Internal/IsExternalInit.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Internal/IsExternalInit.cs
@@ -1,0 +1,11 @@
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Compiler shim enabling <c>init</c> accessors and <c>record</c> types on <c>netstandard2.0</c>, where
+/// the runtime does not ship <c>IsExternalInit</c>. The block models (see the
+/// <c>Assimalign.Vue.Sfc</c> namespace) rely on this. Referenced only by the C# compiler; never used at
+/// run time. Mirrors the shim in <c>Assimalign.Vue.Compiler</c>.
+/// </summary>
+internal static class IsExternalInit
+{
+}

--- a/libraries/Assimalign.Vue.Sfc/src/Internal/RequiredMemberShims.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Internal/RequiredMemberShims.cs
@@ -1,0 +1,41 @@
+// netstandard2.0 shims enabling the C# `required` member feature used by the immutable block models.
+// These attributes ship in the BCL only from net7.0 onward; on the netstandard2.0 analyzer surface the
+// compiler still recognises them by full name, so declaring them here lights up `required` without any
+// runtime dependency. Referenced only by the C# compiler; never used at run time. Mirrors the shims in
+// Assimalign.Vue.Compiler.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Marks a type or member as requiring its <c>required</c> members to be initialised.</summary>
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property,
+        AllowMultiple = false,
+        Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute
+    {
+    }
+
+    /// <summary>Indicates a compiler feature name a consumer must understand to use the annotated element.</summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        /// <summary>Creates the attribute for the named compiler feature.</summary>
+        /// <param name="featureName">The required feature name (e.g. <c>RequiredMembers</c>).</param>
+        public CompilerFeatureRequiredAttribute(string featureName) => FeatureName = featureName;
+
+        /// <summary>The required feature name.</summary>
+        public string FeatureName { get; }
+
+        /// <summary>Whether an unrecognised feature can be safely ignored.</summary>
+        public bool IsOptional { get; init; }
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Signals that a constructor initialises all <c>required</c> members of its type.</summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute
+    {
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/src/Internal/SfcErrorMessages.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Internal/SfcErrorMessages.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The human-readable messages for each <see cref="SfcErrorCode"/>. Kept off the public surface; the
+/// parser attaches the message to each <see cref="SfcError"/> it reports. Mirrors the shape of
+/// <c>Assimalign.Vue.Compiler</c>'s <c>CompilerErrorMessages</c>.
+/// </summary>
+internal static class SfcErrorMessages
+{
+    private static readonly Dictionary<SfcErrorCode, string> Messages = new()
+    {
+        [SfcErrorCode.StrayTopLevelContent] =
+            "Stray content outside any block. Text must live inside an @template, @script, @style, or custom block.",
+        [SfcErrorCode.MalformedBlockHeader] =
+            "Malformed block header. A block opens with '@<name>' at column 0.",
+        [SfcErrorCode.MissingOpeningBrace] =
+            "Block header is missing its opening '{'.",
+        [SfcErrorCode.ContentAfterOpeningBrace] =
+            "Unexpected content after the opening '{'. The '{' must be the last non-whitespace character on the header line.",
+        [SfcErrorCode.MalformedOptionValue] =
+            "Malformed option value. Option values must be double-quoted, e.g. lang=\"scss\".",
+        [SfcErrorCode.DuplicateTemplateBlock] =
+            "Duplicate @template block. A .viu file may contain at most one @template.",
+        [SfcErrorCode.DuplicateScriptBlock] =
+            "Duplicate @script block. A .viu file may contain at most one @script.",
+        [SfcErrorCode.UnterminatedBlock] =
+            "Unterminated block. Expected a closing '}' at column 0 before end of file.",
+    };
+
+    /// <summary>Gets the message for <paramref name="code"/>, or an empty string when none is defined.</summary>
+    /// <param name="code">The diagnostic code.</param>
+    /// <returns>The human-readable message.</returns>
+    public static string GetMessage(SfcErrorCode code)
+        => Messages.TryGetValue(code, out var message) ? message : string.Empty;
+}

--- a/libraries/Assimalign.Vue.Sfc/src/Internal/SfcParseEngine.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Internal/SfcParseEngine.cs
@@ -1,0 +1,476 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The line-oriented state machine behind <see cref="SfcParser"/>. <b>Column 0 is structural:</b> at the
+/// top level a line whose first column is <c>@</c> opens a block; inside a block a line whose first
+/// column is <c>}</c> closes it. Everything else is either block content (which must therefore be
+/// indented) or, at the top level, stray content. Because the parser only slices — it never looks inside
+/// content — literal braces in C# strings, nested CSS braces, HTML text with braces, and even lines that
+/// resemble a block opener are all preserved verbatim as long as they are indented. See
+/// <c>docs/FORMAT.md</c> for the full rule.
+/// </summary>
+/// <remarks>Internal and single-use: construct one engine per parse. Not thread-safe.</remarks>
+internal sealed class SfcParseEngine
+{
+    private readonly string source;
+    private readonly LineSpan[] lines;
+    private readonly List<SfcError> errors = new();
+
+    /// <summary>Creates an engine over <paramref name="source"/>, pre-computing its line table.</summary>
+    /// <param name="source">The full <c>.viu</c> file text (never <see langword="null"/>).</param>
+    public SfcParseEngine(string source)
+    {
+        this.source = source;
+        this.lines = SplitLines(source);
+    }
+
+    /// <summary>Runs the block scan and returns the descriptor plus any recoverable diagnostics.</summary>
+    /// <returns>The parse result.</returns>
+    public SfcParseResult Parse()
+    {
+        SfcTemplateBlock? template = null;
+        SfcScriptBlock? script = null;
+        var styles = new List<SfcStyleBlock>();
+        var customBlocks = new List<SfcCustomBlock>();
+
+        var index = 0;
+        while (index < lines.Length)
+        {
+            var line = lines[index];
+
+            // Blank lines separate blocks at the top level.
+            if (IsBlank(line))
+            {
+                index++;
+                continue;
+            }
+
+            // Column 0 is structural. Only a leading '@' can open a block at the top level.
+            if (source[line.Start] != '@')
+            {
+                Report(SfcErrorCode.StrayTopLevelContent, SpanOf(line.Start, line.TextEnd));
+                index++;
+                continue;
+            }
+
+            if (!TryParseHeader(line, out var header))
+            {
+                // A diagnostic was already reported; recover by skipping the header line.
+                index++;
+                continue;
+            }
+
+            // The block opened. Its content runs from the next line to the closing '}' at column 0.
+            var contentStart = line.End;
+            var closingIndex = FindClosingBraceLine(index + 1);
+
+            int contentEnd;
+            int blockEndOffset;
+            int resumeIndex;
+            if (closingIndex >= 0)
+            {
+                var closing = lines[closingIndex];
+                contentEnd = closing.Start;
+                blockEndOffset = closing.Start + 1; // the whole block ends just past the '}'
+                resumeIndex = closingIndex + 1;
+            }
+            else
+            {
+                // Unterminated: recover by taking content to end of file and reporting at the header.
+                Report(SfcErrorCode.UnterminatedBlock, header.HeaderLocation);
+                contentEnd = source.Length;
+                blockEndOffset = source.Length;
+                resumeIndex = lines.Length;
+            }
+
+            var block = BuildBlock(header, line.Start, blockEndOffset, contentStart, contentEnd);
+            AssignBlock(block, ref template, ref script, styles, customBlocks);
+            index = resumeIndex;
+        }
+
+        var descriptor = new SfcDescriptor
+        {
+            Source = source,
+            Template = template,
+            Script = script,
+            Styles = new SyntaxList<SfcStyleBlock>(styles.ToArray()),
+            CustomBlocks = new SyntaxList<SfcCustomBlock>(customBlocks.ToArray()),
+        };
+
+        return new SfcParseResult(descriptor, new SyntaxList<SfcError>(errors.ToArray()));
+    }
+
+    // Parses a header line "@<name> [options] {". Returns false (with a diagnostic reported) when the
+    // block cannot open — an absent/invalid name, or no opening '{'. Option and trailing-content
+    // problems are reported but still open the block, so recovery keeps the sliced content.
+    private bool TryParseHeader(LineSpan line, out ParsedHeader header)
+    {
+        header = default;
+        var start = line.Start;
+        var end = line.TextEnd;
+
+        // The caller guaranteed source[start] == '@'. The name follows immediately.
+        var position = start + 1;
+        if (position >= end || !IsNameStartCharacter(source[position]))
+        {
+            Report(SfcErrorCode.MalformedBlockHeader, SpanOf(start, end));
+            return false;
+        }
+
+        var nameStart = position;
+        position++;
+        while (position < end && IsNameCharacter(source[position]))
+        {
+            position++;
+        }
+
+        var name = source.Substring(nameStart, position - nameStart);
+
+        var options = new List<BlockOption>();
+        var headerHadError = false;
+        var braceOffset = -1;
+
+        while (position < end)
+        {
+            var current = source[position];
+            if (IsInlineWhitespace(current))
+            {
+                position++;
+                continue;
+            }
+
+            if (current == '{')
+            {
+                braceOffset = position;
+                var trailing = position + 1;
+                while (trailing < end && IsInlineWhitespace(source[trailing]))
+                {
+                    trailing++;
+                }
+
+                if (trailing < end)
+                {
+                    Report(SfcErrorCode.ContentAfterOpeningBrace, SpanOf(trailing, end));
+                }
+
+                break;
+            }
+
+            if (IsNameStartCharacter(current))
+            {
+                var optionStart = position;
+                position++;
+                while (position < end && IsNameCharacter(source[position]))
+                {
+                    position++;
+                }
+
+                var optionName = source.Substring(optionStart, position - optionStart);
+                string? optionValue = null;
+
+                if (position < end && source[position] == '=')
+                {
+                    position++; // consume '='
+                    if (position < end && source[position] == '"')
+                    {
+                        position++; // consume opening quote
+                        var valueStart = position;
+                        while (position < end && source[position] != '"')
+                        {
+                            position++;
+                        }
+
+                        if (position < end)
+                        {
+                            optionValue = source.Substring(valueStart, position - valueStart);
+                            position++; // consume closing quote
+                        }
+                        else
+                        {
+                            // Unterminated quoted value; recover to end of line.
+                            Report(SfcErrorCode.MalformedOptionValue, SpanOf(optionStart, end));
+                            headerHadError = true;
+                        }
+                    }
+                    else
+                    {
+                        // Unquoted value; consume the offending token up to whitespace or the brace.
+                        while (position < end && !IsInlineWhitespace(source[position]) && source[position] != '{')
+                        {
+                            position++;
+                        }
+
+                        Report(SfcErrorCode.MalformedOptionValue, SpanOf(optionStart, position));
+                        headerHadError = true;
+                    }
+                }
+
+                options.Add(new BlockOption(optionName, optionValue, SpanOf(optionStart, position)));
+                continue;
+            }
+
+            // An unexpected character in the header (e.g. '=', '"', '}', or a digit-led token).
+            var strayStart = position;
+            while (position < end && !IsInlineWhitespace(source[position]) && source[position] != '{')
+            {
+                position++;
+            }
+
+            Report(SfcErrorCode.MalformedBlockHeader, SpanOf(strayStart, position));
+            headerHadError = true;
+        }
+
+        if (braceOffset < 0)
+        {
+            // No brace to open the block. Suppress a redundant message when we already flagged the header.
+            if (!headerHadError)
+            {
+                Report(SfcErrorCode.MissingOpeningBrace, SpanOf(start, end));
+            }
+
+            return false;
+        }
+
+        header = new ParsedHeader(name, options.ToArray(), SpanOf(start, end));
+        return true;
+    }
+
+    // Builds the typed block from its header and computed offsets.
+    private SfcBlock BuildBlock(ParsedHeader header, int blockStart, int blockEnd, int contentStart, int contentEnd)
+    {
+        var content = source.Substring(contentStart, contentEnd - contentStart);
+        var options = new SyntaxList<BlockOption>(header.Options);
+        var blockLocation = SpanOf(blockStart, blockEnd);
+        var contentLocation = SpanOf(contentStart, contentEnd);
+        var name = header.Name;
+
+        return name switch
+        {
+            "template" => new SfcTemplateBlock
+            {
+                Name = name,
+                Options = options,
+                Content = content,
+                Location = blockLocation,
+                ContentLocation = contentLocation,
+            },
+            "script" => new SfcScriptBlock
+            {
+                Name = name,
+                Options = options,
+                Content = content,
+                Location = blockLocation,
+                ContentLocation = contentLocation,
+            },
+            "style" => new SfcStyleBlock
+            {
+                Name = name,
+                Options = options,
+                Content = content,
+                Location = blockLocation,
+                ContentLocation = contentLocation,
+            },
+            _ => new SfcCustomBlock
+            {
+                Name = name,
+                Options = options,
+                Content = content,
+                Location = blockLocation,
+                ContentLocation = contentLocation,
+            },
+        };
+    }
+
+    // Routes a block into the descriptor, enforcing at-most-one @template and @script.
+    private void AssignBlock(
+        SfcBlock block,
+        ref SfcTemplateBlock? template,
+        ref SfcScriptBlock? script,
+        List<SfcStyleBlock> styles,
+        List<SfcCustomBlock> customBlocks)
+    {
+        switch (block)
+        {
+            case SfcTemplateBlock templateBlock:
+                if (template is null)
+                {
+                    template = templateBlock;
+                }
+                else
+                {
+                    Report(SfcErrorCode.DuplicateTemplateBlock, block.Location);
+                }
+
+                break;
+            case SfcScriptBlock scriptBlock:
+                if (script is null)
+                {
+                    script = scriptBlock;
+                }
+                else
+                {
+                    Report(SfcErrorCode.DuplicateScriptBlock, block.Location);
+                }
+
+                break;
+            case SfcStyleBlock styleBlock:
+                styles.Add(styleBlock);
+                break;
+            case SfcCustomBlock customBlock:
+                customBlocks.Add(customBlock);
+                break;
+        }
+    }
+
+    // Finds the first line at or after fromIndex whose first column is '}'.
+    private int FindClosingBraceLine(int fromIndex)
+    {
+        for (var index = fromIndex; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            if (line.TextEnd > line.Start && source[line.Start] == '}')
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private bool IsBlank(LineSpan line)
+    {
+        for (var offset = line.Start; offset < line.TextEnd; offset++)
+        {
+            if (!char.IsWhiteSpace(source[offset]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void Report(SfcErrorCode code, SourceLocation location)
+        => errors.Add(new SfcError(code, SfcErrorMessages.GetMessage(code), location));
+
+    private SourceLocation SpanOf(int startOffset, int endOffset)
+        => new(PositionAt(startOffset), PositionAt(endOffset), source.Substring(startOffset, endOffset - startOffset));
+
+    // Maps an absolute offset to its (offset, line, column) via the pre-computed line table.
+    private Position PositionAt(int offset)
+    {
+        var low = 0;
+        var high = lines.Length - 1;
+        while (low < high)
+        {
+            var mid = (low + high + 1) >> 1;
+            if (lines[mid].Start <= offset)
+            {
+                low = mid;
+            }
+            else
+            {
+                high = mid - 1;
+            }
+        }
+
+        var line = lines[low];
+        return new Position(offset, line.Number, (offset - line.Start) + 1);
+    }
+
+    // Splits source into lines, treating \n, \r\n, and a lone \r each as one terminator. A final line
+    // (possibly empty) always closes the table so PositionAt resolves the end-of-file offset.
+    private static LineSpan[] SplitLines(string source)
+    {
+        var result = new List<LineSpan>();
+        var lineStart = 0;
+        var number = 1;
+        var index = 0;
+        var length = source.Length;
+
+        while (index < length)
+        {
+            var current = source[index];
+            if (current == '\n')
+            {
+                result.Add(new LineSpan(lineStart, index, index + 1, number));
+                index++;
+                lineStart = index;
+                number++;
+            }
+            else if (current == '\r')
+            {
+                if (index + 1 < length && source[index + 1] == '\n')
+                {
+                    result.Add(new LineSpan(lineStart, index, index + 2, number));
+                    index += 2;
+                }
+                else
+                {
+                    result.Add(new LineSpan(lineStart, index, index + 1, number));
+                    index++;
+                }
+
+                lineStart = index;
+                number++;
+            }
+            else
+            {
+                index++;
+            }
+        }
+
+        result.Add(new LineSpan(lineStart, length, length, number));
+        return result.ToArray();
+    }
+
+    private static bool IsNameStartCharacter(char value)
+        => (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') || value == '_';
+
+    private static bool IsNameCharacter(char value)
+        => IsNameStartCharacter(value) || (value >= '0' && value <= '9') || value == '-';
+
+    private static bool IsInlineWhitespace(char value)
+        => value == ' ' || value == '\t';
+
+    // A parsed header: the block name, its options, and the header line's span (for the unterminated
+    // diagnostic).
+    private readonly struct ParsedHeader
+    {
+        public ParsedHeader(string name, BlockOption[] options, SourceLocation headerLocation)
+        {
+            Name = name;
+            Options = options;
+            HeaderLocation = headerLocation;
+        }
+
+        public string Name { get; }
+
+        public BlockOption[] Options { get; }
+
+        public SourceLocation HeaderLocation { get; }
+    }
+
+    // A single source line: [Start, TextEnd) is the visible text, End is the next line's start (past the
+    // terminator), and Number is the 1-based line number.
+    private readonly struct LineSpan
+    {
+        public LineSpan(int start, int textEnd, int end, int number)
+        {
+            Start = start;
+            TextEnd = textEnd;
+            End = end;
+            Number = number;
+        }
+
+        public int Start { get; }
+
+        public int TextEnd { get; }
+
+        public int End { get; }
+
+        public int Number { get; }
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/src/Position.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Position.cs
@@ -1,0 +1,14 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A point in a <c>.viu</c> single-file component source: a zero-based character offset plus its
+/// one-based line and column. Mirrors the shape of Vue 3.5's <c>Position</c> interface
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>, re-exported by <c>@vue/compiler-sfc</c>) so a block's spans
+/// line up with the template compiler's own locations. A value type with structural equality so it
+/// participates in the descriptor's value comparison (the incremental-caching contract of
+/// [V01.01.06.01]).
+/// </summary>
+/// <param name="Offset">Zero-based character offset from the start of the file.</param>
+/// <param name="Line">One-based line number.</param>
+/// <param name="Column">One-based column number.</param>
+public readonly record struct Position(int Offset, int Line, int Column);

--- a/libraries/Assimalign.Vue.Sfc/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Assimalign.Vue.Sfc.Tests")]

--- a/libraries/Assimalign.Vue.Sfc/src/SfcBlock.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcBlock.cs
@@ -1,0 +1,76 @@
+using System;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The base of every parsed <c>.viu</c> block: its name, options, raw content, and precise source
+/// spans. Mirrors Vue 3.5's <c>SFCBlock</c> (<c>@vue/compiler-sfc</c> <c>parse.ts</c>) — one immutable,
+/// value-comparable record per block. The block <em>semantics</em> follow the Vue SFC specification
+/// (https://vuejs.org/api/sfc-spec.html); the <c>@name { }</c> container is the documented Vuecs
+/// divergence from Vue's tag wrappers.
+/// </summary>
+/// <remarks>
+/// Records give the block structural equality — the incremental-caching contract of [V01.01.06.01]:
+/// identical file content yields equal blocks (and equal descriptors), so [V01.01.06.02] can cache on
+/// the parse output. <see cref="Content"/> is the exact raw slice between the header line and the
+/// closing brace; it is never re-parsed here — the template compiler ([V01.01.05.01]) and script
+/// analysis ([V01.01.06.03]) consume it downstream.
+/// </remarks>
+public abstract record SfcBlock
+{
+    /// <summary>The block name exactly as authored (e.g. <c>template</c>, <c>style</c>, <c>docs</c>).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>The options on the block header, in source order.</summary>
+    public required SyntaxList<BlockOption> Options { get; init; }
+
+    /// <summary>The raw block content — the exact source between the header line and the closing brace.</summary>
+    public required string Content { get; init; }
+
+    /// <summary>The source range covering the whole block, from the <c>@</c> through the closing <c>}</c>.</summary>
+    public required SourceLocation Location { get; init; }
+
+    /// <summary>The source range covering the content region only (exactly what <see cref="Content"/> holds).</summary>
+    public required SourceLocation ContentLocation { get; init; }
+
+    /// <summary>The block kind discriminator.</summary>
+    public abstract SfcBlockKind Kind { get; }
+
+    /// <summary>
+    /// The <c>lang</c> option's value, or <see langword="null"/> when absent. Mirrors Vue's block
+    /// <c>lang</c> attribute (e.g. <c>@style lang="scss"</c>, <c>@script lang="csharp"</c>).
+    /// </summary>
+    public string? Lang => GetOptionValue("lang");
+
+    /// <summary>Whether an option with the given name is present, regardless of its value.</summary>
+    /// <param name="name">The option name to look for (ordinal comparison).</param>
+    /// <returns><see langword="true"/> when the option is present.</returns>
+    public bool HasOption(string name)
+    {
+        foreach (var option in Options)
+        {
+            if (string.Equals(option.Name, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Gets the value of the named option, or <see langword="null"/> when absent or valueless.</summary>
+    /// <param name="name">The option name to look for (ordinal comparison).</param>
+    /// <returns>The option's value, or <see langword="null"/>.</returns>
+    public string? GetOptionValue(string name)
+    {
+        foreach (var option in Options)
+        {
+            if (string.Equals(option.Name, name, StringComparison.Ordinal))
+            {
+                return option.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcBlockKind.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcBlockKind.cs
@@ -1,0 +1,22 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// Discriminates the kinds of block a <c>.viu</c> single-file component can contain. The block
+/// <em>semantics</em> mirror the Vue SFC specification (https://vuejs.org/api/sfc-spec.html); the
+/// <c>@name { }</c> container syntax is the documented Vuecs divergence from Vue's tag-based wrappers
+/// (decided 2026-07-17).
+/// </summary>
+public enum SfcBlockKind
+{
+    /// <summary>An <c>@template</c> block — the component's markup (Vue's <c>&lt;template&gt;</c>).</summary>
+    Template = 0,
+
+    /// <summary>A <c>@script</c> block — the component's C# body (Vue's <c>&lt;script&gt;</c>).</summary>
+    Script = 1,
+
+    /// <summary>A <c>@style</c> block — the component's CSS (Vue's <c>&lt;style&gt;</c>).</summary>
+    Style = 2,
+
+    /// <summary>A custom block such as <c>@docs</c> (Vue's custom blocks).</summary>
+    Custom = 3,
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcCustomBlock.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcCustomBlock.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A custom block such as <c>@docs { }</c> — any block whose name is not <c>template</c>, <c>script</c>,
+/// or <c>style</c>. Mirrors Vue 3.5's custom blocks (<c>@vue/compiler-sfc</c> <c>customBlocks</c>): the
+/// parser preserves the block with its options and raw content rather than rejecting it, so tooling can
+/// consume it. See https://vuejs.org/api/sfc-spec.html#custom-blocks.
+/// </summary>
+public sealed record SfcCustomBlock : SfcBlock
+{
+    /// <inheritdoc />
+    public override SfcBlockKind Kind => SfcBlockKind.Custom;
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcDescriptor.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcDescriptor.cs
@@ -1,0 +1,33 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The parsed shape of a <c>.viu</c> single-file component: its blocks and their source spans. The C#
+/// port of Vue 3.5's <c>SFCDescriptor</c> (<c>@vue/compiler-sfc</c> <c>parse.ts</c>), adapted to the
+/// <c>.viu</c> @-block container (a documented Vuecs divergence from Vue's tag wrappers, decided
+/// 2026-07-17). Immutable and value-equatable: identical file content yields an equal descriptor — the
+/// incremental-caching prerequisite of [V01.01.06.02].
+/// </summary>
+/// <remarks>
+/// A file has at most one <see cref="Template"/> and at most one <see cref="Script"/> (a second of
+/// either is reported as a duplicate-block diagnostic and ignored, keeping the first), any number of
+/// <see cref="Styles"/>, and any number of <see cref="CustomBlocks"/> — mirroring Vue's tolerance for
+/// multiple <c>&lt;style&gt;</c> and custom blocks. The Vue <c>&lt;script setup&gt;</c> distinction is
+/// script analysis and is deferred to [V01.01.06.03]. See https://vuejs.org/api/sfc-spec.html.
+/// </remarks>
+public sealed record SfcDescriptor
+{
+    /// <summary>The full original <c>.viu</c> source.</summary>
+    public required string Source { get; init; }
+
+    /// <summary>The single <c>@template</c> block, or <see langword="null"/> when the file has none.</summary>
+    public required SfcTemplateBlock? Template { get; init; }
+
+    /// <summary>The single <c>@script</c> block, or <see langword="null"/> when the file has none.</summary>
+    public required SfcScriptBlock? Script { get; init; }
+
+    /// <summary>The <c>@style</c> blocks, in source order.</summary>
+    public required SyntaxList<SfcStyleBlock> Styles { get; init; }
+
+    /// <summary>The custom blocks (e.g. <c>@docs</c>), in source order.</summary>
+    public required SyntaxList<SfcCustomBlock> CustomBlocks { get; init; }
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcError.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcError.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A recoverable parse diagnostic: its code, human-readable message, and source location. Modeled on
+/// <c>Assimalign.Vue.Compiler</c>'s <c>CompilerError</c> but carrying the Sfc area's own
+/// <see cref="SfcErrorCode"/> catalog. The parser reports these through <see cref="SfcParseResult.Errors"/>
+/// and never throws for malformed input, matching Vue's recoverable-parsing model
+/// (<c>@vue/compiler-sfc</c> <c>parse().errors</c>).
+/// </summary>
+/// <param name="Code">The diagnostic code.</param>
+/// <param name="Message">The human-readable message for <paramref name="Code"/>.</param>
+/// <param name="Location">The source range the diagnostic points at.</param>
+public sealed record SfcError(SfcErrorCode Code, string Message, SourceLocation Location);

--- a/libraries/Assimalign.Vue.Sfc/src/SfcErrorCode.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcErrorCode.cs
@@ -1,0 +1,36 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The catalog of diagnostic codes the <c>.viu</c> block parser emits. Unlike
+/// <c>Assimalign.Vue.Compiler</c>'s <c>CompilerErrorCode</c> — whose numbering mirrors vuejs/core's
+/// <c>ErrorCodes</c> — these are <b>Vuecs-defined</b> codes with no upstream counterpart: the
+/// <c>@name { }</c> container is a Vuecs divergence, so its structural diagnostics have no vuejs/core
+/// numbering to align to. Values start at 1000 to stay visibly distinct from any upstream-aligned
+/// catalog.
+/// </summary>
+public enum SfcErrorCode
+{
+    /// <summary>Non-whitespace text appeared at the top level, outside any block.</summary>
+    StrayTopLevelContent = 1001,
+
+    /// <summary>A top-level line began with <c>@</c> but no valid block name followed.</summary>
+    MalformedBlockHeader = 1002,
+
+    /// <summary>A block header named a block but had no opening <c>{</c> on its line.</summary>
+    MissingOpeningBrace = 1003,
+
+    /// <summary>Non-whitespace followed the opening <c>{</c> on a block header line.</summary>
+    ContentAfterOpeningBrace = 1004,
+
+    /// <summary>A block option value was not a well-formed double-quoted string.</summary>
+    MalformedOptionValue = 1005,
+
+    /// <summary>A file declared more than one <c>@template</c> block.</summary>
+    DuplicateTemplateBlock = 1006,
+
+    /// <summary>A file declared more than one <c>@script</c> block.</summary>
+    DuplicateScriptBlock = 1007,
+
+    /// <summary>A block was opened but reached end of file with no column-0 closing <c>}</c>.</summary>
+    UnterminatedBlock = 1008,
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcParseResult.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcParseResult.cs
@@ -1,0 +1,10 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The result of parsing a <c>.viu</c> file: the <see cref="SfcDescriptor"/> plus any recoverable
+/// diagnostics. Mirrors the <c>{ descriptor, errors }</c> return of Vue 3.5's <c>parse()</c>
+/// (<c>@vue/compiler-sfc</c> <c>parse.ts</c>). Value-equatable so identical input yields an equal result.
+/// </summary>
+/// <param name="Descriptor">The parsed descriptor (always produced, even for malformed input).</param>
+/// <param name="Errors">The recoverable diagnostics, in source order; empty when the file is well-formed.</param>
+public sealed record SfcParseResult(SfcDescriptor Descriptor, SyntaxList<SfcError> Errors);

--- a/libraries/Assimalign.Vue.Sfc/src/SfcParser.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcParser.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The <c>.viu</c> single-file component block parser entry point: slices a file into its
+/// <see cref="SfcDescriptor"/> of typed, located blocks. The role Vue 3.5's <c>parse()</c> plays in
+/// <c>@vue/compiler-sfc</c> — block-level slicing only. The markup inside <c>@template</c> stays
+/// standard Vue template syntax and is parsed by the template compiler ([V01.01.05.01]); this parser
+/// never looks inside a block's content.
+/// </summary>
+/// <remarks>
+/// Runs entirely at build time inside a Roslyn generator ([V01.01.06.02]): no file or network I/O — the
+/// source text is handed in as a string — no async, and no reflection. Parsing is recoverable: malformed
+/// input is reported through <see cref="SfcParseResult.Errors"/> and never throws. See the format
+/// specification in <c>docs/FORMAT.md</c> and the Vue SFC spec https://vuejs.org/api/sfc-spec.html.
+/// </remarks>
+public static class SfcParser
+{
+    /// <summary>Parses a <c>.viu</c> <paramref name="source"/> into its descriptor and diagnostics.</summary>
+    /// <param name="source">The full <c>.viu</c> file text.</param>
+    /// <returns>The parse result — the descriptor plus any recoverable diagnostics.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static SfcParseResult Parse(string source)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return new SfcParseEngine(source).Parse();
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcScriptBlock.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcScriptBlock.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A <c>@script</c> block — the component's C# body (its partial-class body). Mirrors Vue 3.5's
+/// <c>SFCScriptBlock</c> (<c>@vue/compiler-sfc</c>); the C# is <em>not</em> analysed here. The Vue
+/// <c>&lt;script setup&gt;</c> counterpart (setup-vs-options distinction) is script analysis and is
+/// deferred to [V01.01.06.03]. See https://vuejs.org/api/sfc-spec.html#script.
+/// </summary>
+public sealed record SfcScriptBlock : SfcBlock
+{
+    /// <inheritdoc />
+    public override SfcBlockKind Kind => SfcBlockKind.Script;
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcStyleBlock.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcStyleBlock.cs
@@ -1,0 +1,32 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// A <c>@style</c> block — the component's CSS. Mirrors Vue 3.5's <c>SFCStyleBlock</c>
+/// (<c>@vue/compiler-sfc</c>), including the <c>scoped</c> and <c>module</c> options. A <c>.viu</c> file
+/// may contain several <c>@style</c> blocks (as Vue allows several <c>&lt;style&gt;</c> tags). See
+/// https://vuejs.org/api/sfc-spec.html#style and https://vuejs.org/api/sfc-css-features.html.
+/// </summary>
+public sealed record SfcStyleBlock : SfcBlock
+{
+    /// <inheritdoc />
+    public override SfcBlockKind Kind => SfcBlockKind.Style;
+
+    /// <summary>
+    /// Whether the <c>scoped</c> option is present — the CSS applies only to the component's own
+    /// elements. Mirrors Vue's <c>&lt;style scoped&gt;</c>
+    /// (https://vuejs.org/api/sfc-css-features.html#scoped-css).
+    /// </summary>
+    public bool Scoped => HasOption("scoped");
+
+    /// <summary>
+    /// Whether the <c>module</c> option is present — the CSS compiles to CSS Modules. Mirrors Vue's
+    /// <c>&lt;style module&gt;</c> (https://vuejs.org/api/sfc-css-features.html#css-modules).
+    /// </summary>
+    public bool IsModule => HasOption("module");
+
+    /// <summary>
+    /// The name given as <c>module="name"</c>, or <see langword="null"/> when <c>module</c> is absent or
+    /// valueless. Mirrors the string form of Vue's <c>module</c> attribute.
+    /// </summary>
+    public string? ModuleName => GetOptionValue("module");
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SfcTemplateBlock.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SfcTemplateBlock.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// An <c>@template</c> block — the component's markup. Mirrors Vue 3.5's <c>SFCTemplateBlock</c>
+/// (<c>@vue/compiler-sfc</c>). The content is standard Vue template syntax and is <em>not</em> parsed
+/// here; the template compiler ([V01.01.05.01]) consumes <see cref="SfcBlock.Content"/>. See
+/// https://vuejs.org/api/sfc-spec.html#template.
+/// </summary>
+public sealed record SfcTemplateBlock : SfcBlock
+{
+    /// <inheritdoc />
+    public override SfcBlockKind Kind => SfcBlockKind.Template;
+}

--- a/libraries/Assimalign.Vue.Sfc/src/SourceLocation.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SourceLocation.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// The half-open source range <c>[Start, End)</c> a block or option spans, plus the exact original
+/// source slice. Mirrors Vue 3.5's <c>SourceLocation</c> interface (<c>@vue/compiler-core</c>
+/// <c>ast.ts</c>); the <c>.viu</c> block parser produces one for every block (both the block as a whole
+/// and its content region) and for every option.
+/// </summary>
+/// <remarks>
+/// For every range the parser emits, <see cref="Source"/> equals
+/// <c>source.Substring(Start.Offset, End.Offset - Start.Offset)</c> — the literal characters between the
+/// two positions. A <c>record</c> so equal ranges compare equal, which (together with the immutable
+/// block models) is what lets an incremental generator ([V01.01.06.02]) cache on the parse output, and
+/// what makes the spans suitable for <c>#line</c> mapping ([V01.01.06.03]) and IDE diagnostics.
+/// </remarks>
+/// <param name="Start">The inclusive start position.</param>
+/// <param name="End">The exclusive end position.</param>
+/// <param name="Source">The exact source substring covered by the range.</param>
+public sealed record SourceLocation(Position Start, Position End, string Source);

--- a/libraries/Assimalign.Vue.Sfc/src/SyntaxList{T}.cs
+++ b/libraries/Assimalign.Vue.Sfc/src/SyntaxList{T}.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// An immutable list of blocks, options, or diagnostics with <b>structural</b> equality: two lists are
+/// equal when they hold equal elements in the same order. The collections on <see cref="SfcDescriptor"/>,
+/// <see cref="SfcBlock"/>, and <see cref="SfcParseResult"/> use this so those records compare by value
+/// end to end — a plain <see cref="IReadOnlyList{T}"/> or array would compare by reference and silently
+/// defeat the incremental-generator cache ([V01.01.06.01]/[V01.01.06.02]). The direct analogue of the
+/// template compiler's <c>SyntaxList&lt;T&gt;</c>.
+/// </summary>
+/// <typeparam name="T">The element type, a reference type with its own value equality (a parse record).</typeparam>
+public readonly struct SyntaxList<T> : IReadOnlyList<T>, IEquatable<SyntaxList<T>>
+    where T : class
+{
+    /// <summary>The empty list.</summary>
+    public static readonly SyntaxList<T> Empty = new(Array.Empty<T>());
+
+    private readonly T[]? items;
+
+    /// <summary>Wraps <paramref name="items"/> without copying; treat the array as owned by the list.</summary>
+    /// <param name="items">The backing array.</param>
+    public SyntaxList(T[] items) => this.items = items;
+
+    /// <summary>The element count.</summary>
+    public int Count => items?.Length ?? 0;
+
+    /// <summary>The element at <paramref name="index"/>.</summary>
+    /// <param name="index">The zero-based index.</param>
+    public T this[int index] => items![index];
+
+    /// <summary>Compares two lists element-by-element in order.</summary>
+    /// <param name="other">The list to compare against.</param>
+    public bool Equals(SyntaxList<T> other)
+    {
+        var left = items ?? Array.Empty<T>();
+        var right = other.items ?? Array.Empty<T>();
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (var index = 0; index < left.Length; index++)
+        {
+            if (!comparer.Equals(left[index], right[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SyntaxList<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        if (items is null)
+        {
+            return 0;
+        }
+
+        var hash = 17;
+        foreach (var item in items)
+        {
+            hash = (hash * 31) + (item?.GetHashCode() ?? 0);
+        }
+
+        return hash;
+    }
+
+    /// <summary>Returns an enumerator over the elements.</summary>
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)(items ?? Array.Empty<T>())).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>Structural equality operator.</summary>
+    /// <param name="left">The left list.</param>
+    /// <param name="right">The right list.</param>
+    public static bool operator ==(SyntaxList<T> left, SyntaxList<T> right) => left.Equals(right);
+
+    /// <summary>Structural inequality operator.</summary>
+    /// <param name="left">The left list.</param>
+    /// <param name="right">The right list.</param>
+    public static bool operator !=(SyntaxList<T> left, SyntaxList<T> right) => !left.Equals(right);
+}

--- a/libraries/Assimalign.Vue.Sfc/test/Assimalign.Vue.Sfc.Tests.csproj
+++ b/libraries/Assimalign.Vue.Sfc/test/Assimalign.Vue.Sfc.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <VuecsPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <VuecsPackageReference Include="xunit" />
+    <VuecsPackageReference Include="xunit.runner.visualstudio" />
+    <VuecsPackageReference Include="Shouldly" />
+  </ItemGroup>
+  <ItemGroup>
+    <VuecsProjectReference Include="Assimalign.Vue.Sfc" />
+  </ItemGroup>
+</Project>

--- a/libraries/Assimalign.Vue.Sfc/test/BlockParsingTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/BlockParsingTests.cs
@@ -1,0 +1,158 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// The happy-path block slicing: a well-formed .viu file yields typed template/script/style/custom
+// blocks with exact raw content. Block semantics mirror the Vue SFC spec
+// (https://vuejs.org/api/sfc-spec.html); the @-block container is the Vuecs divergence (see docs/FORMAT.md).
+public class BlockParsingTests
+{
+    private const string Component =
+        "@template {\n" +
+        "    <div>{{ message }}</div>\n" +
+        "}\n" +
+        "@script {\n" +
+        "    public string Message = \"Hello\";\n" +
+        "}\n" +
+        "@style scoped {\n" +
+        "    .box { color: red; }\n" +
+        "}\n";
+
+    [Fact]
+    public void Parse_WellFormedComponent_ExposesEachBlock()
+    {
+        var descriptor = SfcTestHelpers.Parse(Component);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Script.ShouldNotBeNull();
+        descriptor.Styles.Count.ShouldBe(1);
+        descriptor.CustomBlocks.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_WellFormedComponent_ReportsNoErrors()
+    {
+        SfcTestHelpers.Errors(Component).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_Blocks_CarryTheirKindAndName()
+    {
+        var descriptor = SfcTestHelpers.Parse(Component);
+
+        descriptor.Template!.Kind.ShouldBe(SfcBlockKind.Template);
+        descriptor.Template!.Name.ShouldBe("template");
+        descriptor.Script!.Kind.ShouldBe(SfcBlockKind.Script);
+        descriptor.Script!.Name.ShouldBe("script");
+        descriptor.Styles[0].Kind.ShouldBe(SfcBlockKind.Style);
+        descriptor.Styles[0].Name.ShouldBe("style");
+    }
+
+    [Fact]
+    public void Parse_Content_IsTheExactRawSliceIncludingTrailingNewline()
+    {
+        var descriptor = SfcTestHelpers.Parse(Component);
+
+        // Content runs from the line after the header up to (not including) the closing-brace line, so it
+        // keeps interior indentation and the trailing newline before the '}'.
+        descriptor.Template!.Content.ShouldBe("    <div>{{ message }}</div>\n");
+        descriptor.Script!.Content.ShouldBe("    public string Message = \"Hello\";\n");
+        descriptor.Styles[0].Content.ShouldBe("    .box { color: red; }\n");
+    }
+
+    [Fact]
+    public void Parse_Descriptor_KeepsTheFullSource()
+    {
+        SfcTestHelpers.Parse(Component).Source.ShouldBe(Component);
+    }
+
+    [Fact]
+    public void Parse_EmptyFile_YieldsAnEmptyDescriptorWithNoErrors()
+    {
+        var result = SfcParser.Parse(string.Empty);
+
+        result.Descriptor.Template.ShouldBeNull();
+        result.Descriptor.Script.ShouldBeNull();
+        result.Descriptor.Styles.Count.ShouldBe(0);
+        result.Descriptor.CustomBlocks.Count.ShouldBe(0);
+        result.Errors.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_BlankLinesBetweenBlocks_AreTolerated()
+    {
+        var source = "@template {\n    <p/>\n}\n\n\n@script {\n    // c#\n}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Script.ShouldNotBeNull();
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_EmptyBlockBody_YieldsEmptyContent()
+    {
+        var descriptor = SfcTestHelpers.Parse("@template {\n}\n");
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Template!.Content.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Parse_MultipleStyleBlocks_ArePreservedInOrder()
+    {
+        var source =
+            "@style {\n    .a { color: red; }\n}\n" +
+            "@style scoped {\n    .b { color: blue; }\n}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Styles.Count.ShouldBe(2);
+        descriptor.Styles[0].Scoped.ShouldBeFalse();
+        descriptor.Styles[1].Scoped.ShouldBeTrue();
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_CustomBlock_IsPreservedNotRejected()
+    {
+        var source = "@docs {\n    Usage notes.\n}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.CustomBlocks.Count.ShouldBe(1);
+        descriptor.CustomBlocks[0].Kind.ShouldBe(SfcBlockKind.Custom);
+        descriptor.CustomBlocks[0].Name.ShouldBe("docs");
+        descriptor.CustomBlocks[0].Content.ShouldBe("    Usage notes.\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_FileWithoutTrailingNewline_StillClosesTheBlock()
+    {
+        var source = "@template {\n    <p/>\n}";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Template!.Content.ShouldBe("    <p/>\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_CrlfLineEndings_AreHandledAndPreservedInContent()
+    {
+        // Real .viu files authored on Windows use CRLF; the parser treats \r\n as one terminator and
+        // keeps it verbatim in the raw content slice.
+        var source = "@template {\r\n    <x/>\r\n}\r\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Template!.Content.ShouldBe("    <x/>\r\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/DiagnosticsTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/DiagnosticsTests.cs
@@ -1,0 +1,172 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// Malformed input produces structured, located diagnostics; the parser recovers and never throws for
+// bad content, reporting multiple problems in one pass. These are Vuecs-defined codes (SfcErrorCode) —
+// the @-block container has no upstream vuejs/core numbering to mirror.
+public class DiagnosticsTests
+{
+    [Fact]
+    public void Parse_UnterminatedBlock_ReportsAndRecoversToEndOfFile()
+    {
+        var source = "@script {\n    x\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.UnterminatedBlock);
+        result.Descriptor.Script.ShouldNotBeNull();
+        result.Descriptor.Script!.Content.ShouldBe("    x\n");
+    }
+
+    [Fact]
+    public void Parse_DuplicateTemplate_KeepsFirstAndReports()
+    {
+        var source =
+            "@template {\n    <first/>\n}\n" +
+            "@template {\n    <second/>\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Template!.Content.ShouldBe("    <first/>\n");
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.DuplicateTemplateBlock);
+    }
+
+    [Fact]
+    public void Parse_DuplicateScript_KeepsFirstAndReports()
+    {
+        var source =
+            "@script {\n    // first\n}\n" +
+            "@script {\n    // second\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Script!.Content.ShouldBe("    // first\n");
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.DuplicateScriptBlock);
+    }
+
+    [Fact]
+    public void Parse_StrayTopLevelContent_IsReported()
+    {
+        var source = "oops\n@script {\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Script.ShouldNotBeNull();
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.StrayTopLevelContent);
+    }
+
+    [Fact]
+    public void Parse_ContentAfterOpeningBrace_ReportsButStillOpensTheBlock()
+    {
+        var source = "@script { junk\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Script.ShouldNotBeNull();
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.ContentAfterOpeningBrace);
+    }
+
+    [Fact]
+    public void Parse_UnquotedOptionValue_ReportsButStillOpensTheBlock()
+    {
+        var source = "@style lang=scss {\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Styles.Count.ShouldBe(1);
+        result.Descriptor.Styles[0].Lang.ShouldBeNull();
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.MalformedOptionValue);
+    }
+
+    [Fact]
+    public void Parse_UnterminatedOptionValue_IsReported()
+    {
+        var source = "@style lang=\"scss\n}\n";
+
+        SfcTestHelpers.Errors(source).ShouldContain(error => error.Code == SfcErrorCode.MalformedOptionValue);
+    }
+
+    [Fact]
+    public void Parse_HeaderWithoutName_ReportsMalformedHeader()
+    {
+        var source = "@ {\n}\n";
+
+        SfcTestHelpers.Errors(source).ShouldContain(error => error.Code == SfcErrorCode.MalformedBlockHeader);
+    }
+
+    [Fact]
+    public void Parse_HeaderWithoutBrace_ReportsMissingBrace()
+    {
+        var result = SfcParser.Parse("@script\n");
+
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.MissingOpeningBrace);
+        result.Descriptor.Script.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Parse_SeveralProblems_AreAllReportedInOnePass()
+    {
+        var source =
+            "oops\n" +
+            "@template {\n}\n" +
+            "@template {\n}\n";
+
+        var errors = SfcTestHelpers.Errors(source);
+
+        errors.Count.ShouldBe(2);
+        errors.ShouldContain(error => error.Code == SfcErrorCode.StrayTopLevelContent);
+        errors.ShouldContain(error => error.Code == SfcErrorCode.DuplicateTemplateBlock);
+    }
+
+    [Fact]
+    public void Parse_MessagesAreNonEmptyAndMatchTheCatalog()
+    {
+        var error = SfcParser.Parse("@script\n").Errors[0];
+
+        error.Message.ShouldNotBeNullOrEmpty();
+        error.Message.ShouldBe(SfcErrorMessages.GetMessage(SfcErrorCode.MissingOpeningBrace));
+    }
+
+    [Fact]
+    public void Parse_MalformedInputs_NeverThrow()
+    {
+        var inputs = new[]
+        {
+            "@",
+            "@ {",
+            "@script",
+            "@script {",
+            "@style lang=",
+            "@style lang=\"x",
+            "}",
+            "}}}}",
+            "@@@@",
+            "   ",
+            "@template {\n@template {\n",
+            "random text with { and } braces",
+        };
+
+        foreach (var input in inputs)
+        {
+            Should.NotThrow(() => { SfcParser.Parse(input); });
+        }
+    }
+
+    [Fact]
+    public void Parse_NullSource_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => { SfcParser.Parse(null!); });
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/LocationTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/LocationTests.cs
@@ -1,0 +1,73 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// The [V01.01.06.01] span contract: every block exposes exact start/end line-column-offset spans for
+// both the whole block and its content region (suitable for #line mapping and IDE diagnostics), and
+// every span's Source equals the exact source slice between its offsets.
+public class LocationTests
+{
+    [Fact]
+    public void Parse_Block_HasExactWholeAndContentSpans()
+    {
+        // "@template {\n    <div/>\n}\n"
+        //  offsets: header line [0,11], '\n' at 11; content line [12,21], '\n' at 22; '}' at 23.
+        var descriptor = SfcTestHelpers.Parse("@template {\n    <div/>\n}\n");
+        var template = descriptor.Template!;
+
+        template.Location.Start.ShouldBe(new Position(0, 1, 1));
+        template.Location.End.ShouldBe(new Position(24, 3, 2));
+        template.Location.Source.ShouldBe("@template {\n    <div/>\n}");
+
+        template.ContentLocation.Start.ShouldBe(new Position(12, 2, 1));
+        template.ContentLocation.End.ShouldBe(new Position(23, 3, 1));
+        template.Content.ShouldBe("    <div/>\n");
+    }
+
+    [Fact]
+    public void Parse_BlockStartingOnLaterLine_TracksLineAndColumn()
+    {
+        // The @script header begins at offset 14, which is line 3, column 1.
+        var descriptor = SfcTestHelpers.Parse("@template {\n}\n@script {\n    x\n}\n");
+
+        descriptor.Template!.Content.ShouldBe(string.Empty);
+        descriptor.Template!.ContentLocation.Start.ShouldBe(new Position(12, 2, 1));
+
+        descriptor.Script!.Location.Start.ShouldBe(new Position(14, 3, 1));
+        descriptor.Script!.Content.ShouldBe("    x\n");
+    }
+
+    [Fact]
+    public void Parse_Option_HasATokenSpan()
+    {
+        // "@style scoped {\n}\n": the "scoped" token is offsets [7,13).
+        var style = SfcTestHelpers.Parse("@style scoped {\n}\n").Styles[0];
+        var scoped = style.Options[0];
+
+        scoped.Name.ShouldBe("scoped");
+        scoped.Location.Source.ShouldBe("scoped");
+        scoped.Location.Start.ShouldBe(new Position(7, 1, 8));
+        scoped.Location.End.ShouldBe(new Position(13, 1, 14));
+    }
+
+    [Fact]
+    public void Parse_WellFormedComponent_AllSpansAreExact()
+    {
+        var result = SfcParser.Parse(
+            "@template {\n    <div>{{ x }}</div>\n}\n" +
+            "@script lang=\"csharp\" {\n    var y = \"}\";\n}\n" +
+            "@style scoped {\n    .a { color: red; }\n}\n");
+
+        SfcTestHelpers.AssertAllSpansExact(result);
+    }
+
+    [Fact]
+    public void Parse_MalformedInput_DiagnosticSpansAreExact()
+    {
+        var result = SfcParser.Parse("oops\n@style lang=scss {\n}\n@template {\n");
+
+        SfcTestHelpers.AssertAllSpansExact(result);
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/OptionParsingTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/OptionParsingTests.cs
@@ -1,0 +1,117 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// Block options replace Vue's block attributes and are honored per the spec: scoped, module[="name"],
+// and lang on @style; lang on @script/@template; custom blocks keep their options. Option semantics
+// mirror the Vue SFC spec (https://vuejs.org/api/sfc-spec.html, sfc-css-features).
+public class OptionParsingTests
+{
+    [Fact]
+    public void Parse_StyleScoped_SetsScoped()
+    {
+        var style = SfcTestHelpers.Parse("@style scoped {\n}\n").Styles[0];
+
+        style.Scoped.ShouldBeTrue();
+        style.IsModule.ShouldBeFalse();
+        style.ModuleName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Parse_StyleModuleFlag_SetsModuleWithoutName()
+    {
+        var style = SfcTestHelpers.Parse("@style module {\n}\n").Styles[0];
+
+        style.IsModule.ShouldBeTrue();
+        style.ModuleName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Parse_StyleModuleWithName_SetsModuleName()
+    {
+        var style = SfcTestHelpers.Parse("@style module=\"classes\" {\n}\n").Styles[0];
+
+        style.IsModule.ShouldBeTrue();
+        style.ModuleName.ShouldBe("classes");
+    }
+
+    [Fact]
+    public void Parse_StyleScopedAndLang_HonorsBoth()
+    {
+        var style = SfcTestHelpers.Parse("@style scoped lang=\"scss\" {\n}\n").Styles[0];
+
+        style.Scoped.ShouldBeTrue();
+        style.Lang.ShouldBe("scss");
+    }
+
+    [Fact]
+    public void Parse_ScriptLang_IsHonored()
+    {
+        SfcTestHelpers.Parse("@script lang=\"csharp\" {\n}\n").Script!.Lang.ShouldBe("csharp");
+    }
+
+    [Fact]
+    public void Parse_TemplateLang_IsHonored()
+    {
+        SfcTestHelpers.Parse("@template lang=\"html\" {\n}\n").Template!.Lang.ShouldBe("html");
+    }
+
+    [Fact]
+    public void Parse_OptionsPreserveOrderNamesAndValues()
+    {
+        var style = SfcTestHelpers.Parse("@style scoped module=\"m\" lang=\"scss\" {\n}\n").Styles[0];
+
+        style.Options.Count.ShouldBe(3);
+
+        style.Options[0].Name.ShouldBe("scoped");
+        style.Options[0].Value.ShouldBeNull();
+
+        style.Options[1].Name.ShouldBe("module");
+        style.Options[1].Value.ShouldBe("m");
+
+        style.Options[2].Name.ShouldBe("lang");
+        style.Options[2].Value.ShouldBe("scss");
+    }
+
+    [Fact]
+    public void Parse_CustomBlockOptions_ArePreserved()
+    {
+        var custom = SfcTestHelpers.Parse("@docs lang=\"md\" title=\"Guide\" {\n    text\n}\n").CustomBlocks[0];
+
+        custom.Name.ShouldBe("docs");
+        custom.Lang.ShouldBe("md");
+        custom.GetOptionValue("title").ShouldBe("Guide");
+        custom.HasOption("title").ShouldBeTrue();
+        custom.HasOption("missing").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Parse_BlockWithNoOptions_HasEmptyOptions()
+    {
+        SfcTestHelpers.Parse("@template {\n}\n").Template!.Options.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_OptionImmediatelyBeforeBrace_NeedsNoSpace()
+    {
+        // "scoped{" with no separating space still parses the option and the brace.
+        var style = SfcTestHelpers.Parse("@style scoped{\n}\n").Styles[0];
+
+        style.Scoped.ShouldBeTrue();
+        SfcTestHelpers.Errors("@style scoped{\n}\n").Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_TabSeparatedHeader_ParsesOptions()
+    {
+        // Tabs are valid inline whitespace in a header, between the name, options, and the brace.
+        var source = "@style\tscoped\t{\n}\n";
+
+        var style = SfcTestHelpers.Parse(source).Styles[0];
+
+        style.Scoped.ShouldBeTrue();
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/SfcTestHelpers.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/SfcTestHelpers.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+namespace Assimalign.Vue.Sfc;
+
+/// <summary>
+/// Shared parsing helpers for the Sfc test corpus. All multi-line inputs are built from explicit
+/// <c>\n</c> escapes (never literal control characters) so line endings are deterministic and visible.
+/// </summary>
+internal static class SfcTestHelpers
+{
+    /// <summary>Parses <paramref name="source"/> and returns just the descriptor.</summary>
+    public static SfcDescriptor Parse(string source) => SfcParser.Parse(source).Descriptor;
+
+    /// <summary>Parses <paramref name="source"/> and returns the diagnostics.</summary>
+    public static SyntaxList<SfcError> Errors(string source) => SfcParser.Parse(source).Errors;
+
+    /// <summary>Enumerates every block in the descriptor: template, script, styles, then custom blocks.</summary>
+    public static IEnumerable<SfcBlock> AllBlocks(SfcDescriptor descriptor)
+    {
+        if (descriptor.Template is not null)
+        {
+            yield return descriptor.Template;
+        }
+
+        if (descriptor.Script is not null)
+        {
+            yield return descriptor.Script;
+        }
+
+        foreach (var style in descriptor.Styles)
+        {
+            yield return style;
+        }
+
+        foreach (var custom in descriptor.CustomBlocks)
+        {
+            yield return custom;
+        }
+    }
+
+    /// <summary>
+    /// Asserts the [V01.01.06.01] span contract for every span the parser emits: for every block (whole
+    /// and content region), every option, and every diagnostic, <c>Location.Source</c> equals the exact
+    /// source slice between its offsets — and each block's <see cref="SfcBlock.Content"/> equals its
+    /// content-region slice.
+    /// </summary>
+    public static void AssertAllSpansExact(SfcParseResult result)
+    {
+        var source = result.Descriptor.Source;
+        foreach (var block in AllBlocks(result.Descriptor))
+        {
+            AssertSpan(block.Location, source);
+            AssertSpan(block.ContentLocation, source);
+            block.Content.ShouldBe(block.ContentLocation.Source);
+            foreach (var option in block.Options)
+            {
+                AssertSpan(option.Location, source);
+            }
+        }
+
+        foreach (var error in result.Errors)
+        {
+            AssertSpan(error.Location, source);
+        }
+    }
+
+    private static void AssertSpan(SourceLocation location, string source)
+    {
+        var length = location.End.Offset - location.Start.Offset;
+        location.Source.ShouldBe(source.Substring(location.Start.Offset, length));
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/StructuralEqualityTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/StructuralEqualityTests.cs
@@ -1,0 +1,77 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// The [V01.01.06.01] incremental-caching contract: descriptors and blocks are immutable records with
+// structural equality, so parsing equal input twice yields equal (and equal-hashing) descriptors, and
+// any content or location difference makes them unequal. This is what lets the incremental SFC generator
+// ([V01.01.06.02]) cache on the parse output.
+public class StructuralEqualityTests
+{
+    private const string Component =
+        "@template {\n    <div>{{ title }}</div>\n}\n" +
+        "@script lang=\"csharp\" {\n    public string Title = \"hi\";\n}\n" +
+        "@style scoped {\n    .a { color: red; }\n}\n" +
+        "@docs {\n    notes\n}\n";
+
+    [Fact]
+    public void Parse_SameInputTwice_ProducesEqualDescriptors()
+    {
+        var first = SfcTestHelpers.Parse(Component);
+        var second = SfcTestHelpers.Parse(Component);
+
+        first.ShouldNotBeSameAs(second);
+        first.ShouldBe(second);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Parse_SameInputTwice_ProducesEqualResults()
+    {
+        SfcParser.Parse(Component).ShouldBe(SfcParser.Parse(Component));
+    }
+
+    [Fact]
+    public void Parse_DifferentContent_ProducesUnequalDescriptors()
+    {
+        SfcTestHelpers.Parse("@template {\n    a\n}\n")
+            .ShouldNotBe(SfcTestHelpers.Parse("@template {\n    b\n}\n"));
+    }
+
+    [Fact]
+    public void Parse_ShiftedByWhitespace_ProducesUnequalDescriptors()
+    {
+        // A leading blank line shifts every offset, so the locations — part of the record value — differ,
+        // and the descriptors must not compare equal (a whitespace shift must invalidate the cache).
+        SfcTestHelpers.Parse(Component).ShouldNotBe(SfcTestHelpers.Parse("\n" + Component));
+    }
+
+    [Fact]
+    public void Parse_Blocks_CompareByValueThroughOptionsAndSpans()
+    {
+        var first = SfcTestHelpers.Parse(Component);
+        var second = SfcTestHelpers.Parse(Component);
+
+        first.Script.ShouldBe(second.Script);
+        first.Styles.ShouldBe(second.Styles);
+        first.Styles[0].Options.ShouldBe(second.Styles[0].Options);
+        first.CustomBlocks.ShouldBe(second.CustomBlocks);
+    }
+
+    [Fact]
+    public void Parse_DifferentOptions_ProduceUnequalStyleBlocks()
+    {
+        var scoped = SfcTestHelpers.Parse("@style scoped {\n}\n").Styles[0];
+        var plain = SfcTestHelpers.Parse("@style {\n}\n").Styles[0];
+
+        scoped.ShouldNotBe(plain);
+    }
+
+    [Fact]
+    public void SyntaxList_EmptyEqualsDefault()
+    {
+        SyntaxList<SfcError>.Empty.ShouldBe(default);
+    }
+}

--- a/libraries/Assimalign.Vue.Sfc/test/TerminationRuleTests.cs
+++ b/libraries/Assimalign.Vue.Sfc/test/TerminationRuleTests.cs
@@ -1,0 +1,130 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Sfc;
+
+// The column-0 termination rule (docs/FORMAT.md): a block closes at the first line whose first column is
+// '}'. Because the parser only slices — it never looks inside content — braces in C# strings, nested CSS
+// braces, HTML text with braces, and lines that resemble a block opener are all preserved verbatim as
+// long as content is indented. The final test pins the flip side: an un-indented '}' closes the block
+// early, which is exactly why the rule requires content to be indented.
+public class TerminationRuleTests
+{
+    [Fact]
+    public void Parse_ScriptWithLiteralBracesInStrings_DoesNotCloseEarly()
+    {
+        var source =
+            "@script {\n" +
+            "    var json = \"{ ok }\";\n" +
+            "    var brace = \"}\";\n" +
+            "}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Script.ShouldNotBeNull();
+        descriptor.Script!.Content.ShouldBe("    var json = \"{ ok }\";\n    var brace = \"}\";\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_StyleWithNestedIndentedBraces_DoesNotCloseEarly()
+    {
+        var source =
+            "@style {\n" +
+            "    .a {\n" +
+            "        color: red;\n" +
+            "    }\n" +
+            "    .b { color: blue; }\n" +
+            "}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Styles.Count.ShouldBe(1);
+        descriptor.Styles[0].Content.ShouldBe("    .a {\n        color: red;\n    }\n    .b { color: blue; }\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_TemplateWithBracesInText_DoesNotCloseEarly()
+    {
+        var source =
+            "@template {\n" +
+            "    <p>Use { and } carefully</p>\n" +
+            "    <pre>function() { return {}; }</pre>\n" +
+            "}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Template!.Content.ShouldBe(
+            "    <p>Use { and } carefully</p>\n    <pre>function() { return {}; }</pre>\n");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_IndentedContentResemblingABlockOpener_IsPreservedAsContent()
+    {
+        // An indented "@template {" is content, not a new block: inside a block the parser only looks for a
+        // column-0 '}'. So there is exactly one template and no duplicate diagnostic.
+        var source =
+            "@template {\n" +
+            "    @template {\n" +
+            "    <div>x</div>\n" +
+            "}\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Template.ShouldNotBeNull();
+        descriptor.Template!.Content.ShouldBe("    @template {\n    <div>x</div>\n");
+        descriptor.CustomBlocks.Count.ShouldBe(0);
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_ClosingBraceWithTrailingText_ClosesTheBlock()
+    {
+        // Recognition is "first column is '}'"; anything after the '}' on that line is ignored.
+        var source = "@script {\n    x\n} // done\n";
+
+        var descriptor = SfcTestHelpers.Parse(source);
+
+        descriptor.Script.ShouldNotBeNull();
+        descriptor.Script!.Content.ShouldBe("    x\n");
+        descriptor.Script!.Location.Source.ShouldBe("@script {\n    x\n}");
+        SfcTestHelpers.Errors(source).Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Parse_IndentedHeaderAtTopLevel_IsStrayNotABlock()
+    {
+        // Headers are recognised only at column 0 (symmetric with the column-0 closer). An indented
+        // "@template {" at the top level is therefore stray content, not a block opener.
+        var source = "    @template {\n    <x/>\n}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Template.ShouldBeNull();
+        result.Errors.ShouldContain(error => error.Code == SfcErrorCode.StrayTopLevelContent);
+    }
+
+    [Fact]
+    public void Parse_UnindentedContentBrace_ClosesEarly_DocumentingTheIndentRequirement()
+    {
+        // A CSS rule whose own '}' sits at column 0 terminates the block prematurely; the real closing '}'
+        // then becomes stray top-level content. This is the documented reason content must be indented.
+        var source =
+            "@style {\n" +
+            ".a {\n" +
+            "color: red;\n" +
+            "}\n" +
+            "}\n";
+
+        var result = SfcParser.Parse(source);
+
+        result.Descriptor.Styles.Count.ShouldBe(1);
+        result.Descriptor.Styles[0].Content.ShouldBe(".a {\ncolor: red;\n");
+        result.Errors.Count.ShouldBe(1);
+        result.Errors[0].Code.ShouldBe(SfcErrorCode.StrayTopLevelContent);
+    }
+}


### PR DESCRIPTION
Batch 8D — delegated implementation (Opus 4.8 agent) with design/functionality review; no review fixes needed. Founds the `Assimalign.Vue.Sfc` area, implementing the owner's @-block format decision (2026-07-17). Independent of the other in-flight batch-8 branches.

## What landed

**The `.viu` format and its block parser [V01.01.06.01, #57]** — `SfcParser.Parse(source)` slices a `.viu` file into an immutable, value-equatable `SfcDescriptor` (typed template/script/style blocks + preserved custom blocks), with exact raw content and full offset/line/column spans for both the block and its content region — ready for `#line` mapping (#59) and generator diagnostics (#58). The markup inside `@template` is untouched Vue template syntax; this parser never looks at it.

**The termination rule, exactly as the issue recommended** — *column 0 is structural*: a header opens at a column-0 `@name [options] {`, a block closes at the first later line whose first column is `}`. Nothing else is inspected, so literal braces in C# strings, nested CSS braces, HTML text braces, and even header-looking lines inside content are all inert — each pinned by a test, plus the honest flip-side test (unindented content's own `}` closes early, documented as the format's one demand: content must be indented).

**Options** — `@style scoped { }`, `@style module="classes" lang="scss" { }`: flags and double-quoted values between name and brace, typed accessors for `scoped`/`module`/`lang`, everything preserved in order with spans; unknown options and custom blocks preserved, never rejected (Vue's custom-block tolerance).

**Diagnostics** — a Vuecs-defined `SfcErrorCode` catalog (no upstream numbering exists for a Vuecs format — documented): stray top-level content, malformed headers/options, duplicate `@template`/`@script`, unterminated blocks. Recoverable, multi-error, never throws on bad input; unclosed blocks recover to EOF and still surface.

**`FORMAT.md`** — the authoritative spec, committed at `libraries/Assimalign.Vue.Sfc/docs/FORMAT.md`: the divergence rationale, an upstream-semantics mapping table (`@style scoped` ↔ `<style scoped>` …), the termination rule with worked examples including the flip side. I reviewed it line-by-line against the parser's pinned behavior — it is behavior-exact.

## Review notes / deviations (each documented at the site)

- One agent precisification I endorse: the column-0 rule applies to **headers** as well as closers (the issue stated it only for the closer) — a single symmetric "column 0 is structural" principle beats an asymmetric rule; an indented header is content/stray, pinned by test.
- Multiple `@style` blocks allowed, at most one `@template`/`@script` — matching Vue block-count semantics; the `<script setup>` distinction is script *analysis* and correctly deferred to #59's item ([V01.01.06.03]).
- csproj mirrors the Compiler precedent: `$(TargetFrameworkForAnalyzers)` (netstandard2.0, runs inside the [V01.01.06.02] generator host), `EnablePreviewFeatures=false`, `IsAotCompatible` omitted — all commented in the csproj.
- Case-sensitive lowercase matching for the three well-known names; `@Template` is a preserved custom block. Noted for a possible future analyzer lint (a case-typo is silent today) — not in #57's scope.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors (webapp included).
- **877 tests green**, including the new **Assimalign.Vue.Sfc.Tests: 55**. No pre-existing tests modified. New per-area slnx + `area-sfc.yml` CI wired.
- Browser/AOT gates N/A: build-time netstandard2.0 library.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)