### PR TITLE
feat(runtime-dom): interop command-buffer batching — one JS call per flush

### DIFF
--- a/examples/Assimalign.Vue.WebApp/VuecsDiagnostics.cs
+++ b/examples/Assimalign.Vue.WebApp/VuecsDiagnostics.cs
@@ -35,6 +35,7 @@ internal static class VuecsDiagnostics
 
         RunHandleLifecycleStress(renderer, rootHandle, report);
         RunApplicationLifecycleStress(rootHandle, report);
+        RunApplicationLifecycleStress(rootHandle, report, useCommandBuffer: true);
         RunMarshalingBenchmark(report);
 
         renderer.Render(
@@ -69,16 +70,19 @@ internal static class VuecsDiagnostics
         report.AppendLine();
     }
 
-    private static void RunApplicationLifecycleStress(int rootHandle, StringBuilder report)
+    private static void RunApplicationLifecycleStress(int rootHandle, StringBuilder report, bool useCommandBuffer = false)
     {
         // The [V01.01.04.04] criterion: CreateApp/Mount/Unmount cycles — with component
         // lifecycles, props, emits, and timers — return the bridge registry to its pre-mount
-        // baseline.
+        // baseline. Run once in direct mode and once with the interop command buffer
+        // ([V01.01.04.05]): buffered mode must clean up handles and listeners identically — every
+        // create/insert/remove flows through the batched apply, and released handles come back from
+        // the single apply call to purge the invoker registry.
         var baseline = BrowserRuntime.GetRegistryDiagnostics();
         var peakNodes = 0;
         for (var iteration = 0; iteration < 25; iteration++)
         {
-            var application = BrowserRuntime.CreateApp(new StopwatchApplication());
+            var application = BrowserRuntime.CreateApp(new StopwatchApplication(), useCommandBuffer: useCommandBuffer);
             application.Mount(rootHandle);
             var during = BrowserRuntime.GetRegistryDiagnostics();
             peakNodes = Math.Max(peakNodes, during.JsNodes);
@@ -86,7 +90,7 @@ internal static class VuecsDiagnostics
         }
         var after = BrowserRuntime.GetRegistryDiagnostics();
         var passed = after == baseline;
-        report.AppendLine("APPLICATION LIFECYCLE STRESS (CreateApp/Mount/Unmount)");
+        report.AppendLine($"APPLICATION LIFECYCLE STRESS (CreateApp/Mount/Unmount, {(useCommandBuffer ? "BUFFERED" : "direct")} mode)");
         report.AppendLine($"  cycles: 25 x component tree (root + child, listeners, timers)");
         report.AppendLine($"  baseline: nodes={baseline.JsNodes} listenerMaps={baseline.JsListenerMaps} dotnetListeners={baseline.DotnetListeners}");
         report.AppendLine($"  peak:     nodes={peakNodes}");

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Properties/AssemblyInfo.cs
@@ -2,6 +2,9 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assimalign.Vue.RuntimeCore.Tests")]
 [assembly: InternalsVisibleTo("Assimalign.Vue.Testing")]
+// The browser package arms Scheduler.FlushBoundaryCallback — the interop command-buffer flush
+// seam ([V01.01.04.05]) — which is an internal static hook, not public API surface.
+[assembly: InternalsVisibleTo("Assimalign.Vue.RuntimeDom")]
 // The RuntimeDom directive tests drive the RuntimeCore scheduler directly (v-model/v-show run
 // through the real renderer + post-flush pipeline), so they reset it between tests just as the
 // Testing library does per mount ([V01.01.04.06]).

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
@@ -43,6 +43,22 @@ public static class Scheduler
     /// </summary>
     internal static Action<Action>? FlushDispatcher;
 
+    /// <summary>
+    /// Platform seam invoked exactly once per flush, immediately after the pre/render job queue
+    /// drains and <em>before</em> post-flush callbacks run. It exists for
+    /// <c>Assimalign.Vue.RuntimeDom</c>'s interop command buffer ([V01.01.04.05]): buffered node-ops
+    /// accumulate DOM mutations during the drain and this seam is where the single batched interop
+    /// call applies them. The boundary is deliberate — post-flush callbacks are the mounted/updated
+    /// lifecycle phase, and that user code may read the DOM (layout, template refs), so the buffer
+    /// must be committed before it runs. Fires on both the scheduled flush and the synchronous
+    /// post-render drain (<see cref="FlushAfterSynchronousRender"/>) so a direct <c>Render</c>/mount
+    /// commits its batch too; a nested synchronous render inside an active scheduled flush is covered
+    /// by the outer flush, never double-applied. Owner-managed like <see cref="FlushDispatcher"/>
+    /// (armed by the buffered renderer, cleared on teardown); direct-mode hosts leave it null and pay
+    /// nothing. Ambient static, single-threaded — NOT thread-safe.
+    /// </summary>
+    internal static Action? FlushBoundaryCallback;
+
     /// <summary>Whether a flush is executing right now.</summary>
     public static bool IsFlushing => _isFlushing;
 
@@ -194,6 +210,9 @@ public static class Scheduler
             return;
         }
         FlushPreFlushCallbacks();
+        // Commit batched interop mutations from this synchronous render (mount / direct Render)
+        // before its post-flush callbacks run. See FlushBoundaryCallback.
+        FlushBoundaryCallback?.Invoke();
         FlushPostFlushCallbacks();
         if (_isFlushPending && _queue.Count == 0 && _pendingPostFlushCallbacks.Count == 0)
         {
@@ -312,6 +331,9 @@ public static class Scheduler
             }
             _queue.Clear();
             _flushIndex = -1;
+            // Commit any batched interop mutations before post-flush (mounted/updated) callbacks,
+            // which may read the DOM. See FlushBoundaryCallback.
+            FlushBoundaryCallback?.Invoke();
             FlushPostFlushCallbacks();
             _isFlushing = false;
             if (_queue.Count > 0 || _pendingPostFlushCallbacks.Count > 0)

--- a/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/src/Scheduler.cs
@@ -44,18 +44,25 @@ public static class Scheduler
     internal static Action<Action>? FlushDispatcher;
 
     /// <summary>
-    /// Platform seam invoked exactly once per flush, immediately after the pre/render job queue
-    /// drains and <em>before</em> post-flush callbacks run. It exists for
-    /// <c>Assimalign.Vue.RuntimeDom</c>'s interop command buffer ([V01.01.04.05]): buffered node-ops
-    /// accumulate DOM mutations during the drain and this seam is where the single batched interop
-    /// call applies them. The boundary is deliberate — post-flush callbacks are the mounted/updated
-    /// lifecycle phase, and that user code may read the DOM (layout, template refs), so the buffer
-    /// must be committed before it runs. Fires on both the scheduled flush and the synchronous
-    /// post-render drain (<see cref="FlushAfterSynchronousRender"/>) so a direct <c>Render</c>/mount
-    /// commits its batch too; a nested synchronous render inside an active scheduled flush is covered
-    /// by the outer flush, never double-applied. Owner-managed like <see cref="FlushDispatcher"/>
-    /// (armed by the buffered renderer, cleared on teardown); direct-mode hosts leave it null and pay
-    /// nothing. Ambient static, single-threaded — NOT thread-safe.
+    /// Platform seam for <c>Assimalign.Vue.RuntimeDom</c>'s interop command buffer ([V01.01.04.05]):
+    /// buffered node-ops accumulate DOM mutations and this seam is where the single batched interop
+    /// call commits them. It fires at two boundaries within a flush, so it must be idempotent — a
+    /// no-op when nothing is buffered:
+    /// <list type="number">
+    /// <item>after the pre/render job queue drains and <em>before</em> post-flush callbacks run, so
+    /// the mounted/updated lifecycle phase (which may read the DOM — layout, template refs) observes
+    /// the committed render; and</item>
+    /// <item>again <em>after</em> post-flush callbacks run, because those hooks (and post-flush
+    /// directive hooks such as <c>v-show</c>'s <c>updated</c>) can themselves write the DOM, and their
+    /// buffered writes must commit within the same flush rather than strand until the next one.</item>
+    /// </list>
+    /// A steady-state render flush with no post-flush DOM writes therefore still crosses the boundary
+    /// exactly once (the second call finds an empty buffer). Fires on both the scheduled flush and the
+    /// synchronous post-render drain (<see cref="FlushAfterSynchronousRender"/>) so a direct
+    /// <c>Render</c>/mount commits its batch too; a nested synchronous render inside an active
+    /// scheduled flush is covered by the outer flush, never double-applied. Owner-managed like
+    /// <see cref="FlushDispatcher"/> (armed by the buffered renderer, cleared on teardown); direct-mode
+    /// hosts leave it null and pay nothing. Ambient static, single-threaded — NOT thread-safe.
     /// </summary>
     internal static Action? FlushBoundaryCallback;
 
@@ -211,9 +218,11 @@ public static class Scheduler
         }
         FlushPreFlushCallbacks();
         // Commit batched interop mutations from this synchronous render (mount / direct Render)
-        // before its post-flush callbacks run. See FlushBoundaryCallback.
+        // before its post-flush callbacks run and again after (they may write the DOM). See
+        // FlushBoundaryCallback.
         FlushBoundaryCallback?.Invoke();
         FlushPostFlushCallbacks();
+        FlushBoundaryCallback?.Invoke();
         if (_isFlushPending && _queue.Count == 0 && _pendingPostFlushCallbacks.Count == 0)
         {
             // This synchronous drain emptied everything a scheduled flush was posted for:
@@ -331,10 +340,12 @@ public static class Scheduler
             }
             _queue.Clear();
             _flushIndex = -1;
-            // Commit any batched interop mutations before post-flush (mounted/updated) callbacks,
-            // which may read the DOM. See FlushBoundaryCallback.
+            // Commit batched interop mutations before post-flush (mounted/updated) callbacks, which
+            // may read the DOM, and again after them, since those hooks may write it. See
+            // FlushBoundaryCallback.
             FlushBoundaryCallback?.Invoke();
             FlushPostFlushCallbacks();
+            FlushBoundaryCallback?.Invoke();
             _isFlushing = false;
             if (_queue.Count > 0 || _pendingPostFlushCallbacks.Count > 0)
             {

--- a/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
@@ -25,6 +25,7 @@ public class SchedulerTests : IDisposable
 
     public void Dispose()
     {
+        Scheduler.FlushBoundaryCallback = null;
         Scheduler.Reset();
         _pump.Dispose();
     }
@@ -85,6 +86,56 @@ public class SchedulerTests : IDisposable
         _pump.RunUntilIdle();
 
         order.ShouldBe(["pre", "render", "post"]);
+    }
+
+    // The interop command-buffer seam ([V01.01.04.05]): the boundary callback commits batched DOM
+    // mutations after the render queue drains and before post-flush (mounted/updated) callbacks,
+    // which may read the DOM.
+    [Fact]
+    public void FlushBoundaryCallback_FiresOnce_AfterRenderJobs_BeforePostFlushCallbacks()
+    {
+        var order = new List<string>();
+        var boundaryRuns = 0;
+        Scheduler.FlushBoundaryCallback = () =>
+        {
+            boundaryRuns++;
+            order.Add("boundary");
+        };
+        Scheduler.QueuePostFlushCallback(new SchedulerJob(() => order.Add("post")));
+        Scheduler.QueueJob(new SchedulerJob(() => order.Add("render")) { Identifier = 1 });
+
+        _pump.RunUntilIdle();
+
+        order.ShouldBe(["render", "boundary", "post"]);
+        boundaryRuns.ShouldBe(1); // exactly one commit per flush, regardless of op count
+    }
+
+    // The buffered batch must commit even when nothing observes it afterwards — otherwise a
+    // reactive update with no lifecycle hooks would never reach the DOM.
+    [Fact]
+    public void FlushBoundaryCallback_FiresEvenWithNoPostFlushCallbacks()
+    {
+        var boundaryRuns = 0;
+        Scheduler.FlushBoundaryCallback = () => boundaryRuns++;
+        Scheduler.QueueJob(new SchedulerJob(static () => { }) { Identifier = 1 });
+
+        _pump.RunUntilIdle();
+
+        boundaryRuns.ShouldBe(1);
+    }
+
+    // The synchronous post-render drain (a direct Render / app mount) also commits its batch, so a
+    // mounted hook reading the DOM sees the committed tree.
+    [Fact]
+    public void FlushBoundaryCallback_FiresOnSynchronousRenderDrain_BeforePostFlush()
+    {
+        var order = new List<string>();
+        Scheduler.FlushBoundaryCallback = () => order.Add("boundary");
+        Scheduler.QueuePostFlushCallback(new SchedulerJob(() => order.Add("post")));
+
+        Scheduler.FlushAfterSynchronousRender();
+
+        order.ShouldBe(["boundary", "post"]);
     }
 
     [Fact]

--- a/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/SchedulerTests.cs
@@ -89,25 +89,22 @@ public class SchedulerTests : IDisposable
     }
 
     // The interop command-buffer seam ([V01.01.04.05]): the boundary callback commits batched DOM
-    // mutations after the render queue drains and before post-flush (mounted/updated) callbacks,
-    // which may read the DOM.
+    // mutations after the render queue drains AND again after post-flush callbacks — before them so
+    // mounted/updated hooks that read the DOM see the committed render, after them so hooks that
+    // write the DOM (e.g. v-show's post-flush updated hook) commit within the same flush. The
+    // callback is idempotent (a no-op when nothing is buffered), so a render-only flush still crosses
+    // the interop boundary exactly once in practice.
     [Fact]
-    public void FlushBoundaryCallback_FiresOnce_AfterRenderJobs_BeforePostFlushCallbacks()
+    public void FlushBoundaryCallback_BracketsPostFlushCallbacks()
     {
         var order = new List<string>();
-        var boundaryRuns = 0;
-        Scheduler.FlushBoundaryCallback = () =>
-        {
-            boundaryRuns++;
-            order.Add("boundary");
-        };
+        Scheduler.FlushBoundaryCallback = () => order.Add("boundary");
         Scheduler.QueuePostFlushCallback(new SchedulerJob(() => order.Add("post")));
         Scheduler.QueueJob(new SchedulerJob(() => order.Add("render")) { Identifier = 1 });
 
         _pump.RunUntilIdle();
 
-        order.ShouldBe(["render", "boundary", "post"]);
-        boundaryRuns.ShouldBe(1); // exactly one commit per flush, regardless of op count
+        order.ShouldBe(["render", "boundary", "post", "boundary"]);
     }
 
     // The buffered batch must commit even when nothing observes it afterwards — otherwise a
@@ -121,13 +118,13 @@ public class SchedulerTests : IDisposable
 
         _pump.RunUntilIdle();
 
-        boundaryRuns.ShouldBe(1);
+        boundaryRuns.ShouldBe(2); // brackets the (empty) post-flush phase; the second call no-ops
     }
 
-    // The synchronous post-render drain (a direct Render / app mount) also commits its batch, so a
-    // mounted hook reading the DOM sees the committed tree.
+    // The synchronous post-render drain (a direct Render / app mount) also brackets its post-flush
+    // callbacks, so a mounted hook both reads the committed tree and commits any DOM it writes.
     [Fact]
-    public void FlushBoundaryCallback_FiresOnSynchronousRenderDrain_BeforePostFlush()
+    public void FlushBoundaryCallback_BracketsPostFlush_OnSynchronousRenderDrain()
     {
         var order = new List<string>();
         Scheduler.FlushBoundaryCallback = () => order.Add("boundary");
@@ -135,7 +132,7 @@ public class SchedulerTests : IDisposable
 
         Scheduler.FlushAfterSynchronousRender();
 
-        order.ShouldBe(["boundary", "post"]);
+        order.ShouldBe(["boundary", "post", "boundary"]);
     }
 
     [Fact]

--- a/libraries/Assimalign.Vue.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.RuntimeDom/docs/DESIGN.md
@@ -79,8 +79,46 @@ and `.WithKeys` port `withModifiers`/`withKeys` (guards run .NET-side over the p
 Handler exceptions route to the registry's error sink — a debug trace until the app
 error-handling pipeline ([V01.01.03.12]) replaces it — and never escape into the JS listener.
 
+## Interop command-buffer batching ([V01.01.04.05])
+
+The boundary is the budget, so the batched mode collapses a whole scheduler flush's node-ops into
+**one** interop call. There is no upstream Vue counterpart — the prior art is Blazor's `RenderBatch`
+— but it is behaviorally invisible: buffered and direct modes produce byte-identical DOM. It is a
+construction-time choice (`BrowserRuntime.CreateApp(root, props, useCommandBuffer: true)`); the
+renderer and RuntimeCore see the identical `RendererOptions<int>` either way. Default is direct;
+buffered is opt-in for this delivery.
+
+- **Encoder** (`DomCommandBuffer`): every write op — create/insert/remove/text and each `patchProp`
+  leaf — encodes as `[opcode][operands]` into one growable, reused `byte[]`. A per-flush string table
+  interns repeated tag/prop/event names; a magic + version header byte pair lets the JS applier reject
+  a drifted frame loudly. Little-endian is explicit (`BinaryPrimitives` ↔ `DataView` littleEndian).
+  Zero per-flush managed allocation at steady state.
+- **One-way handles**: a buffered `createElement/Text/Comment` cannot return the JS id, so .NET
+  pre-allocates the handle from its own counter and the op carries "create X **AS** handle N"; the JS
+  applier registers the node under N. The counter rides each frame header so the JS side keeps its
+  own foreign-node allocator (querySelector/parentNode/nextSibling) above it, and a forced-flush read
+  folds any foreign handle it returns back into the counter — the two allocators never collide.
+- **Reads force a flush**: ops that genuinely return data (`parentNode`, `nextSibling`,
+  `querySelector`, `insertStaticContent`) commit the pending batch first (one apply), then read the
+  live bridge. Steady-state block-tree updates issue no such reads, so hundreds of mutations collapse
+  into exactly one apply — the interop-call-counter acceptance criterion.
+- **Released handles**: `remove`/`setElementText` no longer return per op; the applier collects every
+  handle it releases while draining the batch and returns them from the single apply call, feeding the
+  same `PurgeReleasedHandles` path (this settles ADR-0001's "revisit the released-handle shape with
+  the command buffer" consequence).
+- **Flush boundary** (`Scheduler.FlushBoundaryCallback`, the one minimal RuntimeCore seam): the batch
+  applies after the render queue drains and *before* post-flush callbacks (so mounted/updated hooks
+  read the committed DOM), and again *after* them (so post-flush DOM writes — a `v-show` `updated`
+  hook — commit within the same flush). The callback is idempotent, so a render-only flush still
+  crosses the boundary once.
+- **Span marshaling**: the frame crosses as `[JSMarshalAs<JSType.MemoryView>] Span<byte>` — the JS
+  applier reads a typed-array view over WASM memory, not a copied argument — and a static switch over
+  the opcode replays each op, reusing the exact `dom.*` leaves the direct path uses.
+- **Differential proof**: the full renderer scenario battery runs through direct and buffered modes
+  and asserts byte-identical serialized DOM; an instrumented apply counter proves one boundary
+  crossing per flush over hundreds of mutations. Full 10k-row benchmarks belong to [V01.01.11.04].
+
 ## Non-goals (sequenced work)
 
-- Interop command-buffer batching — [V01.01.04.05] (#43).
 - App bootstrap (`CreateApp`-equivalent, container clearing) — [V01.01.04.04] (#42).
 - `v-model` runtime — [V01.01.04.06].

--- a/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Vue.RuntimeDom/docs/OVERVIEW.md
@@ -9,24 +9,28 @@ node-ops and prop patching that the platform-agnostic renderer
 
 - **`BrowserRuntime`** (public entry): `InitializeAsync()` loads the package's JS bridge module;
   `CreateApp(rootComponent).Mount("#app")` is a whole app bootstrap ([V01.01.04.04]);
-  `CreateRenderer()` returns a `Renderer<int>` over the browser node-ops; `QuerySelector()`
-  resolves mount containers; `GetRegistryDiagnostics()` exposes handle-registry sizes for leak
-  checks.
+  `CreateApp(root, props, useCommandBuffer: true)` runs the renderer over the batched interop command
+  buffer ([V01.01.04.05], behaviorally identical to direct); `CreateRenderer()` returns a
+  `Renderer<int>` over the browser node-ops; `QuerySelector()` resolves mount containers;
+  `GetRegistryDiagnostics()` exposes handle-registry sizes for leak checks.
 - **`BrowserApplication`** (public): the mounted app — selector or handle mounting with
   clear-before-mount, and `Unmount()` returning the bridge registry to its pre-mount baseline.
 - **`BrowserDomException`** (public): typed interop failure carrying the operation name and the
   node handle.
 - **`vuecs-dom.js`** (`src/wwwroot/`, shipped with the package): the JS half — the handle
   registry, the `nodeOps` leaves (create/insert/remove/text/static-content, SVG and MathML
-  namespaces), the property/style/attribute leaf appliers, and the per-(element, event)
-  listeners feeding the single `[JSExport]` event dispatch.
+  namespaces), the property/style/attribute leaf appliers, the per-(element, event)
+  listeners feeding the single `[JSExport]` event dispatch, and `applyCommandBuffer` — the batched
+  applier that replays one command-buffer frame per flush ([V01.01.04.05]).
 - **`BrowserEvent` / `BrowserEventModifiers` / `BrowserEvents`** (public): the typed event
   payload with `StopPropagation()`/`PreventDefault()`, and the `WithModifiers`/`WithKeys`
   guard helpers ([V01.01.04.03]).
 - **Internal:** `BrowserDomBridge` (`[JSImport]` bindings + typed-error wrappers),
   `BrowserPropertyPatcher` + `BrowserPropertyLeafOperations` (the `patchProp` decision tree over
-  injected leaves), `BrowserNodeOperations` (the `RendererOptions<int>` factory and event
-  dispatch).
+  injected leaves), `BrowserNodeOperations` (the direct `RendererOptions<int>` factory and event
+  dispatch), and the command-buffer trio `DomCommandOpcode` / `DomCommandBuffer` (the versioned
+  opcode encoder) / `BufferedBrowserNodeOperations` (the buffered `RendererOptions<int>` that batches
+  every write and applies once per flush).
 
 ## Using it
 

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserApplication.cs
@@ -19,10 +19,12 @@ namespace Assimalign.Vue.RuntimeDom;
 public sealed class BrowserApplication
 {
     private readonly VueApplication<int> _application;
+    private readonly BufferedBrowserNodeOperations? _bufferedOperations;
 
-    internal BrowserApplication(VueApplication<int> application)
+    internal BrowserApplication(VueApplication<int> application, BufferedBrowserNodeOperations? bufferedOperations = null)
     {
         _application = application;
+        _bufferedOperations = bufferedOperations;
     }
 
     /// <summary>Whether the app is currently mounted.</summary>
@@ -164,6 +166,10 @@ public sealed class BrowserApplication
     {
         if (!_application.IsMounted)
         {
+            // The container is a foreign node the bridge registered (a QuerySelector result); fold its
+            // handle into the buffered handle counter so a buffered create never reuses it. Harmless
+            // in direct mode (no buffered operations).
+            _bufferedOperations?.ObserveForeignHandle(containerHandle);
             // Non-hydrating client mount clears existing container content (upstream parity);
             // one interop call that also releases any registered child handles.
             BrowserRuntime.ClearContainer(containerHandle);
@@ -174,7 +180,12 @@ public sealed class BrowserApplication
     /// <summary>
     /// Unmounts the app (upstream: <c>app.unmount()</c>): runs component teardown lifecycles,
     /// removes the rendered DOM, and releases every JS-side handle and listener the app
-    /// created.
+    /// created. In buffered mode the teardown mutations commit through the command buffer before the
+    /// buffered operations are detached from the ambient scheduler/dispatch seams.
     /// </summary>
-    public void Unmount() => _application.Unmount();
+    public void Unmount()
+    {
+        _application.Unmount();
+        _bufferedOperations?.Deactivate();
+    }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/BrowserRuntime.cs
@@ -43,16 +43,36 @@ public static class BrowserRuntime
     /// <c>createApp(rootComponent)</c>, https://vuejs.org/api/application.html) —
     /// <c>BrowserRuntime.CreateApp(root).Mount("#app")</c> is a Vuecs WASM app's whole
     /// bootstrap ([V01.01.04.04]).
+    /// <para>
+    /// Set <paramref name="useCommandBuffer"/> to run the renderer over the interop command buffer
+    /// ([V01.01.04.05]): node-ops serialize into a shared binary frame that a single interop call
+    /// applies per scheduler flush instead of one call per mutation. It is behaviorally invisible —
+    /// buffered and direct modes produce byte-identical DOM — and is a construction-time choice the
+    /// renderer and RuntimeCore see through the identical adapter. Default is direct; buffered is
+    /// opt-in for this delivery.
+    /// </para>
     /// </summary>
     /// <param name="rootComponent">The root component definition.</param>
     /// <param name="rootProperties">Props for the root component, or null.</param>
+    /// <param name="useCommandBuffer">Whether to batch node-ops through the command buffer.</param>
     /// <returns>The app; mount it by selector or handle.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="rootComponent"/> is null.</exception>
     /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
-    public static BrowserApplication CreateApp(IComponentDefinition rootComponent, VirtualNodeProperties? rootProperties = null)
+    public static BrowserApplication CreateApp(
+        IComponentDefinition rootComponent,
+        VirtualNodeProperties? rootProperties = null,
+        bool useCommandBuffer = false)
     {
         ArgumentNullException.ThrowIfNull(rootComponent);
         EnsureInitialized();
+        if (useCommandBuffer)
+        {
+            var bufferedOperations = BufferedBrowserNodeOperations.CreateProduction();
+            var bufferedRenderer = RendererFactory.CreateRenderer(bufferedOperations.Create());
+            return new BrowserApplication(
+                bufferedRenderer.CreateApplication(rootComponent, rootProperties),
+                bufferedOperations);
+        }
         var renderer = RendererFactory.CreateRenderer(BrowserNodeOperations.Create());
         return new BrowserApplication(renderer.CreateApplication(rootComponent, rootProperties));
     }

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
@@ -321,6 +321,23 @@ internal static partial class BrowserDomBridge
         }
     }
 
+    // The command-buffer apply ([V01.01.04.05]): the whole batched op frame crosses the boundary
+    // once per flush as a MemoryView over WASM memory (no copy of the argument), and the applier
+    // returns every handle it released while draining the batch so the .NET side purges its invoker
+    // delegates in the same single call — the batched analogue of remove/setElementText's per-op
+    // released-handle return.
+    internal static int[] ApplyCommandBuffer(byte[] frame, int length)
+    {
+        try
+        {
+            return Imports.ApplyCommandBuffer(frame.AsSpan(0, length));
+        }
+        catch (JSException exception)
+        {
+            throw Translate("applyCommandBuffer", 0, exception);
+        }
+    }
+
     // Takes Exception (not JSException) so the pure parsing is testable on the CoreCLR host —
     // JSException cannot even be constructed off-browser.
     internal static BrowserDomException Translate(string operationName, int nodeHandle, Exception exception)
@@ -416,6 +433,9 @@ internal static partial class BrowserDomBridge
 
         [JSImport("dom.getRegistrySizes", ModuleName)]
         internal static partial int[] GetRegistrySizes();
+
+        [JSImport("dom.applyCommandBuffer", ModuleName)]
+        internal static partial int[] ApplyCommandBuffer([JSMarshalAs<JSType.MemoryView>] Span<byte> buffer);
 
         [JSImport("initialize", ModuleName)]
         [return: JSMarshalAs<JSType.Promise<JSType.Void>>]

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -79,8 +79,20 @@ internal static class BrowserNodeOperations
         },
     };
 
+    /// <summary>
+    /// Overrides the invoker registry the single <c>[JSExport]</c> dispatch entry
+    /// (<see cref="BrowserEventDispatch"/>) routes to. Buffered mode ([V01.01.04.05]) sets this to its
+    /// own registry — whose add/remove callbacks encode listener ops into the command buffer rather
+    /// than call the bridge directly — so a live event reaches the handlers registered on the buffered
+    /// renderer. Null selects the direct-path registry. Ambient static (single active renderer per
+    /// process, single-threaded JS event-loop model).
+    /// </summary>
+    internal static Func<int, bool, BrowserEvent, int>? OverrideDispatcher;
+
     internal static int DispatchEvent(int nodeHandle, bool capture, BrowserEvent browserEvent)
-        => Invokers.Dispatch(nodeHandle, capture, browserEvent);
+        => OverrideDispatcher is { } dispatcher
+            ? dispatcher(nodeHandle, capture, browserEvent)
+            : Invokers.Dispatch(nodeHandle, capture, browserEvent);
 
     /// <summary>Clears an element's content (pre-mount container reset), purging released handles.</summary>
     internal static void ClearElement(int nodeHandle)

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Runtime.Versioning;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The buffered <see cref="RendererOptions{TNode}"/> ([V01.01.04.05]): the same adapter shape the
+/// renderer and RuntimeCore see in direct mode (<see cref="BrowserNodeOperations"/>), but every
+/// write op — create/insert/remove/text and every <c>patchProp</c> leaf — encodes into a
+/// <see cref="DomCommandBuffer"/> instead of crossing the interop boundary, and the whole frame
+/// applies in one call at the scheduler flush boundary (<see cref="Scheduler.FlushBoundaryCallback"/>).
+/// Buffered and direct modes produce byte-identical DOM; the choice is a construction-time toggle on
+/// <see cref="BrowserRuntime"/>.
+/// <para>
+/// <b>Reads force a flush.</b> Ops that genuinely return data — <c>parentNode</c>,
+/// <c>nextSibling</c>, <c>querySelector</c>, <c>insertStaticContent</c> — cannot be answered from the
+/// unapplied buffer, so they commit the pending batch first (one apply call) and then read the live
+/// bridge, folding the returned handle into the .NET counter so the two handle allocators never
+/// collide. Handles for created nodes are pre-allocated from <see cref="DomCommandBuffer.AllocateHandle"/>
+/// (the create op is one-way and cannot return the JS id).
+/// </para>
+/// <para>
+/// <b>Released handles</b> from <c>remove</c>/<c>setElementText</c> are not returned per op; the JS
+/// applier collects every handle it releases while draining the batch and returns them from the single
+/// apply call, which purges the invoker registry once — the same
+/// <see cref="BrowserEventInvokerRegistry.PurgeReleasedHandles"/> path the direct mode drives per op.
+/// </para>
+/// Ambient by activation: <see cref="Activate"/> points the flush seam, the event dispatcher, and the
+/// directive operations at this instance; <see cref="Deactivate"/> restores them. Single active
+/// buffered renderer per process (single-threaded JS event-loop model) — NOT thread-safe.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal sealed class BufferedBrowserNodeOperations
+{
+    private readonly DomCommandBuffer _buffer = new();
+    private readonly BrowserEventInvokerRegistry _invokers;
+    private readonly BrowserPropertyLeafOperations _leaf;
+    private readonly Func<byte[], int, int[]> _applier;
+    private readonly Func<string, int> _querySelector;
+    private readonly Func<int, int> _parentNode;
+    private readonly Func<int, int> _nextSibling;
+    private readonly Func<string, int, int, string?, (int First, int Last)> _insertStaticContent;
+
+    private Action? _previousFlushBoundary;
+    private Func<int, bool, BrowserEvent, int>? _previousDispatcher;
+    private BrowserDirectiveOperations? _previousDirectiveOperations;
+    private bool _isActive;
+    private int _interopCallCount;
+
+    internal BufferedBrowserNodeOperations(
+        Func<byte[], int, int[]> applier,
+        Func<string, int> querySelector,
+        Func<int, int> parentNode,
+        Func<int, int> nextSibling,
+        Func<string, int, int, string?, (int First, int Last)> insertStaticContent)
+    {
+        _applier = applier;
+        _querySelector = querySelector;
+        _parentNode = parentNode;
+        _nextSibling = nextSibling;
+        _insertStaticContent = insertStaticContent;
+        _invokers = new BrowserEventInvokerRegistry(
+            (handle, eventName, once, capture, passive) => _buffer.WriteAddEventListener(handle, eventName, once, capture, passive),
+            (handle, eventName, capture) => _buffer.WriteRemoveEventListener(handle, eventName, capture));
+        _leaf = new BrowserPropertyLeafOperations
+        {
+            SetAttribute = (element, name, value) => _buffer.WriteSetAttribute(element, name, value),
+            RemoveAttribute = (element, name) => _buffer.WriteRemoveAttribute(element, name),
+            SetXlinkAttribute = (element, name, value) => _buffer.WriteSetXlinkAttribute(element, name, value),
+            RemoveXlinkAttribute = (element, name) => _buffer.WriteRemoveXlinkAttribute(element, name),
+            SetClassName = (element, value) => _buffer.WriteSetClassName(element, value),
+            SetStringProperty = (element, name, value) => _buffer.WriteSetStringProperty(element, name, value),
+            SetBooleanProperty = (element, name, value) => _buffer.WriteSetBooleanProperty(element, name, value),
+            SetValueGuarded = (element, value) => _buffer.WriteSetValueGuarded(element, value),
+            SetStyleText = (element, cssText) => _buffer.WriteSetStyleText(element, cssText),
+            SetStyleProperty = (element, name, value, important) => _buffer.WriteSetStyleProperty(element, name, value, important),
+            RemoveStyleProperty = (element, name) => _buffer.WriteRemoveStyleProperty(element, name),
+            SetEventListener = (element, rawPropertyName, listener) => _invokers.SetListener(element, rawPropertyName, listener),
+        };
+    }
+
+    /// <summary>The number of apply (boundary-crossing) calls made — the interop-call counter AC.</summary>
+    internal int InteropCallCount => _interopCallCount;
+
+    /// <summary>The invoker registry buffered listener ops register into (event dispatch target).</summary>
+    internal BrowserEventInvokerRegistry Invokers => _invokers;
+
+    /// <summary>The command buffer (diagnostics/tests).</summary>
+    internal DomCommandBuffer Buffer => _buffer;
+
+    /// <summary>Builds the buffered <see cref="RendererOptions{TNode}"/> for the renderer.</summary>
+    internal RendererOptions<int> Create() => new()
+    {
+        Insert = (child, parent, anchor) => _buffer.WriteInsert(parent, child, anchor),
+        Remove = child => _buffer.WriteRemove(child),
+        CreateElement = (tag, elementNamespace) =>
+        {
+            var handle = _buffer.AllocateHandle();
+            _buffer.WriteCreateElement(handle, tag, elementNamespace);
+            return handle;
+        },
+        CreateText = text =>
+        {
+            var handle = _buffer.AllocateHandle();
+            _buffer.WriteCreateText(handle, text);
+            return handle;
+        },
+        CreateComment = text =>
+        {
+            var handle = _buffer.AllocateHandle();
+            _buffer.WriteCreateComment(handle, text);
+            return handle;
+        },
+        SetText = (node, text) => _buffer.WriteSetText(node, text),
+        SetElementText = (node, text) => _buffer.WriteSetElementText(node, text),
+        ParentNode = node => Read(_parentNode, node),
+        NextSibling = node => Read(_nextSibling, node),
+        PatchProperty = (element, elementTag, propertyName, previousValue, nextValue, elementNamespace) =>
+            BrowserPropertyPatcher.Patch(_leaf, element, elementTag, propertyName, previousValue, nextValue, elementNamespace),
+        QuerySelector = selector =>
+        {
+            FlushPending();
+            var handle = _querySelector(selector);
+            _buffer.ObserveForeignHandle(handle);
+            return handle;
+        },
+        InsertStaticContent = (content, parent, anchor, elementNamespace) =>
+        {
+            FlushPending();
+            var (first, last) = _insertStaticContent(content, parent, anchor, elementNamespace);
+            _buffer.ObserveForeignHandle(first);
+            _buffer.ObserveForeignHandle(last);
+            return (first, last);
+        },
+    };
+
+    /// <summary>
+    /// Commits the pending batch: finalize the frame, hand it across the boundary in one call, purge
+    /// the invoker delegates the applier reports released, and reset the frame for the next flush.
+    /// A no-op when nothing is buffered. Armed on <see cref="Scheduler.FlushBoundaryCallback"/>.
+    /// </summary>
+    internal void ApplyPending()
+    {
+        if (!_buffer.HasPendingOperations)
+        {
+            return;
+        }
+        var length = _buffer.FinalizeFrame();
+        _interopCallCount++;
+        var released = _applier(_buffer.BackingArray, length);
+        _buffer.ResetFrame();
+        _invokers.PurgeReleasedHandles(released);
+    }
+
+    /// <summary>
+    /// Folds a handle the bridge issued for a node outside the buffer (a mount container, or a
+    /// <c>parentNode</c>/<c>nextSibling</c> result) into the .NET handle counter so a later buffered
+    /// create never reuses it. The buffered app observes its mount container here before rendering.
+    /// </summary>
+    /// <param name="handle">The externally issued handle.</param>
+    internal void ObserveForeignHandle(int handle) => _buffer.ObserveForeignHandle(handle);
+
+    /// <summary>Points the flush seam, event dispatch, and directive ops at this instance.</summary>
+    internal void Activate()
+    {
+        if (_isActive)
+        {
+            return;
+        }
+        _isActive = true;
+        _previousFlushBoundary = Scheduler.FlushBoundaryCallback;
+        _previousDispatcher = BrowserNodeOperations.OverrideDispatcher;
+        _previousDirectiveOperations = BrowserDirectiveOperations.Current;
+        Scheduler.FlushBoundaryCallback = ApplyPending;
+        BrowserNodeOperations.OverrideDispatcher = _invokers.Dispatch;
+        // v-model / v-show write through the same buffered leaf/invoker channels as the patch engine.
+        BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
+        {
+            SetModelListener = (element, rawPropertyName, handler) => _invokers.SetModelListener(element, rawPropertyName, handler),
+            SetValueGuarded = _leaf.SetValueGuarded,
+            SetBooleanProperty = _leaf.SetBooleanProperty,
+            SetStyleProperty = _leaf.SetStyleProperty,
+            RemoveStyleProperty = _leaf.RemoveStyleProperty,
+        };
+    }
+
+    /// <summary>Restores the seam, dispatcher, and directive ops to their pre-<see cref="Activate"/> values.</summary>
+    internal void Deactivate()
+    {
+        if (!_isActive)
+        {
+            return;
+        }
+        _isActive = false;
+        Scheduler.FlushBoundaryCallback = _previousFlushBoundary;
+        BrowserNodeOperations.OverrideDispatcher = _previousDispatcher;
+        BrowserDirectiveOperations.Current = _previousDirectiveOperations;
+    }
+
+    /// <summary>
+    /// Creates the production instance over the real bridge and activates it. Reads force a flush and
+    /// then hit the live bridge; the applier is the single MemoryView interop call.
+    /// </summary>
+    internal static BufferedBrowserNodeOperations CreateProduction()
+    {
+        var operations = new BufferedBrowserNodeOperations(
+            static (frame, length) => BrowserDomBridge.ApplyCommandBuffer(frame, length),
+            static selector => BrowserDomBridge.QuerySelector(selector),
+            static node => BrowserDomBridge.ParentNode(node),
+            static node => BrowserDomBridge.NextSibling(node),
+            static (content, parent, anchor, elementNamespace) =>
+            {
+                var span = BrowserDomBridge.InsertStaticContent(content, parent, anchor, elementNamespace);
+                return (span[0], span[1]);
+            });
+        operations.Activate();
+        return operations;
+    }
+
+    private int Read(Func<int, int> read, int node)
+    {
+        FlushPending();
+        var handle = read(node);
+        _buffer.ObserveForeignHandle(handle);
+        return handle;
+    }
+
+    private void FlushPending()
+    {
+        if (_buffer.HasPendingOperations)
+        {
+            ApplyPending();
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/DomCommandBuffer.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/DomCommandBuffer.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The .NET writer half of the interop command buffer ([V01.01.04.05]): buffered node-ops encode
+/// each DOM mutation as an opcode + operands into one growable, reused <see cref="byte"/> array, and
+/// a single interop call hands the whole frame to the JS applier (<c>vuecs-dom.js</c>'s
+/// <c>applyCommandBuffer</c>) per scheduler flush — collapsing hundreds of boundary crossings into
+/// one. There is no upstream Vue counterpart; the prior art is Blazor's <c>RenderBatch</c>. The
+/// design is behaviorally invisible: buffered and direct modes produce identical DOM.
+/// <para>
+/// <b>Handles are pre-allocated on the .NET side.</b> A buffered <c>createElement/Text/Comment</c>
+/// cannot return the JS handle (the call is one-way), so <see cref="AllocateHandle"/> draws the id
+/// from this counter and the op carries "create X AS handle N"; the JS applier registers the new
+/// node under N into the same registry the direct path uses. The counter survives across flushes and
+/// is carried in every frame header so the JS side keeps its own foreign-node allocator ahead of it.
+/// </para>
+/// <para>
+/// <b>Frame layout</b> (all multi-byte integers little-endian, explicit via
+/// <see cref="BinaryPrimitives"/>; the JS applier reads a <c>DataView</c> with <c>littleEndian=true</c>):
+/// <code>
+/// [0]        magic  (byte)  = 0xB6
+/// [1]        version(byte)  = 0x01
+/// [2..6)     opCount           (int32)
+/// [6..10)    nextHandle        (int32)  -- the .NET counter after this batch; JS adopts max(its, this)
+/// [10..14)   stringTableOffset (int32)  -- absolute byte offset where the string table begins
+/// [14..)     ops: each = [opcode:byte] then operands (int32 handles/indices, 1-byte bools)
+/// [offset]   stringCount(int32), then per string: [utf8ByteLength:int32][utf8 bytes]
+/// </code>
+/// Strings (tags, prop/event names, values) are interned per flush and referenced by int32 index; a
+/// null string is index <c>-1</c>. The <c>magic</c>/<c>version</c> pair lets the applier reject a
+/// drifted or corrupt frame loudly instead of misapplying it.
+/// </para>
+/// Zero per-flush managed allocation at steady state: the byte array, the intern dictionary, and the
+/// string list are cleared and reused; growth (array doubling) happens only when a flush exceeds the
+/// current capacity. Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+internal sealed class DomCommandBuffer
+{
+    /// <summary>The frame's leading byte — a sanity marker the applier validates.</summary>
+    internal const byte Magic = 0xB6;
+
+    /// <summary>The frame format version — bump on any layout or opcode change so drift fails loudly.</summary>
+    internal const byte Version = 0x01;
+
+    /// <summary>Header size: magic + version + opCount + nextHandle + stringTableOffset.</summary>
+    internal const int HeaderSize = 2 + 4 + 4 + 4;
+
+    /// <summary>Index sentinel for a null string operand.</summary>
+    internal const int NullStringIndex = -1;
+
+    private readonly Dictionary<string, int> _stringIndex = new(StringComparer.Ordinal);
+    private readonly List<string> _strings = [];
+    private byte[] _buffer;
+    private int _position;
+    private int _operationCount;
+    private int _nextHandle = 1; // JS handle registry starts at 1 (0 is the "no node" sentinel).
+
+    /// <summary>Creates a buffer with an initial capacity in bytes (grows as needed).</summary>
+    /// <param name="initialCapacity">The starting byte-array size.</param>
+    internal DomCommandBuffer(int initialCapacity = 8192)
+    {
+        _buffer = new byte[Math.Max(HeaderSize, initialCapacity)];
+        ResetFrame();
+    }
+
+    /// <summary>Whether any op has been written since the last <see cref="ResetFrame"/>.</summary>
+    internal bool HasPendingOperations => _operationCount > 0;
+
+    /// <summary>The number of ops written to the current frame (diagnostics/tests).</summary>
+    internal int OperationCount => _operationCount;
+
+    /// <summary>The next handle this buffer would allocate (tests/diagnostics).</summary>
+    internal int NextHandle => _nextHandle;
+
+    /// <summary>The backing array; valid only up to the length <see cref="FinalizeFrame"/> returns.</summary>
+    internal byte[] BackingArray => _buffer;
+
+    /// <summary>
+    /// Reserves and returns the next node handle from the .NET-side counter (upstream: the JS
+    /// <c>registerNode</c> id, moved to .NET so a one-way create op can name its result).
+    /// </summary>
+    internal int AllocateHandle() => _nextHandle++;
+
+    /// <summary>
+    /// Raises the handle counter above a handle the JS side just allocated for a foreign node (a
+    /// <c>parentNode</c>/<c>nextSibling</c>/<c>querySelector</c> result), keeping the two allocators
+    /// from ever issuing the same id. Called after a forced-flush read returns.
+    /// </summary>
+    /// <param name="foreignHandle">The handle the bridge returned.</param>
+    internal void ObserveForeignHandle(int foreignHandle)
+    {
+        if (foreignHandle >= _nextHandle)
+        {
+            _nextHandle = foreignHandle + 1;
+        }
+    }
+
+    /// <summary>Clears the frame for reuse — keeps the handle counter, which spans flushes.</summary>
+    internal void ResetFrame()
+    {
+        _position = HeaderSize;
+        _operationCount = 0;
+        _stringIndex.Clear();
+        _strings.Clear();
+    }
+
+    /// <summary>
+    /// Appends the string table, back-patches the header, and returns the frame's total byte length.
+    /// Read <see cref="BackingArray"/> only after this call — the string-table write may have grown
+    /// (reallocated) the array.
+    /// </summary>
+    internal int FinalizeFrame()
+    {
+        var stringTableOffset = _position;
+        EnsureCapacity(4);
+        WriteInt32Raw(_strings.Count);
+        foreach (var value in _strings)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            EnsureCapacity(4 + byteCount);
+            WriteInt32Raw(byteCount);
+            Encoding.UTF8.GetBytes(value, _buffer.AsSpan(_position, byteCount));
+            _position += byteCount;
+        }
+        _buffer[0] = Magic;
+        _buffer[1] = Version;
+        BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(2), _operationCount);
+        BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(6), _nextHandle);
+        BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(10), stringTableOffset);
+        return _position;
+    }
+
+    // --- op writers (one per buffered bridge op; operand order mirrors the JS applier) ------------
+
+    internal void WriteCreateElement(int handle, string tag, string? elementNamespace)
+    {
+        WriteOpcode(DomCommandOpcode.CreateElement);
+        WriteInt32(handle);
+        WriteStringReference(tag);
+        WriteStringReference(elementNamespace);
+    }
+
+    internal void WriteCreateText(int handle, string text)
+    {
+        WriteOpcode(DomCommandOpcode.CreateText);
+        WriteInt32(handle);
+        WriteStringReference(text);
+    }
+
+    internal void WriteCreateComment(int handle, string text)
+    {
+        WriteOpcode(DomCommandOpcode.CreateComment);
+        WriteInt32(handle);
+        WriteStringReference(text);
+    }
+
+    internal void WriteSetText(int handle, string text)
+    {
+        WriteOpcode(DomCommandOpcode.SetText);
+        WriteInt32(handle);
+        WriteStringReference(text);
+    }
+
+    internal void WriteSetElementText(int handle, string text)
+    {
+        WriteOpcode(DomCommandOpcode.SetElementText);
+        WriteInt32(handle);
+        WriteStringReference(text);
+    }
+
+    internal void WriteInsert(int parentHandle, int childHandle, int anchorHandle)
+    {
+        WriteOpcode(DomCommandOpcode.Insert);
+        WriteInt32(parentHandle);
+        WriteInt32(childHandle);
+        WriteInt32(anchorHandle);
+    }
+
+    internal void WriteRemove(int childHandle)
+    {
+        WriteOpcode(DomCommandOpcode.Remove);
+        WriteInt32(childHandle);
+    }
+
+    internal void WriteSetAttribute(int handle, string name, string value)
+        => WriteHandleNameValue(DomCommandOpcode.SetAttribute, handle, name, value);
+
+    internal void WriteRemoveAttribute(int handle, string name)
+        => WriteHandleName(DomCommandOpcode.RemoveAttribute, handle, name);
+
+    internal void WriteSetXlinkAttribute(int handle, string name, string value)
+        => WriteHandleNameValue(DomCommandOpcode.SetXlinkAttribute, handle, name, value);
+
+    internal void WriteRemoveXlinkAttribute(int handle, string name)
+        => WriteHandleName(DomCommandOpcode.RemoveXlinkAttribute, handle, name);
+
+    internal void WriteSetClassName(int handle, string value)
+    {
+        WriteOpcode(DomCommandOpcode.SetClassName);
+        WriteInt32(handle);
+        WriteStringReference(value);
+    }
+
+    internal void WriteSetStringProperty(int handle, string name, string value)
+        => WriteHandleNameValue(DomCommandOpcode.SetStringProperty, handle, name, value);
+
+    internal void WriteSetBooleanProperty(int handle, string name, bool value)
+    {
+        WriteOpcode(DomCommandOpcode.SetBooleanProperty);
+        WriteInt32(handle);
+        WriteStringReference(name);
+        WriteBoolean(value);
+    }
+
+    internal void WriteSetValueGuarded(int handle, string value)
+    {
+        WriteOpcode(DomCommandOpcode.SetValueGuarded);
+        WriteInt32(handle);
+        WriteStringReference(value);
+    }
+
+    internal void WriteSetStyleText(int handle, string cssText)
+    {
+        WriteOpcode(DomCommandOpcode.SetStyleText);
+        WriteInt32(handle);
+        WriteStringReference(cssText);
+    }
+
+    internal void WriteSetStyleProperty(int handle, string name, string value, bool important)
+    {
+        WriteOpcode(DomCommandOpcode.SetStyleProperty);
+        WriteInt32(handle);
+        WriteStringReference(name);
+        WriteStringReference(value);
+        WriteBoolean(important);
+    }
+
+    internal void WriteRemoveStyleProperty(int handle, string name)
+        => WriteHandleName(DomCommandOpcode.RemoveStyleProperty, handle, name);
+
+    internal void WriteAddEventListener(int handle, string eventName, bool once, bool capture, bool passive)
+    {
+        WriteOpcode(DomCommandOpcode.AddEventListener);
+        WriteInt32(handle);
+        WriteStringReference(eventName);
+        WriteBoolean(once);
+        WriteBoolean(capture);
+        WriteBoolean(passive);
+    }
+
+    internal void WriteRemoveEventListener(int handle, string eventName, bool capture)
+    {
+        WriteOpcode(DomCommandOpcode.RemoveEventListener);
+        WriteInt32(handle);
+        WriteStringReference(eventName);
+        WriteBoolean(capture);
+    }
+
+    // --- primitives ------------------------------------------------------------------------------
+
+    private void WriteHandleName(DomCommandOpcode opcode, int handle, string name)
+    {
+        WriteOpcode(opcode);
+        WriteInt32(handle);
+        WriteStringReference(name);
+    }
+
+    private void WriteHandleNameValue(DomCommandOpcode opcode, int handle, string name, string value)
+    {
+        WriteOpcode(opcode);
+        WriteInt32(handle);
+        WriteStringReference(name);
+        WriteStringReference(value);
+    }
+
+    private void WriteOpcode(DomCommandOpcode opcode)
+    {
+        EnsureCapacity(1);
+        _buffer[_position++] = (byte)opcode;
+        _operationCount++;
+    }
+
+    private void WriteInt32(int value)
+    {
+        EnsureCapacity(4);
+        WriteInt32Raw(value);
+    }
+
+    private void WriteInt32Raw(int value)
+    {
+        BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(_position, 4), value);
+        _position += 4;
+    }
+
+    private void WriteBoolean(bool value)
+    {
+        EnsureCapacity(1);
+        _buffer[_position++] = value ? (byte)1 : (byte)0;
+    }
+
+    private void WriteStringReference(string? value)
+    {
+        if (value is null)
+        {
+            WriteInt32(NullStringIndex);
+            return;
+        }
+        if (!_stringIndex.TryGetValue(value, out var index))
+        {
+            index = _strings.Count;
+            _strings.Add(value);
+            _stringIndex[value] = index;
+        }
+        WriteInt32(index);
+    }
+
+    private void EnsureCapacity(int additional)
+    {
+        var required = _position + additional;
+        if (required <= _buffer.Length)
+        {
+            return;
+        }
+        var capacity = _buffer.Length * 2;
+        while (capacity < required)
+        {
+            capacity *= 2;
+        }
+        Array.Resize(ref _buffer, capacity);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/DomCommandOpcode.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/DomCommandOpcode.cs
@@ -1,0 +1,78 @@
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The opcode for one buffered DOM node-op in the interop command buffer ([V01.01.04.05]). Every
+/// <em>write</em> op of <see cref="BrowserDomBridge"/> (the ones that return no data) has an opcode;
+/// read ops (<c>querySelector</c>, <c>parentNode</c>, <c>nextSibling</c>, <c>insertStaticContent</c>,
+/// <c>getRegistrySizes</c>) are not buffered — they force the buffer to apply and then call the
+/// bridge directly (see <see cref="BufferedBrowserNodeOperations"/>).
+/// <para>
+/// These values are a <b>wire contract</b> shared byte-for-byte with the JS applier in
+/// <c>vuecs-dom.js</c> (<c>applyCommandBuffer</c>): the frame carries a version byte so the two sides
+/// fail loudly rather than drift. Never renumber or reuse a value without bumping
+/// <see cref="DomCommandBuffer.Version"/> and the JS applier's accepted version. 0 is reserved
+/// (an all-zero buffer must decode as "no valid op", not a real op).
+/// </para>
+/// </summary>
+internal enum DomCommandOpcode : byte
+{
+    /// <summary>Create an element AS a pre-allocated handle: <c>[handle][tag][namespace?]</c>.</summary>
+    CreateElement = 1,
+
+    /// <summary>Create a text node AS a pre-allocated handle: <c>[handle][text]</c>.</summary>
+    CreateText = 2,
+
+    /// <summary>Create a comment node AS a pre-allocated handle: <c>[handle][text]</c>.</summary>
+    CreateComment = 3,
+
+    /// <summary>Set a text/comment node's content: <c>[handle][text]</c>.</summary>
+    SetText = 4,
+
+    /// <summary>Replace an element's content with text: <c>[handle][text]</c> (releases replaced children).</summary>
+    SetElementText = 5,
+
+    /// <summary>Insert child before anchor (0 anchor appends): <c>[parent][child][anchor]</c>.</summary>
+    Insert = 6,
+
+    /// <summary>Remove a node and release its subtree: <c>[handle]</c>.</summary>
+    Remove = 7,
+
+    /// <summary>Set an attribute: <c>[handle][name][value]</c>.</summary>
+    SetAttribute = 8,
+
+    /// <summary>Remove an attribute: <c>[handle][name]</c>.</summary>
+    RemoveAttribute = 9,
+
+    /// <summary>Set an <c>xlink:</c> attribute: <c>[handle][name][value]</c>.</summary>
+    SetXlinkAttribute = 10,
+
+    /// <summary>Remove an <c>xlink:</c> attribute: <c>[handle][name]</c>.</summary>
+    RemoveXlinkAttribute = 11,
+
+    /// <summary>Set <c>className</c>: <c>[handle][value]</c>.</summary>
+    SetClassName = 12,
+
+    /// <summary>Set a string DOM property: <c>[handle][name][value]</c>.</summary>
+    SetStringProperty = 13,
+
+    /// <summary>Set a boolean DOM property: <c>[handle][name][value:1]</c>.</summary>
+    SetBooleanProperty = 14,
+
+    /// <summary>Compare-and-set <c>value</c>: <c>[handle][value]</c>.</summary>
+    SetValueGuarded = 15,
+
+    /// <summary>Replace inline <c>style.cssText</c>: <c>[handle][cssText]</c>.</summary>
+    SetStyleText = 16,
+
+    /// <summary>Set one style property: <c>[handle][name][value][important:1]</c>.</summary>
+    SetStyleProperty = 17,
+
+    /// <summary>Remove one style property: <c>[handle][name]</c>.</summary>
+    RemoveStyleProperty = 18,
+
+    /// <summary>Attach a listener: <c>[handle][event][once:1][capture:1][passive:1]</c>.</summary>
+    AddEventListener = 19,
+
+    /// <summary>Detach a listener: <c>[handle][event][capture:1]</c>.</summary>
+    RemoveEventListener = 20,
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
@@ -88,6 +88,93 @@ function releaseSubtree(node, released) {
     return released
 }
 
+// Shared cores of setElementText/remove so the direct ops and the command-buffer applier release
+// handles identically (the applier collects them into one batch-wide array). [V01.01.04.05]
+function applySetElementText(nodeHandle, textContent, released) {
+    const element = getNode('setElementText', nodeHandle)
+    let child = element.firstChild
+    while (child) {
+        releaseSubtree(child, released)
+        child = child.nextSibling
+    }
+    element.textContent = textContent
+}
+
+function applyRemove(childHandle, released) {
+    const child = getNode('remove', childHandle)
+    if (child.parentNode) {
+        child.parentNode.removeChild(child)
+    }
+    releaseSubtree(child, released)
+}
+
+// --- command buffer ([V01.01.04.05]) --------------------------------------------------------------
+// The batched applier: the whole frame of node-ops crosses the boundary once per scheduler flush as
+// a MemoryView over WASM memory, is decoded by a static switch (no dynamic dispatch), and returns
+// every handle it released so the .NET side purges its invoker delegates in the same single call.
+// The frame layout and opcodes are the wire contract of DomCommandBuffer.cs; the leading magic and
+// version bytes make drift fail loudly. Buffered mode is behaviorally identical to the direct ops
+// (the void ops below reuse the exact same dom.* leaves).
+
+const COMMAND_MAGIC = 0xB6
+const COMMAND_VERSION = 0x01
+const textDecoder = new TextDecoder()
+
+// Register a node AS a handle the .NET side pre-allocated (a one-way buffered create cannot return
+// the id). Never advances nextHandle past the .NET counter; the frame header carries that.
+function registerNodeAs(handle, node) {
+    nodes.set(handle, node)
+    nodeHandles.set(node, handle)
+    if (handle >= nextHandle) {
+        nextHandle = handle + 1
+    }
+}
+
+function createElementAs(handle, tagName, namespaceName) {
+    try {
+        const namespaceUri = namespaceName ? namespaceUris[namespaceName] : undefined
+        const element = namespaceUri
+            ? document.createElementNS(namespaceUri, tagName)
+            : document.createElement(tagName)
+        registerNodeAs(handle, element)
+    } catch (error) {
+        fail('createElement', handle, `cannot create <${tagName}>: ${error.message}`)
+    }
+}
+
+function createTextAs(handle, textContent) {
+    registerNodeAs(handle, document.createTextNode(textContent))
+}
+
+function createCommentAs(handle, textContent) {
+    registerNodeAs(handle, document.createComment(textContent))
+}
+
+// Read the frame bytes out of the MemoryView. slice() returns a Uint8Array copy of the whole view;
+// copyTo is the fallback for runtimes that expose only it. This is one batched read, not per-op.
+function readCommandFrame(memoryView) {
+    if (typeof memoryView.slice === 'function') {
+        return memoryView.slice()
+    }
+    const length = memoryView.byteLength !== undefined ? memoryView.byteLength : memoryView.length
+    const target = new Uint8Array(length)
+    memoryView.copyTo(target)
+    return target
+}
+
+function readCommandStrings(bytes, view, offset) {
+    const count = view.getInt32(offset, true)
+    offset += 4
+    const strings = new Array(count)
+    for (let index = 0; index < count; index++) {
+        const byteLength = view.getInt32(offset, true)
+        offset += 4
+        strings[index] = textDecoder.decode(bytes.subarray(offset, offset + byteLength))
+        offset += byteLength
+    }
+    return strings
+}
+
 export async function initialize() {
     // Bind the single .NET dispatch entry point ([V01.01.04.03]): one JSExport carries the
     // whole typed payload as primitives and returns stop/prevent flags for the live event.
@@ -127,15 +214,9 @@ export const dom = {
     },
 
     setElementText: (nodeHandle, textContent) => {
-        const element = getNode('setElementText', nodeHandle)
         // Replacing content drops any registered child handles deterministically first.
         const released = []
-        let child = element.firstChild
-        while (child) {
-            releaseSubtree(child, released)
-            child = child.nextSibling
-        }
-        element.textContent = textContent
+        applySetElementText(nodeHandle, textContent, released)
         return released
     },
 
@@ -156,12 +237,9 @@ export const dom = {
     },
 
     remove: childHandle => {
-        const child = getNode('remove', childHandle)
-        if (child.parentNode) {
-            child.parentNode.removeChild(child)
-        }
-
-        return releaseSubtree(child, [])
+        const released = []
+        applyRemove(childHandle, released)
+        return released
     },
 
     parentNode: nodeHandle => {
@@ -349,5 +427,65 @@ export const dom = {
     // --- diagnostics ------------------------------------------------------------------------
 
     // Registry sizes for leak assertions (the [V01.01.04.01] stress criterion): [nodes, listener maps].
-    getRegistrySizes: () => [nodes.size, listeners.size]
+    getRegistrySizes: () => [nodes.size, listeners.size],
+
+    // Applies one batched command frame ([V01.01.04.05]) and returns the handles it released across
+    // the whole batch (the batched analogue of remove/setElementText's per-op return). The void
+    // leaves reuse the exact dom.* functions, so buffered output is identical to direct output.
+    applyCommandBuffer: memoryView => {
+        const bytes = readCommandFrame(memoryView)
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+        if (bytes[0] !== COMMAND_MAGIC || bytes[1] !== COMMAND_VERSION) {
+            fail('applyCommandBuffer', 0,
+                `command buffer version ${bytes[0]}/${bytes[1]} does not match ${COMMAND_MAGIC}/${COMMAND_VERSION}`)
+        }
+        const operationCount = view.getInt32(2, true)
+        const headerNextHandle = view.getInt32(6, true)
+        const stringTableOffset = view.getInt32(10, true)
+        const strings = readCommandStrings(bytes, view, stringTableOffset)
+        const released = []
+        let cursor = 14
+        // Operand readers advance the cursor; ECMAScript evaluates call arguments left-to-right, so
+        // inline reads consume operands in the exact order DomCommandBuffer encoded them.
+        const int = () => {
+            const value = view.getInt32(cursor, true)
+            cursor += 4
+            return value
+        }
+        const flag = () => bytes[cursor++] !== 0
+        const str = () => {
+            const index = int()
+            return index < 0 ? null : strings[index]
+        }
+        for (let operation = 0; operation < operationCount; operation++) {
+            const opcode = bytes[cursor++]
+            switch (opcode) {
+                case 1: createElementAs(int(), str(), str()); break
+                case 2: createTextAs(int(), str()); break
+                case 3: createCommentAs(int(), str()); break
+                case 4: dom.setText(int(), str()); break
+                case 5: applySetElementText(int(), str(), released); break
+                case 6: dom.insert(int(), int(), int()); break
+                case 7: applyRemove(int(), released); break
+                case 8: dom.setAttribute(int(), str(), str()); break
+                case 9: dom.removeAttribute(int(), str()); break
+                case 10: dom.setXlinkAttribute(int(), str(), str()); break
+                case 11: dom.removeXlinkAttribute(int(), str()); break
+                case 12: dom.setClassName(int(), str()); break
+                case 13: dom.setStringProperty(int(), str(), str()); break
+                case 14: dom.setBooleanProperty(int(), str(), flag()); break
+                case 15: dom.setValueGuarded(int(), str()); break
+                case 16: dom.setStyleText(int(), str()); break
+                case 17: dom.setStyleProperty(int(), str(), str(), flag()); break
+                case 18: dom.removeStyleProperty(int(), str()); break
+                case 19: dom.addEventListener(int(), str(), flag(), flag(), flag()); break
+                case 20: dom.removeEventListener(int(), str(), flag()); break
+                default: fail('applyCommandBuffer', 0, `unknown opcode ${opcode}`)
+            }
+        }
+        if (headerNextHandle > nextHandle) {
+            nextHandle = headerNextHandle
+        }
+        return released
+    }
 }

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// The C# reference decoder for the interop command buffer ([V01.01.04.05]): it decodes a finalized
+// frame and replays every op onto an InMemoryHandleDom, collecting the handles that remove /
+// setElementText released and returning them as the single apply-call result (the same shape the JS
+// applier returns and the same shape PurgeReleasedHandles consumes). It mirrors vuecs-dom.js's
+// applyCommandBuffer op-for-op; the browser applier is cross-checked live by the reviewer, this
+// decoder is the DOM-free CI oracle. Validates magic/version so a drifted frame fails loudly.
+internal static class CommandBufferDecoder
+{
+    internal static int[] Apply(byte[] frame, int length, InMemoryHandleDom dom)
+    {
+        if (length < DomCommandBuffer.HeaderSize)
+        {
+            throw new InvalidOperationException("Command buffer frame is shorter than its header.");
+        }
+        if (frame[0] != DomCommandBuffer.Magic || frame[1] != DomCommandBuffer.Version)
+        {
+            throw new InvalidOperationException(
+                $"Command buffer version mismatch: expected {DomCommandBuffer.Magic:X2}/{DomCommandBuffer.Version:X2}, "
+                + $"got {frame[0]:X2}/{frame[1]:X2}.");
+        }
+        var span = frame.AsSpan(0, length);
+        var operationCount = BinaryPrimitives.ReadInt32LittleEndian(span[2..]);
+        var stringTableOffset = BinaryPrimitives.ReadInt32LittleEndian(span[10..]);
+        var strings = ReadStringTable(span, stringTableOffset);
+
+        var released = new List<int>();
+        var cursor = DomCommandBuffer.HeaderSize;
+        for (var index = 0; index < operationCount; index++)
+        {
+            var opcode = (DomCommandOpcode)span[cursor++];
+            switch (opcode)
+            {
+                case DomCommandOpcode.CreateElement:
+                    dom.CreateElementAs(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, Str(strings, ReadInt(span, ref cursor)));
+                    break;
+                case DomCommandOpcode.CreateText:
+                    dom.CreateTextAs(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.CreateComment:
+                    dom.CreateCommentAs(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetText:
+                    dom.SetText(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetElementText:
+                    released.AddRange(dom.SetElementText(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!));
+                    break;
+                case DomCommandOpcode.Insert:
+                    dom.Insert(ReadInt(span, ref cursor), ReadInt(span, ref cursor), ReadInt(span, ref cursor));
+                    break;
+                case DomCommandOpcode.Remove:
+                    released.AddRange(dom.Remove(ReadInt(span, ref cursor)));
+                    break;
+                case DomCommandOpcode.SetAttribute:
+                    dom.SetAttribute(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.RemoveAttribute:
+                    dom.RemoveAttribute(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetXlinkAttribute:
+                    dom.SetXlinkAttribute(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.RemoveXlinkAttribute:
+                    dom.RemoveXlinkAttribute(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetClassName:
+                    dom.SetClassName(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetStringProperty:
+                    dom.SetStringProperty(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetBooleanProperty:
+                    dom.SetBooleanProperty(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, ReadBool(span, ref cursor));
+                    break;
+                case DomCommandOpcode.SetValueGuarded:
+                    dom.SetValueGuarded(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetStyleText:
+                    dom.SetStyleText(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.SetStyleProperty:
+                    dom.SetStyleProperty(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, Str(strings, ReadInt(span, ref cursor))!, ReadBool(span, ref cursor));
+                    break;
+                case DomCommandOpcode.RemoveStyleProperty:
+                    dom.RemoveStyleProperty(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.AddEventListener:
+                    dom.AddEventListener(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, ReadBool(span, ref cursor), ReadBool(span, ref cursor), ReadBool(span, ref cursor));
+                    break;
+                case DomCommandOpcode.RemoveEventListener:
+                    dom.RemoveEventListener(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, ReadBool(span, ref cursor));
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown command-buffer opcode {(byte)opcode}.");
+            }
+        }
+        return [.. released];
+    }
+
+    private static string?[] ReadStringTable(ReadOnlySpan<byte> span, int offset)
+    {
+        var count = BinaryPrimitives.ReadInt32LittleEndian(span[offset..]);
+        offset += 4;
+        var strings = new string?[count];
+        for (var index = 0; index < count; index++)
+        {
+            var byteLength = BinaryPrimitives.ReadInt32LittleEndian(span[offset..]);
+            offset += 4;
+            strings[index] = Encoding.UTF8.GetString(span.Slice(offset, byteLength));
+            offset += byteLength;
+        }
+        return strings;
+    }
+
+    private static string? Str(string?[] strings, int index) => index < 0 ? null : strings[index];
+
+    private static int ReadInt(ReadOnlySpan<byte> span, ref int cursor)
+    {
+        var value = BinaryPrimitives.ReadInt32LittleEndian(span[cursor..]);
+        cursor += 4;
+        return value;
+    }
+
+    private static bool ReadBool(ReadOnlySpan<byte> span, ref int cursor) => span[cursor++] != 0;
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/CommandBufferDifferentialTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/CommandBufferDifferentialTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+using Assimalign.Vue.Shared;
+using Assimalign.Vue.Testing;
+
+using static Assimalign.Vue.RuntimeCore.VirtualNodeFactory;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// The heart of [V01.01.04.05]: a rich battery of renderer scenarios runs through the DIRECT node-ops
+// and through the BUFFERED node-ops (encode -> single-apply decode/replay) and must produce
+// byte-identical serialized DOM — batching is behaviorally invisible. Plus the interop-call-counter
+// criterion: hundreds of mutations in one flush collapse into exactly one apply call. Both worlds
+// share the ambient scheduler, so they run sequentially with a reset between (single-threaded model).
+// Browser-annotated like the other tests that touch the browser-only node-ops types; nothing here
+// crosses a real interop boundary (the buffered applier is the in-memory CommandBufferDecoder).
+[SupportedOSPlatform("browser")]
+public sealed class CommandBufferDifferentialTests
+{
+    [Theory]
+    [InlineData("element-text")]
+    [InlineData("attributes")]
+    [InlineData("style-string-then-map")]
+    [InlineData("fragment-children")]
+    [InlineData("comment")]
+    [InlineData("static-content")]
+    [InlineData("keyed-reorder")]
+    [InlineData("keyed-insert-remove")]
+    [InlineData("unkeyed-fragment")]
+    [InlineData("array-to-text")]
+    [InlineData("component-reactive")]
+    [InlineData("event-listeners")]
+    [InlineData("v-show-toggle")]
+    [InlineData("replace-mismatched-type")]
+    [InlineData("svg-xlink")]
+    [InlineData("mount-then-unmount")]
+    public void BufferedMode_ProducesByteIdenticalDom_ToDirectMode(string scenarioName)
+    {
+        var outcome = Run(GetScenario(scenarioName));
+
+        outcome.BufferedSerialized.ShouldBe(outcome.DirectSerialized);
+    }
+
+    // The interop-call-counter acceptance criterion: one boundary crossing per scheduler flush
+    // regardless of op count, on a workload of hundreds of mutations per flush.
+    [Fact]
+    public void BufferedFlush_MakesExactlyOneInteropCall_PerFlush_RegardlessOfOpCount()
+    {
+        const int itemCount = 300;
+        var outcome = Run((renderer, container, pump) =>
+        {
+            var revision = Reactive.Reference(0);
+            var component = new RenderComponent((_, _) => () =>
+            {
+                var items = new VirtualNode?[itemCount];
+                for (var index = 0; index < items.Length; index++)
+                {
+                    items[index] = Element("span", $"item {index}:{revision.Value}");
+                }
+                return Element("div", (VirtualNodeProperties?)null, items);
+            });
+            renderer.Render(Component(component), container); // flush 1: mount
+            revision.Value = 1;
+            pump.RunUntilIdle();                              // flush 2: reactive update
+        });
+
+        outcome.BufferedSerialized.ShouldBe(outcome.DirectSerialized);
+        // Two flushes, each exactly one apply — never one-per-mutation.
+        outcome.InteropCalls.ShouldBe(2);
+        outcome.ApplyOperationCounts.Count.ShouldBe(2);
+        outcome.ApplyOperationCounts[0].ShouldBeGreaterThan(itemCount); // mount: creates + text + inserts
+        outcome.ApplyOperationCounts[1].ShouldBe(itemCount);            // update: itemCount text writes, one call
+    }
+
+    // --- scenarios -------------------------------------------------------------------------------
+
+    private static Action<Renderer<int>, int, TestSchedulerPump> GetScenario(string name) => name switch
+    {
+        "element-text" => ElementText,
+        "attributes" => Attributes,
+        "style-string-then-map" => StyleStringThenMap,
+        "fragment-children" => FragmentChildren,
+        "comment" => CommentNode,
+        "static-content" => StaticContent,
+        "keyed-reorder" => KeyedReorder,
+        "keyed-insert-remove" => KeyedInsertRemove,
+        "unkeyed-fragment" => UnkeyedFragment,
+        "array-to-text" => ArrayToText,
+        "component-reactive" => ComponentReactive,
+        "event-listeners" => EventListeners,
+        "v-show-toggle" => VShowToggle,
+        "replace-mismatched-type" => ReplaceMismatchedType,
+        "svg-xlink" => SvgXlink,
+        "mount-then-unmount" => MountThenUnmount,
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown scenario."),
+    };
+
+    private static void ElementText(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Element("span", "hi")), container);
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Element("span", "bye")), container);
+    }
+
+    private static void Attributes(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(
+            Element("input", Properties(("id", "a"), ("class", "row"), ("data-index", 1), ("disabled", true), ("title", "first"))),
+            container);
+        renderer.Render(
+            Element("input", Properties(("id", "b"), ("class", "row active"), ("disabled", false), ("title", "second"))),
+            container);
+    }
+
+    private static void StyleStringThenMap(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", Properties(("style", "color:red")), "x"), container);
+        renderer.Render(Element("div", Properties(("style", StyleMap(("color", "blue"), ("font-weight", "bold")))), "x"), container);
+        renderer.Render(Element("div", Properties(("style", StyleMap(("color", "green !important")))), "x"), container);
+    }
+
+    private static void FragmentChildren(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Fragment(Element("span", "a"), Element("span", "b"))), container);
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Fragment(Element("span", "a"), Element("span", "c"), Element("span", "d"))), container);
+    }
+
+    private static void CommentNode(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Comment("first"), Element("span", "x")), container);
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Comment("first"), Element("span", "y")), container);
+    }
+
+    private static void StaticContent(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Static("<b>bold</b><i>italic</i>"), Element("span", "y")), container);
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Static("<b>bold</b><i>italic</i>"), Element("span", "z")), container);
+    }
+
+    private static void KeyedReorder(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("ul", (VirtualNodeProperties?)null, Li("a"), Li("b"), Li("c"), Li("d")), container);
+        renderer.Render(Element("ul", (VirtualNodeProperties?)null, Li("d"), Li("b"), Li("a"), Li("c")), container);
+    }
+
+    private static void KeyedInsertRemove(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("ul", (VirtualNodeProperties?)null, Li("a"), Li("b"), Li("c")), container);
+        renderer.Render(Element("ul", (VirtualNodeProperties?)null, Li("a"), Li("x"), Li("c")), container);
+        renderer.Render(Element("ul", (VirtualNodeProperties?)null, Li("a"), Li("c")), container);
+    }
+
+    private static void UnkeyedFragment(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(
+            Element("div", (VirtualNodeProperties?)null, Fragment(new VirtualNode?[] { Element("span", "a"), Element("span", "b") }, null, PatchFlags.UnkeyedFragment)),
+            container);
+        renderer.Render(
+            Element("div", (VirtualNodeProperties?)null, Fragment(new VirtualNode?[] { Element("span", "a") }, null, PatchFlags.UnkeyedFragment)),
+            container);
+    }
+
+    private static void ArrayToText(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Element("span", "x"), Element("span", "y")), container);
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, "just text"), container);
+    }
+
+    private static void ComponentReactive(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        var count = Reactive.Reference(0);
+        var component = new RenderComponent((_, _) => () => Element("div", (VirtualNodeProperties?)null, Element("span", $"count {count.Value}")));
+        renderer.Render(Component(component), container);
+        count.Value = 5;
+        pump.RunUntilIdle();
+    }
+
+    private static void EventListeners(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        Action first = static () => { };
+        Action second = static () => { };
+        renderer.Render(Element("button", Properties(("onClick", first)), "go"), container);
+        renderer.Render(Element("button", Properties(("onClick", second)), "go"), container); // delegate swap
+        renderer.Render(Element("button", Properties(("type", "button")), "go"), container);   // listener removed
+    }
+
+    private static void VShowToggle(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        var condition = Reactive.Reference<object?>(true);
+        var component = new RenderComponent((_, _) => () =>
+            Directives.WithDirectives(Element("div", (VirtualNodeProperties?)null, "content"), VShow.Instance, condition.Value));
+        renderer.Render(Component(component), container);
+        pump.RunUntilIdle();
+        condition.Value = false;
+        pump.RunUntilIdle();
+        condition.Value = true;
+        pump.RunUntilIdle();
+    }
+
+    private static void ReplaceMismatchedType(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Element("span", "a"), Element("p", "b")), container);
+        // span -> aside is a type mismatch: the renderer reads NextSibling(span) for the mount anchor,
+        // which forces the buffered path to flush before reading. The DOM must still match direct mode.
+        renderer.Render(Element("div", (VirtualNodeProperties?)null, Element("aside", "a"), Element("p", "b")), container);
+    }
+
+    private static void SvgXlink(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(Element("svg", (VirtualNodeProperties?)null, Element("use", Properties(("xlink:href", "#a")))), container);
+        renderer.Render(Element("svg", (VirtualNodeProperties?)null, Element("use", Properties(("xlink:href", "#b")))), container);
+    }
+
+    private static void MountThenUnmount(Renderer<int> renderer, int container, TestSchedulerPump pump)
+    {
+        renderer.Render(
+            Element("div", (VirtualNodeProperties?)null, Element("span", "a"), Element("button", Properties(("onClick", (Action)(static () => { }))), "b")),
+            container);
+        renderer.Render(null, container); // full unmount: teardown + released-handle purge
+    }
+
+    private static VirtualNode Li(string key) => Element("li", Properties(("key", key)), key);
+
+    private static IReadOnlyDictionary<string, object?> StyleMap(params (string Name, string Value)[] entries)
+    {
+        var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var (name, value) in entries)
+        {
+            map[name] = value;
+        }
+        return map;
+    }
+
+    // --- differential runner ---------------------------------------------------------------------
+
+    private static DifferentialOutcome Run(Action<Renderer<int>, int, TestSchedulerPump> scenario)
+    {
+        var direct = RunDirect(scenario);
+        var (buffered, interopCalls, applyOperationCounts) = RunBuffered(scenario);
+        return new DifferentialOutcome(direct, buffered, interopCalls, applyOperationCounts);
+    }
+
+    private static string RunDirect(Action<Renderer<int>, int, TestSchedulerPump> scenario)
+    {
+        Scheduler.Reset();
+        var pump = TestSchedulerPump.Install();
+        var dom = new InMemoryHandleDom();
+        var container = dom.CreateElement("root", null);
+        using var world = new DirectHandleDomWorld(dom);
+        var renderer = RendererFactory.CreateRenderer(world.Options);
+        try
+        {
+            scenario(renderer, container, pump);
+            pump.RunUntilIdle();
+            return dom.Serialize(container);
+        }
+        finally
+        {
+            pump.Dispose();
+            Scheduler.Reset();
+        }
+    }
+
+    private static (string Serialized, int InteropCalls, IReadOnlyList<int> ApplyOperationCounts) RunBuffered(
+        Action<Renderer<int>, int, TestSchedulerPump> scenario)
+    {
+        Scheduler.Reset();
+        var pump = TestSchedulerPump.Install();
+        var applyOperationCounts = new List<int>();
+        var dom = new InMemoryHandleDom();
+        var container = dom.CreateElement("root", null);
+        var buffered = new BufferedBrowserNodeOperations(
+            (frame, length) =>
+            {
+                applyOperationCounts.Add(BinaryPrimitives.ReadInt32LittleEndian(frame.AsSpan(2)));
+                return CommandBufferDecoder.Apply(frame, length, dom);
+            },
+            static _ => 0,
+            dom.ParentNode,
+            dom.NextSibling,
+            dom.InsertStaticContent);
+        buffered.Activate();
+        buffered.ObserveForeignHandle(container);
+        var renderer = RendererFactory.CreateRenderer(buffered.Create());
+        try
+        {
+            scenario(renderer, container, pump);
+            pump.RunUntilIdle();
+            return (dom.Serialize(container), buffered.InteropCallCount, applyOperationCounts);
+        }
+        finally
+        {
+            buffered.Deactivate();
+            pump.Dispose();
+            Scheduler.Reset();
+        }
+    }
+
+    private sealed record DifferentialOutcome(
+        string DirectSerialized,
+        string BufferedSerialized,
+        int InteropCalls,
+        IReadOnlyList<int> ApplyOperationCounts);
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DirectHandleDomWorld.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DirectHandleDomWorld.cs
@@ -1,0 +1,67 @@
+using System;
+
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// The DIRECT-mode world for the differential test ([V01.01.04.05]): a RendererOptions<int> wired to
+// an InMemoryHandleDom exactly the way production BrowserNodeOperations wires the JS bridge — an
+// invoker registry for events, BrowserPropertyPatcher over leaf ops, per-op released-handle purge on
+// remove/setElementText — plus the ambient BrowserDirectiveOperations (v-model/v-show) pointed at the
+// same DOM for the scope's lifetime. The buffered world runs the identical scenario through the
+// command buffer; byte-identical Serialize() output proves batching is behaviorally invisible.
+internal sealed class DirectHandleDomWorld : IDisposable
+{
+    private readonly BrowserDirectiveOperations? _previousDirectiveOperations;
+
+    internal DirectHandleDomWorld(InMemoryHandleDom dom)
+    {
+        var invokers = new BrowserEventInvokerRegistry(
+            (handle, eventName, once, capture, passive) => dom.AddEventListener(handle, eventName, once, capture, passive),
+            (handle, eventName, capture) => dom.RemoveEventListener(handle, eventName, capture));
+        var leaf = new BrowserPropertyLeafOperations
+        {
+            SetAttribute = dom.SetAttribute,
+            RemoveAttribute = dom.RemoveAttribute,
+            SetXlinkAttribute = dom.SetXlinkAttribute,
+            RemoveXlinkAttribute = dom.RemoveXlinkAttribute,
+            SetClassName = dom.SetClassName,
+            SetStringProperty = dom.SetStringProperty,
+            SetBooleanProperty = dom.SetBooleanProperty,
+            SetValueGuarded = dom.SetValueGuarded,
+            SetStyleText = dom.SetStyleText,
+            SetStyleProperty = dom.SetStyleProperty,
+            RemoveStyleProperty = dom.RemoveStyleProperty,
+            SetEventListener = invokers.SetListener,
+        };
+        Options = new RendererOptions<int>
+        {
+            Insert = (child, parent, anchor) => dom.Insert(parent, child, anchor),
+            Remove = child => invokers.PurgeReleasedHandles(dom.Remove(child)),
+            CreateElement = dom.CreateElement,
+            CreateText = dom.CreateText,
+            CreateComment = dom.CreateComment,
+            SetText = dom.SetText,
+            SetElementText = (node, text) => invokers.PurgeReleasedHandles(dom.SetElementText(node, text)),
+            ParentNode = dom.ParentNode,
+            NextSibling = dom.NextSibling,
+            PatchProperty = (element, elementTag, propertyName, previousValue, nextValue, elementNamespace) =>
+                BrowserPropertyPatcher.Patch(leaf, element, elementTag, propertyName, previousValue, nextValue, elementNamespace),
+            QuerySelector = _ => 0,
+            InsertStaticContent = dom.InsertStaticContent,
+        };
+        _previousDirectiveOperations = BrowserDirectiveOperations.Current;
+        BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
+        {
+            SetModelListener = (element, rawPropertyName, handler) => invokers.SetModelListener(element, rawPropertyName, handler),
+            SetValueGuarded = leaf.SetValueGuarded,
+            SetBooleanProperty = leaf.SetBooleanProperty,
+            SetStyleProperty = leaf.SetStyleProperty,
+            RemoveStyleProperty = leaf.RemoveStyleProperty,
+        };
+    }
+
+    internal RendererOptions<int> Options { get; }
+
+    public void Dispose() => BrowserDirectiveOperations.Current = _previousDirectiveOperations;
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DomCommandBufferTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DomCommandBufferTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Buffers.Binary;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// Unit-level coverage of the command-buffer encoder ([V01.01.04.05]): every opcode round-trips
+// through encode -> finalize -> decode to the same DOM the ops describe, the frame header is
+// well-formed, strings are interned, handles are pre-allocated from the .NET counter, and a version
+// mismatch is rejected loudly. The full renderer differential run is in
+// CommandBufferDifferentialTests; this file pins the wire format itself.
+public sealed class DomCommandBufferTests
+{
+    [Fact]
+    public void EveryOpcode_RoundTripsThroughEncodeAndDecode_ToTheSameDom()
+    {
+        var expected = new InMemoryHandleDom();
+        var buffer = new DomCommandBuffer();
+
+        // Pre-allocate handles from the buffer so the "expected" DOM and the decoded DOM agree on ids.
+        var root = buffer.AllocateHandle();
+        expected.CreateElementAs(root, "div", null);
+        buffer.WriteCreateElement(root, "div", null);
+
+        var svg = buffer.AllocateHandle();
+        expected.CreateElementAs(svg, "svg", "svg");
+        buffer.WriteCreateElement(svg, "svg", "svg");
+
+        var text = buffer.AllocateHandle();
+        expected.CreateTextAs(text, "hello");
+        buffer.WriteCreateText(text, "hello");
+
+        var comment = buffer.AllocateHandle();
+        expected.CreateCommentAs(comment, "note");
+        buffer.WriteCreateComment(comment, "note");
+
+        foreach (var (child, anchor) in new[] { (text, 0), (svg, text), (comment, 0) })
+        {
+            expected.Insert(root, child, anchor);
+            buffer.WriteInsert(root, child, anchor);
+        }
+
+        expected.SetText(text, "world");
+        buffer.WriteSetText(text, "world");
+        expected.SetAttribute(root, "id", "app");
+        buffer.WriteSetAttribute(root, "id", "app");
+        expected.RemoveAttribute(root, "id");
+        buffer.WriteRemoveAttribute(root, "id");
+        expected.SetXlinkAttribute(svg, "xlink:href", "#x");
+        buffer.WriteSetXlinkAttribute(svg, "xlink:href", "#x");
+        expected.RemoveXlinkAttribute(svg, "xlink:href");
+        buffer.WriteRemoveXlinkAttribute(svg, "xlink:href");
+        expected.SetClassName(root, "row active");
+        buffer.WriteSetClassName(root, "row active");
+        expected.SetStringProperty(root, "innerHTML", "<b>x</b>");
+        buffer.WriteSetStringProperty(root, "innerHTML", "<b>x</b>");
+        expected.SetBooleanProperty(root, "hidden", true);
+        buffer.WriteSetBooleanProperty(root, "hidden", true);
+        expected.SetValueGuarded(root, "typed");
+        buffer.WriteSetValueGuarded(root, "typed");
+        expected.SetStyleText(root, "color:red");
+        buffer.WriteSetStyleText(root, "color:red");
+        expected.SetStyleProperty(root, "color", "blue", important: true);
+        buffer.WriteSetStyleProperty(root, "color", "blue", important: true);
+        expected.RemoveStyleProperty(root, "color");
+        buffer.WriteRemoveStyleProperty(root, "color");
+        expected.AddEventListener(root, "click", once: true, capture: false, passive: true);
+        buffer.WriteAddEventListener(root, "click", once: true, capture: false, passive: true);
+        expected.RemoveEventListener(root, "click", capture: false);
+        buffer.WriteRemoveEventListener(root, "click", capture: false);
+
+        var actual = new InMemoryHandleDom();
+        var length = buffer.FinalizeFrame();
+        CommandBufferDecoder.Apply(buffer.BackingArray, length, actual);
+
+        actual.Serialize(root).ShouldBe(expected.Serialize(root));
+    }
+
+    [Fact]
+    public void FinalizeFrame_WritesAWellFormedVersionedHeader()
+    {
+        var buffer = new DomCommandBuffer();
+        var handle = buffer.AllocateHandle();
+        buffer.WriteCreateElement(handle, "div", null);
+        buffer.WriteSetAttribute(handle, "id", "a");
+
+        var length = buffer.FinalizeFrame();
+        var frame = buffer.BackingArray.AsSpan(0, length);
+
+        frame[0].ShouldBe(DomCommandBuffer.Magic);
+        frame[1].ShouldBe(DomCommandBuffer.Version);
+        BinaryPrimitives.ReadInt32LittleEndian(frame[2..]).ShouldBe(2); // opCount
+        BinaryPrimitives.ReadInt32LittleEndian(frame[6..]).ShouldBe(2); // nextHandle after 1 allocation
+        var stringTableOffset = BinaryPrimitives.ReadInt32LittleEndian(frame[10..]);
+        stringTableOffset.ShouldBeGreaterThanOrEqualTo(DomCommandBuffer.HeaderSize);
+        stringTableOffset.ShouldBeLessThan(length);
+    }
+
+    [Fact]
+    public void RepeatedStrings_AreInternedOnce_InTheStringTable()
+    {
+        var buffer = new DomCommandBuffer();
+        // "div" and "class" each appear many times; the table should hold each exactly once.
+        for (var index = 0; index < 5; index++)
+        {
+            var handle = buffer.AllocateHandle();
+            buffer.WriteCreateElement(handle, "div", null);
+            buffer.WriteSetClassName(handle, "class");
+        }
+
+        var length = buffer.FinalizeFrame();
+        var stringTableOffset = BinaryPrimitives.ReadInt32LittleEndian(buffer.BackingArray.AsSpan(10));
+        var stringCount = BinaryPrimitives.ReadInt32LittleEndian(buffer.BackingArray.AsSpan(stringTableOffset));
+
+        stringCount.ShouldBe(2); // "div", "class" — deduplicated regardless of op count
+        length.ShouldBeGreaterThan(DomCommandBuffer.HeaderSize);
+    }
+
+    [Fact]
+    public void AllocateHandle_DrawsAscendingIdsFromOne()
+    {
+        var buffer = new DomCommandBuffer();
+
+        buffer.AllocateHandle().ShouldBe(1);
+        buffer.AllocateHandle().ShouldBe(2);
+        buffer.AllocateHandle().ShouldBe(3);
+        buffer.NextHandle.ShouldBe(4);
+    }
+
+    [Fact]
+    public void ObserveForeignHandle_KeepsTheCounterAboveJsAllocatedHandles()
+    {
+        var buffer = new DomCommandBuffer();
+        buffer.AllocateHandle().ShouldBe(1);
+
+        // A read (parentNode/nextSibling/querySelector) registered a foreign node JS-side as handle 7.
+        buffer.ObserveForeignHandle(7);
+
+        buffer.AllocateHandle().ShouldBe(8); // never collides with the foreign id
+    }
+
+    [Fact]
+    public void ResetFrame_ClearsOpsButKeepsTheHandleCounter()
+    {
+        var buffer = new DomCommandBuffer();
+        var first = buffer.AllocateHandle();
+        buffer.WriteCreateElement(first, "div", null);
+        buffer.FinalizeFrame();
+        buffer.HasPendingOperations.ShouldBeTrue();
+
+        buffer.ResetFrame();
+
+        buffer.HasPendingOperations.ShouldBeFalse();
+        buffer.OperationCount.ShouldBe(0);
+        buffer.AllocateHandle().ShouldBe(2); // counter survived the reset (handles are process-global)
+    }
+
+    [Fact]
+    public void Remove_ReturnsTheReleasedSubtreeHandles_FromTheApplyCall()
+    {
+        var dom = new InMemoryHandleDom();
+        var buffer = new DomCommandBuffer();
+        var parent = buffer.AllocateHandle();
+        var child = buffer.AllocateHandle();
+        var grandchild = buffer.AllocateHandle();
+        buffer.WriteCreateElement(parent, "ul", null);
+        buffer.WriteCreateElement(child, "li", null);
+        buffer.WriteCreateText(grandchild, "x");
+        buffer.WriteInsert(parent, child, 0);
+        buffer.WriteInsert(child, grandchild, 0);
+        buffer.WriteRemove(child);
+
+        var released = CommandBufferDecoder.Apply(buffer.BackingArray, buffer.FinalizeFrame(), dom);
+
+        // The single apply call reports every released handle in the removed subtree (child + text).
+        released.ShouldBe([child, grandchild], ignoreOrder: false);
+    }
+
+    [Fact]
+    public void Decoder_RejectsAFrameWithAMismatchedVersion()
+    {
+        var buffer = new DomCommandBuffer();
+        var handle = buffer.AllocateHandle();
+        buffer.WriteCreateElement(handle, "div", null);
+        var length = buffer.FinalizeFrame();
+        buffer.BackingArray[1] = 0x7F; // corrupt the version byte
+
+        var dom = new InMemoryHandleDom();
+        var exception = Record.Exception(() => CommandBufferDecoder.Apply(buffer.BackingArray, length, dom));
+
+        exception.ShouldBeOfType<InvalidOperationException>();
+        exception!.Message.ShouldContain("version mismatch");
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+// A DOM-free, int-handle in-memory DOM that mirrors vuecs-dom.js faithfully: a handle -> node
+// registry, deterministic subtree release on remove/setElementText, and the create/insert/text/leaf
+// ops the renderer drives. It is the shared "device" both the DIRECT node-ops and the command-buffer
+// DECODER drive in the differential test ([V01.01.04.05]) — the only variable under test is direct
+// calls vs. encode/decode/replay, so byte-identical Serialize() output proves the buffer round-trips
+// every op with its exact arguments. Serialize() emits a deterministic, total fingerprint of node
+// state (attributes/props/styles/listeners sorted), not merely visible HTML, so any divergence shows.
+internal sealed class InMemoryHandleDom
+{
+    private readonly Dictionary<int, Node> _nodes = [];
+    private int _nextHandle = 1; // mirrors the JS registry; 0 is the "no node" sentinel.
+
+    internal int NodeCount => _nodes.Count;
+
+    // --- allocation (direct path allocates here; buffered path pre-allocates and registers AS) -----
+
+    internal int CreateElement(string tag, string? elementNamespace)
+        => Register(new Node(NodeKind.Element, tag) { ElementNamespace = elementNamespace });
+
+    internal int CreateText(string text) => Register(new Node(NodeKind.Text, "#text") { Text = text });
+
+    internal int CreateComment(string text) => Register(new Node(NodeKind.Comment, "#comment") { Text = text });
+
+    internal void CreateElementAs(int handle, string tag, string? elementNamespace)
+        => RegisterAs(handle, new Node(NodeKind.Element, tag) { ElementNamespace = elementNamespace });
+
+    internal void CreateTextAs(int handle, string text)
+        => RegisterAs(handle, new Node(NodeKind.Text, "#text") { Text = text });
+
+    internal void CreateCommentAs(int handle, string text)
+        => RegisterAs(handle, new Node(NodeKind.Comment, "#comment") { Text = text });
+
+    // --- structural ------------------------------------------------------------------------------
+
+    internal void Insert(int parentHandle, int childHandle, int anchorHandle)
+    {
+        var parent = Get(parentHandle);
+        var child = Get(childHandle);
+        if (child.Parent != 0 && _nodes.TryGetValue(child.Parent, out var oldParent))
+        {
+            oldParent.Children.Remove(childHandle);
+        }
+        child.Parent = parentHandle;
+        if (anchorHandle == 0)
+        {
+            parent.Children.Add(childHandle);
+            return;
+        }
+        var index = parent.Children.IndexOf(anchorHandle);
+        parent.Children.Insert(index < 0 ? parent.Children.Count : index, childHandle);
+    }
+
+    internal int[] Remove(int childHandle)
+    {
+        var child = Get(childHandle);
+        if (child.Parent != 0 && _nodes.TryGetValue(child.Parent, out var parent))
+        {
+            parent.Children.Remove(childHandle);
+        }
+        child.Parent = 0;
+        var released = new List<int>();
+        ReleaseSubtree(childHandle, released);
+        return [.. released];
+    }
+
+    internal int[] SetElementText(int handle, string text)
+    {
+        var element = Get(handle);
+        var released = new List<int>();
+        foreach (var childHandle in element.Children.ToArray())
+        {
+            ReleaseSubtree(childHandle, released);
+        }
+        element.Children.Clear();
+        // Content becomes a single text run; model it as the element's own text (serialized inline).
+        element.Text = text;
+        return [.. released];
+    }
+
+    internal void SetText(int handle, string text) => Get(handle).Text = text;
+
+    internal int ParentNode(int handle)
+    {
+        var parent = Get(handle).Parent;
+        return parent;
+    }
+
+    internal int NextSibling(int handle)
+    {
+        var node = Get(handle);
+        if (node.Parent == 0 || !_nodes.TryGetValue(node.Parent, out var parent))
+        {
+            return 0;
+        }
+        var index = parent.Children.IndexOf(handle);
+        return index >= 0 && index + 1 < parent.Children.Count ? parent.Children[index + 1] : 0;
+    }
+
+    internal (int First, int Last) InsertStaticContent(string content, int parentHandle, int anchorHandle, string? elementNamespace)
+    {
+        // One raw node stands in for the parsed chunk (parity with @vue/runtime-test): the buffered
+        // path forces a flush and calls this exactly as the direct path does, so both DOMs match.
+        var handle = Register(new Node(NodeKind.RawStatic, "#static") { Text = content, ElementNamespace = elementNamespace });
+        Insert(parentHandle, handle, anchorHandle);
+        return (handle, handle);
+    }
+
+    // --- leaf appliers (mirror BrowserPropertyLeafOperations 1:1) --------------------------------
+
+    internal void SetAttribute(int handle, string name, string value) => Get(handle).Attributes[name] = value;
+
+    internal void RemoveAttribute(int handle, string name) => Get(handle).Attributes.Remove(name);
+
+    internal void SetXlinkAttribute(int handle, string name, string value) => Get(handle).Attributes[name] = value;
+
+    internal void RemoveXlinkAttribute(int handle, string name) => Get(handle).Attributes.Remove(name);
+
+    internal void SetClassName(int handle, string value) => Get(handle).Attributes["class"] = value;
+
+    internal void SetStringProperty(int handle, string name, string value) => Get(handle).Properties[name] = value;
+
+    internal void SetBooleanProperty(int handle, string name, bool value) => Get(handle).BooleanProperties[name] = value;
+
+    internal void SetValueGuarded(int handle, string value)
+    {
+        var node = Get(handle);
+        if (!string.Equals(node.Value, value, StringComparison.Ordinal))
+        {
+            node.Value = value;
+            node.ValueWriteCount++;
+        }
+    }
+
+    internal void SetStyleText(int handle, string cssText) => Get(handle).StyleText = cssText;
+
+    internal void SetStyleProperty(int handle, string name, string value, bool important)
+        => Get(handle).Styles[name] = important ? value + " !important" : value;
+
+    internal void RemoveStyleProperty(int handle, string name) => Get(handle).Styles.Remove(name);
+
+    internal void AddEventListener(int handle, string eventName, bool once, bool capture, bool passive)
+        => Get(handle).Listeners[capture ? eventName + "|capture" : eventName] = $"once={once},passive={passive}";
+
+    internal void RemoveEventListener(int handle, string eventName, bool capture)
+        => Get(handle).Listeners.Remove(capture ? eventName + "|capture" : eventName);
+
+    // --- serialization (deterministic total fingerprint) -----------------------------------------
+
+    internal string Serialize(int handle)
+    {
+        var builder = new StringBuilder();
+        SerializeNode(builder, handle);
+        return builder.ToString();
+    }
+
+    private void SerializeNode(StringBuilder builder, int handle)
+    {
+        var node = Get(handle);
+        switch (node.Kind)
+        {
+            case NodeKind.Text:
+                builder.Append(node.Text);
+                return;
+            case NodeKind.Comment:
+                builder.Append("<!--").Append(node.Text).Append("-->");
+                return;
+            case NodeKind.RawStatic:
+                builder.Append("[static:").Append(node.ElementNamespace ?? "html").Append(':').Append(node.Text).Append(']');
+                return;
+        }
+        builder.Append('<').Append(node.Tag);
+        foreach (var (name, value) in node.Attributes.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            builder.Append(' ').Append(name).Append("=\"").Append(value).Append('"');
+        }
+        foreach (var (name, value) in node.Properties.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            builder.Append(" .").Append(name).Append("=\"").Append(value).Append('"');
+        }
+        foreach (var (name, value) in node.BooleanProperties.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            builder.Append(" ?").Append(name).Append('=').Append(value ? "true" : "false");
+        }
+        if (node.StyleText is not null)
+        {
+            builder.Append(" style.cssText=\"").Append(node.StyleText).Append('"');
+        }
+        foreach (var (name, value) in node.Styles.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            builder.Append(" style.").Append(name).Append("=\"").Append(value).Append('"');
+        }
+        if (node.Value is not null)
+        {
+            builder.Append(string.Create(CultureInfo.InvariantCulture, $" value=\"{node.Value}\"@{node.ValueWriteCount}"));
+        }
+        foreach (var key in node.Listeners.Keys.OrderBy(static key => key, StringComparer.Ordinal))
+        {
+            builder.Append(" @").Append(key);
+        }
+        builder.Append('>');
+        if (node.Text.Length > 0 && node.Children.Count == 0)
+        {
+            builder.Append(node.Text);
+        }
+        foreach (var childHandle in node.Children)
+        {
+            SerializeNode(builder, childHandle);
+        }
+        builder.Append("</").Append(node.Tag).Append('>');
+    }
+
+    // --- registry --------------------------------------------------------------------------------
+
+    private int Register(Node node)
+    {
+        var handle = _nextHandle++;
+        _nodes[handle] = node;
+        return handle;
+    }
+
+    private void RegisterAs(int handle, Node node)
+    {
+        _nodes[handle] = node;
+        if (handle >= _nextHandle)
+        {
+            _nextHandle = handle + 1;
+        }
+    }
+
+    private Node Get(int handle)
+        => _nodes.TryGetValue(handle, out var node)
+            ? node
+            : throw new InvalidOperationException($"Unknown DOM handle {handle}.");
+
+    private void ReleaseSubtree(int handle, List<int> released)
+    {
+        if (!_nodes.TryGetValue(handle, out var node))
+        {
+            return;
+        }
+        released.Add(handle);
+        foreach (var childHandle in node.Children)
+        {
+            ReleaseSubtree(childHandle, released);
+        }
+        _nodes.Remove(handle);
+    }
+
+    private enum NodeKind
+    {
+        Element,
+        Text,
+        Comment,
+        RawStatic,
+    }
+
+    private sealed class Node(NodeKind kind, string tag)
+    {
+        internal NodeKind Kind { get; } = kind;
+
+        internal string Tag { get; } = tag;
+
+        internal string? ElementNamespace { get; init; }
+
+        internal string Text { get; set; } = string.Empty;
+
+        internal string? Value { get; set; }
+
+        internal int ValueWriteCount { get; set; }
+
+        internal string? StyleText { get; set; }
+
+        internal int Parent { get; set; }
+
+        internal List<int> Children { get; } = [];
+
+        internal Dictionary<string, string> Attributes { get; } = new(StringComparer.Ordinal);
+
+        internal Dictionary<string, string> Properties { get; } = new(StringComparer.Ordinal);
+
+        internal Dictionary<string, bool> BooleanProperties { get; } = new(StringComparer.Ordinal);
+
+        internal Dictionary<string, string> Styles { get; } = new(StringComparer.Ordinal);
+
+        internal Dictionary<string, string> Listeners { get; } = new(StringComparer.Ordinal);
+    }
+}


### PR DESCRIPTION
Batch 8B — delegated implementation (Opus 4.8 agent, relaunched once after a dead-on-arrival first spawn) with design/functionality review and full live verification. Includes a merge of current main (#121, #122); the combined result is what was verified.

## What landed

**The command buffer [V01.01.04.05, #43]** — the project's headline interop lever (Blazor `RenderBatch` prior art; no Vue counterpart — documented Vuecs architecture): all 20 write node-ops serialize into one pooled, versioned, little-endian binary frame (opcode stream + per-flush string table for repeated tag/prop/event names, zero steady-state managed allocation) that a single `[JSMarshalAs<JSType.MemoryView>] Span<byte>` interop call applies per scheduler flush. The JS applier decodes via a static opcode switch over a typed-array view — no copy, no dynamic dispatch — and validates the magic/version header so encoder/applier drift fails loudly.

**One-way handle protocol** — buffered creates can't return ids, so .NET pre-allocates handles and the frame says "create AS handle N"; the frame header carries the counter so the JS foreign-node allocator stays above it, and released handles from removes are collected across the whole batch and returned from the single apply call into the existing `PurgeReleasedHandles` path — settling ADR-0001's open released-handle consequence.

**The flush boundary (the one RuntimeCore change)** — an internal `Scheduler.FlushBoundaryCallback` (+33 lines total, armed via `InternalsVisibleTo`, no public API growth), invoked twice per flush: before post-flush callbacks (mounted/updated hooks may *read* the committed DOM) and after them (post-flush directive hooks like v-show's `updated` may *write* it — those writes commit in the same flush). Idempotent; a steady-state flush crosses the boundary once; direct mode pays a null check.

**Mode selection** — `BrowserRuntime.CreateApp(root, props, useCommandBuffer: true)`; **default stays direct** for this PR. I endorse that conservatism: buffered is fully wired and verified below, but flipping the default deserves the #88 benchmark numbers. That flip is a one-argument change when ready.

## Verification (the part the agent explicitly could not do — done here)

- **Live browser, dev build**: the diagnostics harness now runs a **buffered-mode application lifecycle stress** beside the direct one — 25 CreateApp/Mount/Unmount cycles through the command buffer: all registries return to baseline, zero console errors. This is the real proof of the MemoryView marshaling, the C#↔JS frame-layout agreement, the dual handle allocators, and the batched released-handle return.
- **Live browser, AOT build**: the same suite run against the AOT publish — **buffered mode passes under AOT** too. The AOT publish itself: **0 IL/trim/AOT warnings**. (Side observation: AOT per-op interop costs measured 3–9× faster than the interpreted dev build.)
- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings. **913 tests green** on the merged branch (RuntimeDom 133 with 25 new: encoder round-trips, 16 differential direct-vs-buffered scenarios asserting identical serialized DOM, and the interop-call counter proving one apply call for a 300-mutation flush; RuntimeCore 210 with 3 flush-boundary tests). No existing tests modified.
- Verified against current main (merged in): the block-unmount fast path (#121) and buffered teardown compose correctly.

## Deviations

- One public API addition: the optional `useCommandBuffer` parameter (documented).
- Container clear at mount stays a direct call in buffered mode (pre-render, releases nothing) — documented at the site.

## Deferred (per the issue)

Full 10k-row create/update/swap benchmarks → [V01.01.11.04] (#88), which also gates the buffered-by-default decision. A raw `CreateRenderer(useCommandBuffer)` overload — deliberately scoped out until a use case needs it.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)