### PR TITLE
feat(compiler): transform pipeline with structural and directive transforms

### DIFF
--- a/libraries/Assimalign.Vue.Compiler/src/ArrayExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/ArrayExpression.cs
@@ -1,0 +1,17 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation array literal, e.g. the directive arguments array or the dynamic-slots entries. The C#
+/// port of Vue 3.5's <c>ArrayExpression</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+public sealed record ArrayExpression : SyntaxNode
+{
+    /// <summary>
+    /// The array elements. Each is a literal <see cref="string"/> or a <see cref="SyntaxNode"/>, mirroring
+    /// upstream's <c>Array&lt;string | Node&gt;</c>.
+    /// </summary>
+    public required SyntaxList<object> Elements { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsArrayExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Assimalign.Vue.Compiler.csproj
+++ b/libraries/Assimalign.Vue.Compiler/src/Assimalign.Vue.Compiler.csproj
@@ -22,5 +22,14 @@
          net10.0 and cannot be referenced from netstandard2.0). See the file header and the
          Assimalign.Vue.Shared.GeneratorFixture precedent. -->
     <Compile Include="..\..\Assimalign.Vue.Shared\src\Internal\DomKnowledgeData.cs" Link="Internal\DomKnowledgeData.cs" />
+    <!-- Linked shared-source seam ([V01.01.01.03], per the #50 boundary note): PatchFlags and SlotFlags are the
+         compiler <-> runtime contract authored in Assimalign.Vue.Shared. Shared is net10.0 and cannot be
+         referenced from this netstandard2.0 analyzer-host project, so — exactly as with DomKnowledgeData above —
+         the two enum source files are <Compile Include>'d here. Both are netstandard2.0-clean (a [Flags] enum and
+         a plain enum, System-only), keeping one authoritative definition instead of a drifting mirror. The
+         compiler assembly is consumed only at build time by the generator ([V01.01.05.05]), never shipped into the
+         same runtime as Shared, so the duplicated public type is inert. -->
+    <Compile Include="..\..\Assimalign.Vue.Shared\src\PatchFlags.cs" Link="Shared\PatchFlags.cs" />
+    <Compile Include="..\..\Assimalign.Vue.Shared\src\SlotFlags.cs" Link="Shared\SlotFlags.cs" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Vue.Compiler/src/BlockStatement.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/BlockStatement.cs
@@ -1,0 +1,18 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation block statement — a sequence of statements forming a function body. The C# port of Vue
+/// 3.5's <c>BlockStatement</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>). In this build it is produced only
+/// for the memoized <c>v-for</c> loop body (<c>v-memo</c> combined with <c>v-for</c>).
+/// </summary>
+public sealed record BlockStatement : SyntaxNode
+{
+    /// <summary>
+    /// The ordered statements. Each is a literal <see cref="string"/> or a <see cref="SyntaxNode"/>, mirroring
+    /// upstream's untyped body array.
+    /// </summary>
+    public required SyntaxList<object> Body { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsBlockStatement;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/CacheExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/CacheExpression.cs
@@ -1,0 +1,28 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation cache-slot expression: the value is computed once and stored in the render function's
+/// per-instance cache array at <see cref="Index"/>, then reused. The C# port of Vue 3.5's
+/// <c>CacheExpression</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>). Produced by <c>v-once</c> (cached
+/// subtree) and by cached event handlers.
+/// </summary>
+public sealed record CacheExpression : SyntaxNode
+{
+    /// <summary>The slot index in the render function's <c>_cache</c> array.</summary>
+    public required int Index { get; init; }
+
+    /// <summary>The value to cache.</summary>
+    public required SyntaxNode Value { get; init; }
+
+    /// <summary>Whether the cached value is a vnode requiring block-tracking to be paused (upstream <c>needPauseTracking</c>).</summary>
+    public bool NeedPauseTracking { get; init; }
+
+    /// <summary>Whether the cache was produced inside a <c>v-once</c> (upstream <c>inVOnce</c>).</summary>
+    public bool InVOnce { get; init; }
+
+    /// <summary>Whether code generation must spread the cached array (upstream <c>needArraySpread</c>).</summary>
+    public bool NeedArraySpread { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsCacheExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/CallExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/CallExpression.cs
@@ -1,0 +1,25 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation call expression, e.g. <c>renderList(list, ...)</c> or <c>resolveDynamicComponent(is)</c>.
+/// The C# port of Vue 3.5's <c>CallExpression</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>), part of the
+/// intentionally minimal JavaScript AST subset the compiler emits for render-function generation.
+/// </summary>
+public sealed record CallExpression : SyntaxNode
+{
+    /// <summary>
+    /// The callee: either a literal identifier <see cref="string"/> or a <see cref="RuntimeHelper"/> to be
+    /// imported from the runtime (upstream's <c>string | symbol</c>).
+    /// </summary>
+    public required object Callee { get; init; }
+
+    /// <summary>
+    /// The call arguments. Each element is a literal <see cref="string"/>, a <see cref="RuntimeHelper"/>, or a
+    /// <see cref="SyntaxNode"/> (a template child or another JS node), mirroring upstream's untyped argument
+    /// array.
+    /// </summary>
+    public required SyntaxList<object> Arguments { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsCallExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/CompilerErrorCode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/CompilerErrorCode.cs
@@ -181,8 +181,56 @@ public enum CompilerErrorCode
     XVBindInvalidSameNameArgument = 52,
 
     /// <summary>
-    /// The reserved value one past the last defined code, so higher-order compilers can extend the
-    /// catalog without collisions (upstream <c>__EXTEND_POINT__</c>). Always keep this last.
+    /// The reserved value one past the last defined <b>core</b> code, matching upstream
+    /// <c>@vue/compiler-core</c>'s <c>__EXTEND_POINT__</c>. The DOM diagnostics below extend the catalog from
+    /// here, exactly as <c>@vue/compiler-dom</c>'s <c>DOMErrorCodes</c> enum extends core's error codes.
     /// </summary>
     ExtendPoint = 53,
+
+    // ---- DOM directive transform errors ([V01.01.05.03], the C# port of @vue/compiler-dom's DOMErrorCodes) ----
+    //
+    // DESIGN DECISION (flagged): Vuecs merges @vue/compiler-core and @vue/compiler-dom into a single
+    // Assimalign.Vue.Compiler project, so the DOM codes live in THIS one enum rather than a separate one.
+    // Upstream's DOMErrorCodes begins at core's __EXTEND_POINT__ value (53) — its first real code reuses the
+    // sentinel's number because the two enums are distinct types. A single C# enum cannot give ExtendPoint the
+    // value 53 (pinned by ErrorCatalog_NumericValues_MatchUpstreamErrorCodes, which must not change) AND give
+    // X_V_HTML_NO_EXPRESSION the same 53. The DOM codes are therefore appended after the preserved sentinel
+    // (starting at 54), so each equals its upstream DOMErrorCodes value + 1. Core codes 0..53 remain numeric-
+    // exact with upstream; the +1 DOM offset is pinned by DomErrorCatalog_NumericValues below.
+
+    /// <summary><c>v-html</c> is missing its expression (upstream DOM <c>X_V_HTML_NO_EXPRESSION</c>).</summary>
+    XVHtmlNoExpression = 54,
+
+    /// <summary><c>v-html</c> will override the element's children (upstream DOM <c>X_V_HTML_WITH_CHILDREN</c>).</summary>
+    XVHtmlWithChildren = 55,
+
+    /// <summary><c>v-text</c> is missing its expression (upstream DOM <c>X_V_TEXT_NO_EXPRESSION</c>).</summary>
+    XVTextNoExpression = 56,
+
+    /// <summary><c>v-text</c> will override the element's children (upstream DOM <c>X_V_TEXT_WITH_CHILDREN</c>).</summary>
+    XVTextWithChildren = 57,
+
+    /// <summary><c>v-model</c> used on an unsupported element (upstream DOM <c>X_V_MODEL_ON_INVALID_ELEMENT</c>).</summary>
+    XVModelOnInvalidElement = 58,
+
+    /// <summary><c>v-model</c> argument used on a plain element (upstream DOM <c>X_V_MODEL_ARG_ON_ELEMENT</c>).</summary>
+    XVModelArgumentOnElement = 59,
+
+    /// <summary><c>v-model</c> used on a file input (upstream DOM <c>X_V_MODEL_ON_FILE_INPUT_ELEMENT</c>).</summary>
+    XVModelOnFileInputElement = 60,
+
+    /// <summary>Unnecessary <c>value</c> binding alongside <c>v-model</c> (upstream DOM <c>X_V_MODEL_UNNECESSARY_VALUE</c>).</summary>
+    XVModelUnnecessaryValue = 61,
+
+    /// <summary><c>v-show</c> is missing its expression (upstream DOM <c>X_V_SHOW_NO_EXPRESSION</c>).</summary>
+    XVShowNoExpression = 62,
+
+    /// <summary><c>&lt;Transition&gt;</c> expects exactly one child (upstream DOM <c>X_TRANSITION_INVALID_CHILDREN</c>).</summary>
+    XTransitionInvalidChildren = 63,
+
+    /// <summary>A side-effect tag (<c>&lt;script&gt;</c>/<c>&lt;style&gt;</c>) was ignored (upstream DOM <c>X_IGNORED_SIDE_EFFECT_TAG</c>).</summary>
+    XIgnoredSideEffectTag = 64,
+
+    /// <summary>The reserved value one past the last defined DOM code (upstream DOM <c>__EXTEND_POINT__</c>).</summary>
+    DomExtendPoint = 65,
 }

--- a/libraries/Assimalign.Vue.Compiler/src/CompoundExpressionNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/CompoundExpressionNode.cs
@@ -1,0 +1,31 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// An expression assembled by concatenating parts — interleaved literal strings, helper references, and
+/// child expression nodes. The C# port of Vue 3.5's <c>CompoundExpressionNode</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>). The parser never produces these; transforms introduce them
+/// (e.g. a dynamic <c>v-on</c> event name wrapped in <c>toHandlerKey(...)</c>, or merged adjacent text).
+/// </summary>
+/// <remarks>
+/// <see cref="Parts"/> models upstream's heterogeneous <c>children</c> array. Each element is one of a
+/// literal <see cref="string"/>, a <see cref="RuntimeHelper"/>, or a <see cref="SyntaxNode"/>
+/// (<see cref="SimpleExpressionNode"/>, <see cref="InterpolationNode"/>, <see cref="TextNode"/>, or a
+/// nested <see cref="CompoundExpressionNode"/>). Expression bodies remain opaque at this stage
+/// ([V01.01.05.04] layers in identifier prefixing); a compound expression only records how the pieces
+/// concatenate.
+/// </remarks>
+public sealed record CompoundExpressionNode : ExpressionNode
+{
+    /// <summary>The ordered concatenation parts (strings, <see cref="RuntimeHelper"/>s, or nodes).</summary>
+    public required SyntaxList<object> Parts { get; init; }
+
+    /// <summary>
+    /// Whether this expression is an event-handler key (upstream's <c>isHandlerKey</c>). Set by the
+    /// <c>v-on</c> transform ([V01.01.05.03]) for dynamic event names so prop normalization does not treat the
+    /// handler key as a dynamic prop key.
+    /// </summary>
+    public bool IsHandlerKey { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.CompoundExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/ConditionalExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/ConditionalExpression.cs
@@ -1,0 +1,27 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation ternary conditional, the shape a <c>v-if</c>/<c>v-else-if</c>/<c>v-else</c> chain
+/// compiles to (each branch's condition selecting its block, falling through to the next). The C# port of
+/// Vue 3.5's <c>ConditionalExpression</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+public sealed record ConditionalExpression : SyntaxNode
+{
+    /// <summary>The condition being tested.</summary>
+    public required SyntaxNode Test { get; init; }
+
+    /// <summary>The value when <see cref="Test"/> is truthy (this branch's block).</summary>
+    public required SyntaxNode Consequent { get; init; }
+
+    /// <summary>
+    /// The value when <see cref="Test"/> is falsy: the next branch's <see cref="ConditionalExpression"/>, a
+    /// block, or a comment vnode call terminating the chain.
+    /// </summary>
+    public required SyntaxNode Alternate { get; init; }
+
+    /// <summary>Whether code generation should break the alternate onto a new line (upstream's <c>newline</c>).</summary>
+    public bool Newline { get; init; } = true;
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsConditionalExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/DirectiveTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/DirectiveTransform.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A transform that translates a single directive on an element into vnode properties (and optionally a
+/// runtime directive). The C# port of Vue 3.5's <c>DirectiveTransform</c> function type
+/// (<c>@vue/compiler-core</c> <c>transform.ts</c>). Directive transforms are keyed by directive name and run
+/// during element prop building. A platform compiler can wrap a base transform through the
+/// <paramref name="augmentor"/>.
+/// </summary>
+/// <param name="directive">The directive being transformed.</param>
+/// <param name="element">The element the directive is on.</param>
+/// <param name="context">The active transform context.</param>
+/// <param name="augmentor">An optional wrapper that a platform-specific transform applies to the base result.</param>
+/// <returns>The directive's contributed properties and runtime needs.</returns>
+public delegate DirectiveTransformResult DirectiveTransform(
+    DirectiveNode directive,
+    ElementNode element,
+    TransformContext context,
+    Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor);

--- a/libraries/Assimalign.Vue.Compiler/src/DirectiveTransformResult.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/DirectiveTransformResult.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The result of a directive transform: the vnode properties it contributes and, optionally, the runtime
+/// directive it needs applied via <c>withDirectives</c>. The C# port of Vue 3.5's
+/// <c>DirectiveTransformResult</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// </summary>
+public sealed record DirectiveTransformResult
+{
+    /// <summary>The properties this directive contributes to the element's props object.</summary>
+    public required IReadOnlyList<Property> Properties { get; init; }
+
+    /// <summary>
+    /// The runtime directive helper to apply (e.g. <c>vShow</c>, <c>vModelText</c>), or <see langword="null"/>
+    /// when the directive contributes only props. Mirrors upstream's <c>needRuntime</c> symbol case.
+    /// </summary>
+    public RuntimeHelper? NeedRuntime { get; init; }
+
+    /// <summary>
+    /// Whether the directive needs a resolved (user) runtime directive without a specific helper symbol,
+    /// mirroring upstream's <c>needRuntime: true</c> boolean case.
+    /// </summary>
+    public bool NeedsResolvedDirective { get; init; }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/ForNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/ForNode.cs
@@ -1,0 +1,38 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A <c>v-for</c> loop: the iterated source, the decomposed aliases, and the repeated children, which
+/// compile to a fragment block rendered via <c>renderList</c>. The C# port of Vue 3.5's <c>ForNode</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>). See https://vuejs.org/guide/essentials/list.html.
+/// </summary>
+/// <remarks>
+/// The fragment's keyed/unkeyed classification (carried on <see cref="CodegenNode"/>'s patch flag) feeds
+/// patch-flag inference in [V01.01.05.06]. Alias decomposition (value/key/index, including tuple patterns) is
+/// captured in <see cref="ParseResult"/>.
+/// </remarks>
+public sealed record ForNode : TemplateChildNode
+{
+    /// <summary>The iterated source expression.</summary>
+    public required ExpressionNode Source { get; init; }
+
+    /// <summary>The value alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? ValueAlias { get; init; }
+
+    /// <summary>The key alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? KeyAlias { get; init; }
+
+    /// <summary>The object index alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? ObjectIndexAlias { get; init; }
+
+    /// <summary>The decomposed <c>v-for</c> expression pieces.</summary>
+    public required ForParseResult ParseResult { get; init; }
+
+    /// <summary>The repeated children (the <c>&lt;template v-for&gt;</c> contents, or the single element).</summary>
+    public required SyntaxList<TemplateChildNode> Children { get; init; }
+
+    /// <summary>The compiled fragment-block vnode call, or <see langword="null"/> before code generation.</summary>
+    public SyntaxNode? CodegenNode { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.For;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/ForParseResult.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/ForParseResult.cs
@@ -1,0 +1,17 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The decomposed pieces of a <c>v-for</c> expression: the iterated <see cref="Source"/> and the value, key,
+/// and index aliases. The C# port of Vue 3.5's <c>ForParseResult</c> (<c>@vue/compiler-core</c>
+/// <c>ast.ts</c>). Upstream fills this during parsing; in this port the <c>v-for</c> transform performs the
+/// minimal alias tokenization ([V01.01.05.02]), leaving expression bodies opaque for [V01.01.05.04].
+/// </summary>
+/// <param name="Source">The iterated source expression (right of <c>in</c>/<c>of</c>).</param>
+/// <param name="Value">The value alias, or <see langword="null"/> (e.g. <c>v-for="n in 10"</c>'s <c>n</c>).</param>
+/// <param name="Key">The key alias, or <see langword="null"/> (the second alias in <c>(value, key)</c>).</param>
+/// <param name="Index">The index alias, or <see langword="null"/> (the third alias in <c>(value, key, index)</c>).</param>
+public sealed record ForParseResult(
+    ExpressionNode Source,
+    ExpressionNode? Value,
+    ExpressionNode? Key,
+    ExpressionNode? Index);

--- a/libraries/Assimalign.Vue.Compiler/src/FunctionExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/FunctionExpression.cs
@@ -1,0 +1,37 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation function expression — the slot function of a compiled slot, or the iterator of a
+/// <c>renderList</c> call. The C# port of Vue 3.5's <c>FunctionExpression</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+public sealed record FunctionExpression : SyntaxNode
+{
+    /// <summary>
+    /// The parameter list, or <see langword="null"/>. Each element is an <see cref="ExpressionNode"/> or a
+    /// literal <see cref="string"/> (upstream's <c>ExpressionNode | string | (…)[] | undefined</c>).
+    /// </summary>
+    public SyntaxList<object> Parameters { get; init; }
+
+    /// <summary>
+    /// The function body's return value: a single <see cref="SyntaxNode"/> or a
+    /// <see cref="SyntaxList{T}"/> of <see cref="TemplateChildNode"/> (upstream's <c>returns</c>), or
+    /// <see langword="null"/>.
+    /// </summary>
+    public object? Returns { get; init; }
+
+    /// <summary>
+    /// The function body as a <see cref="BlockStatement"/> when the function has explicit statements (the
+    /// memoized <c>v-for</c> loop), or <see langword="null"/> when it simply returns <see cref="Returns"/>.
+    /// </summary>
+    public BlockStatement? Body { get; init; }
+
+    /// <summary>Whether code generation should place the body on a new line (upstream's <c>newline</c>).</summary>
+    public bool Newline { get; init; }
+
+    /// <summary>Whether this function is a slot function requiring the <c>withCtx</c> wrapper.</summary>
+    public bool IsSlot { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsFunctionExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/HelperNames.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/HelperNames.cs
@@ -1,0 +1,154 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The canonical table of runtime helper references the transform pipeline can emit. The C# port of the
+/// <c>helperNameMap</c> in Vue 3.5's <c>@vue/compiler-core</c> <c>runtimeHelpers.ts</c> plus the DOM helpers
+/// registered by <c>@vue/compiler-dom</c> <c>runtimeHelpers.ts</c>. Each field is a <see cref="RuntimeHelper"/>
+/// whose <see cref="RuntimeHelper.Name"/> equals the runtime export name; code generation ([V01.01.05.05])
+/// binds these names to the concrete runtime symbols. The compiler itself never references the runtime.
+/// </summary>
+public static class HelperNames
+{
+    /// <summary>The <c>Fragment</c> block type (upstream <c>FRAGMENT</c>).</summary>
+    public static readonly RuntimeHelper Fragment = new("Fragment");
+
+    /// <summary>The <c>Teleport</c> built-in (upstream <c>TELEPORT</c>).</summary>
+    public static readonly RuntimeHelper Teleport = new("Teleport");
+
+    /// <summary>The <c>Suspense</c> built-in (upstream <c>SUSPENSE</c>).</summary>
+    public static readonly RuntimeHelper Suspense = new("Suspense");
+
+    /// <summary>The <c>KeepAlive</c> built-in (upstream <c>KEEP_ALIVE</c>).</summary>
+    public static readonly RuntimeHelper KeepAlive = new("KeepAlive");
+
+    /// <summary>The <c>BaseTransition</c> built-in (upstream <c>BASE_TRANSITION</c>).</summary>
+    public static readonly RuntimeHelper BaseTransition = new("BaseTransition");
+
+    /// <summary>Opens an optimization block (upstream <c>OPEN_BLOCK</c>).</summary>
+    public static readonly RuntimeHelper OpenBlock = new("openBlock");
+
+    /// <summary>Creates a component block vnode (upstream <c>CREATE_BLOCK</c>).</summary>
+    public static readonly RuntimeHelper CreateBlock = new("createBlock");
+
+    /// <summary>Creates an element block vnode (upstream <c>CREATE_ELEMENT_BLOCK</c>).</summary>
+    public static readonly RuntimeHelper CreateElementBlock = new("createElementBlock");
+
+    /// <summary>Creates a component vnode (upstream <c>CREATE_VNODE</c>).</summary>
+    public static readonly RuntimeHelper CreateVNode = new("createVNode");
+
+    /// <summary>Creates an element vnode (upstream <c>CREATE_ELEMENT_VNODE</c>).</summary>
+    public static readonly RuntimeHelper CreateElementVNode = new("createElementVNode");
+
+    /// <summary>Creates a comment vnode (upstream <c>CREATE_COMMENT</c>).</summary>
+    public static readonly RuntimeHelper CreateComment = new("createCommentVNode");
+
+    /// <summary>Creates a text vnode (upstream <c>CREATE_TEXT</c>).</summary>
+    public static readonly RuntimeHelper CreateText = new("createTextVNode");
+
+    /// <summary>Creates a static vnode (upstream <c>CREATE_STATIC</c>).</summary>
+    public static readonly RuntimeHelper CreateStatic = new("createStaticVNode");
+
+    /// <summary>Resolves a component by name (upstream <c>RESOLVE_COMPONENT</c>).</summary>
+    public static readonly RuntimeHelper ResolveComponent = new("resolveComponent");
+
+    /// <summary>Resolves a dynamic component (upstream <c>RESOLVE_DYNAMIC_COMPONENT</c>).</summary>
+    public static readonly RuntimeHelper ResolveDynamicComponent = new("resolveDynamicComponent");
+
+    /// <summary>Resolves a directive by name (upstream <c>RESOLVE_DIRECTIVE</c>).</summary>
+    public static readonly RuntimeHelper ResolveDirective = new("resolveDirective");
+
+    /// <summary>Resolves a filter by name (upstream <c>RESOLVE_FILTER</c>).</summary>
+    public static readonly RuntimeHelper ResolveFilter = new("resolveFilter");
+
+    /// <summary>Applies runtime directives to a vnode (upstream <c>WITH_DIRECTIVES</c>).</summary>
+    public static readonly RuntimeHelper WithDirectives = new("withDirectives");
+
+    /// <summary>Renders a list for <c>v-for</c> (upstream <c>RENDER_LIST</c>).</summary>
+    public static readonly RuntimeHelper RenderList = new("renderList");
+
+    /// <summary>Renders a slot outlet (upstream <c>RENDER_SLOT</c>).</summary>
+    public static readonly RuntimeHelper RenderSlot = new("renderSlot");
+
+    /// <summary>Creates a dynamic slots object (upstream <c>CREATE_SLOTS</c>).</summary>
+    public static readonly RuntimeHelper CreateSlots = new("createSlots");
+
+    /// <summary>Stringifies an interpolation value (upstream <c>TO_DISPLAY_STRING</c>).</summary>
+    public static readonly RuntimeHelper ToDisplayString = new("toDisplayString");
+
+    /// <summary>Merges multiple props sources (upstream <c>MERGE_PROPS</c>).</summary>
+    public static readonly RuntimeHelper MergeProps = new("mergeProps");
+
+    /// <summary>Normalizes a dynamic <c>class</c> binding (upstream <c>NORMALIZE_CLASS</c>).</summary>
+    public static readonly RuntimeHelper NormalizeClass = new("normalizeClass");
+
+    /// <summary>Normalizes a dynamic <c>style</c> binding (upstream <c>NORMALIZE_STYLE</c>).</summary>
+    public static readonly RuntimeHelper NormalizeStyle = new("normalizeStyle");
+
+    /// <summary>Normalizes a props object with dynamic keys (upstream <c>NORMALIZE_PROPS</c>).</summary>
+    public static readonly RuntimeHelper NormalizeProps = new("normalizeProps");
+
+    /// <summary>Guards a reactive props object (upstream <c>GUARD_REACTIVE_PROPS</c>).</summary>
+    public static readonly RuntimeHelper GuardReactiveProps = new("guardReactiveProps");
+
+    /// <summary>Normalizes a <c>v-on="object"</c> handlers map (upstream <c>TO_HANDLERS</c>).</summary>
+    public static readonly RuntimeHelper ToHandlers = new("toHandlers");
+
+    /// <summary>Camel-cases a dynamic argument (upstream <c>CAMELIZE</c>).</summary>
+    public static readonly RuntimeHelper Camelize = new("camelize");
+
+    /// <summary>Capitalizes a string (upstream <c>CAPITALIZE</c>).</summary>
+    public static readonly RuntimeHelper Capitalize = new("capitalize");
+
+    /// <summary>Builds an <c>onXxx</c> handler key (upstream <c>TO_HANDLER_KEY</c>).</summary>
+    public static readonly RuntimeHelper ToHandlerKey = new("toHandlerKey");
+
+    /// <summary>Toggles block tracking for <c>v-once</c> (upstream <c>SET_BLOCK_TRACKING</c>).</summary>
+    public static readonly RuntimeHelper SetBlockTracking = new("setBlockTracking");
+
+    /// <summary>Wraps a slot function with the render context (upstream <c>WITH_CTX</c>).</summary>
+    public static readonly RuntimeHelper WithCtx = new("withCtx");
+
+    /// <summary>Unwraps a ref (upstream <c>UNREF</c>).</summary>
+    public static readonly RuntimeHelper Unref = new("unref");
+
+    /// <summary>Tests whether a value is a ref (upstream <c>IS_REF</c>).</summary>
+    public static readonly RuntimeHelper IsRef = new("isRef");
+
+    /// <summary>Memoizes a subtree for <c>v-memo</c> (upstream <c>WITH_MEMO</c>).</summary>
+    public static readonly RuntimeHelper WithMemo = new("withMemo");
+
+    /// <summary>Compares two memo dependency arrays (upstream <c>IS_MEMO_SAME</c>).</summary>
+    public static readonly RuntimeHelper IsMemoSame = new("isMemoSame");
+
+    // ---- DOM helpers (upstream @vue/compiler-dom runtimeHelpers.ts) ----
+
+    /// <summary>The <c>v-model</c> directive for radio inputs (upstream <c>V_MODEL_RADIO</c>).</summary>
+    public static readonly RuntimeHelper VModelRadio = new("vModelRadio");
+
+    /// <summary>The <c>v-model</c> directive for checkbox inputs (upstream <c>V_MODEL_CHECKBOX</c>).</summary>
+    public static readonly RuntimeHelper VModelCheckbox = new("vModelCheckbox");
+
+    /// <summary>The <c>v-model</c> directive for text inputs (upstream <c>V_MODEL_TEXT</c>).</summary>
+    public static readonly RuntimeHelper VModelText = new("vModelText");
+
+    /// <summary>The <c>v-model</c> directive for select elements (upstream <c>V_MODEL_SELECT</c>).</summary>
+    public static readonly RuntimeHelper VModelSelect = new("vModelSelect");
+
+    /// <summary>The <c>v-model</c> directive for dynamic input types (upstream <c>V_MODEL_DYNAMIC</c>).</summary>
+    public static readonly RuntimeHelper VModelDynamic = new("vModelDynamic");
+
+    /// <summary>The <c>v-on</c> modifier guard wrapper (upstream <c>V_ON_WITH_MODIFIERS</c>).</summary>
+    public static readonly RuntimeHelper WithModifiers = new("withModifiers");
+
+    /// <summary>The <c>v-on</c> key guard wrapper (upstream <c>V_ON_WITH_KEYS</c>).</summary>
+    public static readonly RuntimeHelper WithKeys = new("withKeys");
+
+    /// <summary>The <c>v-show</c> directive (upstream <c>V_SHOW</c>).</summary>
+    public static readonly RuntimeHelper VShow = new("vShow");
+
+    /// <summary>The <c>Transition</c> DOM built-in (upstream <c>TRANSITION</c>).</summary>
+    public static readonly RuntimeHelper Transition = new("Transition");
+
+    /// <summary>The <c>TransitionGroup</c> DOM built-in (upstream <c>TRANSITION_GROUP</c>).</summary>
+    public static readonly RuntimeHelper TransitionGroup = new("TransitionGroup");
+}

--- a/libraries/Assimalign.Vue.Compiler/src/IfBranchNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/IfBranchNode.cs
@@ -1,0 +1,29 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A single branch of a grouped <see cref="IfNode"/> chain — one <c>v-if</c>, <c>v-else-if</c>, or
+/// <c>v-else</c>. The C# port of Vue 3.5's <c>IfBranchNode</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+public sealed record IfBranchNode : SyntaxNode
+{
+    /// <summary>The branch condition, or <see langword="null"/> for the <c>v-else</c> branch.</summary>
+    public ExpressionNode? Condition { get; init; }
+
+    /// <summary>
+    /// The branch's rendered children. For a <c>&lt;template v-if&gt;</c> without <c>v-for</c> these are the
+    /// template's own children; otherwise the single directive-bearing element.
+    /// </summary>
+    public required SyntaxList<TemplateChildNode> Children { get; init; }
+
+    /// <summary>
+    /// The user-authored <c>key</c> attribute or binding on the branch element, if any (used to diagnose
+    /// duplicate keys across branches). A <see cref="AttributeNode"/> or <see cref="DirectiveNode"/>.
+    /// </summary>
+    public PropertyNode? UserKey { get; init; }
+
+    /// <summary>Whether this branch came from a <c>&lt;template&gt;</c> container carrying the directive.</summary>
+    public bool IsTemplateIf { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.IfBranch;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/IfNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/IfNode.cs
@@ -1,0 +1,24 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A grouped <c>v-if</c>/<c>v-else-if</c>/<c>v-else</c> chain: the adjacent conditional siblings are folded
+/// into one node with ordered <see cref="Branches"/>. The C# port of Vue 3.5's <c>IfNode</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>). See https://vuejs.org/guide/essentials/conditional.html.
+/// </summary>
+/// <remarks>
+/// Each branch compiles to its own block with a stable synthetic <c>key</c> so switching branches replaces
+/// rather than patches across branches. <see cref="CodegenNode"/> is the compiled
+/// <see cref="ConditionalExpression"/> chain (or a <see cref="CacheExpression"/> when combined with
+/// <c>v-once</c>).
+/// </remarks>
+public sealed record IfNode : TemplateChildNode
+{
+    /// <summary>The branches, in source order: the <c>v-if</c> first, then any <c>v-else-if</c>/<c>v-else</c>.</summary>
+    public required SyntaxList<IfBranchNode> Branches { get; init; }
+
+    /// <summary>The compiled conditional-expression chain, or <see langword="null"/> before code generation.</summary>
+    public SyntaxNode? CodegenNode { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.If;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/BuildPropsResult.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/BuildPropsResult.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The result of building an element's props: the props expression, the runtime directives to apply, the
+/// accumulated patch flag, the dynamic prop names, and whether the element must be forced into a block. The
+/// C# port of the return shape of Vue 3.5's <c>buildProps</c> (<c>@vue/compiler-core</c>
+/// <c>transforms/transformElement.ts</c>).
+/// </summary>
+internal sealed record BuildPropsResult
+{
+    /// <summary>The props expression (object, merge call, or single binding), or <see langword="null"/>.</summary>
+    public SyntaxNode? Props { get; init; }
+
+    /// <summary>The runtime directives to apply via <c>withDirectives</c>.</summary>
+    public required IReadOnlyList<DirectiveNode> Directives { get; init; }
+
+    /// <summary>The accumulated patch flag.</summary>
+    public PatchFlags PatchFlag { get; init; }
+
+    /// <summary>The dynamic prop names (consumed by [V01.01.05.06]).</summary>
+    public required IReadOnlyList<string> DynamicPropNames { get; init; }
+
+    /// <summary>Whether the element must be forced into an optimization block.</summary>
+    public bool ShouldUseBlock { get; init; }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerErrorFactory.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerErrorFactory.cs
@@ -1,0 +1,15 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Builds <see cref="CompilerError"/> diagnostics from a code and location, resolving the human-readable
+/// message from <see cref="CompilerErrorMessages"/>. The transform-stage analogue of the parser's error
+/// emission and of Vue 3.5's <c>createCompilerError</c> (<c>@vue/compiler-core</c> <c>errors.ts</c>).
+/// </summary>
+internal static class CompilerErrorFactory
+{
+    /// <summary>Creates a diagnostic for <paramref name="code"/> at <paramref name="location"/>.</summary>
+    /// <param name="code">The error code.</param>
+    /// <param name="location">The source location the diagnostic points at.</param>
+    public static CompilerError Create(CompilerErrorCode code, SourceLocation location)
+        => new(code, CompilerErrorMessages.GetMessage(code), location);
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerErrorMessages.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerErrorMessages.cs
@@ -89,6 +89,24 @@ internal static class CompilerErrorMessages
             "@vnode-* hooks in templates are no longer supported. Use the vue: prefix instead. " +
             "For example, @vnode-mounted should be changed to @vue:mounted. " +
             "@vnode-* hooks support has been removed in 3.4.",
+
+        // DOM directive transform errors (verbatim from @vue/compiler-dom errors.ts DOMErrorMessages)
+        [CompilerErrorCode.XVHtmlNoExpression] = "v-html is missing expression.",
+        [CompilerErrorCode.XVHtmlWithChildren] = "v-html will override element children.",
+        [CompilerErrorCode.XVTextNoExpression] = "v-text is missing expression.",
+        [CompilerErrorCode.XVTextWithChildren] = "v-text will override element children.",
+        [CompilerErrorCode.XVModelOnInvalidElement] =
+            "v-model can only be used on <input>, <textarea> and <select> elements.",
+        [CompilerErrorCode.XVModelArgumentOnElement] = "v-model argument is not supported on plain elements.",
+        [CompilerErrorCode.XVModelOnFileInputElement] =
+            "v-model cannot be used on file inputs since they are read-only. Use a v-on:change listener instead.",
+        [CompilerErrorCode.XVModelUnnecessaryValue] =
+            "Unnecessary value binding used alongside v-model. It will interfere with v-model's behavior.",
+        [CompilerErrorCode.XVShowNoExpression] = "v-show is missing expression.",
+        [CompilerErrorCode.XTransitionInvalidChildren] =
+            "<Transition> expects exactly one child element or component.",
+        [CompilerErrorCode.XIgnoredSideEffectTag] =
+            "Tags with side effect (<script> and <style>) are ignored in client component templates.",
     };
 
     /// <summary>Gets the message for <paramref name="code"/>, or an empty string when none is defined.</summary>

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerText.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/CompilerText.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The text and naming helpers the transform pipeline needs, ported from <c>@vue/shared</c>
+/// (<c>general.ts</c>, <c>domAttrConfig.ts</c>) so the netstandard2.0 compiler front end does not depend on
+/// the net10.0 runtime. Casing rules match upstream exactly because generated prop/handler names must agree
+/// with the runtime.
+/// </summary>
+internal static class CompilerText
+{
+    private static readonly HashSet<string> BuiltInDirectives = new()
+    {
+        "bind", "cloak", "else-if", "else", "for", "html", "if", "model", "on", "once", "pre", "show", "slot",
+        "text", "memo",
+    };
+
+    // Upstream isReservedProp's makeMap input begins with a comma, so the empty string is reserved too.
+    private static readonly HashSet<string> ReservedProperties = new()
+    {
+        "", "key", "ref", "ref_for", "ref_key",
+        "onVnodeBeforeMount", "onVnodeMounted", "onVnodeBeforeUpdate", "onVnodeUpdated",
+        "onVnodeBeforeUnmount", "onVnodeUnmounted",
+    };
+
+    /// <summary>Camel-cases a hyphenated name (upstream <c>camelize</c>: <c>/-(\w)/</c> → uppercase).</summary>
+    /// <param name="value">The name to camel-case.</param>
+    public static string Camelize(string value)
+    {
+        if (value.IndexOf('-') < 0)
+        {
+            return value;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (character == '-' && index + 1 < value.Length && IsWordCharacter(value[index + 1]))
+            {
+                builder.Append(char.ToUpperInvariant(value[index + 1]));
+                index++;
+            }
+            else
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Capitalizes the first character (upstream <c>capitalize</c>).</summary>
+    /// <param name="value">The value to capitalize.</param>
+    public static string Capitalize(string value)
+        => value.Length == 0 ? value : char.ToUpperInvariant(value[0]) + value.Substring(1);
+
+    /// <summary>Builds an <c>onXxx</c> handler key (upstream <c>toHandlerKey</c>).</summary>
+    /// <param name="value">The event name.</param>
+    public static string ToHandlerKey(string value)
+        => value.Length == 0 ? string.Empty : "on" + Capitalize(value);
+
+    /// <summary>Whether <paramref name="name"/> is an event-handler key (upstream <c>isOn</c>: <c>/^on[^a-z]/</c>).</summary>
+    /// <param name="name">The prop name.</param>
+    public static bool IsOn(string name)
+        => name.Length >= 3 && name[0] == 'o' && name[1] == 'n' && !(name[2] >= 'a' && name[2] <= 'z');
+
+    /// <summary>Whether <paramref name="name"/> is a reserved vnode prop (upstream <c>isReservedProp</c>).</summary>
+    /// <param name="name">The prop name.</param>
+    public static bool IsReservedProperty(string name) => ReservedProperties.Contains(name);
+
+    /// <summary>Whether <paramref name="name"/> is a compiler built-in directive (upstream <c>isBuiltInDirective</c>).</summary>
+    /// <param name="name">The normalized directive name.</param>
+    public static bool IsBuiltInDirective(string name) => BuiltInDirectives.Contains(name);
+
+    /// <summary>
+    /// Whether <paramref name="name"/> is a simple JavaScript identifier (upstream <c>isSimpleIdentifier</c>:
+    /// <c>nonIdentifierRE = /^\d|[^\$\w\xA0-￿]/</c>).
+    /// </summary>
+    /// <param name="name">The candidate identifier.</param>
+    public static bool IsSimpleIdentifier(string name)
+    {
+        if (name.Length == 0)
+        {
+            return true;
+        }
+
+        if (name[0] >= '0' && name[0] <= '9')
+        {
+            return false;
+        }
+
+        foreach (var character in name)
+        {
+            if (!IsIdentifierCharacter(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsWordCharacter(char character)
+        => (character >= 'a' && character <= 'z') ||
+           (character >= 'A' && character <= 'Z') ||
+           (character >= '0' && character <= '9') ||
+           character == '_';
+
+    // Upstream's identifier char class: $, word chars, or the U+00A0..U+FFFF range.
+    private static bool IsIdentifierCharacter(char character)
+        => character == '$' || IsWordCharacter(character) || character >= '\u00A0';
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/ConstantAnalysis.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/ConstantAnalysis.cs
@@ -1,0 +1,61 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The reduced constant-type analysis the transform pipeline needs — an opaque-expression subset of Vue
+/// 3.5's <c>getConstantType</c> (<c>@vue/compiler-core</c> <c>transforms/cacheStatic.ts</c>).
+/// </summary>
+/// <remarks>
+/// Because this stage keeps expression bodies opaque (upstream's non-<c>prefixIdentifiers</c> mode), the
+/// analysis reads the <see cref="ConstantType"/> the parser stamped on each <see cref="SimpleExpressionNode"/>
+/// rather than walking a JavaScript AST. The full element-subtree constant analysis that drives static
+/// hoisting is deferred to [V01.01.05.07]; element nodes therefore report
+/// <see cref="ConstantType.NotConstant"/> here. Only the expression/text cases matter for the patch-flag and
+/// text-vnode decisions made in [V01.01.05.02]/[V01.01.05.03].
+/// </remarks>
+internal static class ConstantAnalysis
+{
+    /// <summary>Returns the static-ness level of <paramref name="node"/> (upstream <c>getConstantType</c>, reduced).</summary>
+    /// <param name="node">The node to analyze.</param>
+    public static ConstantType GetConstantType(SyntaxNode node)
+    {
+        switch (node)
+        {
+            case SimpleExpressionNode simple:
+                return simple.ConstantType;
+            case TextNode:
+                return ConstantType.CanStringify;
+            case InterpolationNode interpolation:
+                return GetConstantType(interpolation.Content);
+            case TextCallNode textCall:
+                return GetConstantType(textCall.Content);
+            case CompoundExpressionNode compound:
+                var result = ConstantType.CanStringify;
+                foreach (var part in compound.Parts)
+                {
+                    if (part is string)
+                    {
+                        continue;
+                    }
+
+                    if (part is SyntaxNode child)
+                    {
+                        var childType = GetConstantType(child);
+                        if (childType == ConstantType.NotConstant)
+                        {
+                            return ConstantType.NotConstant;
+                        }
+
+                        if (childType < result)
+                        {
+                            result = childType;
+                        }
+                    }
+                }
+
+                return result;
+            default:
+                // Element / container constant analysis (for static hoisting) is [V01.01.05.07]'s job.
+                return ConstantType.NotConstant;
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/DomDirectiveTransforms.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/DomDirectiveTransforms.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The built-in directive transform table the transform pipeline applies, keyed by directive name. The C#
+/// port of the merged base preset (<c>@vue/compiler-core</c> <c>compile.ts</c>: <c>on</c>/<c>bind</c>/
+/// <c>model</c>) and <c>@vue/compiler-dom</c>'s <c>DOMDirectiveTransforms</c> (<c>cloak</c>/<c>html</c>/
+/// <c>text</c>/<c>model</c>/<c>on</c>/<c>show</c>). Vuecs targets the DOM, so the DOM overrides of <c>on</c>
+/// and <c>model</c> are the defaults. User-supplied transforms in <see cref="TransformOptions"/> override
+/// these by name.
+/// </summary>
+internal static class DomDirectiveTransforms
+{
+    /// <summary>Builds the built-in directive transform table.</summary>
+    public static IReadOnlyDictionary<string, DirectiveTransform> Create() => new Dictionary<string, DirectiveTransform>
+    {
+        ["bind"] = VBindTransform.Transform,
+        ["on"] = VOnTransform.Transform,
+        ["model"] = VModelTransform.Transform,
+        ["show"] = VShowTransform.Transform,
+        ["html"] = VHtmlTransform.Transform,
+        ["text"] = VTextTransform.Transform,
+        ["cloak"] = NoopDirectiveTransform.Transform,
+    };
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/ExpressionShape.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/ExpressionShape.cs
@@ -1,0 +1,153 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Lax structural checks over opaque expression text — is it a member expression, is it a function
+/// expression — ported from the browser-build lexers in <c>@vue/compiler-core</c> <c>utils.ts</c>
+/// (<c>isMemberExpressionBrowser</c>, <c>isFnExpressionBrowser</c>). This build never parses expression
+/// bodies into a JavaScript AST ([V01.01.05.04] adds that), so — exactly like upstream's <c>__BROWSER__</c>
+/// path — these string lexers decide the shape. False positives are invalid expressions anyway.
+/// </summary>
+internal static class ExpressionShape
+{
+    // Upstream fnExpRE.
+    private static readonly Regex FunctionExpressionRegex = new(
+        @"^\s*(async\s*)?(\([^)]*?\)|[\w$_]+)\s*(:[^=]+)?=>|^\s*(async\s+)?function(?:\s+[\w$]+)?\s*\(",
+        RegexOptions.Compiled);
+
+    // Upstream whitespaceRE: whitespace around . or [ is trimmed before member-expression lexing.
+    private static readonly Regex WhitespaceAroundAccessRegex = new(@"\s+[.[]\s*|\s*[.[]\s+", RegexOptions.Compiled);
+
+    private enum MemberLexState
+    {
+        InMemberExpression,
+        InBrackets,
+        InParentheses,
+        InString,
+    }
+
+    private static string GetSource(ExpressionNode expression)
+        => expression is SimpleExpressionNode simple ? simple.Content : expression.Location.Source;
+
+    /// <summary>Whether <paramref name="expression"/> is a function expression (upstream <c>isFnExpression</c>).</summary>
+    /// <param name="expression">The expression to test.</param>
+    public static bool IsFunctionExpression(ExpressionNode expression)
+        => FunctionExpressionRegex.IsMatch(GetSource(expression));
+
+    /// <summary>
+    /// Whether <paramref name="expression"/> is a member expression or plain identifier (upstream
+    /// <c>isMemberExpressionBrowser</c>). Lax: only validates root-level structure, not bracket contents.
+    /// </summary>
+    /// <param name="expression">The expression to test.</param>
+    public static bool IsMemberExpression(ExpressionNode expression)
+    {
+        var path = WhitespaceAroundAccessRegex.Replace(
+            GetSource(expression).Trim(),
+            match => match.Value.Trim());
+
+        var state = MemberLexState.InMemberExpression;
+        var stateStack = new System.Collections.Generic.Stack<MemberLexState>();
+        var openBracketCount = 0;
+        var openParenthesesCount = 0;
+        var currentStringType = '\0';
+
+        for (var index = 0; index < path.Length; index++)
+        {
+            var character = path[index];
+            switch (state)
+            {
+                case MemberLexState.InMemberExpression:
+                    if (character == '[')
+                    {
+                        stateStack.Push(state);
+                        state = MemberLexState.InBrackets;
+                        openBracketCount++;
+                    }
+                    else if (character == '(')
+                    {
+                        stateStack.Push(state);
+                        state = MemberLexState.InParentheses;
+                        openParenthesesCount++;
+                    }
+                    else if (!(index == 0 ? IsValidFirstIdentifierChar(character) : IsValidIdentifierChar(character)))
+                    {
+                        return false;
+                    }
+
+                    break;
+                case MemberLexState.InBrackets:
+                    if (character is '\'' or '"' or '`')
+                    {
+                        stateStack.Push(state);
+                        state = MemberLexState.InString;
+                        currentStringType = character;
+                    }
+                    else if (character == '[')
+                    {
+                        openBracketCount++;
+                    }
+                    else if (character == ']')
+                    {
+                        if (--openBracketCount == 0)
+                        {
+                            state = stateStack.Pop();
+                        }
+                    }
+
+                    break;
+                case MemberLexState.InParentheses:
+                    if (character is '\'' or '"' or '`')
+                    {
+                        stateStack.Push(state);
+                        state = MemberLexState.InString;
+                        currentStringType = character;
+                    }
+                    else if (character == '(')
+                    {
+                        openParenthesesCount++;
+                    }
+                    else if (character == ')')
+                    {
+                        // an expression ending as a call is not a valid member expression
+                        if (index == path.Length - 1)
+                        {
+                            return false;
+                        }
+
+                        if (--openParenthesesCount == 0)
+                        {
+                            state = stateStack.Pop();
+                        }
+                    }
+
+                    break;
+                case MemberLexState.InString:
+                    if (character == currentStringType)
+                    {
+                        state = stateStack.Pop();
+                        currentStringType = '\0';
+                    }
+
+                    break;
+            }
+        }
+
+        return openBracketCount == 0 && openParenthesesCount == 0;
+    }
+
+    // validFirstIdentCharRE = /[A-Za-z_$\xA0-￿]/
+    private static bool IsValidFirstIdentifierChar(char character)
+        => (character >= 'A' && character <= 'Z') ||
+           (character >= 'a' && character <= 'z') ||
+           character == '_' || character == '$' || character >= '\u00A0';
+
+    // validIdentCharRE = /[\.\?\w$\xA0-￿]/
+    private static bool IsValidIdentifierChar(char character)
+        => character == '.' || character == '?' || character == '$' ||
+           (character >= 'A' && character <= 'Z') ||
+           (character >= 'a' && character <= 'z') ||
+           (character >= '0' && character <= '9') ||
+           character == '_' || character >= '\u00A0';
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/ForExpressionParser.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/ForExpressionParser.cs
@@ -1,0 +1,134 @@
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The minimal <c>v-for</c> alias tokenizer: splits <c>"(value, key, index) in source"</c> into its source
+/// and value/key/index aliases. The C# port of Vue 3.5's <c>parseForExpression</c>
+/// (<c>@vue/compiler-core</c> <c>parser.ts</c>), using the same <c>forAliasRE</c>/<c>forIteratorRE</c>/
+/// <c>stripParensRE</c> regular expressions rather than Babel.
+/// </summary>
+/// <remarks>
+/// This is the single documented exception to the opaque-expression rule of [V01.01.05.02]: the alias list
+/// must be decomposed structurally to build the iterator function's parameter list. Alias bodies themselves
+/// stay opaque; full expression/scope analysis ([V01.01.05.04]) replaces this tokenizer. Upstream performs
+/// this split during parsing; this port performs it in the <c>v-for</c> transform because the [V01.01.05.01]
+/// parser leaves it out.
+/// </remarks>
+internal static class ForExpressionParser
+{
+    // Upstream forAliasRE / forIteratorRE / stripParensRE. [\s\S] matches any character (incl. newlines).
+    private static readonly Regex ForAliasRegex = new(@"([\s\S]*?)\s+(?:in|of)\s+(\S[\s\S]*)", RegexOptions.Compiled);
+    private static readonly Regex ForIteratorRegex = new(@",([^,\}\]]*)(?:,([^,\}\]]*))?$", RegexOptions.Compiled);
+    private static readonly Regex StripParenthesesRegex = new(@"^\(|\)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parses the <c>v-for</c> expression, or returns <see langword="null"/> when the alias list is malformed
+    /// (upstream reports <c>X_V_FOR_MALFORMED_EXPRESSION</c>).
+    /// </summary>
+    /// <param name="input">The raw <c>v-for</c> expression node.</param>
+    public static ForParseResult? Parse(SimpleExpressionNode input)
+    {
+        var location = input.Location;
+        var expression = input.Content;
+        var aliasMatch = ForAliasRegex.Match(expression);
+        if (!aliasMatch.Success)
+        {
+            return null;
+        }
+
+        var leftHandSide = aliasMatch.Groups[1].Value;
+        var rightHandSide = aliasMatch.Groups[2].Value;
+
+        SimpleExpressionNode CreateAlias(string content, int offset) => new()
+        {
+            Content = content,
+            IsStatic = false,
+            ConstantType = ConstantType.NotConstant,
+            Location = SubLocation(location, expression, offset, content.Length),
+        };
+
+        var source = CreateAlias(
+            rightHandSide.Trim(),
+            IndexOf(expression, rightHandSide, leftHandSide.Length));
+
+        ExpressionNode? value = null;
+        ExpressionNode? key = null;
+        ExpressionNode? index = null;
+
+        var valueContent = StripParenthesesRegex.Replace(leftHandSide.Trim(), string.Empty).Trim();
+        var trimmedOffset = leftHandSide.IndexOf(valueContent, System.StringComparison.Ordinal);
+
+        var iteratorMatch = ForIteratorRegex.Match(valueContent);
+        if (iteratorMatch.Success)
+        {
+            valueContent = ForIteratorRegex.Replace(valueContent, string.Empty).Trim();
+
+            var keyContent = iteratorMatch.Groups[1].Value.Trim();
+            var keyOffset = 0;
+            if (keyContent.Length > 0)
+            {
+                keyOffset = IndexOf(expression, keyContent, trimmedOffset + valueContent.Length);
+                key = CreateAlias(keyContent, keyOffset);
+            }
+
+            if (iteratorMatch.Groups[2].Success)
+            {
+                var indexContent = iteratorMatch.Groups[2].Value.Trim();
+                if (indexContent.Length > 0)
+                {
+                    index = CreateAlias(
+                        indexContent,
+                        IndexOf(
+                            expression,
+                            indexContent,
+                            key is not null ? keyOffset + keyContent.Length : trimmedOffset + valueContent.Length));
+                }
+            }
+        }
+
+        if (valueContent.Length > 0)
+        {
+            value = CreateAlias(valueContent, trimmedOffset);
+        }
+
+        return new ForParseResult(source, value, key, index);
+    }
+
+    private static int IndexOf(string source, string value, int startIndex)
+    {
+        var found = source.IndexOf(value, System.Math.Max(0, startIndex), System.StringComparison.Ordinal);
+        return found < 0 ? 0 : found;
+    }
+
+    // Builds a sub-location within the expression by advancing the expression's start position over the
+    // skipped prefix. Line/column stay approximate for multi-line aliases; [V01.01.05.04] recomputes these.
+    private static SourceLocation SubLocation(SourceLocation expressionLocation, string expression, int offset, int length)
+    {
+        var start = Advance(expressionLocation.Start, expression, 0, offset);
+        var end = Advance(start, expression, offset, length);
+        var slice = offset >= 0 && offset + length <= expression.Length
+            ? expression.Substring(offset, length)
+            : string.Empty;
+        return new SourceLocation(start, end, slice);
+    }
+
+    private static Position Advance(Position from, string source, int start, int count)
+    {
+        var line = from.Line;
+        var column = from.Column;
+        var lastNewLine = -1;
+        var end = System.Math.Min(source.Length, start + count);
+        for (var i = start; i < end; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                lastNewLine = i;
+            }
+        }
+
+        column = lastNewLine == -1 ? column + count : end - lastNewLine;
+        return new Position(from.Offset + count, line, column);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/Ir.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/Ir.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Factory helpers for the code-generation intermediate representation, the C# port of the <c>createXxx</c>
+/// functions in Vue 3.5's <c>@vue/compiler-core</c> <c>ast.ts</c>. Synthesized nodes that never map to
+/// template source carry the <see cref="LocationStub"/>.
+/// </summary>
+internal static class Ir
+{
+    /// <summary>The stub source location for synthesized nodes (upstream <c>locStub</c>).</summary>
+    public static readonly SourceLocation LocationStub =
+        new(new Position(0, 1, 1), new Position(0, 1, 1), string.Empty);
+
+    /// <summary>Creates a simple expression (upstream <c>createSimpleExpression</c>).</summary>
+    public static SimpleExpressionNode SimpleExpression(
+        string content,
+        bool isStatic = false,
+        SourceLocation? location = null,
+        ConstantType constantType = ConstantType.NotConstant)
+        => new()
+        {
+            Content = content,
+            IsStatic = isStatic,
+            ConstantType = isStatic ? ConstantType.CanStringify : constantType,
+            Location = location ?? LocationStub,
+        };
+
+    /// <summary>Creates a compound expression from ordered parts (upstream <c>createCompoundExpression</c>).</summary>
+    public static CompoundExpressionNode CompoundExpression(params object[] parts)
+        => new() { Parts = new SyntaxList<object>(parts), Location = LocationStub };
+
+    /// <summary>Creates an object property with a static string key (upstream <c>createObjectProperty</c>).</summary>
+    public static Property ObjectProperty(string key, SyntaxNode value)
+        => new() { Key = SimpleExpression(key, true), Value = value, Location = LocationStub };
+
+    /// <summary>Creates an object property with an expression key (upstream <c>createObjectProperty</c>).</summary>
+    public static Property ObjectProperty(ExpressionNode key, SyntaxNode value)
+        => new() { Key = key, Value = value, Location = LocationStub };
+
+    /// <summary>Creates an object literal (upstream <c>createObjectExpression</c>).</summary>
+    public static ObjectExpression ObjectExpression(IReadOnlyList<Property> properties, SourceLocation? location = null)
+        => new() { Properties = ToList(properties), Location = location ?? LocationStub };
+
+    /// <summary>Creates an array literal (upstream <c>createArrayExpression</c>).</summary>
+    public static ArrayExpression ArrayExpression(IReadOnlyList<object> elements, SourceLocation? location = null)
+        => new() { Elements = ToList(elements), Location = location ?? LocationStub };
+
+    /// <summary>Creates a call expression (upstream <c>createCallExpression</c>).</summary>
+    public static CallExpression CallExpression(object callee, IReadOnlyList<object> arguments, SourceLocation? location = null)
+        => new() { Callee = callee, Arguments = ToList(arguments), Location = location ?? LocationStub };
+
+    /// <summary>Creates a ternary conditional (upstream <c>createConditionalExpression</c>).</summary>
+    public static ConditionalExpression ConditionalExpression(
+        SyntaxNode test,
+        SyntaxNode consequent,
+        SyntaxNode alternate,
+        bool newline = true)
+        => new() { Test = test, Consequent = consequent, Alternate = alternate, Newline = newline, Location = LocationStub };
+
+    /// <summary>Creates a function expression (upstream <c>createFunctionExpression</c>).</summary>
+    public static FunctionExpression FunctionExpression(
+        IReadOnlyList<object>? parameters,
+        object? returns = null,
+        bool newline = false,
+        bool isSlot = false,
+        SourceLocation? location = null)
+        => new()
+        {
+            Parameters = parameters is null ? SyntaxList<object>.Empty : ToList(parameters),
+            Returns = returns,
+            Newline = newline,
+            IsSlot = isSlot,
+            Location = location ?? LocationStub,
+        };
+
+    /// <summary>Creates a block statement (upstream <c>createBlockStatement</c>).</summary>
+    public static BlockStatement BlockStatement(IReadOnlyList<object> body)
+        => new() { Body = ToList(body), Location = LocationStub };
+
+    /// <summary>Creates a cache-slot expression (upstream <c>createCacheExpression</c>).</summary>
+    public static CacheExpression CacheExpression(int index, SyntaxNode value, bool needPauseTracking = false, bool inVOnce = false)
+        => new()
+        {
+            Index = index,
+            Value = value,
+            NeedPauseTracking = needPauseTracking,
+            InVOnce = inVOnce,
+            Location = LocationStub,
+        };
+
+    private static SyntaxList<T> ToList<T>(IReadOnlyList<T> items)
+        where T : class
+    {
+        if (items.Count == 0)
+        {
+            return SyntaxList<T>.Empty;
+        }
+
+        var array = new T[items.Count];
+        for (var index = 0; index < items.Count; index++)
+        {
+            array[index] = items[index];
+        }
+
+        return new SyntaxList<T>(array);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/NoopDirectiveTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/NoopDirectiveTransform.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A directive transform that contributes nothing — used for <c>v-cloak</c>, which needs no runtime prop at
+/// compile time (the runtime removes the <c>v-cloak</c> attribute on mount; CSS hides <c>[v-cloak]</c> until
+/// then). The C# port of Vue 3.5's <c>noopDirectiveTransform</c> (<c>@vue/compiler-core</c>
+/// <c>transforms/noopDirectiveTransform.ts</c>).
+/// </summary>
+internal static class NoopDirectiveTransform
+{
+    /// <summary>The directive transform delegate.</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+        => new() { Properties = Array.Empty<Property>() };
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/ReferenceComparer.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/ReferenceComparer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// An identity comparer for the transform's per-node side tables. The parse AST records compare by value, so
+/// keying code-generation results by value would conflate distinct-but-equal nodes; the transform needs
+/// reference identity instead. netstandard2.0 has no <c>ReferenceEqualityComparer</c>, so this small
+/// equivalent is used.
+/// </summary>
+internal sealed class ReferenceComparer : IEqualityComparer<SyntaxNode>
+{
+    /// <summary>The shared instance.</summary>
+    public static readonly ReferenceComparer Instance = new();
+
+    private ReferenceComparer()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SyntaxNode? left, SyntaxNode? right) => ReferenceEquals(left, right);
+
+    /// <inheritdoc />
+    public int GetHashCode(SyntaxNode value) => RuntimeHelpers.GetHashCode(value);
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/StructuralDirectiveFactory.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/StructuralDirectiveFactory.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A transform that rewrites the node it is applied to, driven by a matched structural directive. The C#
+/// port of Vue 3.5's <c>StructuralDirectiveTransform</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// Only <c>v-if</c> and <c>v-for</c> fall into this category.
+/// </summary>
+/// <param name="element">The element carrying the directive, with the matched directive already removed.</param>
+/// <param name="directive">The matched structural directive.</param>
+/// <param name="context">The active transform context.</param>
+/// <returns>An exit callback, or <see langword="null"/>.</returns>
+internal delegate Action? StructuralDirectiveTransform(
+    ElementNode element,
+    DirectiveNode directive,
+    TransformContext context);
+
+/// <summary>
+/// Builds a <see cref="NodeTransform"/> from a structural directive transform, matching directives by name
+/// and removing them before applying so the transform can re-traverse the node. The C# port of Vue 3.5's
+/// <c>createStructuralDirectiveTransform</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// </summary>
+internal static class StructuralDirectiveFactory
+{
+    public static NodeTransform Create(Func<string, bool> matches, StructuralDirectiveTransform transform)
+        => (node, context) =>
+        {
+            if (node is not ElementNode element)
+            {
+                return null;
+            }
+
+            // Structural directives are not concerned with slots; those are handled by the slot transform.
+            if (element.ElementType == ElementType.Template && HasVSlot(element))
+            {
+                return null;
+            }
+
+            var properties = element.Properties;
+            for (var index = 0; index < properties.Count; index++)
+            {
+                if (properties[index] is DirectiveNode directive && matches(directive.Name))
+                {
+                    // Remove the structural directive before applying so the node can traverse itself.
+                    var reduced = RemoveProperty(element, index);
+                    return transform(reduced, directive, context);
+                }
+            }
+
+            return null;
+        };
+
+    private static bool HasVSlot(ElementNode element)
+    {
+        foreach (var property in element.Properties)
+        {
+            if (property is DirectiveNode { Name: "slot" })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ElementNode RemoveProperty(ElementNode element, int index)
+    {
+        var remaining = new PropertyNode[element.Properties.Count - 1];
+        var target = 0;
+        for (var source = 0; source < element.Properties.Count; source++)
+        {
+            if (source == index)
+            {
+                continue;
+            }
+
+            remaining[target++] = element.Properties[source];
+        }
+
+        return element with { Properties = new SyntaxList<PropertyNode>(remaining) };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformElement.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformElement.cs
@@ -1,0 +1,744 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The element transform: on exit it builds the element's <see cref="VNodeCall"/> code-generation node,
+/// resolving the vnode tag (including dynamic components), building its props, and attaching its children or
+/// slots. The C# port of Vue 3.5's <c>transformElement</c>, <c>resolveComponentType</c>, <c>buildProps</c>,
+/// and <c>buildDirectiveArgs</c> (<c>@vue/compiler-core</c> <c>transforms/transformElement.ts</c>).
+/// </summary>
+/// <remarks>
+/// The patch-flag analysis in <see cref="BuildProps"/> is ported here because it is inseparable from prop
+/// building and because [V01.01.05.03] requires the <c>FULL_PROPS</c> escalation and the <c>dynamicProps</c>
+/// list. The full element-level patch-flag refinement (static class/style elision, text) is [V01.01.05.06].
+/// </remarks>
+internal static class TransformElement
+{
+    /// <summary>The node transform (work happens on exit, after children are transformed).</summary>
+    public static Action? Transform(SyntaxNode node, TransformContext context) => () =>
+    {
+        var current = context.CurrentNode;
+        if (current is not ElementNode element ||
+            (element.ElementType != ElementType.Element && element.ElementType != ElementType.Component))
+        {
+            return;
+        }
+
+        var tag = element.Tag;
+        var isComponent = element.ElementType == ElementType.Component;
+
+        object vnodeTag = isComponent ? ResolveComponentType(element, context) : $"\"{tag}\"";
+        var isDynamicComponent = vnodeTag is CallExpression { Callee: RuntimeHelper dynamicCallee } &&
+                                 dynamicCallee == HelperNames.ResolveDynamicComponent;
+
+        var shouldUseBlock =
+            isDynamicComponent ||
+            (vnodeTag is RuntimeHelper tagHelper && (tagHelper == HelperNames.Teleport || tagHelper == HelperNames.Suspense)) ||
+            (!isComponent && (tag is "svg" or "foreignObject" or "math"));
+
+        SyntaxNode? vnodeProps = null;
+        object? vnodeChildren = null;
+        PatchFlags patchFlag = 0;
+        object? vnodeDynamicProps = null;
+        IReadOnlyList<string>? dynamicPropNames = null;
+        ArrayExpression? vnodeDirectives = null;
+
+        if (element.Properties.Count > 0)
+        {
+            var built = BuildProps(element, context, element.Properties, isComponent, isDynamicComponent);
+            vnodeProps = built.Props;
+            patchFlag = built.PatchFlag;
+            dynamicPropNames = built.DynamicPropNames;
+            if (built.Directives.Count > 0)
+            {
+                var directiveArguments = new object[built.Directives.Count];
+                for (var index = 0; index < built.Directives.Count; index++)
+                {
+                    directiveArguments[index] = BuildDirectiveArguments(built.Directives[index], context);
+                }
+
+                vnodeDirectives = Ir.ArrayExpression(directiveArguments);
+            }
+
+            if (built.ShouldUseBlock)
+            {
+                shouldUseBlock = true;
+            }
+        }
+
+        var children = context.WorkingChildrenOf(element, element.Children);
+        if (children.Count > 0)
+        {
+            if (vnodeTag is RuntimeHelper keepAlive && keepAlive == HelperNames.KeepAlive)
+            {
+                shouldUseBlock = true;
+                patchFlag |= PatchFlags.DynamicSlots;
+                if (children.Count > 1)
+                {
+                    context.ReportError(CompilerErrorFactory.Create(
+                        CompilerErrorCode.XKeepAliveInvalidChildren,
+                        new SourceLocation(children[0].Location.Start, children[children.Count - 1].Location.End, string.Empty)));
+                }
+            }
+
+            var shouldBuildAsSlots = isComponent &&
+                                     !(vnodeTag is RuntimeHelper teleport && teleport == HelperNames.Teleport) &&
+                                     !(vnodeTag is RuntimeHelper keep && keep == HelperNames.KeepAlive);
+
+            if (shouldBuildAsSlots)
+            {
+                var (slots, hasDynamicSlots) = VSlotTransform.BuildSlots(element, context, children);
+                vnodeChildren = slots;
+                if (hasDynamicSlots)
+                {
+                    patchFlag |= PatchFlags.DynamicSlots;
+                }
+            }
+            else if (children.Count == 1 && !(vnodeTag is RuntimeHelper t && t == HelperNames.Teleport))
+            {
+                var child = children[0];
+                var hasDynamicTextChild = child is InterpolationNode or CompoundExpressionNode;
+                if (hasDynamicTextChild && ConstantAnalysis.GetConstantType(child) == ConstantType.NotConstant)
+                {
+                    patchFlag |= PatchFlags.Text;
+                }
+
+                vnodeChildren = hasDynamicTextChild || child is TextNode
+                    ? child
+                    : TransformFreeze.FreezeChildren(children);
+            }
+            else
+            {
+                vnodeChildren = TransformFreeze.FreezeChildren(children);
+            }
+        }
+
+        if (dynamicPropNames is { Count: > 0 })
+        {
+            vnodeDynamicProps = StringifyDynamicPropNames(dynamicPropNames);
+        }
+
+        var codegenNode = context.CreateVNodeCall(
+            vnodeTag,
+            vnodeProps,
+            vnodeChildren,
+            patchFlag == 0 ? null : patchFlag,
+            vnodeDynamicProps,
+            vnodeDirectives,
+            shouldUseBlock,
+            disableTracking: false,
+            isComponent,
+            element.Location);
+
+        context.SetCodegenNode(element, codegenNode);
+    };
+
+    /// <summary>Resolves the vnode tag for a component, including dynamic components (upstream <c>resolveComponentType</c>).</summary>
+    public static object ResolveComponentType(ElementNode element, TransformContext context)
+    {
+        var tag = element.Tag;
+        var isExplicitDynamic = IsComponentTag(tag);
+        var isProperty = TransformUtilities.FindProperty(element, "is", dynamicOnly: false, allowEmpty: true);
+        if (isProperty is not null)
+        {
+            if (isExplicitDynamic)
+            {
+                ExpressionNode? expression = null;
+                if (isProperty is AttributeNode attribute)
+                {
+                    expression = attribute.Value is not null ? Ir.SimpleExpression(attribute.Value.Content, true) : null;
+                }
+                else if (isProperty is DirectiveNode directive)
+                {
+                    expression = directive.Expression ?? Ir.SimpleExpression("is", false, directive.Argument!.Location);
+                }
+
+                if (expression is not null)
+                {
+                    return Ir.CallExpression(context.Helper(HelperNames.ResolveDynamicComponent), new object[] { expression });
+                }
+            }
+            else if (isProperty is AttributeNode { Value: { } value } && value.Content.StartsWith("vue:", StringComparison.Ordinal))
+            {
+                tag = value.Content.Substring(4);
+            }
+        }
+
+        var builtIn = CoreComponent(tag) ?? context.IsBuiltInComponent?.Invoke(tag);
+        if (builtIn is not null)
+        {
+            if (!context.Ssr)
+            {
+                context.Helper(builtIn);
+            }
+
+            return builtIn;
+        }
+
+        context.Helper(HelperNames.ResolveComponent);
+        context.AddComponent(tag);
+        return ToValidAssetId(tag, "component");
+    }
+
+    /// <summary>Builds an element's props, directives, and patch-flag analysis (upstream <c>buildProps</c>).</summary>
+    public static BuildPropsResult BuildProps(
+        ElementNode element,
+        TransformContext context,
+        SyntaxList<PropertyNode> properties,
+        bool isComponent,
+        bool isDynamicComponent)
+    {
+        var tag = element.Tag;
+        var hasChildren = element.Children.Count > 0;
+        var elementProperties = new List<Property>();
+        var mergeArguments = new List<SyntaxNode>();
+        var runtimeDirectives = new List<DirectiveNode>();
+        var shouldUseBlock = false;
+
+        var patchFlag = 0;
+        var hasReference = false;
+        var hasClassBinding = false;
+        var hasStyleBinding = false;
+        var hasHydrationEventBinding = false;
+        var hasDynamicKeys = false;
+        var hasVnodeHook = false;
+        var dynamicPropNames = new List<string>();
+
+        void PushMergeArgument(SyntaxNode? argument = null)
+        {
+            if (elementProperties.Count > 0)
+            {
+                mergeArguments.Add(Ir.ObjectExpression(DedupeProperties(elementProperties), element.Location));
+                elementProperties = new List<Property>();
+            }
+
+            if (argument is not null)
+            {
+                mergeArguments.Add(argument);
+            }
+        }
+
+        void PushReferenceForVForMarker()
+        {
+            if (context.ScopeVFor > 0)
+            {
+                elementProperties.Add(Ir.ObjectProperty(
+                    Ir.SimpleExpression("ref_for", true),
+                    Ir.SimpleExpression("true")));
+            }
+        }
+
+        void AnalyzePatchFlag(Property property)
+        {
+            var key = property.Key;
+            var value = property.Value;
+            if (key is SimpleExpressionNode { IsStatic: true } staticKey)
+            {
+                var name = staticKey.Content;
+                var isEventHandler = CompilerText.IsOn(name);
+                if (isEventHandler && (!isComponent || isDynamicComponent) &&
+                    name.ToLowerInvariant() != "onclick" &&
+                    name != "onUpdate:modelValue" &&
+                    !CompilerText.IsReservedProperty(name))
+                {
+                    hasHydrationEventBinding = true;
+                }
+
+                if (isEventHandler && CompilerText.IsReservedProperty(name))
+                {
+                    hasVnodeHook = true;
+                }
+
+                if (isEventHandler && value is CallExpression handlerCall && handlerCall.Arguments.Count > 0 &&
+                    handlerCall.Arguments[0] is SyntaxNode innerValue)
+                {
+                    value = innerValue;
+                }
+
+                if (value is CacheExpression ||
+                    ((value is SimpleExpressionNode or CompoundExpressionNode) &&
+                     ConstantAnalysis.GetConstantType(value) > ConstantType.NotConstant))
+                {
+                    return;
+                }
+
+                if (name == "ref")
+                {
+                    hasReference = true;
+                }
+                else if (name == "class")
+                {
+                    hasClassBinding = true;
+                }
+                else if (name == "style")
+                {
+                    hasStyleBinding = true;
+                }
+                else if (name != "key" && !dynamicPropNames.Contains(name))
+                {
+                    dynamicPropNames.Add(name);
+                }
+
+                if (isComponent && (name == "class" || name == "style") && !dynamicPropNames.Contains(name))
+                {
+                    dynamicPropNames.Add(name);
+                }
+            }
+            else
+            {
+                hasDynamicKeys = true;
+            }
+        }
+
+        foreach (var property in properties)
+        {
+            if (property is AttributeNode attribute)
+            {
+                var name = attribute.Name;
+                if (name == "ref")
+                {
+                    hasReference = true;
+                    PushReferenceForVForMarker();
+                }
+
+                if (name == "is" && (IsComponentTag(tag) || (attribute.Value is not null && attribute.Value.Content.StartsWith("vue:", StringComparison.Ordinal))))
+                {
+                    continue;
+                }
+
+                elementProperties.Add(Ir.ObjectProperty(
+                    Ir.SimpleExpression(name, true, attribute.NameLocation),
+                    Ir.SimpleExpression(attribute.Value?.Content ?? string.Empty, true, attribute.Value?.Location ?? attribute.Location)));
+            }
+            else if (property is DirectiveNode directive)
+            {
+                var name = directive.Name;
+                var argument = directive.Argument;
+                var expression = directive.Expression;
+                var isVBind = name == "bind";
+                var isVOn = name == "on";
+
+                if (name == "slot")
+                {
+                    if (!isComponent)
+                    {
+                        context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVSlotMisplaced, directive.Location));
+                    }
+
+                    continue;
+                }
+
+                if (name is "once" or "memo")
+                {
+                    continue;
+                }
+
+                if (name == "is" || (isVBind && TransformUtilities.IsStaticArgumentOf(argument, "is") && IsComponentTag(tag)))
+                {
+                    continue;
+                }
+
+                if (isVOn && context.Ssr)
+                {
+                    continue;
+                }
+
+                if ((isVBind && TransformUtilities.IsStaticArgumentOf(argument, "key")) ||
+                    (isVOn && hasChildren && TransformUtilities.IsStaticArgumentOf(argument, "vue:before-update")))
+                {
+                    shouldUseBlock = true;
+                }
+
+                if (isVBind && TransformUtilities.IsStaticArgumentOf(argument, "ref"))
+                {
+                    PushReferenceForVForMarker();
+                }
+
+                if (argument is null && (isVBind || isVOn))
+                {
+                    hasDynamicKeys = true;
+                    if (expression is not null)
+                    {
+                        if (isVBind)
+                        {
+                            PushReferenceForVForMarker();
+                            PushMergeArgument();
+                            mergeArguments.Add(expression);
+                        }
+                        else
+                        {
+                            PushMergeArgument(Ir.CallExpression(
+                                context.Helper(HelperNames.ToHandlers),
+                                isComponent ? new object[] { expression } : new object[] { expression, "true" }));
+                        }
+                    }
+                    else
+                    {
+                        context.ReportError(CompilerErrorFactory.Create(
+                            isVBind ? CompilerErrorCode.XVBindNoExpression : CompilerErrorCode.XVOnNoExpression,
+                            directive.Location));
+                    }
+
+                    continue;
+                }
+
+                if (isVBind && HasModifier(directive, "prop"))
+                {
+                    patchFlag |= (int)PatchFlags.NeedHydration;
+                }
+
+                if (context.DirectiveTransforms.TryGetValue(name, out var directiveTransform))
+                {
+                    var result = directiveTransform(directive, element, context, null);
+                    if (!context.Ssr)
+                    {
+                        foreach (var built in result.Properties)
+                        {
+                            AnalyzePatchFlag(built);
+                        }
+                    }
+
+                    if (isVOn && argument is not null && !TransformUtilities.IsStaticExpression(argument))
+                    {
+                        PushMergeArgument(Ir.ObjectExpression(result.Properties, element.Location));
+                    }
+                    else
+                    {
+                        elementProperties.AddRange(result.Properties);
+                    }
+
+                    if (result.NeedRuntime is not null || result.NeedsResolvedDirective)
+                    {
+                        runtimeDirectives.Add(directive);
+                        if (result.NeedRuntime is not null)
+                        {
+                            context.SetDirectiveRuntime(directive, result.NeedRuntime);
+                        }
+                    }
+                }
+                else if (!CompilerText.IsBuiltInDirective(name))
+                {
+                    runtimeDirectives.Add(directive);
+                    if (hasChildren)
+                    {
+                        shouldUseBlock = true;
+                    }
+                }
+            }
+        }
+
+        SyntaxNode? propsExpression = null;
+        if (mergeArguments.Count > 0)
+        {
+            PushMergeArgument();
+            propsExpression = mergeArguments.Count > 1
+                ? Ir.CallExpression(context.Helper(HelperNames.MergeProps), ToObjectList(mergeArguments), element.Location)
+                : mergeArguments[0];
+        }
+        else if (elementProperties.Count > 0)
+        {
+            propsExpression = Ir.ObjectExpression(DedupeProperties(elementProperties), element.Location);
+        }
+
+        if (hasDynamicKeys)
+        {
+            patchFlag |= (int)PatchFlags.FullProps;
+        }
+        else
+        {
+            if (hasClassBinding && !isComponent)
+            {
+                patchFlag |= (int)PatchFlags.Class;
+            }
+
+            if (hasStyleBinding && !isComponent)
+            {
+                patchFlag |= (int)PatchFlags.Style;
+            }
+
+            if (dynamicPropNames.Count > 0)
+            {
+                patchFlag |= (int)PatchFlags.Props;
+            }
+
+            if (hasHydrationEventBinding)
+            {
+                patchFlag |= (int)PatchFlags.NeedHydration;
+            }
+        }
+
+        if (!shouldUseBlock &&
+            (patchFlag == 0 || patchFlag == (int)PatchFlags.NeedHydration) &&
+            (hasReference || hasVnodeHook || runtimeDirectives.Count > 0))
+        {
+            patchFlag |= (int)PatchFlags.NeedPatch;
+        }
+
+        if (!context.InSSR && propsExpression is not null)
+        {
+            propsExpression = NormalizeProps(propsExpression, context, hasStyleBinding);
+        }
+
+        return new BuildPropsResult
+        {
+            Props = propsExpression,
+            Directives = runtimeDirectives,
+            PatchFlag = (PatchFlags)patchFlag,
+            DynamicPropNames = dynamicPropNames,
+            ShouldUseBlock = shouldUseBlock,
+        };
+    }
+
+    /// <summary>Builds the runtime directive argument array for a custom/model directive (upstream <c>buildDirectiveArgs</c>).</summary>
+    public static ArrayExpression BuildDirectiveArguments(DirectiveNode directive, TransformContext context)
+    {
+        var arguments = new List<object>();
+        var runtime = context.GetDirectiveRuntime(directive);
+        if (runtime is not null)
+        {
+            arguments.Add(context.HelperString(runtime));
+        }
+        else
+        {
+            context.Helper(HelperNames.ResolveDirective);
+            context.AddDirective(directive.Name);
+            arguments.Add(ToValidAssetId(directive.Name, "directive"));
+        }
+
+        if (directive.Expression is not null)
+        {
+            arguments.Add(directive.Expression);
+        }
+
+        if (directive.Argument is not null)
+        {
+            if (directive.Expression is null)
+            {
+                arguments.Add("void 0");
+            }
+
+            arguments.Add(directive.Argument);
+        }
+
+        if (directive.Modifiers.Count > 0)
+        {
+            if (directive.Argument is null)
+            {
+                if (directive.Expression is null)
+                {
+                    arguments.Add("void 0");
+                }
+
+                arguments.Add("void 0");
+            }
+
+            var trueExpression = Ir.SimpleExpression("true", false, directive.Location);
+            var modifierProperties = new List<Property>();
+            foreach (var modifier in directive.Modifiers)
+            {
+                modifierProperties.Add(Ir.ObjectProperty(modifier, trueExpression));
+            }
+
+            arguments.Add(Ir.ObjectExpression(modifierProperties, directive.Location));
+        }
+
+        return Ir.ArrayExpression(arguments, directive.Location);
+    }
+
+    private static SyntaxNode NormalizeProps(SyntaxNode propsExpression, TransformContext context, bool hasStyleBinding)
+    {
+        switch (propsExpression)
+        {
+            case ObjectExpression objectExpression:
+                var classIndex = -1;
+                var styleIndex = -1;
+                var hasDynamicKey = false;
+                for (var index = 0; index < objectExpression.Properties.Count; index++)
+                {
+                    var key = objectExpression.Properties[index].Key;
+                    if (key is SimpleExpressionNode { IsStatic: true } staticKey)
+                    {
+                        if (staticKey.Content == "class")
+                        {
+                            classIndex = index;
+                        }
+                        else if (staticKey.Content == "style")
+                        {
+                            styleIndex = index;
+                        }
+                    }
+                    else if (!(key is SimpleExpressionNode { IsHandlerKey: true }) &&
+                             !(key is CompoundExpressionNode { IsHandlerKey: true }))
+                    {
+                        hasDynamicKey = true;
+                    }
+                }
+
+                if (!hasDynamicKey)
+                {
+                    var updated = new List<Property>(objectExpression.Properties);
+                    if (classIndex >= 0 && !TransformUtilities.IsStaticExpression(updated[classIndex].Value))
+                    {
+                        updated[classIndex] = updated[classIndex] with
+                        {
+                            Value = Ir.CallExpression(context.Helper(HelperNames.NormalizeClass), new object[] { updated[classIndex].Value }),
+                        };
+                    }
+
+                    if (styleIndex >= 0)
+                    {
+                        var styleProperty = updated[styleIndex];
+                        var isDynamicStyle = hasStyleBinding ||
+                                             (styleProperty.Value is SimpleExpressionNode s && s.Content.TrimStart().StartsWith("[", StringComparison.Ordinal)) ||
+                                             styleProperty.Value is ArrayExpression;
+                        if (isDynamicStyle)
+                        {
+                            updated[styleIndex] = styleProperty with
+                            {
+                                Value = Ir.CallExpression(context.Helper(HelperNames.NormalizeStyle), new object[] { styleProperty.Value }),
+                            };
+                        }
+                    }
+
+                    return objectExpression with { Properties = new SyntaxList<Property>(updated.ToArray()) };
+                }
+
+                return Ir.CallExpression(context.Helper(HelperNames.NormalizeProps), new object[] { objectExpression });
+            case CallExpression:
+                return propsExpression;
+            default:
+                return Ir.CallExpression(
+                    context.Helper(HelperNames.NormalizeProps),
+                    new object[] { Ir.CallExpression(context.Helper(HelperNames.GuardReactiveProps), new object[] { propsExpression }) });
+        }
+    }
+
+    private static List<Property> DedupeProperties(List<Property> properties)
+    {
+        var known = new Dictionary<string, Property>();
+        var deduped = new List<Property>();
+        foreach (var property in properties)
+        {
+            if (property.Key is CompoundExpressionNode || property.Key is SimpleExpressionNode { IsStatic: false })
+            {
+                deduped.Add(property);
+                continue;
+            }
+
+            var name = ((SimpleExpressionNode)property.Key).Content;
+            if (known.TryGetValue(name, out var existing))
+            {
+                if (name is "style" or "class" || CompilerText.IsOn(name))
+                {
+                    var merged = MergeAsArray(existing, property);
+                    var replaceIndex = deduped.IndexOf(existing);
+                    if (replaceIndex >= 0)
+                    {
+                        deduped[replaceIndex] = merged;
+                    }
+
+                    known[name] = merged;
+                }
+            }
+            else
+            {
+                known[name] = property;
+                deduped.Add(property);
+            }
+        }
+
+        return deduped;
+    }
+
+    private static Property MergeAsArray(Property existing, Property incoming)
+    {
+        if (existing.Value is ArrayExpression array)
+        {
+            var elements = new List<object>(array.Elements) { incoming.Value };
+            return existing with { Value = array with { Elements = new SyntaxList<object>(elements.ToArray()) } };
+        }
+
+        return existing with { Value = Ir.ArrayExpression(new object[] { existing.Value, incoming.Value }, existing.Location) };
+    }
+
+    private static bool HasModifier(DirectiveNode directive, string modifier)
+    {
+        foreach (var entry in directive.Modifiers)
+        {
+            if (entry.Content == modifier)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static RuntimeHelper? CoreComponent(string tag) => tag switch
+    {
+        "Teleport" or "teleport" => HelperNames.Teleport,
+        "Suspense" or "suspense" => HelperNames.Suspense,
+        "KeepAlive" or "keep-alive" => HelperNames.KeepAlive,
+        "BaseTransition" or "base-transition" => HelperNames.BaseTransition,
+        _ => null,
+    };
+
+    private static bool IsComponentTag(string tag) => tag is "component" or "Component";
+
+    private static string ToValidAssetId(string name, string type)
+    {
+        var builder = new StringBuilder("_").Append(type).Append('_');
+        foreach (var character in name)
+        {
+            var isWord = (character >= 'A' && character <= 'Z') ||
+                         (character >= 'a' && character <= 'z') ||
+                         (character >= '0' && character <= '9') ||
+                         character == '_';
+            if (isWord)
+            {
+                builder.Append(character);
+            }
+            else if (character == '-')
+            {
+                builder.Append('_');
+            }
+            else
+            {
+                builder.Append(((int)character).ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string StringifyDynamicPropNames(IReadOnlyList<string> names)
+    {
+        var builder = new StringBuilder("[");
+        for (var index = 0; index < names.Count; index++)
+        {
+            builder.Append('"').Append(names[index]).Append('"');
+            if (index < names.Count - 1)
+            {
+                builder.Append(", ");
+            }
+        }
+
+        return builder.Append(']').ToString();
+    }
+
+    private static IReadOnlyList<object> ToObjectList(List<SyntaxNode> nodes)
+    {
+        var array = new object[nodes.Count];
+        for (var index = 0; index < nodes.Count; index++)
+        {
+            array[index] = nodes[index];
+        }
+
+        return array;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformFreeze.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformFreeze.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Freezes the transform's mutable working containers (<see cref="WorkingIf"/>, <see cref="WorkingFor"/>,
+/// <see cref="WorkingIfBranch"/>) into their immutable, value-equatable public counterparts
+/// (<see cref="IfNode"/>, <see cref="ForNode"/>, <see cref="IfBranchNode"/>) as they are consumed. Elements
+/// and leaf nodes are already immutable and pass through unchanged; their code-generation results stay in the
+/// context's side table. This is what upholds the "immutable and value-equatable after transform" contract.
+/// </summary>
+internal static class TransformFreeze
+{
+    public static SyntaxList<TemplateChildNode> FreezeChildren(IReadOnlyList<SyntaxNode> children)
+    {
+        if (children.Count == 0)
+        {
+            return SyntaxList<TemplateChildNode>.Empty;
+        }
+
+        var array = new TemplateChildNode[children.Count];
+        for (var index = 0; index < children.Count; index++)
+        {
+            array[index] = FreezeNode(children[index]);
+        }
+
+        return new SyntaxList<TemplateChildNode>(array);
+    }
+
+    public static TemplateChildNode FreezeNode(SyntaxNode node) => node switch
+    {
+        WorkingIf workingIf => new IfNode
+        {
+            Branches = FreezeBranches(workingIf.Branches),
+            CodegenNode = workingIf.CodegenNode,
+            Location = workingIf.Location,
+        },
+        WorkingFor workingFor => new ForNode
+        {
+            Source = workingFor.Source,
+            ValueAlias = workingFor.ValueAlias,
+            KeyAlias = workingFor.KeyAlias,
+            ObjectIndexAlias = workingFor.ObjectIndexAlias,
+            ParseResult = workingFor.ParseResult,
+            Children = FreezeChildren(workingFor.Children),
+            CodegenNode = workingFor.CodegenNode,
+            Location = workingFor.Location,
+        },
+        TemplateChildNode templateChild => templateChild,
+        _ => (TemplateChildNode)node,
+    };
+
+    private static SyntaxList<IfBranchNode> FreezeBranches(IReadOnlyList<WorkingIfBranch> branches)
+    {
+        var array = new IfBranchNode[branches.Count];
+        for (var index = 0; index < branches.Count; index++)
+        {
+            var branch = branches[index];
+            array[index] = new IfBranchNode
+            {
+                Condition = branch.Condition,
+                Children = FreezeChildren(branch.Children),
+                UserKey = branch.UserKey,
+                IsTemplateIf = branch.IsTemplateIf,
+                Location = branch.Location,
+            };
+        }
+
+        return new SyntaxList<IfBranchNode>(array);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformSlotOutlet.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformSlotOutlet.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The slot-outlet transform: compiles a <c>&lt;slot&gt;</c> element to a <c>renderSlot</c> call carrying the
+/// slot name, forwarded props, and fallback content. The C# port of Vue 3.5's <c>transformSlotOutlet</c> and
+/// <c>processSlotOutlet</c> (<c>@vue/compiler-core</c> <c>transforms/transformSlotOutlet.ts</c>).
+/// </summary>
+internal static class TransformSlotOutlet
+{
+    /// <summary>The node transform (builds the render-slot call on exit, after fallback children are transformed).</summary>
+    public static Action? Transform(SyntaxNode node, TransformContext context)
+    {
+        if (node is not ElementNode { ElementType: ElementType.Slot } element)
+        {
+            return null;
+        }
+
+        return () =>
+        {
+            var (slotName, slotProps) = ProcessSlotOutlet(element, context);
+            var slotChildren = context.WorkingChildrenOf(element, element.Children);
+
+            var slotArguments = new List<object> { "$slots", slotName, "{}", "undefined", "true" };
+            var expectedLength = 2;
+
+            if (slotProps is not null)
+            {
+                slotArguments[2] = slotProps;
+                expectedLength = 3;
+            }
+
+            if (slotChildren.Count > 0)
+            {
+                slotArguments[3] = Ir.FunctionExpression(
+                    Array.Empty<object>(),
+                    TransformFreeze.FreezeChildren(slotChildren),
+                    newline: false,
+                    isSlot: false,
+                    element.Location);
+                expectedLength = 4;
+            }
+
+            if (context.ScopeId is not null && !context.Slotted)
+            {
+                expectedLength = 5;
+            }
+
+            slotArguments.RemoveRange(expectedLength, slotArguments.Count - expectedLength);
+            context.SetCodegenNode(element, Ir.CallExpression(context.Helper(HelperNames.RenderSlot), slotArguments, element.Location));
+        };
+    }
+
+    private static (object SlotName, SyntaxNode? SlotProps) ProcessSlotOutlet(ElementNode element, TransformContext context)
+    {
+        object slotName = "\"default\"";
+        SyntaxNode? slotProps = null;
+        var nonNameProperties = new List<PropertyNode>();
+
+        foreach (var property in element.Properties)
+        {
+            if (property is AttributeNode attribute)
+            {
+                if (attribute.Value is not null)
+                {
+                    if (attribute.Name == "name")
+                    {
+                        slotName = "\"" + attribute.Value.Content + "\"";
+                    }
+                    else
+                    {
+                        nonNameProperties.Add(attribute with { Name = CompilerText.Camelize(attribute.Name) });
+                    }
+                }
+            }
+            else if (property is DirectiveNode directive)
+            {
+                if (directive.Name == "bind" && TransformUtilities.IsStaticArgumentOf(directive.Argument, "name"))
+                {
+                    if (directive.Expression is not null)
+                    {
+                        slotName = directive.Expression;
+                    }
+                    else if (directive.Argument is SimpleExpressionNode argument)
+                    {
+                        slotName = Ir.SimpleExpression(CompilerText.Camelize(argument.Content), false, argument.Location);
+                    }
+                }
+                else
+                {
+                    if (directive.Name == "bind" && directive.Argument is SimpleExpressionNode { IsStatic: true } bindArgument)
+                    {
+                        directive = directive with { Argument = bindArgument with { Content = CompilerText.Camelize(bindArgument.Content) } };
+                    }
+
+                    nonNameProperties.Add(directive);
+                }
+            }
+        }
+
+        if (nonNameProperties.Count > 0)
+        {
+            var built = TransformElement.BuildProps(
+                element,
+                context,
+                new SyntaxList<PropertyNode>(nonNameProperties.ToArray()),
+                isComponent: false,
+                isDynamicComponent: false);
+            slotProps = built.Props;
+
+            if (built.Directives.Count > 0)
+            {
+                context.ReportError(CompilerErrorFactory.Create(
+                    CompilerErrorCode.XVSlotUnexpectedDirectiveOnSlotOutlet, built.Directives[0].Location));
+            }
+        }
+
+        return (slotName, slotProps);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformText.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformText.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The text transform: merges adjacent text and interpolation children into a single compound expression and
+/// pre-converts text children to <c>createTextVNode</c> calls so the runtime skips normalization. The C# port
+/// of Vue 3.5's <c>transformText</c> (<c>@vue/compiler-core</c> <c>transforms/transformText.ts</c>).
+/// </summary>
+internal static class TransformText
+{
+    /// <summary>The node transform (runs on exit so child expressions are already processed).</summary>
+    public static Action? Transform(SyntaxNode node, TransformContext context)
+    {
+        var children = ResolveChildren(node, context);
+        if (children is null)
+        {
+            return null;
+        }
+
+        return () =>
+        {
+            List<object>? containerParts = null;
+            var containerIndex = 0;
+            var hasText = false;
+
+            for (var i = 0; i < children.Count; i++)
+            {
+                if (!IsText(children[i]))
+                {
+                    continue;
+                }
+
+                hasText = true;
+                for (var j = i + 1; j < children.Count;)
+                {
+                    var next = children[j];
+                    if (IsText(next))
+                    {
+                        if (containerParts is null)
+                        {
+                            containerParts = new List<object> { children[i] };
+                            containerIndex = i;
+                            children[i] = Ir.CompoundExpression(containerParts.ToArray());
+                        }
+
+                        containerParts.Add(" + ");
+                        containerParts.Add(next);
+                        children[containerIndex] = Ir.CompoundExpression(containerParts.ToArray());
+                        children.RemoveAt(j);
+                    }
+                    else
+                    {
+                        containerParts = null;
+                        break;
+                    }
+                }
+            }
+
+            if (!hasText || (children.Count == 1 && IsFastPathTextParent(node, context)))
+            {
+                return;
+            }
+
+            for (var i = 0; i < children.Count; i++)
+            {
+                var child = children[i];
+                if (!IsText(child) && child is not CompoundExpressionNode)
+                {
+                    continue;
+                }
+
+                var callArguments = new List<object>();
+                if (!(child is TextNode { Content: " " }))
+                {
+                    callArguments.Add(child);
+                }
+
+                if (!context.Ssr && ConstantAnalysis.GetConstantType(child) == ConstantType.NotConstant)
+                {
+                    callArguments.Add(((int)PatchFlags.Text).ToString(CultureInfo.InvariantCulture));
+                }
+
+                children[i] = new TextCallNode
+                {
+                    Content = child,
+                    CodegenNode = Ir.CallExpression(context.Helper(HelperNames.CreateText), callArguments),
+                    Location = child.Location,
+                };
+            }
+        };
+    }
+
+    private static List<SyntaxNode>? ResolveChildren(SyntaxNode node, TransformContext context) => node switch
+    {
+        RootNode root => context.WorkingChildrenOf(root, root.Children),
+        ElementNode element => context.WorkingChildrenOf(element, element.Children),
+        WorkingFor workingFor => workingFor.Children,
+        WorkingIfBranch branch => branch.Children,
+        _ => null,
+    };
+
+    private static bool IsText(SyntaxNode node) => node is TextNode or InterpolationNode;
+
+    private static bool IsFastPathTextParent(SyntaxNode node, TransformContext context)
+    {
+        if (node is RootNode)
+        {
+            return true;
+        }
+
+        if (node is ElementNode { ElementType: ElementType.Element } element)
+        {
+            foreach (var property in element.Properties)
+            {
+                if (property is DirectiveNode directive && !context.DirectiveTransforms.ContainsKey(directive.Name))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformTraversal.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformTraversal.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The transform traversal: applies node transforms on entry (collecting exit callbacks), recurses into
+/// children, then runs the exit callbacks in reverse. The C# port of Vue 3.5's <c>traverseNode</c> and
+/// <c>traverseChildren</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// </summary>
+internal static class TransformTraversal
+{
+    public static void TraverseNode(SyntaxNode node, TransformContext context)
+    {
+        context.CurrentNode = node;
+        var exitCallbacks = new List<Action>();
+        foreach (var transform in context.NodeTransforms)
+        {
+            var onExit = transform(node, context);
+            if (onExit is not null)
+            {
+                exitCallbacks.Add(onExit);
+            }
+
+            if (context.CurrentNode is null)
+            {
+                // node was removed
+                return;
+            }
+
+            node = context.CurrentNode;
+        }
+
+        switch (node)
+        {
+            case CommentNode:
+                if (!context.Ssr)
+                {
+                    context.Helper(HelperNames.CreateComment);
+                }
+
+                break;
+            case InterpolationNode:
+                if (!context.Ssr)
+                {
+                    context.Helper(HelperNames.ToDisplayString);
+                }
+
+                break;
+            case WorkingIf workingIf:
+                foreach (var branch in workingIf.Branches)
+                {
+                    TraverseNode(branch, context);
+                }
+
+                break;
+            case WorkingIfBranch branch:
+                TraverseChildren(branch, branch.Children, context);
+                break;
+            case WorkingFor workingFor:
+                TraverseChildren(workingFor, workingFor.Children, context);
+                break;
+            case ElementNode element:
+                TraverseChildren(element, context.WorkingChildrenOf(element, element.Children), context);
+                break;
+            case RootNode root:
+                TraverseChildren(root, context.WorkingChildrenOf(root, root.Children), context);
+                break;
+        }
+
+        context.CurrentNode = node;
+        for (var index = exitCallbacks.Count - 1; index >= 0; index--)
+        {
+            exitCallbacks[index]();
+        }
+    }
+
+    public static void TraverseChildren(SyntaxNode parent, List<SyntaxNode> children, TransformContext context)
+    {
+        var i = 0;
+        Action nodeRemoved = () => i--;
+        for (; i < children.Count; i++)
+        {
+            context.Parent = parent;
+            context.CurrentChildren = children;
+            context.ChildIndex = i;
+            context.OnNodeRemoved = nodeRemoved;
+            TraverseNode(children[i], context);
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/TransformUtilities.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/TransformUtilities.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Shared query and rewrite helpers over the AST used across the transforms, ported from Vue 3.5's
+/// <c>@vue/compiler-core</c> <c>utils.ts</c> (<c>findDir</c>, <c>findProp</c>, <c>isStaticExp</c>,
+/// <c>injectProp</c>, <c>getMemoedVNodeCall</c>, …) and <c>ast.ts</c> (<c>convertToBlock</c>).
+/// </summary>
+internal static class TransformUtilities
+{
+    /// <summary>Whether <paramref name="node"/> is a static simple expression (upstream <c>isStaticExp</c>).</summary>
+    public static bool IsStaticExpression(SyntaxNode? node)
+        => node is SimpleExpressionNode { IsStatic: true };
+
+    /// <summary>Whether <paramref name="argument"/> is the static argument <paramref name="name"/> (upstream <c>isStaticArgOf</c>).</summary>
+    public static bool IsStaticArgumentOf(ExpressionNode? argument, string name)
+        => argument is SimpleExpressionNode { IsStatic: true } simple && simple.Content == name;
+
+    /// <summary>Finds a directive by name (upstream <c>findDir</c>).</summary>
+    public static DirectiveNode? FindDirective(ElementNode element, string name, bool allowEmpty = false)
+    {
+        foreach (var property in element.Properties)
+        {
+            if (property is DirectiveNode directive && (allowEmpty || directive.Expression is not null) &&
+                directive.Name == name)
+            {
+                return directive;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Finds a directive whose name matches <paramref name="pattern"/> (upstream <c>findDir</c> regex form).</summary>
+    public static DirectiveNode? FindDirective(ElementNode element, Regex pattern, bool allowEmpty = false)
+    {
+        foreach (var property in element.Properties)
+        {
+            if (property is DirectiveNode directive && (allowEmpty || directive.Expression is not null) &&
+                pattern.IsMatch(directive.Name))
+            {
+                return directive;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Finds a plain attribute or static <c>v-bind</c> by name (upstream <c>findProp</c>).</summary>
+    public static PropertyNode? FindProperty(ElementNode element, string name, bool dynamicOnly = false, bool allowEmpty = false)
+    {
+        foreach (var property in element.Properties)
+        {
+            if (property is AttributeNode attribute)
+            {
+                if (dynamicOnly)
+                {
+                    continue;
+                }
+
+                if (attribute.Name == name && (attribute.Value is not null || allowEmpty))
+                {
+                    return attribute;
+                }
+            }
+            else if (property is DirectiveNode { Name: "bind" } directive &&
+                     (directive.Expression is not null || allowEmpty) &&
+                     IsStaticArgumentOf(directive.Argument, name))
+            {
+                return directive;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether the element has a <c>v-bind</c> with a dynamic key (upstream <c>hasDynamicKeyVBind</c>).</summary>
+    public static bool HasDynamicKeyVBind(ElementNode element)
+    {
+        foreach (var property in element.Properties)
+        {
+            if (property is DirectiveNode { Name: "bind" } directive &&
+                (directive.Argument is null ||
+                 directive.Argument is not SimpleExpressionNode ||
+                 directive.Argument is SimpleExpressionNode { IsStatic: false }))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Whether <paramref name="node"/> is a <c>&lt;template&gt;</c> container (upstream <c>isTemplateNode</c>).</summary>
+    public static bool IsTemplateNode(SyntaxNode node)
+        => node is ElementNode { ElementType: ElementType.Template };
+
+    /// <summary>Whether <paramref name="node"/> is a <c>&lt;slot&gt;</c> outlet (upstream <c>isSlotOutlet</c>).</summary>
+    public static bool IsSlotOutlet(SyntaxNode node)
+        => node is ElementNode { ElementType: ElementType.Slot };
+
+    /// <summary>Unwraps a <c>withMemo(...)</c>-wrapped vnode call (upstream <c>getMemoedVNodeCall</c>).</summary>
+    public static SyntaxNode GetMemoedVNodeCall(SyntaxNode node)
+    {
+        if (node is CallExpression { Callee: RuntimeHelper helper } call &&
+            helper == HelperNames.WithMemo &&
+            call.Arguments.Count > 1 &&
+            call.Arguments[1] is FunctionExpression { Returns: SyntaxNode returns })
+        {
+            return returns;
+        }
+
+        return node;
+    }
+
+    /// <summary>Turns a vnode call into a block, registering the block helpers (upstream <c>convertToBlock</c>).</summary>
+    public static VNodeCall ConvertToBlock(VNodeCall node, TransformContext context)
+    {
+        if (node.IsBlock)
+        {
+            return node;
+        }
+
+        context.RemoveHelper(TransformContext.GetVNodeHelper(context.InSSR, node.IsComponent));
+        context.Helper(HelperNames.OpenBlock);
+        context.Helper(TransformContext.GetVNodeBlockHelper(context.InSSR, node.IsComponent));
+        return node with { IsBlock = true };
+    }
+
+    /// <summary>
+    /// Injects <paramref name="property"/> as the first prop of a vnode call or <c>renderSlot</c> call
+    /// (upstream <c>injectProp</c>), returning the rewritten node.
+    /// </summary>
+    public static SyntaxNode InjectProperty(SyntaxNode node, Property property, TransformContext context)
+    {
+        var isVNodeCall = node is VNodeCall;
+        var properties = isVNodeCall
+            ? ((VNodeCall)node).Props
+            : ((CallExpression)node).Arguments.Count > 2 ? ((CallExpression)node).Arguments[2] as SyntaxNode : null;
+
+        SyntaxNode? propertiesWithInjection;
+        if (properties is null)
+        {
+            propertiesWithInjection = Ir.ObjectExpression(new[] { property });
+        }
+        else if (properties is CallExpression callProperties)
+        {
+            // merged props via mergeProps(...): inject into the first object-literal arg if present.
+            var first = callProperties.Arguments.Count > 0 ? callProperties.Arguments[0] : null;
+            if (first is ObjectExpression firstObject)
+            {
+                if (!HasProperty(property, firstObject))
+                {
+                    propertiesWithInjection = callProperties with
+                    {
+                        Arguments = ReplaceAt(callProperties.Arguments, 0, Unshift(firstObject, property)),
+                    };
+                }
+                else
+                {
+                    propertiesWithInjection = callProperties;
+                }
+            }
+            else if (callProperties.Callee is RuntimeHelper toHandlers && toHandlers == HelperNames.ToHandlers)
+            {
+                propertiesWithInjection = Ir.CallExpression(
+                    context.Helper(HelperNames.MergeProps),
+                    new object[] { Ir.ObjectExpression(new[] { property }), callProperties });
+            }
+            else
+            {
+                propertiesWithInjection = callProperties with
+                {
+                    Arguments = Prepend(callProperties.Arguments, Ir.ObjectExpression(new[] { property })),
+                };
+            }
+        }
+        else if (properties is ObjectExpression objectProperties)
+        {
+            propertiesWithInjection = HasProperty(property, objectProperties)
+                ? objectProperties
+                : Unshift(objectProperties, property);
+        }
+        else
+        {
+            // single v-bind expression: merge.
+            propertiesWithInjection = Ir.CallExpression(
+                context.Helper(HelperNames.MergeProps),
+                new object[] { Ir.ObjectExpression(new[] { property }), properties });
+        }
+
+        if (isVNodeCall)
+        {
+            return ((VNodeCall)node) with { Props = propertiesWithInjection };
+        }
+
+        var arguments = new List<object>(((CallExpression)node).Arguments);
+        while (arguments.Count <= 2)
+        {
+            arguments.Add("{}");
+        }
+
+        arguments[2] = propertiesWithInjection!;
+        return ((CallExpression)node) with { Arguments = new SyntaxList<object>(arguments.ToArray()) };
+    }
+
+    private static ObjectExpression Unshift(ObjectExpression target, Property property)
+    {
+        var properties = new List<Property>(target.Properties.Count + 1) { property };
+        properties.AddRange(target.Properties);
+        return target with { Properties = new SyntaxList<Property>(properties.ToArray()) };
+    }
+
+    private static SyntaxList<object> ReplaceAt(SyntaxList<object> arguments, int index, object value)
+    {
+        var array = new object[arguments.Count];
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            array[i] = i == index ? value : arguments[i];
+        }
+
+        return new SyntaxList<object>(array);
+    }
+
+    private static SyntaxList<object> Prepend(SyntaxList<object> arguments, object value)
+    {
+        var array = new object[arguments.Count + 1];
+        array[0] = value;
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            array[i + 1] = arguments[i];
+        }
+
+        return new SyntaxList<object>(array);
+    }
+
+    private static bool HasProperty(Property property, ObjectExpression target)
+    {
+        if (property.Key is not SimpleExpressionNode key)
+        {
+            return false;
+        }
+
+        foreach (var existing in target.Properties)
+        {
+            if (existing.Key is SimpleExpressionNode existingKey && existingKey.Content == key.Content)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VBindTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VBindTransform.cs
@@ -1,0 +1,128 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-bind</c> (with argument) directive transform: emits a single prop and applies the
+/// <c>.camel</c>/<c>.prop</c>/<c>.attr</c> modifiers and the same-name shorthand. The C# port of Vue 3.5's
+/// <c>transformBind</c> (<c>@vue/compiler-core</c> <c>transforms/vBind.ts</c>). Argument-less <c>v-bind</c>
+/// (<c>v-bind="object"</c>) is handled by the element transform.
+/// </summary>
+internal static class VBindTransform
+{
+    /// <summary>The directive transform delegate.</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+    {
+        var argument = directive.Argument!;
+        var expression = directive.Expression;
+
+        // Empty expression (e.g. `:foo=""`). Non-browser semantics: report and emit an empty prop.
+        if (expression is SimpleExpressionNode { IsStatic: false } simpleEmpty && simpleEmpty.Content.Trim().Length == 0)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVBindNoExpression, directive.Location));
+            return new DirectiveTransformResult
+            {
+                Properties = new[] { Ir.ObjectProperty(argument, Ir.SimpleExpression(string.Empty, true, directive.Location)) },
+            };
+        }
+
+        // Same-name shorthand: `:arg` expands to `:arg="arg"`.
+        if (expression is null)
+        {
+            if (argument is not SimpleExpressionNode { IsStatic: true })
+            {
+                context.ReportError(
+                    CompilerErrorFactory.Create(CompilerErrorCode.XVBindInvalidSameNameArgument, argument.Location));
+                return new DirectiveTransformResult
+                {
+                    Properties = new[] { Ir.ObjectProperty(argument, Ir.SimpleExpression(string.Empty, true, directive.Location)) },
+                };
+            }
+
+            expression = CreateShorthandExpression((SimpleExpressionNode)argument);
+        }
+
+        // Null-guard a dynamic argument.
+        if (argument is not SimpleExpressionNode simpleArgument)
+        {
+            argument = WrapCompound((CompoundExpressionNode)argument, "(", ") || \"\"");
+        }
+        else if (!simpleArgument.IsStatic)
+        {
+            argument = simpleArgument with { Content = simpleArgument.Content + " || \"\"" };
+        }
+
+        if (HasModifier(directive, "camel"))
+        {
+            argument = argument is SimpleExpressionNode camelArgument
+                ? camelArgument.IsStatic
+                    ? camelArgument with { Content = CompilerText.Camelize(camelArgument.Content) }
+                    : camelArgument with { Content = $"{context.HelperString(HelperNames.Camelize)}({camelArgument.Content})" }
+                : WrapCompound((CompoundExpressionNode)argument, $"{context.HelperString(HelperNames.Camelize)}(", ")");
+        }
+
+        if (!context.InSSR)
+        {
+            if (HasModifier(directive, "prop"))
+            {
+                argument = InjectPrefix(argument, ".");
+            }
+
+            if (HasModifier(directive, "attr"))
+            {
+                argument = InjectPrefix(argument, "^");
+            }
+        }
+
+        return new DirectiveTransformResult
+        {
+            Properties = new[] { Ir.ObjectProperty(argument, expression) },
+        };
+    }
+
+    /// <summary>Expands the same-name <c>v-bind</c> shorthand to its camel-cased binding (upstream <c>transformBindShorthand</c>).</summary>
+    public static SimpleExpressionNode CreateShorthandExpression(SimpleExpressionNode argument)
+        => Ir.SimpleExpression(CompilerText.Camelize(argument.Content), false, argument.Location);
+
+    private static bool HasModifier(DirectiveNode directive, string modifier)
+    {
+        foreach (var entry in directive.Modifiers)
+        {
+            if (entry.Content == modifier)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ExpressionNode InjectPrefix(ExpressionNode argument, string prefix)
+    {
+        if (argument is SimpleExpressionNode simple)
+        {
+            return simple.IsStatic
+                ? simple with { Content = prefix + simple.Content }
+                : simple with { Content = "`" + prefix + "${" + simple.Content + "}`" };
+        }
+
+        return WrapCompound((CompoundExpressionNode)argument, $"'{prefix}' + (", ")");
+    }
+
+    private static CompoundExpressionNode WrapCompound(CompoundExpressionNode compound, string open, string close)
+    {
+        var parts = new object[compound.Parts.Count + 2];
+        parts[0] = open;
+        for (var index = 0; index < compound.Parts.Count; index++)
+        {
+            parts[index + 1] = compound.Parts[index];
+        }
+
+        parts[parts.Length - 1] = close;
+        return compound with { Parts = new SyntaxList<object>(parts) };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VForTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VForTransform.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-for</c> transform: builds a <see cref="WorkingFor"/> capturing the source and decomposed aliases
+/// and compiles it to a <c>renderList</c> fragment block whose keyed/unkeyed/stable classification drives the
+/// runtime diff. The C# port of Vue 3.5's <c>transformFor</c> and <c>processFor</c>
+/// (<c>@vue/compiler-core</c> <c>transforms/vFor.ts</c>). See https://vuejs.org/guide/essentials/list.html.
+/// </summary>
+internal static class VForTransform
+{
+    /// <summary>The node transform (built via the structural directive factory).</summary>
+    public static readonly NodeTransform Transform = StructuralDirectiveFactory.Create(
+        static name => name == "for",
+        (element, directive, context) => ProcessFor(element, directive, context));
+
+    private static Action? ProcessFor(ElementNode element, DirectiveNode directive, TransformContext context)
+    {
+        if (directive.Expression is not SimpleExpressionNode expression)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVForNoExpression, directive.Location));
+            return null;
+        }
+
+        var parseResult = ForExpressionParser.Parse(expression);
+        if (parseResult is null)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVForMalformedExpression, directive.Location));
+            return null;
+        }
+
+        var workingFor = new WorkingFor
+        {
+            Source = parseResult.Source,
+            ValueAlias = parseResult.Value,
+            KeyAlias = parseResult.Key,
+            ObjectIndexAlias = parseResult.Index,
+            ParseResult = parseResult,
+            Location = directive.Location,
+        };
+
+        var isTemplate = element.ElementType == ElementType.Template;
+        if (isTemplate)
+        {
+            foreach (var child in element.Children)
+            {
+                workingFor.Children.Add(child);
+            }
+        }
+        else
+        {
+            workingFor.Children.Add(element);
+        }
+
+        // v-memo on a v-for element is handled here (per-item memoization in the render-list loop). Mark the
+        // inner element as seen so transformMemo does not also wrap it — mirroring upstream's WeakSet guard,
+        // which the immutable model breaks because the structural factory produces a fresh reduced element.
+        if (!isTemplate && TransformUtilities.FindDirective(element, "memo") is not null)
+        {
+            context.SeenMemo.Add(element);
+        }
+
+        context.ReplaceNode(workingFor);
+        context.ScopeVFor++;
+
+        var onExit = ProcessCodegen(element, directive, context, workingFor, parseResult, isTemplate);
+
+        return () =>
+        {
+            context.ScopeVFor--;
+            onExit?.Invoke();
+        };
+    }
+
+    private static Action ProcessCodegen(
+        ElementNode element,
+        DirectiveNode directive,
+        TransformContext context,
+        WorkingFor workingFor,
+        ForParseResult parseResult,
+        bool isTemplate)
+    {
+        var renderExpArguments = new List<object> { workingFor.Source };
+        var memo = TransformUtilities.FindDirective(element, "memo");
+        var keyProperty = ResolveKeyProperty(element, out var keyExpression);
+
+        var isStableFragment = workingFor.Source is SimpleExpressionNode source &&
+                               source.ConstantType > ConstantType.NotConstant;
+        var fragmentFlag = isStableFragment
+            ? PatchFlags.StableFragment
+            : keyProperty is not null ? PatchFlags.KeyedFragment : PatchFlags.UnkeyedFragment;
+
+        var renderExpression = Ir.CallExpression(context.Helper(HelperNames.RenderList), renderExpArguments);
+        workingFor.CodegenNode = context.CreateVNodeCall(
+            context.Helper(HelperNames.Fragment),
+            null,
+            renderExpression,
+            fragmentFlag,
+            null,
+            null,
+            isBlock: true,
+            disableTracking: !isStableFragment,
+            isComponent: false,
+            directive.Location);
+
+        return () =>
+        {
+            var children = workingFor.Children;
+
+            // <template v-for> key must be on the <template>, not a child.
+            if (isTemplate)
+            {
+                foreach (var child in element.Children)
+                {
+                    if (child is ElementNode childElement)
+                    {
+                        var childKey = TransformUtilities.FindProperty(childElement, "key");
+                        if (childKey is not null)
+                        {
+                            context.ReportError(CompilerErrorFactory.Create(
+                                CompilerErrorCode.XVForTemplateKeyPlacement, childKey.Location));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            var needFragmentWrapper = children.Count != 1 || children[0] is not ElementNode;
+            var slotOutlet = ResolveSlotOutlet(element, isTemplate);
+
+            SyntaxNode childBlock;
+            if (slotOutlet is not null)
+            {
+                childBlock = context.GetCodegenNode(slotOutlet)!;
+                if (isTemplate && keyProperty is not null)
+                {
+                    childBlock = TransformUtilities.InjectProperty(childBlock, keyProperty, context);
+                }
+            }
+            else if (needFragmentWrapper)
+            {
+                childBlock = context.CreateVNodeCall(
+                    context.Helper(HelperNames.Fragment),
+                    keyProperty is not null ? Ir.ObjectExpression(new[] { keyProperty }) : null,
+                    TransformFreeze.FreezeChildren(children),
+                    PatchFlags.StableFragment,
+                    null,
+                    null,
+                    isBlock: true,
+                    disableTracking: false,
+                    isComponent: false);
+            }
+            else
+            {
+                var elementBlock = (VNodeCall)context.GetCodegenNode(children[0])!;
+                if (isTemplate && keyProperty is not null)
+                {
+                    elementBlock = (VNodeCall)TransformUtilities.InjectProperty(elementBlock, keyProperty, context);
+                }
+
+                var targetIsBlock = !isStableFragment;
+                if (elementBlock.IsBlock != targetIsBlock)
+                {
+                    if (elementBlock.IsBlock)
+                    {
+                        context.RemoveHelper(HelperNames.OpenBlock);
+                        context.RemoveHelper(TransformContext.GetVNodeBlockHelper(context.InSSR, elementBlock.IsComponent));
+                    }
+                    else
+                    {
+                        context.RemoveHelper(TransformContext.GetVNodeHelper(context.InSSR, elementBlock.IsComponent));
+                    }
+                }
+
+                elementBlock = elementBlock with { IsBlock = targetIsBlock };
+                if (targetIsBlock)
+                {
+                    context.Helper(HelperNames.OpenBlock);
+                    context.Helper(TransformContext.GetVNodeBlockHelper(context.InSSR, elementBlock.IsComponent));
+                }
+                else
+                {
+                    context.Helper(TransformContext.GetVNodeHelper(context.InSSR, elementBlock.IsComponent));
+                }
+
+                context.SetCodegenNode(children[0], elementBlock);
+                childBlock = elementBlock;
+            }
+
+            if (memo is not null)
+            {
+                var loopParameters = CreateForLoopParameters(parseResult, new object[] { Ir.SimpleExpression("_cached") });
+                var body = BuildMemoLoopBody(memo, keyExpression, childBlock, context);
+                var loop = Ir.FunctionExpression(loopParameters) with { Body = body };
+                renderExpArguments.Add(loop);
+                renderExpArguments.Add(Ir.SimpleExpression("_cache"));
+                renderExpArguments.Add(Ir.SimpleExpression(context.CacheCount.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                context.AppendEmptyCacheSlot();
+            }
+            else
+            {
+                renderExpArguments.Add(Ir.FunctionExpression(CreateForLoopParameters(parseResult), childBlock, newline: true));
+            }
+
+            var finalRenderExpression = renderExpression with { Arguments = new SyntaxList<object>(renderExpArguments.ToArray()) };
+            workingFor.CodegenNode = ((VNodeCall)workingFor.CodegenNode!) with { Children = finalRenderExpression };
+        };
+    }
+
+    private static Property? ResolveKeyProperty(ElementNode element, out ExpressionNode? keyExpression)
+    {
+        keyExpression = null;
+        var keyProperty = TransformUtilities.FindProperty(element, "key", dynamicOnly: false, allowEmpty: true);
+        if (keyProperty is null)
+        {
+            return null;
+        }
+
+        if (keyProperty is AttributeNode attribute)
+        {
+            keyExpression = attribute.Value is not null ? Ir.SimpleExpression(attribute.Value.Content, true) : null;
+        }
+        else if (keyProperty is DirectiveNode directive)
+        {
+            keyExpression = directive.Expression ??
+                            (directive.Argument is SimpleExpressionNode argument
+                                ? VBindTransform.CreateShorthandExpression(argument)
+                                : null);
+        }
+
+        return keyExpression is not null ? Ir.ObjectProperty("key", keyExpression) : null;
+    }
+
+    private static ElementNode? ResolveSlotOutlet(ElementNode element, bool isTemplate)
+    {
+        if (element.ElementType == ElementType.Slot)
+        {
+            return element;
+        }
+
+        if (isTemplate && element.Children.Count == 1 && element.Children[0] is ElementNode { ElementType: ElementType.Slot } slot)
+        {
+            return slot;
+        }
+
+        return null;
+    }
+
+    private static BlockStatement BuildMemoLoopBody(
+        DirectiveNode memo,
+        ExpressionNode? keyExpression,
+        SyntaxNode childBlock,
+        TransformContext context)
+    {
+        var conditionParts = new List<object> { "if (_cached" };
+        if (keyExpression is not null)
+        {
+            conditionParts.Add(" && _cached.key === ");
+            conditionParts.Add(keyExpression);
+        }
+
+        conditionParts.Add($" && {context.HelperString(HelperNames.IsMemoSame)}(_cached, _memo)) return _cached");
+
+        return Ir.BlockStatement(new object[]
+        {
+            Ir.CompoundExpression("const _memo = (", memo.Expression!, ")"),
+            Ir.CompoundExpression(conditionParts.ToArray()),
+            Ir.CompoundExpression("const _item = ", childBlock),
+            Ir.SimpleExpression("_item.memo = _memo"),
+            Ir.SimpleExpression("return _item"),
+        });
+    }
+
+    // Port of createForLoopParams / createParamsList.
+    internal static IReadOnlyList<object> CreateForLoopParameters(ForParseResult parseResult, IReadOnlyList<object>? memoArguments = null)
+    {
+        var arguments = new List<ExpressionNode?> { parseResult.Value, parseResult.Key, parseResult.Index };
+        if (memoArguments is not null)
+        {
+            foreach (var argument in memoArguments)
+            {
+                arguments.Add((ExpressionNode)argument);
+            }
+        }
+
+        var last = -1;
+        for (var index = arguments.Count - 1; index >= 0; index--)
+        {
+            if (arguments[index] is not null)
+            {
+                last = index;
+                break;
+            }
+        }
+
+        var result = new List<object>(last + 1);
+        for (var index = 0; index <= last; index++)
+        {
+            result.Add(arguments[index] ?? (object)Ir.SimpleExpression(new string('_', index + 1), false));
+        }
+
+        return result;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VHtmlTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VHtmlTransform.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-html</c> directive transform: compiles to an <c>innerHTML</c> prop and raises the child-conflict
+/// diagnostic when the element also has template children. The C# port of Vue 3.5's <c>transformVHtml</c>
+/// (<c>@vue/compiler-dom</c> <c>transforms/vHtml.ts</c>).
+/// </summary>
+internal static class VHtmlTransform
+{
+    /// <summary>The directive transform delegate.</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+    {
+        var expression = directive.Expression;
+        if (expression is null)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVHtmlNoExpression, directive.Location));
+        }
+
+        if (element.Children.Count > 0)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVHtmlWithChildren, directive.Location));
+            if (context.TryGetWorkingChildren(element, out var workingChildren))
+            {
+                workingChildren.Clear();
+            }
+        }
+
+        return new DirectiveTransformResult
+        {
+            Properties = new[]
+            {
+                Ir.ObjectProperty("innerHTML", expression ?? Ir.SimpleExpression(string.Empty, true)),
+            },
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VIfTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VIfTransform.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-if</c>/<c>v-else-if</c>/<c>v-else</c> transform: groups adjacent conditional siblings into one
+/// <see cref="WorkingIf"/> with ordered branches and compiles it to a conditional-expression chain where each
+/// branch is its own block with a stable synthetic key. The C# port of Vue 3.5's <c>transformIf</c> and
+/// <c>processIf</c> (<c>@vue/compiler-core</c> <c>transforms/vIf.ts</c>).
+/// See https://vuejs.org/guide/essentials/conditional.html.
+/// </summary>
+internal static class VIfTransform
+{
+    /// <summary>The node transform (built via the structural directive factory).</summary>
+    public static readonly NodeTransform Transform = StructuralDirectiveFactory.Create(
+        static name => name is "if" or "else" or "else-if",
+        (element, directive, context) => ProcessIf(element, directive, context, (workingIf, branch, isRoot) =>
+        {
+            // #1587: key increments over sibling conditional chains rendered at the same depth. Computed on
+            // entry (siblings are intact here); the exit callback closes over the captured key.
+            var siblings = context.CurrentChildren!;
+            var startIndex = ReferenceIndexOf(siblings, workingIf);
+            var key = 0;
+            for (var i = startIndex - 1; i >= 0; i--)
+            {
+                if (siblings[i] is WorkingIf sibling)
+                {
+                    key += sibling.Branches.Count;
+                }
+            }
+
+            return () =>
+            {
+                if (isRoot)
+                {
+                    workingIf.CodegenNode = CreateCodegenNodeForBranch(branch, key, context);
+                }
+                else
+                {
+                    var alternate = CreateCodegenNodeForBranch(branch, key + workingIf.Branches.Count - 1, context);
+                    workingIf.CodegenNode = AppendAlternate(workingIf.CodegenNode!, alternate);
+                }
+            };
+        }));
+
+    private static Action? ProcessIf(
+        ElementNode element,
+        DirectiveNode directive,
+        TransformContext context,
+        Func<WorkingIf, WorkingIfBranch, bool, Action> processCodegen)
+    {
+        if (directive.Name != "else" &&
+            (directive.Expression is null ||
+             (directive.Expression is SimpleExpressionNode simple && simple.Content.Trim().Length == 0)))
+        {
+            var location = directive.Expression?.Location ?? element.Location;
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVIfNoExpression, directive.Location));
+            directive = directive with { Expression = Ir.SimpleExpression("true", false, location) };
+        }
+
+        if (directive.Name == "if")
+        {
+            var branch = CreateIfBranch(element, directive);
+            var workingIf = new WorkingIf { Location = element.Location };
+            workingIf.Branches.Add(branch);
+            context.ReplaceNode(workingIf);
+            return processCodegen(workingIf, branch, true);
+        }
+
+        // v-else / v-else-if: locate the adjacent v-if. The current element sits at context.ChildIndex; its
+        // reduced copy (with v-else removed) is not itself in the sibling list, so we scan from the index.
+        var siblings = context.CurrentChildren!;
+        var comments = new List<SyntaxNode>();
+        var index = context.ChildIndex;
+        while (true)
+        {
+            index--;
+            if (index < -1)
+            {
+                break;
+            }
+
+            var sibling = index >= 0 && index < siblings.Count ? siblings[index] : null;
+            if (sibling is CommentNode)
+            {
+                context.RemoveNode(sibling);
+                comments.Insert(0, sibling);
+                continue;
+            }
+
+            if (sibling is TextNode text && text.Content.Trim().Length == 0)
+            {
+                context.RemoveNode(sibling);
+                continue;
+            }
+
+            if (sibling is WorkingIf adjacent)
+            {
+                if (directive.Name == "else-if" &&
+                    adjacent.Branches[adjacent.Branches.Count - 1].Condition is null)
+                {
+                    context.ReportError(
+                        CompilerErrorFactory.Create(CompilerErrorCode.XVElseNoAdjacentIf, element.Location));
+                }
+
+                context.RemoveNode();
+                var branch = CreateIfBranch(element, directive);
+                if (comments.Count > 0 && !IsTransitionParent(context.Parent))
+                {
+                    branch.Children.InsertRange(0, comments);
+                }
+
+                if (branch.UserKey is not null)
+                {
+                    foreach (var existing in adjacent.Branches)
+                    {
+                        if (IsSameKey(existing.UserKey, branch.UserKey))
+                        {
+                            context.ReportError(
+                                CompilerErrorFactory.Create(CompilerErrorCode.XVIfSameKey, branch.UserKey.Location));
+                        }
+                    }
+                }
+
+                adjacent.Branches.Add(branch);
+                var onExit = processCodegen(adjacent, branch, false);
+                TransformTraversal.TraverseNode(branch, context);
+                onExit();
+                context.CurrentNode = null;
+            }
+            else
+            {
+                context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVElseNoAdjacentIf, element.Location));
+            }
+
+            break;
+        }
+
+        return null;
+    }
+
+    private static WorkingIfBranch CreateIfBranch(ElementNode element, DirectiveNode directive)
+    {
+        var isTemplateIf = element.ElementType == ElementType.Template;
+        var branch = new WorkingIfBranch
+        {
+            Location = element.Location,
+            Condition = directive.Name == "else" ? null : directive.Expression,
+            UserKey = TransformUtilities.FindProperty(element, "key"),
+            IsTemplateIf = isTemplateIf,
+        };
+
+        if (isTemplateIf && TransformUtilities.FindDirective(element, "for") is null)
+        {
+            foreach (var child in element.Children)
+            {
+                branch.Children.Add(child);
+            }
+        }
+        else
+        {
+            branch.Children.Add(element);
+        }
+
+        return branch;
+    }
+
+    private static SyntaxNode CreateCodegenNodeForBranch(WorkingIfBranch branch, int keyIndex, TransformContext context)
+    {
+        if (branch.Condition is not null)
+        {
+            return Ir.ConditionalExpression(
+                branch.Condition,
+                CreateChildrenCodegenNode(branch, keyIndex, context),
+                Ir.CallExpression(context.Helper(HelperNames.CreateComment), new object[] { "\"v-if\"", "true" }));
+        }
+
+        return CreateChildrenCodegenNode(branch, keyIndex, context);
+    }
+
+    private static SyntaxNode CreateChildrenCodegenNode(WorkingIfBranch branch, int keyIndex, TransformContext context)
+    {
+        var keyProperty = Ir.ObjectProperty(
+            "key",
+            Ir.SimpleExpression(keyIndex.ToString(System.Globalization.CultureInfo.InvariantCulture), false, Ir.LocationStub, ConstantType.CanCache));
+        var children = branch.Children;
+        var firstChild = children[0];
+        var needFragmentWrapper = children.Count != 1 || firstChild is not ElementNode;
+
+        if (needFragmentWrapper)
+        {
+            if (children.Count == 1 && firstChild is WorkingFor forChild)
+            {
+                var forCodegen = context.GetCodegenNode(forChild)!;
+                var injected = TransformUtilities.InjectProperty(forCodegen, keyProperty, context);
+                forChild.CodegenNode = injected;
+                return injected;
+            }
+
+            var patchFlag = PatchFlags.StableFragment;
+            if (!branch.IsTemplateIf && CountNonComment(children) == 1)
+            {
+                patchFlag |= PatchFlags.DevRootFragment;
+            }
+
+            return context.CreateVNodeCall(
+                context.Helper(HelperNames.Fragment),
+                Ir.ObjectExpression(new[] { keyProperty }),
+                TransformFreeze.FreezeChildren(children),
+                patchFlag,
+                null,
+                null,
+                isBlock: true,
+                disableTracking: false,
+                isComponent: false,
+                branch.Location);
+        }
+
+        var codegen = context.GetCodegenNode(firstChild)!;
+        var inner = TransformUtilities.GetMemoedVNodeCall(codegen);
+        var isMemo = !ReferenceEquals(inner, codegen);
+
+        var vnodeCall = inner;
+        if (vnodeCall is VNodeCall block)
+        {
+            vnodeCall = TransformUtilities.ConvertToBlock(block, context);
+        }
+
+        var withKey = TransformUtilities.InjectProperty(vnodeCall, keyProperty, context);
+        if (!isMemo)
+        {
+            return withKey;
+        }
+
+        // memo-wrapped: rebuild the memo's inner function return.
+        var memo = (CallExpression)codegen;
+        var factory = (FunctionExpression)memo.Arguments[1];
+        return memo with { Arguments = Replace(memo.Arguments, 1, factory with { Returns = withKey }) };
+    }
+
+    private static SyntaxNode AppendAlternate(SyntaxNode chain, SyntaxNode newAlternate)
+    {
+        var parentCondition = GetParentCondition(chain);
+        return ReplaceAlternate(chain, parentCondition, newAlternate);
+    }
+
+    private static ConditionalExpression GetParentCondition(SyntaxNode node)
+    {
+        while (true)
+        {
+            if (node is ConditionalExpression conditional)
+            {
+                if (conditional.Alternate is ConditionalExpression)
+                {
+                    node = conditional.Alternate;
+                }
+                else
+                {
+                    return conditional;
+                }
+            }
+            else if (node is CacheExpression cache)
+            {
+                node = cache.Value;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unexpected node in v-if conditional chain.");
+            }
+        }
+    }
+
+    // Rebuilds the immutable chain, replacing the alternate of the identified parent condition.
+    private static SyntaxNode ReplaceAlternate(SyntaxNode node, ConditionalExpression target, SyntaxNode newAlternate)
+    {
+        switch (node)
+        {
+            case ConditionalExpression conditional when ReferenceEquals(conditional, target):
+                return conditional with { Alternate = newAlternate };
+            case ConditionalExpression conditional:
+                return conditional with { Alternate = ReplaceAlternate(conditional.Alternate, target, newAlternate) };
+            case CacheExpression cache:
+                return cache with { Value = ReplaceAlternate(cache.Value, target, newAlternate) };
+            default:
+                return node;
+        }
+    }
+
+    private static bool IsSameKey(PropertyNode? left, PropertyNode? right)
+    {
+        if (left is null || right is null || left.GetType() != right.GetType())
+        {
+            return false;
+        }
+
+        if (left is AttributeNode leftAttribute && right is AttributeNode rightAttribute)
+        {
+            return leftAttribute.Value?.Content == rightAttribute.Value?.Content;
+        }
+
+        if (left is DirectiveNode leftDirective && right is DirectiveNode rightDirective)
+        {
+            if (leftDirective.Expression is not SimpleExpressionNode leftExpression ||
+                rightDirective.Expression is not SimpleExpressionNode rightExpression)
+            {
+                return false;
+            }
+
+            return leftExpression.IsStatic == rightExpression.IsStatic &&
+                   leftExpression.Content == rightExpression.Content;
+        }
+
+        return false;
+    }
+
+    private static bool IsTransitionParent(SyntaxNode? parent)
+        => parent is ElementNode { Tag: "transition" or "Transition" };
+
+    private static int CountNonComment(IReadOnlyList<SyntaxNode> children)
+    {
+        var count = 0;
+        foreach (var child in children)
+        {
+            if (child is not CommentNode)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int ReferenceIndexOf(IReadOnlyList<SyntaxNode> list, SyntaxNode node)
+    {
+        for (var index = 0; index < list.Count; index++)
+        {
+            if (ReferenceEquals(list[index], node))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static SyntaxList<object> Replace(SyntaxList<object> arguments, int index, object value)
+    {
+        var array = new object[arguments.Count];
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            array[i] = i == index ? value : arguments[i];
+        }
+
+        return new SyntaxList<object>(array);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VMemoTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VMemoTransform.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Globalization;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-memo</c> transform: wraps the element's compiled subtree in a <c>withMemo</c> call carrying the
+/// dependency expression and a per-instance cache index. The C# port of Vue 3.5's <c>transformMemo</c>
+/// (<c>@vue/compiler-core</c> <c>transforms/vMemo.ts</c>). See
+/// https://vuejs.org/api/built-in-directives.html#v-memo.
+/// </summary>
+internal static class VMemoTransform
+{
+    /// <summary>The node transform.</summary>
+    public static Action? Transform(SyntaxNode node, TransformContext context)
+    {
+        if (node is not ElementNode element)
+        {
+            return null;
+        }
+
+        var directive = TransformUtilities.FindDirective(element, "memo");
+        if (directive is null || context.SeenMemo.Contains(element))
+        {
+            return null;
+        }
+
+        // v-memo on a v-for element is memoized per item by the v-for transform's render-list loop, not by a
+        // whole-subtree withMemo. This guard skips the outer element that still carries v-for; the v-for
+        // transform separately marks its reduced inner element as seen (SeenMemo). Together they prevent the
+        // double handling that upstream's shared WeakSet suppresses on a single mutated node — which the
+        // immutable model, producing a fresh reduced element, cannot rely on. Pinned by
+        // VOnceMemoTransformTests.VMemo_WithVFor_ProducesPerItemMemoLoop.
+        if (TransformUtilities.FindDirective(element, "for") is not null)
+        {
+            return null;
+        }
+
+        context.SeenMemo.Add(element);
+
+        return () =>
+        {
+            if (context.GetCodegenNode(element) is not VNodeCall codegenNode)
+            {
+                return;
+            }
+
+            // A non-component subtree must be turned into a block.
+            var subtree = element.ElementType != ElementType.Component
+                ? TransformUtilities.ConvertToBlock(codegenNode, context)
+                : codegenNode;
+
+            var memoCall = Ir.CallExpression(
+                context.Helper(HelperNames.WithMemo),
+                new object[]
+                {
+                    directive.Expression!,
+                    Ir.FunctionExpression(null, subtree),
+                    "_cache",
+                    context.CacheCount.ToString(CultureInfo.InvariantCulture),
+                });
+
+            context.SetCodegenNode(element, memoCall);
+            context.AppendEmptyCacheSlot();
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VModelTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VModelTransform.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-model</c> directive transform. Combines Vue 3.5's base <c>transformModel</c>
+/// (<c>@vue/compiler-core</c> <c>transforms/vModel.ts</c> — the <c>modelValue</c> prop plus the
+/// <c>onUpdate:modelValue</c> handler and, on components, the modifiers object) with the DOM
+/// <c>transformModel</c> (<c>@vue/compiler-dom</c> <c>transforms/vModel.ts</c> — selecting the runtime model
+/// directive by element and input type). See https://vuejs.org/guide/essentials/forms.html.
+/// </summary>
+internal static class VModelTransform
+{
+    /// <summary>The directive transform delegate (DOM behaviour layered over the base transform).</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+    {
+        var baseResult = Base(directive, element, context);
+
+        // Base errored OR this is a component v-model (props are enough).
+        if (baseResult.Properties.Count == 0 || element.ElementType == ElementType.Component)
+        {
+            return baseResult;
+        }
+
+        if (directive.Argument is not null)
+        {
+            context.ReportError(
+                CompilerErrorFactory.Create(CompilerErrorCode.XVModelArgumentOnElement, directive.Argument.Location));
+        }
+
+        var tag = element.Tag;
+        var isCustomElement = context.IsCustomElement(tag);
+        var runtimeDirective = HelperNames.VModelText;
+        var isInvalidType = false;
+
+        if (tag is "input" or "textarea" or "select" || isCustomElement)
+        {
+            if (tag == "input" || isCustomElement)
+            {
+                var type = TransformUtilities.FindProperty(element, "type");
+                if (type is DirectiveNode)
+                {
+                    runtimeDirective = HelperNames.VModelDynamic;
+                }
+                else if (type is AttributeNode { Value: { } typeValue })
+                {
+                    switch (typeValue.Content)
+                    {
+                        case "radio":
+                            runtimeDirective = HelperNames.VModelRadio;
+                            break;
+                        case "checkbox":
+                            runtimeDirective = HelperNames.VModelCheckbox;
+                            break;
+                        case "file":
+                            isInvalidType = true;
+                            context.ReportError(CompilerErrorFactory.Create(
+                                CompilerErrorCode.XVModelOnFileInputElement, directive.Location));
+                            break;
+                        default:
+                            CheckDuplicatedValue(element, context);
+                            break;
+                    }
+                }
+                else if (TransformUtilities.HasDynamicKeyVBind(element))
+                {
+                    runtimeDirective = HelperNames.VModelDynamic;
+                }
+                else
+                {
+                    CheckDuplicatedValue(element, context);
+                }
+            }
+            else if (tag == "select")
+            {
+                runtimeDirective = HelperNames.VModelSelect;
+            }
+            else
+            {
+                CheckDuplicatedValue(element, context);
+            }
+
+            if (!isInvalidType)
+            {
+                baseResult = baseResult with { NeedRuntime = context.Helper(runtimeDirective) };
+            }
+        }
+        else
+        {
+            context.ReportError(
+                CompilerErrorFactory.Create(CompilerErrorCode.XVModelOnInvalidElement, directive.Location));
+        }
+
+        // Native v-model doesn't need the modelValue prop — it is passed as binding.value.
+        var filtered = new List<Property>(baseResult.Properties.Count);
+        foreach (var property in baseResult.Properties)
+        {
+            if (property.Key is SimpleExpressionNode { Content: "modelValue" })
+            {
+                continue;
+            }
+
+            filtered.Add(property);
+        }
+
+        return baseResult with { Properties = filtered };
+    }
+
+    // Port of the target-agnostic base transformModel.
+    private static DirectiveTransformResult Base(DirectiveNode directive, ElementNode element, TransformContext context)
+    {
+        var expression = directive.Expression;
+        var argument = directive.Argument;
+        if (expression is null)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVModelNoExpression, directive.Location));
+            return Empty();
+        }
+
+        var rawExpression = expression.Location.Source.Trim();
+        var expressionString = expression is SimpleExpressionNode simple ? simple.Content : rawExpression;
+
+        if (expressionString.Trim().Length == 0 || !ExpressionShape.IsMemberExpression(expression))
+        {
+            context.ReportError(
+                CompilerErrorFactory.Create(CompilerErrorCode.XVModelMalformedExpression, expression.Location));
+            return Empty();
+        }
+
+        var propertyName = argument ?? Ir.SimpleExpression("modelValue", true);
+        var eventName = BuildEventName(argument);
+
+        // eventArg is "$event" in the opaque (non-TS) build.
+        var assignment = Ir.CompoundExpression("$event => ((", expression, ") = $event)");
+
+        var properties = new List<Property>
+        {
+            Ir.ObjectProperty(propertyName, directive.Expression!),
+            Ir.ObjectProperty(eventName, assignment),
+        };
+
+        // modelModifiers: { foo: true } — only emitted for component v-model.
+        if (directive.Modifiers.Count > 0 && element.ElementType == ElementType.Component)
+        {
+            var modifiers = new StringBuilder();
+            for (var index = 0; index < directive.Modifiers.Count; index++)
+            {
+                var modifier = directive.Modifiers[index].Content;
+                if (index > 0)
+                {
+                    modifiers.Append(", ");
+                }
+
+                modifiers.Append(CompilerText.IsSimpleIdentifier(modifier) ? modifier : JsonString(modifier)).Append(": true");
+            }
+
+            var modifiersKey = BuildModifiersKey(argument);
+            properties.Add(Ir.ObjectProperty(
+                modifiersKey,
+                Ir.SimpleExpression($"{{ {modifiers} }}", false, directive.Location, ConstantType.CanCache)));
+        }
+
+        return new DirectiveTransformResult { Properties = properties };
+    }
+
+    private static ExpressionNode BuildEventName(ExpressionNode? argument)
+    {
+        if (argument is null)
+        {
+            return Ir.SimpleExpression("onUpdate:modelValue", true);
+        }
+
+        return TransformUtilities.IsStaticExpression(argument)
+            ? Ir.SimpleExpression("onUpdate:" + CompilerText.Camelize(((SimpleExpressionNode)argument).Content), true)
+            : Ir.CompoundExpression("\"onUpdate:\" + ", argument);
+    }
+
+    private static ExpressionNode BuildModifiersKey(ExpressionNode? argument)
+    {
+        if (argument is null)
+        {
+            return Ir.SimpleExpression("modelModifiers", true);
+        }
+
+        return TransformUtilities.IsStaticExpression(argument)
+            ? Ir.SimpleExpression(((SimpleExpressionNode)argument).Content + "Modifiers", true)
+            : Ir.CompoundExpression(argument, " + \"Modifiers\"");
+    }
+
+    private static void CheckDuplicatedValue(ElementNode element, TransformContext context)
+    {
+        var value = TransformUtilities.FindDirective(element, "bind");
+        if (value is not null && TransformUtilities.IsStaticArgumentOf(value.Argument, "value"))
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVModelUnnecessaryValue, value.Location));
+        }
+    }
+
+    private static DirectiveTransformResult Empty() => new() { Properties = Array.Empty<Property>() };
+
+    private static string JsonString(string value) => "\"" + value + "\"";
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VOnTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VOnTransform.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-on</c> (with argument) directive transform. Combines Vue 3.5's base <c>transformOn</c>
+/// (<c>@vue/compiler-core</c> <c>transforms/vOn.ts</c> — event-name resolution, inline-statement wrapping,
+/// handler caching) with the DOM <c>transformOn</c> (<c>@vue/compiler-dom</c> <c>transforms/vOn.ts</c> —
+/// key/system modifier guards via <c>withModifiers</c>/<c>withKeys</c> and <c>.once</c>/<c>.capture</c>/
+/// <c>.passive</c> event-option suffixes), because Vuecs is one merged compiler project.
+/// </summary>
+internal static class VOnTransform
+{
+    private static readonly HashSet<string> EventOptionModifiers = new() { "passive", "once", "capture" };
+
+    private static readonly HashSet<string> NonKeyModifiers = new()
+    {
+        "stop", "prevent", "self", "ctrl", "shift", "alt", "meta", "exact", "middle",
+    };
+
+    private static readonly HashSet<string> MaybeKeyModifiers = new() { "left", "right" };
+
+    private static readonly HashSet<string> KeyboardEvents = new() { "onkeyup", "onkeydown", "onkeypress" };
+
+    /// <summary>The directive transform delegate (the DOM behaviour: base transform augmented with modifiers).</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+        => Base(directive, element, context, baseResult =>
+        {
+            var modifiers = directive.Modifiers;
+            if (modifiers.Count == 0)
+            {
+                return baseResult;
+            }
+
+            var key = baseResult.Properties[0].Key;
+            var handlerExpression = baseResult.Properties[0].Value;
+            var (keyModifiers, nonKeyModifiers, eventOptionModifiers) =
+                ResolveModifiers(key, modifiers, context);
+
+            // click.right and click.middle don't actually fire; normalize the event.
+            if (nonKeyModifiers.Contains("right"))
+            {
+                key = TransformClick(key, "onContextmenu");
+            }
+
+            if (nonKeyModifiers.Contains("middle"))
+            {
+                key = TransformClick(key, "onMouseup");
+            }
+
+            if (nonKeyModifiers.Count > 0)
+            {
+                handlerExpression = Ir.CallExpression(
+                    context.Helper(HelperNames.WithModifiers),
+                    new object[] { handlerExpression, StringifyStringArray(nonKeyModifiers) });
+            }
+
+            if (keyModifiers.Count > 0 &&
+                (!TransformUtilities.IsStaticExpression(key) ||
+                 KeyboardEvents.Contains(((SimpleExpressionNode)key).Content.ToLowerInvariant())))
+            {
+                handlerExpression = Ir.CallExpression(
+                    context.Helper(HelperNames.WithKeys),
+                    new object[] { handlerExpression, StringifyStringArray(keyModifiers) });
+            }
+
+            if (eventOptionModifiers.Count > 0)
+            {
+                var postfix = new StringBuilder();
+                foreach (var modifier in eventOptionModifiers)
+                {
+                    postfix.Append(CompilerText.Capitalize(modifier));
+                }
+
+                key = TransformUtilities.IsStaticExpression(key)
+                    ? Ir.SimpleExpression(((SimpleExpressionNode)key).Content + postfix, true)
+                    : Ir.CompoundExpression("(", key, ") + \"" + postfix + "\"");
+            }
+
+            return new DirectiveTransformResult { Properties = new[] { Ir.ObjectProperty((ExpressionNode)key, handlerExpression) } };
+        });
+
+    // Port of the target-agnostic base transformOn.
+    private static DirectiveTransformResult Base(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult> augmentor)
+    {
+        var modifiers = directive.Modifiers;
+        if (directive.Expression is null && modifiers.Count == 0)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVOnNoExpression, directive.Location));
+        }
+
+        var eventName = BuildEventName(directive.Argument!, element, context);
+
+        var expression = directive.Expression as SimpleExpressionNode;
+        if (expression is not null && expression.Content.Trim().Length == 0)
+        {
+            expression = null;
+        }
+
+        var shouldCache = context.CacheHandlers && expression is null && !context.InVOnce;
+        SyntaxNode? handler = expression;
+        if (expression is not null)
+        {
+            var isMemberExpression = ExpressionShape.IsMemberExpression(expression);
+            var isInlineStatement = !(isMemberExpression || ExpressionShape.IsFunctionExpression(expression));
+            var hasMultipleStatements = expression.Content.IndexOf(';') >= 0;
+
+            if (isInlineStatement || (shouldCache && isMemberExpression))
+            {
+                handler = Ir.CompoundExpression(
+                    (isInlineStatement ? "$event" : "(...args)") + " => " + (hasMultipleStatements ? "{" : "("),
+                    expression,
+                    hasMultipleStatements ? "}" : ")");
+            }
+        }
+
+        handler ??= Ir.SimpleExpression("() => {}", false, directive.Location);
+
+        var result = new DirectiveTransformResult { Properties = new[] { Ir.ObjectProperty(eventName, handler) } };
+        result = augmentor(result);
+
+        if (shouldCache)
+        {
+            var property = result.Properties[0];
+            result = result with { Properties = new[] { property with { Value = context.Cache(property.Value) } } };
+        }
+
+        // Mark keys as handler keys so prop normalization ignores dynamic handler keys.
+        var marked = new Property[result.Properties.Count];
+        for (var index = 0; index < result.Properties.Count; index++)
+        {
+            var property = result.Properties[index];
+            marked[index] = property with { Key = MarkHandlerKey(property.Key) };
+        }
+
+        return result with { Properties = marked };
+    }
+
+    private static ExpressionNode BuildEventName(ExpressionNode argument, ElementNode element, TransformContext context)
+    {
+        if (argument is SimpleExpressionNode simple)
+        {
+            if (simple.IsStatic)
+            {
+                var rawName = simple.Content;
+                if (rawName.StartsWith("vue:", StringComparison.Ordinal))
+                {
+                    rawName = "vnode-" + rawName.Substring(4);
+                }
+
+                var eventString =
+                    element.ElementType != ElementType.Element ||
+                    rawName.StartsWith("vnode", StringComparison.Ordinal) ||
+                    !HasUppercase(rawName)
+                        ? CompilerText.ToHandlerKey(CompilerText.Camelize(rawName))
+                        : "on:" + rawName;
+                return Ir.SimpleExpression(eventString, true, simple.Location);
+            }
+
+            return Ir.CompoundExpression($"{context.HelperString(HelperNames.ToHandlerKey)}(", argument, ")");
+        }
+
+        var compound = (CompoundExpressionNode)argument;
+        var parts = new object[compound.Parts.Count + 2];
+        parts[0] = $"{context.HelperString(HelperNames.ToHandlerKey)}(";
+        for (var index = 0; index < compound.Parts.Count; index++)
+        {
+            parts[index + 1] = compound.Parts[index];
+        }
+
+        parts[parts.Length - 1] = ")";
+        return compound with { Parts = new SyntaxList<object>(parts) };
+    }
+
+    private static (List<string> Key, List<string> NonKey, List<string> EventOption) ResolveModifiers(
+        ExpressionNode key,
+        SyntaxList<SimpleExpressionNode> modifiers,
+        TransformContext context)
+    {
+        var keyModifiers = new List<string>();
+        var nonKeyModifiers = new List<string>();
+        var eventOptionModifiers = new List<string>();
+
+        foreach (var entry in modifiers)
+        {
+            var modifier = entry.Content;
+            if (EventOptionModifiers.Contains(modifier))
+            {
+                eventOptionModifiers.Add(modifier);
+            }
+            else if (MaybeKeyModifiers.Contains(modifier))
+            {
+                if (TransformUtilities.IsStaticExpression(key))
+                {
+                    if (KeyboardEvents.Contains(((SimpleExpressionNode)key).Content.ToLowerInvariant()))
+                    {
+                        keyModifiers.Add(modifier);
+                    }
+                    else
+                    {
+                        nonKeyModifiers.Add(modifier);
+                    }
+                }
+                else
+                {
+                    keyModifiers.Add(modifier);
+                    nonKeyModifiers.Add(modifier);
+                }
+            }
+            else if (NonKeyModifiers.Contains(modifier))
+            {
+                nonKeyModifiers.Add(modifier);
+            }
+            else
+            {
+                keyModifiers.Add(modifier);
+            }
+        }
+
+        return (keyModifiers, nonKeyModifiers, eventOptionModifiers);
+    }
+
+    private static ExpressionNode TransformClick(ExpressionNode key, string @event)
+    {
+        var isStaticClick = TransformUtilities.IsStaticExpression(key) &&
+                            ((SimpleExpressionNode)key).Content.ToLowerInvariant() == "onclick";
+        if (isStaticClick)
+        {
+            return Ir.SimpleExpression(@event, true);
+        }
+
+        if (key is SimpleExpressionNode)
+        {
+            return key;
+        }
+
+        return Ir.CompoundExpression("(", key, $") === \"onClick\" ? \"{@event}\" : (", key, ")");
+    }
+
+    private static ExpressionNode MarkHandlerKey(ExpressionNode key) => key switch
+    {
+        SimpleExpressionNode simple => simple with { IsHandlerKey = true },
+        CompoundExpressionNode compound => compound with { IsHandlerKey = true },
+        _ => key,
+    };
+
+    private static bool HasUppercase(string value)
+    {
+        foreach (var character in value)
+        {
+            if (character >= 'A' && character <= 'Z')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // JSON.stringify of a string array, e.g. ["stop","prevent"].
+    private static string StringifyStringArray(IReadOnlyList<string> values)
+    {
+        var builder = new StringBuilder("[");
+        for (var index = 0; index < values.Count; index++)
+        {
+            builder.Append('"').Append(values[index]).Append('"');
+            if (index < values.Count - 1)
+            {
+                builder.Append(',');
+            }
+        }
+
+        return builder.Append(']').ToString();
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VOnceTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VOnceTransform.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-once</c> transform: marks the element's subtree as rendered once and cached, and pauses block
+/// tracking around it. The C# port of Vue 3.5's <c>transformOnce</c> (<c>@vue/compiler-core</c>
+/// <c>transforms/vOnce.ts</c>). See https://vuejs.org/api/built-in-directives.html#v-once.
+/// </summary>
+internal static class VOnceTransform
+{
+    /// <summary>The node transform.</summary>
+    public static Action? Transform(SyntaxNode node, TransformContext context)
+    {
+        if (node is not ElementNode element || TransformUtilities.FindDirective(element, "once", allowEmpty: true) is null)
+        {
+            return null;
+        }
+
+        if (context.SeenOnce.Contains(element) || context.InVOnce || context.InSSR)
+        {
+            return null;
+        }
+
+        context.SeenOnce.Add(element);
+        context.InVOnce = true;
+        context.Helper(HelperNames.SetBlockTracking);
+
+        return () =>
+        {
+            context.InVOnce = false;
+            var current = context.CurrentNode;
+            if (current is null)
+            {
+                return;
+            }
+
+            var codegenNode = context.GetCodegenNode(current);
+            if (codegenNode is not null)
+            {
+                context.SetCodegenNode(current, context.Cache(codegenNode, isVNode: true, inVOnce: true));
+            }
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VShowTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VShowTransform.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-show</c> directive transform: it contributes no props and requests the runtime <c>vShow</c>
+/// directive. The C# port of Vue 3.5's <c>transformShow</c> (<c>@vue/compiler-dom</c>
+/// <c>transforms/vShow.ts</c>). See https://vuejs.org/api/built-in-directives.html#v-show.
+/// </summary>
+internal static class VShowTransform
+{
+    /// <summary>The directive transform delegate.</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+    {
+        if (directive.Expression is null)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVShowNoExpression, directive.Location));
+        }
+
+        return new DirectiveTransformResult
+        {
+            Properties = Array.Empty<Property>(),
+            NeedRuntime = context.Helper(HelperNames.VShow),
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VSlotTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VSlotTransform.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-slot</c> compilation: builds a component's slots object annotated with <see cref="SlotFlags"/>,
+/// and tracks slot scopes so nested slots are marked dynamic. The C# port of Vue 3.5's <c>buildSlots</c> and
+/// <c>trackSlotScopes</c> (<c>@vue/compiler-core</c> <c>transforms/vSlot.ts</c>).
+/// See https://vuejs.org/guide/components/slots.html.
+/// </summary>
+internal static class VSlotTransform
+{
+    private static readonly Regex ElseFamilyPattern = new(@"^else(-if)?$", RegexOptions.Compiled);
+    private static readonly Regex IfFamilyPattern = new(@"^(else-)?if$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A node transform that tracks <c>v-slot</c> depth so a slot inside another slot or a <c>v-for</c> is
+    /// forced dynamic. The C# port of <c>trackSlotScopes</c>.
+    /// </summary>
+    public static Action? TrackSlotScopes(SyntaxNode node, TransformContext context)
+    {
+        if (node is ElementNode { ElementType: ElementType.Component or ElementType.Template } element &&
+            TransformUtilities.FindDirective(element, "slot") is not null)
+        {
+            context.ScopeVSlot++;
+            return () => context.ScopeVSlot--;
+        }
+
+        return null;
+    }
+
+    /// <summary>Compiles a component's slots into a slots object (upstream <c>buildSlots</c>).</summary>
+    /// <param name="element">The component element.</param>
+    /// <param name="context">The active transform context.</param>
+    /// <param name="children">The component's transformed working children.</param>
+    public static (SyntaxNode Slots, bool HasDynamicSlots) BuildSlots(
+        ElementNode element,
+        TransformContext context,
+        IReadOnlyList<SyntaxNode> children)
+    {
+        context.Helper(HelperNames.WithCtx);
+
+        var slotsProperties = new List<Property>();
+        var dynamicSlots = new List<SyntaxNode>();
+        var hasDynamicSlots = context.ScopeVSlot > 0 || context.ScopeVFor > 0;
+
+        // 1. Slot props on the component itself: <Comp v-slot="{ prop }"/>.
+        var onComponentSlot = TransformUtilities.FindDirective(element, "slot", allowEmpty: true);
+        if (onComponentSlot is not null)
+        {
+            var argument = onComponentSlot.Argument;
+            if (argument is not null && !TransformUtilities.IsStaticExpression(argument))
+            {
+                hasDynamicSlots = true;
+            }
+
+            slotsProperties.Add(Ir.ObjectProperty(
+                argument ?? Ir.SimpleExpression("default", true),
+                BuildSlotFunction(onComponentSlot.Expression, children, element.Location)));
+        }
+
+        // 2. Template slots: <template v-slot:foo="{ prop }">.
+        var hasTemplateSlots = false;
+        var hasNamedDefaultSlot = false;
+        var implicitDefaultChildren = new List<SyntaxNode>();
+        var seenSlotNames = new HashSet<string>();
+        var conditionalBranchIndex = 0;
+
+        for (var i = 0; i < children.Count; i++)
+        {
+            var slotElement = children[i];
+            DirectiveNode? slotDirective = null;
+            if (slotElement is ElementNode { ElementType: ElementType.Template } templateElement)
+            {
+                slotDirective = TransformUtilities.FindDirective(templateElement, "slot", allowEmpty: true);
+            }
+
+            if (slotDirective is null)
+            {
+                if (slotElement is not CommentNode)
+                {
+                    implicitDefaultChildren.Add(slotElement);
+                }
+
+                continue;
+            }
+
+            if (onComponentSlot is not null)
+            {
+                context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVSlotMixedSlotUsage, slotDirective.Location));
+                break;
+            }
+
+            var slotTemplate = (ElementNode)slotElement;
+            hasTemplateSlots = true;
+            var slotChildren = context.WorkingChildrenOf(slotTemplate, slotTemplate.Children);
+            var slotName = slotDirective.Argument ?? Ir.SimpleExpression("default", true);
+            var slotProps = slotDirective.Expression;
+
+            string? staticSlotName = null;
+            if (TransformUtilities.IsStaticExpression(slotName))
+            {
+                staticSlotName = ((SimpleExpressionNode)slotName).Content;
+            }
+            else
+            {
+                hasDynamicSlots = true;
+            }
+
+            var slotForDirective = TransformUtilities.FindDirective(slotTemplate, "for");
+            var slotFunction = BuildSlotFunction(slotProps, slotChildren, slotTemplate.Location);
+
+            var slotIf = TransformUtilities.FindDirective(slotTemplate, "if");
+            DirectiveNode? slotElse;
+            if (slotIf is not null)
+            {
+                hasDynamicSlots = true;
+                dynamicSlots.Add(Ir.ConditionalExpression(
+                    slotIf.Expression!,
+                    BuildDynamicSlot(slotName, slotFunction, conditionalBranchIndex++),
+                    DefaultFallback()));
+            }
+            else if ((slotElse = TransformUtilities.FindDirective(slotTemplate, ElseFamilyPattern, allowEmpty: true)) is not null)
+            {
+                var j = i;
+                SyntaxNode? previous = null;
+                while (j-- > 0)
+                {
+                    previous = children[j];
+                    if (previous is not CommentNode)
+                    {
+                        break;
+                    }
+                }
+
+                if (previous is ElementNode { ElementType: ElementType.Template } previousTemplate &&
+                    TransformUtilities.FindDirective(previousTemplate, IfFamilyPattern) is not null)
+                {
+                    SyntaxNode newAlternate = slotElse.Expression is not null
+                        ? Ir.ConditionalExpression(
+                            slotElse.Expression,
+                            BuildDynamicSlot(slotName, slotFunction, conditionalBranchIndex++),
+                            DefaultFallback())
+                        : BuildDynamicSlot(slotName, slotFunction, conditionalBranchIndex++);
+                    dynamicSlots[dynamicSlots.Count - 1] =
+                        AttachToDeepestAlternate((ConditionalExpression)dynamicSlots[dynamicSlots.Count - 1], newAlternate);
+                }
+                else
+                {
+                    context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVElseNoAdjacentIf, slotElse.Location));
+                }
+            }
+            else if (slotForDirective is not null)
+            {
+                hasDynamicSlots = true;
+                var parseResult = slotForDirective.Expression is SimpleExpressionNode forExpression
+                    ? ForExpressionParser.Parse(forExpression)
+                    : null;
+                if (parseResult is not null)
+                {
+                    dynamicSlots.Add(Ir.CallExpression(
+                        context.Helper(HelperNames.RenderList),
+                        new object[]
+                        {
+                            parseResult.Source,
+                            Ir.FunctionExpression(
+                                VForTransform.CreateForLoopParameters(parseResult),
+                                BuildDynamicSlot(slotName, slotFunction, null),
+                                newline: true),
+                        }));
+                }
+                else
+                {
+                    context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVForMalformedExpression, slotForDirective.Location));
+                }
+            }
+            else
+            {
+                if (staticSlotName is not null)
+                {
+                    if (seenSlotNames.Contains(staticSlotName))
+                    {
+                        context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVSlotDuplicateSlotNames, slotDirective.Location));
+                        continue;
+                    }
+
+                    seenSlotNames.Add(staticSlotName);
+                    if (staticSlotName == "default")
+                    {
+                        hasNamedDefaultSlot = true;
+                    }
+                }
+
+                slotsProperties.Add(Ir.ObjectProperty(slotName, slotFunction));
+            }
+        }
+
+        if (onComponentSlot is null)
+        {
+            if (!hasTemplateSlots)
+            {
+                slotsProperties.Add(Ir.ObjectProperty("default", BuildSlotFunction(null, children, element.Location)));
+            }
+            else if (implicitDefaultChildren.Count > 0 && HasNonWhitespaceContent(implicitDefaultChildren))
+            {
+                if (hasNamedDefaultSlot)
+                {
+                    context.ReportError(CompilerErrorFactory.Create(
+                        CompilerErrorCode.XVSlotExtraneousDefaultSlotChildren, implicitDefaultChildren[0].Location));
+                }
+                else
+                {
+                    slotsProperties.Add(Ir.ObjectProperty("default", BuildSlotFunction(null, implicitDefaultChildren, element.Location)));
+                }
+            }
+        }
+
+        var slotFlag = hasDynamicSlots
+            ? SlotFlags.Dynamic
+            : HasForwardedSlots(children, context) ? SlotFlags.Forwarded : SlotFlags.Stable;
+
+        var allProperties = new List<Property>(slotsProperties)
+        {
+            Ir.ObjectProperty("_", Ir.SimpleExpression(((int)slotFlag).ToString(CultureInfo.InvariantCulture), false)),
+        };
+
+        SyntaxNode slots = Ir.ObjectExpression(allProperties, element.Location);
+        if (dynamicSlots.Count > 0)
+        {
+            slots = Ir.CallExpression(
+                context.Helper(HelperNames.CreateSlots),
+                new object[] { slots, Ir.ArrayExpression(ToObjectList(dynamicSlots)) });
+        }
+
+        return (slots, hasDynamicSlots);
+    }
+
+    private static FunctionExpression BuildSlotFunction(ExpressionNode? props, IReadOnlyList<SyntaxNode> children, SourceLocation loc)
+        => Ir.FunctionExpression(
+            props is null ? null : new object[] { props },
+            TransformFreeze.FreezeChildren(children),
+            newline: false,
+            isSlot: true,
+            children.Count > 0 ? children[0].Location : loc);
+
+    private static ObjectExpression BuildDynamicSlot(ExpressionNode name, FunctionExpression fn, int? index)
+    {
+        var properties = new List<Property>
+        {
+            Ir.ObjectProperty("name", name),
+            Ir.ObjectProperty("fn", fn),
+        };
+
+        if (index is not null)
+        {
+            properties.Add(Ir.ObjectProperty("key", Ir.SimpleExpression(index.Value.ToString(CultureInfo.InvariantCulture), true)));
+        }
+
+        return Ir.ObjectExpression(properties);
+    }
+
+    private static ConditionalExpression AttachToDeepestAlternate(ConditionalExpression chain, SyntaxNode newAlternate)
+    {
+        if (chain.Alternate is ConditionalExpression inner)
+        {
+            return chain with { Alternate = AttachToDeepestAlternate(inner, newAlternate) };
+        }
+
+        return chain with { Alternate = newAlternate };
+    }
+
+    private static bool HasForwardedSlots(IReadOnlyList<SyntaxNode> children, TransformContext context)
+    {
+        foreach (var child in children)
+        {
+            switch (child)
+            {
+                case ElementNode { ElementType: ElementType.Slot }:
+                    return true;
+                case ElementNode element:
+                    var elementChildren = context.TryGetWorkingChildren(element, out var working)
+                        ? (IReadOnlyList<SyntaxNode>)working
+                        : element.Children;
+                    if (HasForwardedSlots(elementChildren, context))
+                    {
+                        return true;
+                    }
+
+                    break;
+                case WorkingIf workingIf:
+                    foreach (var branch in workingIf.Branches)
+                    {
+                        if (HasForwardedSlots(branch.Children, context))
+                        {
+                            return true;
+                        }
+                    }
+
+                    break;
+                case WorkingFor workingFor:
+                    if (HasForwardedSlots(workingFor.Children, context))
+                    {
+                        return true;
+                    }
+
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasNonWhitespaceContent(IReadOnlyList<SyntaxNode> children)
+    {
+        foreach (var child in children)
+        {
+            if (IsNonWhitespace(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsNonWhitespace(SyntaxNode node) => node switch
+    {
+        TextNode text => text.Content.Trim().Length > 0,
+        TextCallNode textCall => IsNonWhitespace(textCall.Content),
+        _ => true,
+    };
+
+    private static ExpressionNode DefaultFallback() => Ir.SimpleExpression("undefined", false);
+
+    private static IReadOnlyList<object> ToObjectList(List<SyntaxNode> nodes)
+    {
+        var array = new object[nodes.Count];
+        for (var index = 0; index < nodes.Count; index++)
+        {
+            array[index] = nodes[index];
+        }
+
+        return array;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/VTextTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/VTextTransform.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The <c>v-text</c> directive transform: compiles to a <c>textContent</c> prop (wrapping non-constant
+/// expressions in <c>toDisplayString</c>) and raises the child-conflict diagnostic when the element also has
+/// template children. The C# port of Vue 3.5's <c>transformVText</c> (<c>@vue/compiler-dom</c>
+/// <c>transforms/vText.ts</c>).
+/// </summary>
+internal static class VTextTransform
+{
+    /// <summary>The directive transform delegate.</summary>
+    public static DirectiveTransformResult Transform(
+        DirectiveNode directive,
+        ElementNode element,
+        TransformContext context,
+        Func<DirectiveTransformResult, DirectiveTransformResult>? augmentor)
+    {
+        var expression = directive.Expression;
+        if (expression is null)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVTextNoExpression, directive.Location));
+        }
+
+        if (element.Children.Count > 0)
+        {
+            context.ReportError(CompilerErrorFactory.Create(CompilerErrorCode.XVTextWithChildren, directive.Location));
+            if (context.TryGetWorkingChildren(element, out var workingChildren))
+            {
+                workingChildren.Clear();
+            }
+        }
+
+        SyntaxNode textValue;
+        if (expression is null)
+        {
+            textValue = Ir.SimpleExpression(string.Empty, true);
+        }
+        else if (ConstantAnalysis.GetConstantType(expression) > ConstantType.NotConstant)
+        {
+            textValue = expression;
+        }
+        else
+        {
+            textValue = Ir.CallExpression(
+                context.HelperString(HelperNames.ToDisplayString),
+                new object[] { expression },
+                directive.Location);
+        }
+
+        return new DirectiveTransformResult
+        {
+            Properties = new[] { Ir.ObjectProperty("textContent", textValue) },
+        };
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingFor.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingFor.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The mutable working form of a <see cref="ForNode"/> used while the transform pipeline traverses the tree.
+/// Mirrors the mutable <c>ForNode</c> upstream mutates in <c>@vue/compiler-core</c> <c>transforms/vFor.ts</c>;
+/// frozen into an immutable <see cref="ForNode"/> when consumed.
+/// </summary>
+internal sealed record WorkingFor : TemplateChildNode
+{
+    /// <summary>The iterated source expression.</summary>
+    public required ExpressionNode Source { get; set; }
+
+    /// <summary>The value alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? ValueAlias { get; set; }
+
+    /// <summary>The key alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? KeyAlias { get; set; }
+
+    /// <summary>The object index alias, or <see langword="null"/>.</summary>
+    public ExpressionNode? ObjectIndexAlias { get; set; }
+
+    /// <summary>The decomposed <c>v-for</c> pieces.</summary>
+    public required ForParseResult ParseResult { get; set; }
+
+    /// <summary>The mutable working children (the repeated content).</summary>
+    public List<SyntaxNode> Children { get; } = new();
+
+    /// <summary>The compiled fragment-block vnode call (an immutable value, set on exit).</summary>
+    public SyntaxNode? CodegenNode { get; set; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.For;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingIf.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingIf.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The mutable working form of an <see cref="IfNode"/>: adjacent <c>v-if</c>/<c>v-else-if</c>/<c>v-else</c>
+/// siblings are folded into one node whose <see cref="Branches"/> grow as later siblings are processed, and
+/// whose <see cref="CodegenNode"/> conditional chain is extended in place. Mirrors the mutable <c>IfNode</c>
+/// upstream mutates in <c>@vue/compiler-core</c> <c>transforms/vIf.ts</c>; frozen into an immutable
+/// <see cref="IfNode"/> when consumed.
+/// </summary>
+internal sealed record WorkingIf : TemplateChildNode
+{
+    /// <summary>The branches, in source order.</summary>
+    public List<WorkingIfBranch> Branches { get; } = new();
+
+    /// <summary>The compiled conditional-expression chain (an immutable value, reassigned as branches are appended).</summary>
+    public SyntaxNode? CodegenNode { get; set; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.If;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingIfBranch.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Internal/WorkingIfBranch.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The mutable working form of an <see cref="IfBranchNode"/> used while the transform pipeline traverses and
+/// rewrites the tree. Structural rewriting (branch grouping, child replacement/removal) needs stable node
+/// identity and in-place child lists, which immutable records cannot provide; this working node is frozen
+/// into an immutable <see cref="IfBranchNode"/> when its containing element's vnode children are built.
+/// Mirrors the mutable <c>IfBranchNode</c> upstream mutates in <c>@vue/compiler-core</c> <c>transforms/vIf.ts</c>.
+/// </summary>
+internal sealed record WorkingIfBranch : SyntaxNode
+{
+    /// <summary>The branch condition, or <see langword="null"/> for <c>v-else</c>.</summary>
+    public ExpressionNode? Condition { get; set; }
+
+    /// <summary>The mutable working children of the branch (traversed and rewritten in place).</summary>
+    public List<SyntaxNode> Children { get; } = new();
+
+    /// <summary>The user-authored <c>key</c> attribute/binding on the branch element, if any.</summary>
+    public PropertyNode? UserKey { get; set; }
+
+    /// <summary>Whether the branch came from a <c>&lt;template&gt;</c> container.</summary>
+    public bool IsTemplateIf { get; set; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.IfBranch;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/NodeTransform.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/NodeTransform.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A transform that operates directly on a node, optionally replacing or removing it via the
+/// <see cref="TransformContext"/>. The C# port of Vue 3.5's <c>NodeTransform</c> function type
+/// (<c>@vue/compiler-core</c> <c>transform.ts</c>). Node transforms run in registration order on entry and
+/// their returned exit callbacks run in reverse on exit, after all children have been transformed.
+/// </summary>
+/// <param name="node">The node being visited (a template node or a transform-introduced container).</param>
+/// <param name="context">The active transform context.</param>
+/// <returns>An exit callback to run after the node's children are transformed, or <see langword="null"/>.</returns>
+public delegate Action? NodeTransform(SyntaxNode node, TransformContext context);

--- a/libraries/Assimalign.Vue.Compiler/src/NodeType.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/NodeType.cs
@@ -30,4 +30,50 @@ public enum NodeType
 
     /// <summary>A directive such as <c>v-if</c> or <c>:class</c> (upstream <c>DIRECTIVE</c>).</summary>
     Directive = 7,
+
+    // ---- container types introduced by the transform stage ([V01.01.05.02]/[V01.01.05.03]) ----
+
+    /// <summary>A compound expression built from concatenated parts (upstream <c>COMPOUND_EXPRESSION</c>).</summary>
+    CompoundExpression = 8,
+
+    /// <summary>A grouped <c>v-if</c>/<c>v-else-if</c>/<c>v-else</c> chain (upstream <c>IF</c>).</summary>
+    If = 9,
+
+    /// <summary>A single branch of an <see cref="If"/> chain (upstream <c>IF_BRANCH</c>).</summary>
+    IfBranch = 10,
+
+    /// <summary>A <c>v-for</c> fragment block (upstream <c>FOR</c>).</summary>
+    For = 11,
+
+    /// <summary>A pre-converted text vnode call (upstream <c>TEXT_CALL</c>).</summary>
+    TextCall = 12,
+
+    // ---- code-generation node types (upstream's minimal JS AST subset) ----
+
+    /// <summary>A <c>createVNode</c>/<c>createElementBlock</c> vnode call (upstream <c>VNODE_CALL</c>).</summary>
+    VNodeCall = 13,
+
+    /// <summary>A JavaScript call expression (upstream <c>JS_CALL_EXPRESSION</c>).</summary>
+    JsCallExpression = 14,
+
+    /// <summary>A JavaScript object literal (upstream <c>JS_OBJECT_EXPRESSION</c>).</summary>
+    JsObjectExpression = 15,
+
+    /// <summary>A JavaScript object property (upstream <c>JS_PROPERTY</c>).</summary>
+    JsProperty = 16,
+
+    /// <summary>A JavaScript array literal (upstream <c>JS_ARRAY_EXPRESSION</c>).</summary>
+    JsArrayExpression = 17,
+
+    /// <summary>A JavaScript function expression (upstream <c>JS_FUNCTION_EXPRESSION</c>).</summary>
+    JsFunctionExpression = 18,
+
+    /// <summary>A JavaScript conditional (ternary) expression (upstream <c>JS_CONDITIONAL_EXPRESSION</c>).</summary>
+    JsConditionalExpression = 19,
+
+    /// <summary>A JavaScript cache-slot expression for <c>v-once</c>/cached handlers (upstream <c>JS_CACHE_EXPRESSION</c>).</summary>
+    JsCacheExpression = 20,
+
+    /// <summary>A JavaScript block statement, the body of a memoized <c>v-for</c> loop (upstream <c>JS_BLOCK_STATEMENT</c>).</summary>
+    JsBlockStatement = 21,
 }

--- a/libraries/Assimalign.Vue.Compiler/src/ObjectExpression.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/ObjectExpression.cs
@@ -1,0 +1,14 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A code-generation object literal, e.g. a vnode props object or a compiled slots object. The C# port of
+/// Vue 3.5's <c>ObjectExpression</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+public sealed record ObjectExpression : SyntaxNode
+{
+    /// <summary>The object's properties, in source/emit order.</summary>
+    public required SyntaxList<Property> Properties { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsObjectExpression;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Property.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Property.cs
@@ -1,0 +1,17 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A single key/value entry in an <see cref="ObjectExpression"/>. The C# port of Vue 3.5's <c>Property</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>). Used for vnode props, slot objects, and modifier maps.
+/// </summary>
+public sealed record Property : SyntaxNode
+{
+    /// <summary>The property key expression (static or dynamic).</summary>
+    public required ExpressionNode Key { get; init; }
+
+    /// <summary>The property value — a code-generation node (expression, call, object, function, …).</summary>
+    public required SyntaxNode Value { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.JsProperty;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/RuntimeHelper.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/RuntimeHelper.cs
@@ -1,0 +1,16 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A by-name reference to a runtime helper the generated render function will import from the runtime
+/// (e.g. <c>createElementBlock</c>, <c>renderList</c>, <c>withModifiers</c>). The C# port of the
+/// <c>symbol</c> helper identities in Vue 3.5's <c>@vue/compiler-core</c> <c>runtimeHelpers.ts</c> and
+/// <c>@vue/compiler-dom</c> <c>runtimeHelpers.ts</c>.
+/// </summary>
+/// <remarks>
+/// The compiler NEVER references the runtime assembly: helpers are carried as plain names and resolved to
+/// concrete symbols by code generation ([V01.01.05.05]) and the runtime ([V01.01.05.02]). Two helpers with
+/// the same <see cref="Name"/> are equal, mirroring upstream's shared symbol identity; the canonical names
+/// live in <see cref="HelperNames"/>.
+/// </remarks>
+/// <param name="Name">The helper's runtime name, matching upstream's <c>helperNameMap</c> value.</param>
+public sealed record RuntimeHelper(string Name);

--- a/libraries/Assimalign.Vue.Compiler/src/SimpleExpressionNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/SimpleExpressionNode.cs
@@ -18,6 +18,13 @@ public sealed record SimpleExpressionNode : ExpressionNode
     /// <summary>The static-ness level (see <see cref="ConstantType"/>).</summary>
     public ConstantType ConstantType { get; init; }
 
+    /// <summary>
+    /// Whether this expression is an event-handler key (upstream's <c>isHandlerKey</c>). Set by the
+    /// <c>v-on</c> transform ([V01.01.05.03]) so prop normalization does not treat a dynamic handler key as a
+    /// dynamic prop key. The parser never sets this.
+    /// </summary>
+    public bool IsHandlerKey { get; init; }
+
     /// <inheritdoc />
     public override NodeType NodeType => NodeType.SimpleExpression;
 }

--- a/libraries/Assimalign.Vue.Compiler/src/TextCallNode.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/TextCallNode.cs
@@ -1,0 +1,18 @@
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// A text child pre-converted to a <c>createTextVNode(...)</c> call so the runtime skips normalization. The
+/// C# port of Vue 3.5's <c>TextCallNode</c> (<c>@vue/compiler-core</c> <c>ast.ts</c>). Produced by the text
+/// transform when an element has mixed or multiple text/interpolation children.
+/// </summary>
+public sealed record TextCallNode : TemplateChildNode
+{
+    /// <summary>The wrapped text content: a <see cref="TextNode"/>, <see cref="InterpolationNode"/>, or <see cref="CompoundExpressionNode"/>.</summary>
+    public required SyntaxNode Content { get; init; }
+
+    /// <summary>The compiled <c>createTextVNode</c> call.</summary>
+    public required SyntaxNode CodegenNode { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.TextCall;
+}

--- a/libraries/Assimalign.Vue.Compiler/src/TransformContext.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/TransformContext.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The mutable state threaded through the transform pipeline: helper/component/directive registration, scope
+/// tracking, node replacement/removal, and the hoist/cache hooks later stages consume. The C# port of Vue
+/// 3.5's <c>TransformContext</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// </summary>
+/// <remarks>
+/// This type is single-threaded, matching the compiler's single-pass model. Because the parse AST is
+/// immutable, per-node code-generation results are held in reference-keyed side tables rather than mutated
+/// onto the nodes, and structural containers use their mutable working forms while traversal is in flight.
+/// </remarks>
+public sealed class TransformContext
+{
+    private readonly Dictionary<RuntimeHelper, int> helpers = new();
+    private readonly HashSet<string> components = new();
+    private readonly HashSet<string> directives = new();
+    private readonly List<SyntaxNode?> hoists = new();
+    private readonly List<CacheExpression?> cached = new();
+    private readonly Dictionary<SyntaxNode, SyntaxNode> codegenNodes = new(ReferenceComparer.Instance);
+    private readonly Dictionary<SyntaxNode, List<SyntaxNode>> workingChildren = new(ReferenceComparer.Instance);
+    private readonly HashSet<SyntaxNode> seenOnce = new(ReferenceComparer.Instance);
+    private readonly HashSet<SyntaxNode> seenMemo = new(ReferenceComparer.Instance);
+    private readonly Dictionary<SyntaxNode, RuntimeHelper> directiveRuntime = new(ReferenceComparer.Instance);
+
+    internal TransformContext(
+        RootNode root,
+        IReadOnlyList<NodeTransform> nodeTransforms,
+        IReadOnlyDictionary<string, DirectiveTransform> directiveTransforms,
+        TransformOptions options)
+    {
+        Root = root;
+        NodeTransforms = nodeTransforms;
+        DirectiveTransforms = directiveTransforms;
+        IsBuiltInComponent = options.IsBuiltInComponent;
+        IsCustomElement = options.IsCustomElement;
+        CacheHandlers = options.CacheHandlers;
+        InSSR = options.InSSR;
+        Ssr = options.Ssr;
+        Slotted = options.Slotted;
+        ScopeId = options.ScopeId;
+        onError = options.OnError;
+        CurrentNode = root;
+        OnNodeRemoved = static () => { };
+    }
+
+    private readonly Action<CompilerError>? onError;
+
+    /// <summary>The root of the template being transformed.</summary>
+    public RootNode Root { get; }
+
+    /// <summary>The resolved, ordered node transforms (built-in preset then user transforms).</summary>
+    public IReadOnlyList<NodeTransform> NodeTransforms { get; }
+
+    /// <summary>The resolved directive transforms, keyed by directive name.</summary>
+    public IReadOnlyDictionary<string, DirectiveTransform> DirectiveTransforms { get; }
+
+    /// <summary>Resolves a built-in component tag to its runtime helper, or <see langword="null"/>.</summary>
+    public Func<string, RuntimeHelper?>? IsBuiltInComponent { get; }
+
+    /// <summary>Whether a tag is a custom element.</summary>
+    public Func<string, bool> IsCustomElement { get; }
+
+    /// <summary>Whether static event handlers are cached (upstream <c>cacheHandlers</c>).</summary>
+    public bool CacheHandlers { get; }
+
+    /// <summary>
+    /// Whether identifier prefixing is enabled. Always <see langword="false"/> in this build; expression and
+    /// scope analysis is [V01.01.05.04].
+    /// </summary>
+    public bool PrefixIdentifiers => false;
+
+    /// <summary>Whether this is a nested SSR slot compilation.</summary>
+    public bool InSSR { get; }
+
+    /// <summary>Whether compilation targets SSR.</summary>
+    public bool Ssr { get; }
+
+    /// <summary>Whether component slots inherit the parent scope id.</summary>
+    public bool Slotted { get; }
+
+    /// <summary>The scoped-styles id, or <see langword="null"/>.</summary>
+    public string? ScopeId { get; }
+
+    /// <summary>The number of <c>v-for</c> scopes currently open (upstream <c>scopes.vFor</c>).</summary>
+    public int ScopeVFor { get; set; }
+
+    /// <summary>The number of <c>v-slot</c> scopes currently open (upstream <c>scopes.vSlot</c>).</summary>
+    public int ScopeVSlot { get; set; }
+
+    /// <summary>Whether transformation is inside a <c>v-once</c> subtree (upstream <c>inVOnce</c>).</summary>
+    public bool InVOnce { get; set; }
+
+    // ---- traversal state ----
+
+    /// <summary>The node currently being transformed, or <see langword="null"/> after removal.</summary>
+    public SyntaxNode? CurrentNode { get; internal set; }
+
+    /// <summary>The parent of <see cref="CurrentNode"/>.</summary>
+    public SyntaxNode? Parent { get; internal set; }
+
+    /// <summary>The mutable working children list of <see cref="Parent"/> (the current sibling list).</summary>
+    internal List<SyntaxNode>? CurrentChildren { get; set; }
+
+    /// <summary>The index of <see cref="CurrentNode"/> within <see cref="CurrentChildren"/>.</summary>
+    public int ChildIndex { get; internal set; }
+
+    /// <summary>The callback the traversal installs so removals keep the loop index aligned.</summary>
+    internal Action OnNodeRemoved { get; set; }
+
+    // ---- diagnostics ----
+
+    /// <summary>Reports a transform diagnostic (never throws; recoverable), matching upstream's <c>onError</c>.</summary>
+    /// <param name="error">The diagnostic to report.</param>
+    public void ReportError(CompilerError error) => onError?.Invoke(error);
+
+    // ---- helper / component / directive registration ----
+
+    /// <summary>Registers a use of <paramref name="helper"/> and returns it (upstream <c>helper</c>).</summary>
+    /// <param name="helper">The runtime helper.</param>
+    public RuntimeHelper Helper(RuntimeHelper helper)
+    {
+        helpers.TryGetValue(helper, out var count);
+        helpers[helper] = count + 1;
+        return helper;
+    }
+
+    /// <summary>Removes a use of <paramref name="helper"/> (upstream <c>removeHelper</c>).</summary>
+    /// <param name="helper">The runtime helper.</param>
+    public void RemoveHelper(RuntimeHelper helper)
+    {
+        if (helpers.TryGetValue(helper, out var count) && count > 0)
+        {
+            if (count - 1 == 0)
+            {
+                helpers.Remove(helper);
+            }
+            else
+            {
+                helpers[helper] = count - 1;
+            }
+        }
+    }
+
+    /// <summary>Registers and returns the <c>_name</c> reference string for <paramref name="helper"/> (upstream <c>helperString</c>).</summary>
+    /// <param name="helper">The runtime helper.</param>
+    public string HelperString(RuntimeHelper helper) => "_" + Helper(helper).Name;
+
+    /// <summary>Registers a resolved component name (upstream <c>components.add</c>).</summary>
+    /// <param name="name">The component tag name.</param>
+    public void AddComponent(string name) => components.Add(name);
+
+    /// <summary>Registers a resolved directive name (upstream <c>directives.add</c>).</summary>
+    /// <param name="name">The directive name.</param>
+    public void AddDirective(string name) => directives.Add(name);
+
+    // ---- node replacement / removal ----
+
+    /// <summary>Replaces the current node with <paramref name="node"/> (upstream <c>replaceNode</c>).</summary>
+    /// <param name="node">The replacement node.</param>
+    public void ReplaceNode(SyntaxNode node)
+    {
+        if (CurrentChildren is not null)
+        {
+            CurrentChildren[ChildIndex] = node;
+        }
+
+        CurrentNode = node;
+    }
+
+    /// <summary>Removes <paramref name="node"/> (or the current node) from the sibling list (upstream <c>removeNode</c>).</summary>
+    /// <param name="node">The node to remove, or <see langword="null"/> for the current node.</param>
+    public void RemoveNode(SyntaxNode? node = null)
+    {
+        var list = CurrentChildren;
+        if (list is null)
+        {
+            return;
+        }
+
+        var removalIndex = node is not null
+            ? ReferenceIndexOf(list, node)
+            : CurrentNode is not null ? ChildIndex : -1;
+        if (removalIndex < 0)
+        {
+            return;
+        }
+
+        if (node is null || ReferenceEquals(node, CurrentNode))
+        {
+            CurrentNode = null;
+            OnNodeRemoved();
+        }
+        else if (ChildIndex > removalIndex)
+        {
+            ChildIndex--;
+            OnNodeRemoved();
+        }
+
+        list.RemoveAt(removalIndex);
+    }
+
+    // ---- hoist / cache hooks ([V01.01.05.07] consumes these) ----
+
+    /// <summary>
+    /// Registers a hoisted constant and returns a placeholder identifier (upstream <c>hoist</c>). The hoisting
+    /// pass itself is [V01.01.05.07]; this records the slot so that pass can plug in without reshaping the
+    /// pipeline.
+    /// </summary>
+    /// <param name="expression">The constant expression to hoist.</param>
+    public SimpleExpressionNode Hoist(SyntaxNode expression)
+    {
+        hoists.Add(expression);
+        return Ir.SimpleExpression(
+            $"_hoisted_{hoists.Count}",
+            false,
+            expression.Location,
+            ConstantType.CanCache);
+    }
+
+    /// <summary>Wraps <paramref name="expression"/> in a cache slot (upstream <c>cache</c>).</summary>
+    /// <param name="expression">The expression to cache.</param>
+    /// <param name="isVNode">Whether the cached value is a vnode.</param>
+    /// <param name="inVOnce">Whether the cache is produced inside a <c>v-once</c>.</param>
+    public CacheExpression Cache(SyntaxNode expression, bool isVNode = false, bool inVOnce = false)
+    {
+        var cacheExpression = Ir.CacheExpression(cached.Count, expression, isVNode, inVOnce);
+        cached.Add(cacheExpression);
+        return cacheExpression;
+    }
+
+    /// <summary>The current cache slot count (upstream <c>context.cached.length</c>).</summary>
+    public int CacheCount => cached.Count;
+
+    /// <summary>Reserves an empty cache slot, incrementing the count (upstream <c>context.cached.push(null)</c>).</summary>
+    public void AppendEmptyCacheSlot() => cached.Add(null);
+
+    // ---- vnode-call construction ----
+
+    /// <summary>
+    /// Builds a <see cref="VNodeCall"/> and registers the block/vnode helpers it needs (upstream
+    /// <c>createVNodeCall</c>).
+    /// </summary>
+    public VNodeCall CreateVNodeCall(
+        object tag,
+        SyntaxNode? props,
+        object? children,
+        PatchFlags? patchFlag,
+        object? dynamicProps,
+        ArrayExpression? directiveArguments,
+        bool isBlock,
+        bool disableTracking,
+        bool isComponent,
+        SourceLocation? location = null)
+    {
+        if (isBlock)
+        {
+            Helper(HelperNames.OpenBlock);
+            Helper(GetVNodeBlockHelper(InSSR, isComponent));
+        }
+        else
+        {
+            Helper(GetVNodeHelper(InSSR, isComponent));
+        }
+
+        if (directiveArguments is not null)
+        {
+            Helper(HelperNames.WithDirectives);
+        }
+
+        return new VNodeCall
+        {
+            Tag = tag,
+            Props = props,
+            Children = children,
+            PatchFlag = patchFlag,
+            DynamicProps = dynamicProps,
+            Directives = directiveArguments,
+            IsBlock = isBlock,
+            DisableTracking = disableTracking,
+            IsComponent = isComponent,
+            Location = location ?? Ir.LocationStub,
+        };
+    }
+
+    /// <summary>The vnode-creation helper for the given SSR/component flags (upstream <c>getVNodeHelper</c>).</summary>
+    public static RuntimeHelper GetVNodeHelper(bool ssr, bool isComponent)
+        => ssr || isComponent ? HelperNames.CreateVNode : HelperNames.CreateElementVNode;
+
+    /// <summary>The block-vnode-creation helper for the given SSR/component flags (upstream <c>getVNodeBlockHelper</c>).</summary>
+    public static RuntimeHelper GetVNodeBlockHelper(bool ssr, bool isComponent)
+        => ssr || isComponent ? HelperNames.CreateBlock : HelperNames.CreateElementBlock;
+
+    // ---- per-node code-generation side tables (immutable AST cannot carry a codegenNode) ----
+
+    internal void SetCodegenNode(SyntaxNode node, SyntaxNode codegenNode)
+    {
+        switch (node)
+        {
+            case WorkingIf workingIf:
+                workingIf.CodegenNode = codegenNode;
+                break;
+            case WorkingFor workingFor:
+                workingFor.CodegenNode = codegenNode;
+                break;
+            default:
+                codegenNodes[node] = codegenNode;
+                break;
+        }
+    }
+
+    internal SyntaxNode? GetCodegenNode(SyntaxNode node) => node switch
+    {
+        WorkingIf workingIf => workingIf.CodegenNode,
+        WorkingFor workingFor => workingFor.CodegenNode,
+        _ => codegenNodes.TryGetValue(node, out var codegenNode) ? codegenNode : null,
+    };
+
+    internal List<SyntaxNode> WorkingChildrenOf(SyntaxNode node, IReadOnlyList<TemplateChildNode> initial)
+    {
+        if (!workingChildren.TryGetValue(node, out var list))
+        {
+            list = new List<SyntaxNode>(initial.Count);
+            for (var index = 0; index < initial.Count; index++)
+            {
+                list.Add(initial[index]);
+            }
+
+            workingChildren[node] = list;
+        }
+
+        return list;
+    }
+
+    internal bool TryGetWorkingChildren(SyntaxNode node, out List<SyntaxNode> children)
+        => workingChildren.TryGetValue(node, out children!);
+
+    internal HashSet<SyntaxNode> SeenOnce => seenOnce;
+
+    internal HashSet<SyntaxNode> SeenMemo => seenMemo;
+
+    // The C# analogue of upstream's directiveImportMap: records the runtime helper a directive transform
+    // requested, so the element transform can emit a helper reference instead of a resolveDirective call.
+    internal void SetDirectiveRuntime(DirectiveNode directive, RuntimeHelper helper) => directiveRuntime[directive] = helper;
+
+    internal RuntimeHelper? GetDirectiveRuntime(DirectiveNode directive)
+        => directiveRuntime.TryGetValue(directive, out var helper) ? helper : null;
+
+    // ---- finalize accessors (the facade reads these after traversal) ----
+
+    internal IReadOnlyCollection<RuntimeHelper> HelperKeys => helpers.Keys;
+
+    internal IReadOnlyCollection<string> ComponentNames => components;
+
+    internal IReadOnlyCollection<string> DirectiveNames => directives;
+
+    internal IReadOnlyList<SyntaxNode?> Hoists => hoists;
+
+    internal IReadOnlyList<CacheExpression?> CachedSlots => cached;
+
+    private static int ReferenceIndexOf(List<SyntaxNode> list, SyntaxNode node)
+    {
+        for (var index = 0; index < list.Count; index++)
+        {
+            if (ReferenceEquals(list[index], node))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/TransformOptions.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/TransformOptions.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Configures <see cref="Transformer"/>. The C# port of the transform-relevant members of Vue 3.5's
+/// <c>TransformOptions</c> (<c>@vue/compiler-core</c> <c>options.ts</c>). Defaults reproduce the platform-
+/// agnostic base compiler; <see cref="CreateDom"/> installs the DOM directive transforms mirroring
+/// <c>@vue/compiler-dom</c>.
+/// </summary>
+public sealed class TransformOptions
+{
+    /// <summary>
+    /// Additional node transforms, appended after the built-in preset (upstream's user
+    /// <c>nodeTransforms</c>). Lets third parties inject custom transforms.
+    /// </summary>
+    public IReadOnlyList<NodeTransform> NodeTransforms { get; set; } = Array.Empty<NodeTransform>();
+
+    /// <summary>
+    /// Additional or overriding directive transforms, keyed by directive name (upstream's user
+    /// <c>directiveTransforms</c>). Entries override the built-in transforms of the same name.
+    /// </summary>
+    public IReadOnlyDictionary<string, DirectiveTransform> DirectiveTransforms { get; set; }
+        = new Dictionary<string, DirectiveTransform>();
+
+    /// <summary>
+    /// Resolves a built-in component tag to its runtime helper, or <see langword="null"/> (upstream
+    /// <c>isBuiltInComponent</c>).
+    /// </summary>
+    public Func<string, RuntimeHelper?>? IsBuiltInComponent { get; set; }
+
+    /// <summary>Whether a tag is a custom element (never a component); defaults to never (upstream <c>isCustomElement</c>).</summary>
+    public Func<string, bool> IsCustomElement { get; set; } = static _ => false;
+
+    /// <summary>Receives transform diagnostics. Defaults to swallowing them (recoverable).</summary>
+    public Action<CompilerError>? OnError { get; set; }
+
+    /// <summary>
+    /// Whether static event handlers are cached so blocks are not invalidated (upstream <c>cacheHandlers</c>).
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    public bool CacheHandlers { get; set; }
+
+    /// <summary>
+    /// Whether the static-hoisting/caching pass runs. Defaults to <see langword="false"/>; the pass itself is
+    /// [V01.01.05.07], which consumes the hooks this transform exposes.
+    /// </summary>
+    public bool HoistStatic { get; set; }
+
+    /// <summary>Whether compilation targets SSR. Defaults to <see langword="false"/>.</summary>
+    public bool Ssr { get; set; }
+
+    /// <summary>Whether this is a nested SSR slot compilation. Defaults to <see langword="false"/>.</summary>
+    public bool InSSR { get; set; }
+
+    /// <summary>Whether component slots inherit the parent's scope id. Defaults to <see langword="true"/>.</summary>
+    public bool Slotted { get; set; } = true;
+
+    /// <summary>The scoped-styles id, or <see langword="null"/>. Out of scope here; carried for parity.</summary>
+    public string? ScopeId { get; set; }
+
+    /// <summary>
+    /// Creates transform options with the DOM component defaults: <c>Transition</c>/<c>TransitionGroup</c>
+    /// recognized as built-in components, and <paramref name="isCustomElement"/> reporting custom elements.
+    /// The DOM directive transforms (<c>v-model</c>, <c>v-on</c>, <c>v-show</c>, <c>v-html</c>, <c>v-text</c>,
+    /// <c>v-cloak</c>) are always installed as the pipeline's built-ins, so this only configures component
+    /// recognition. Mirrors the setup <c>@vue/compiler-dom</c> applies in its <c>compile()</c>.
+    /// </summary>
+    /// <param name="isCustomElement">Whether a tag is a custom element; defaults to never.</param>
+    public static TransformOptions CreateDom(Func<string, bool>? isCustomElement = null) => new()
+    {
+        IsCustomElement = isCustomElement ?? (static _ => false),
+        IsBuiltInComponent = static tag => tag switch
+        {
+            "Transition" or "transition" => HelperNames.Transition,
+            "TransitionGroup" or "transition-group" => HelperNames.TransitionGroup,
+            _ => null,
+        },
+    };
+}

--- a/libraries/Assimalign.Vue.Compiler/src/TransformResult.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/TransformResult.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The output of <see cref="Transformer.Transform(RootNode, TransformOptions)"/>: the root code-generation
+/// node plus the finalized helper/component/directive/hoist/cache metadata. The C# port of the fields Vue
+/// 3.5's <c>transform()</c> stamps onto the <c>RootNode</c> (<c>@vue/compiler-core</c> <c>transform.ts</c>).
+/// </summary>
+/// <remarks>
+/// Because the parse AST is immutable, the transformed structure and its code-generation nodes are surfaced
+/// here rather than mutated onto the input. <see cref="Children"/> is the transformed top-level tree (for
+/// structural inspection); <see cref="CodegenNode"/> is the render-function IR that code generation
+/// ([V01.01.05.05]) consumes, and <see cref="GetCodegenNode"/> resolves the code-generation node of any
+/// element/container reachable from it.
+/// </remarks>
+public sealed record TransformResult
+{
+    private readonly TransformContext context;
+
+    internal TransformResult(
+        TransformContext context,
+        SyntaxNode? codegenNode,
+        SyntaxList<TemplateChildNode> children,
+        IReadOnlyList<RuntimeHelper> helpers,
+        IReadOnlyList<string> components,
+        IReadOnlyList<string> directives,
+        IReadOnlyList<SyntaxNode?> hoists,
+        IReadOnlyList<CacheExpression?> cached)
+    {
+        this.context = context;
+        CodegenNode = codegenNode;
+        Children = children;
+        Helpers = helpers;
+        Components = components;
+        Directives = directives;
+        Hoists = hoists;
+        Cached = cached;
+    }
+
+    /// <summary>The root render-function code-generation node, or <see langword="null"/> for an empty template.</summary>
+    public SyntaxNode? CodegenNode { get; }
+
+    /// <summary>The transformed top-level children (structural directives folded into <see cref="IfNode"/>/<see cref="ForNode"/>).</summary>
+    public SyntaxList<TemplateChildNode> Children { get; }
+
+    /// <summary>The runtime helpers the generated render function imports.</summary>
+    public IReadOnlyList<RuntimeHelper> Helpers { get; }
+
+    /// <summary>The user component names to resolve.</summary>
+    public IReadOnlyList<string> Components { get; }
+
+    /// <summary>The user directive names to resolve.</summary>
+    public IReadOnlyList<string> Directives { get; }
+
+    /// <summary>The hoisted constant slots (populated by [V01.01.05.07]).</summary>
+    public IReadOnlyList<SyntaxNode?> Hoists { get; }
+
+    /// <summary>The cache slots reserved by <c>v-once</c>, <c>v-memo</c>, and cached handlers.</summary>
+    public IReadOnlyList<CacheExpression?> Cached { get; }
+
+    /// <summary>
+    /// Resolves the code-generation node of <paramref name="node"/>: a container carries it directly, while an
+    /// element's node is looked up from the transform's side table.
+    /// </summary>
+    /// <param name="node">An element or container reachable from the transformed tree.</param>
+    public SyntaxNode? GetCodegenNode(SyntaxNode node) => node switch
+    {
+        IfNode ifNode => ifNode.CodegenNode,
+        ForNode forNode => forNode.CodegenNode,
+        TextCallNode textCall => textCall.CodegenNode,
+        _ => context.GetCodegenNode(node),
+    };
+}

--- a/libraries/Assimalign.Vue.Compiler/src/Transformer.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/Transformer.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The template transform entry point: runs the ordered node and directive transforms over a parsed
+/// <see cref="RootNode"/> and produces the render-function code-generation tree. The C# port of Vue 3.5's
+/// <c>transform()</c> plus the base preset from <c>getBaseTransformPreset</c> (<c>@vue/compiler-core</c>
+/// <c>transform.ts</c>/<c>compile.ts</c>), merged with the DOM directive transforms.
+/// </summary>
+/// <remarks>
+/// This type has no instance state; each call is a fresh, deterministic, pure transform over its input,
+/// producing immutable, value-equatable output suitable for incremental-generator caching.
+/// </remarks>
+public static class Transformer
+{
+    /// <summary>Transforms <paramref name="root"/> using the default (DOM) transform set.</summary>
+    /// <param name="root">The parsed template root.</param>
+    public static TransformResult Transform(RootNode root) => Transform(root, new TransformOptions());
+
+    /// <summary>Transforms <paramref name="root"/> with the given <paramref name="options"/>.</summary>
+    /// <param name="root">The parsed template root.</param>
+    /// <param name="options">The transform configuration.</param>
+    public static TransformResult Transform(RootNode root, TransformOptions options)
+    {
+        var nodeTransforms = BuildNodeTransforms(options);
+        var directiveTransforms = BuildDirectiveTransforms(options);
+        var context = new TransformContext(root, nodeTransforms, directiveTransforms, options);
+
+        TransformTraversal.TraverseNode(root, context);
+        // The static-hoisting/caching pass ([V01.01.05.07]) would run here when options.HoistStatic is set.
+
+        var rootChildren = context.WorkingChildrenOf(root, root.Children);
+        var codegenNode = CreateRootCodegen(context, rootChildren);
+
+        return new TransformResult(
+            context,
+            codegenNode,
+            TransformFreeze.FreezeChildren(rootChildren),
+            ToArray(context.HelperKeys),
+            ToArray(context.ComponentNames),
+            ToArray(context.DirectiveNames),
+            context.Hoists,
+            context.CachedSlots);
+    }
+
+    // The base preset order: structural transforms, then slot outlet, then element, then slot-scope tracking,
+    // then text. Expression transforms ([V01.01.05.04]) slot in before transformSlotOutlet when added.
+    private static IReadOnlyList<NodeTransform> BuildNodeTransforms(TransformOptions options)
+    {
+        var transforms = new List<NodeTransform>
+        {
+            VOnceTransform.Transform,
+            VIfTransform.Transform,
+            VMemoTransform.Transform,
+            VForTransform.Transform,
+            TransformSlotOutlet.Transform,
+            TransformElement.Transform,
+            VSlotTransform.TrackSlotScopes,
+            TransformText.Transform,
+        };
+        transforms.AddRange(options.NodeTransforms);
+        return transforms;
+    }
+
+    private static IReadOnlyDictionary<string, DirectiveTransform> BuildDirectiveTransforms(TransformOptions options)
+    {
+        var transforms = new Dictionary<string, DirectiveTransform>();
+        foreach (var entry in DomDirectiveTransforms.Create())
+        {
+            transforms[entry.Key] = entry.Value;
+        }
+
+        foreach (var entry in options.DirectiveTransforms)
+        {
+            transforms[entry.Key] = entry.Value;
+        }
+
+        return transforms;
+    }
+
+    // Port of createRootCodegen.
+    private static SyntaxNode? CreateRootCodegen(TransformContext context, List<SyntaxNode> children)
+    {
+        if (children.Count == 1)
+        {
+            var child = children[0];
+            if (child is ElementNode { ElementType: ElementType.Element or ElementType.Component } element &&
+                element.ElementType != ElementType.Slot &&
+                context.GetCodegenNode(element) is { } elementCodegen)
+            {
+                if (elementCodegen is VNodeCall vnodeCall)
+                {
+                    var block = TransformUtilities.ConvertToBlock(vnodeCall, context);
+                    context.SetCodegenNode(element, block);
+                    return block;
+                }
+
+                return elementCodegen;
+            }
+
+            // Single slot outlet, IfNode, ForNode, or text: use its own codegen node, or the node itself.
+            return context.GetCodegenNode(child) ?? TransformFreeze.FreezeNode(child);
+        }
+
+        if (children.Count > 1)
+        {
+            var patchFlag = PatchFlags.StableFragment;
+            if (CountNonComment(children) == 1)
+            {
+                patchFlag |= PatchFlags.DevRootFragment;
+            }
+
+            return context.CreateVNodeCall(
+                context.Helper(HelperNames.Fragment),
+                null,
+                TransformFreeze.FreezeChildren(children),
+                patchFlag,
+                null,
+                null,
+                isBlock: true,
+                disableTracking: false,
+                isComponent: false);
+        }
+
+        return null;
+    }
+
+    private static int CountNonComment(IReadOnlyList<SyntaxNode> children)
+    {
+        var count = 0;
+        foreach (var child in children)
+        {
+            if (child is not CommentNode)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static IReadOnlyList<T> ToArray<T>(IReadOnlyCollection<T> source)
+    {
+        var array = new T[source.Count];
+        var index = 0;
+        foreach (var item in source)
+        {
+            array[index++] = item;
+        }
+
+        return array;
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/src/VNodeCall.cs
+++ b/libraries/Assimalign.Vue.Compiler/src/VNodeCall.cs
@@ -1,0 +1,57 @@
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// The central code-generation node describing one <c>createVNode</c>/<c>createElementBlock</c> call — the
+/// vnode a template element, component, or fragment compiles to. The C# port of Vue 3.5's <c>VNodeCall</c>
+/// (<c>@vue/compiler-core</c> <c>ast.ts</c>).
+/// </summary>
+/// <remarks>
+/// The <see cref="PatchFlag"/> and <see cref="DynamicProps"/> fields are populated by prop analysis
+/// ([V01.01.05.03]); the full element-level patch-flag inference (class/style/text elision) is refined by
+/// [V01.01.05.06]. This node deliberately carries every field those stages fill so downstream passes never
+/// reshape it.
+/// </remarks>
+public sealed record VNodeCall : SyntaxNode
+{
+    /// <summary>
+    /// The vnode type: an element tag <see cref="string"/> (already quoted), a <see cref="RuntimeHelper"/>
+    /// (e.g. <c>Fragment</c>/<c>Teleport</c>), or a <see cref="CallExpression"/>
+    /// (<c>resolveDynamicComponent(...)</c>).
+    /// </summary>
+    public required object Tag { get; init; }
+
+    /// <summary>The props expression (<see cref="ObjectExpression"/>/<see cref="CallExpression"/>/expression), or <see langword="null"/>.</summary>
+    public SyntaxNode? Props { get; init; }
+
+    /// <summary>
+    /// The children: a <see cref="SyntaxList{T}"/> of <see cref="TemplateChildNode"/>, a single text child, a
+    /// slots object, a <c>renderList</c> call for <c>v-for</c>, or <see langword="null"/> (upstream's union).
+    /// </summary>
+    public object? Children { get; init; }
+
+    /// <summary>The patch-flag optimization hint, or <see langword="null"/> when none applies.</summary>
+    public PatchFlags? PatchFlag { get; init; }
+
+    /// <summary>
+    /// The dynamic prop names list: a stringified array literal or a <see cref="SimpleExpressionNode"/>, or
+    /// <see langword="null"/> (upstream's <c>string | SimpleExpressionNode | undefined</c>).
+    /// </summary>
+    public object? DynamicProps { get; init; }
+
+    /// <summary>The runtime-directive arguments array (<c>withDirectives</c>), or <see langword="null"/>.</summary>
+    public ArrayExpression? Directives { get; init; }
+
+    /// <summary>Whether this vnode opens an optimization block.</summary>
+    public bool IsBlock { get; init; }
+
+    /// <summary>Whether block child tracking is disabled (a <c>v-for</c> fragment with a dynamic source).</summary>
+    public bool DisableTracking { get; init; }
+
+    /// <summary>Whether the vnode is a component (selects the <c>createVNode</c> vs <c>createElementVNode</c> helper).</summary>
+    public bool IsComponent { get; init; }
+
+    /// <inheritdoc />
+    public override NodeType NodeType => NodeType.VNodeCall;
+}

--- a/libraries/Assimalign.Vue.Compiler/test/DomDirectiveTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/DomDirectiveTransformTests.cs
@@ -1,0 +1,84 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-dom/__tests__/transforms/{vShow,vHtml,vText}.spec.ts, plus the
+// v-pre (parser-driven) and v-cloak (noop) integration cases.
+public class DomDirectiveTransformTests
+{
+    [Fact]
+    public void VShow_EmitsShowRuntimeDirective()
+    {
+        var result = TransformTestHelpers.Transform("<div v-show=\"visible\"></div>");
+
+        result.ShouldUseHelper("vShow");
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Directives.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VShow_NoExpression_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-show></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVShowNoExpression);
+    }
+
+    [Fact]
+    public void VHtml_EmitsInnerHtmlProp()
+    {
+        var result = TransformTestHelpers.Transform("<div v-html=\"raw\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("innerHTML").Value.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("raw");
+    }
+
+    [Fact]
+    public void VHtml_WithChildren_ReportsErrorAndClearsChildren()
+    {
+        var result = TransformTestHelpers.Transform("<div v-html=\"raw\"><span></span></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVHtmlWithChildren);
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Children.ShouldBeNull();
+    }
+
+    [Fact]
+    public void VText_EmitsTextContentPropWrappedInToDisplayString()
+    {
+        var result = TransformTestHelpers.Transform("<div v-text=\"msg\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        var value = props.Property("textContent").Value.ShouldBeOfType<CallExpression>();
+        value.Callee.ShouldBe("_toDisplayString");
+    }
+
+    [Fact]
+    public void VText_WithChildren_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-text=\"msg\"><span></span></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVTextWithChildren);
+    }
+
+    [Fact]
+    public void VCloak_EmitsNoRuntimeProp()
+    {
+        var result = TransformTestHelpers.Transform("<div v-cloak></div>");
+
+        // v-cloak contributes nothing at compile time; the element has no props.
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeNull();
+    }
+
+    [Fact]
+    public void VPre_PreservesInterpolationDelimitersAsLiteralText()
+    {
+        // The parser handles v-pre: {{ raw }} inside a v-pre subtree becomes literal text, and no
+        // toDisplayString helper is emitted. The transform must leave it untouched.
+        var result = TransformTestHelpers.Transform("<div v-pre>{{ raw }}</div>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        codegen.Children.ShouldBeOfType<TextNode>().Content.ShouldBe("{{ raw }}");
+        result.UsesHelper("toDisplayString").ShouldBeFalse();
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/DomErrorCatalogTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/DomErrorCatalogTests.cs
@@ -1,0 +1,35 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Pins the DOM error-code numbering decision for [V01.01.05.03]. Vuecs merges compiler-core and
+// compiler-dom into one error enum; upstream's DOMErrorCodes reuses core's __EXTEND_POINT__ value (53) as
+// its first code, which one C# enum cannot do while keeping ExtendPoint == 53 (pinned by ErrorTests). The
+// DOM codes are therefore appended after the preserved sentinel (each = its upstream DOMErrorCodes value + 1).
+public class DomErrorCatalogTests
+{
+    [Fact]
+    public void DomErrorCatalog_ExtendsCoreAfterThePreservedExtendPoint()
+    {
+        ((int)CompilerErrorCode.ExtendPoint).ShouldBe(53);
+        ((int)CompilerErrorCode.XVHtmlNoExpression).ShouldBe(54);
+        ((int)CompilerErrorCode.XVHtmlWithChildren).ShouldBe(55);
+        ((int)CompilerErrorCode.XVModelOnInvalidElement).ShouldBe(58);
+        ((int)CompilerErrorCode.XVShowNoExpression).ShouldBe(62);
+        ((int)CompilerErrorCode.XIgnoredSideEffectTag).ShouldBe(64);
+        ((int)CompilerErrorCode.DomExtendPoint).ShouldBe(65);
+    }
+
+    [Fact]
+    public void DomErrorMessages_MatchUpstreamVerbatim()
+    {
+        CompilerErrorMessages.GetMessage(CompilerErrorCode.XVHtmlWithChildren)
+            .ShouldBe("v-html will override element children.");
+        CompilerErrorMessages.GetMessage(CompilerErrorCode.XVModelOnInvalidElement)
+            .ShouldBe("v-model can only be used on <input>, <textarea> and <select> elements.");
+        CompilerErrorMessages.GetMessage(CompilerErrorCode.XVShowNoExpression)
+            .ShouldBe("v-show is missing expression.");
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/DynamicComponentTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/DynamicComponentTests.cs
@@ -1,0 +1,53 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/transformElement.spec.ts: component
+// type resolution, including dynamic components (<component :is>) and built-in components.
+public class DynamicComponentTests
+{
+    [Fact]
+    public void DynamicComponent_WithBoundIs_CompilesToResolveDynamicComponent()
+    {
+        var result = TransformTestHelpers.Transform("<component :is=\"foo\"></component>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        var tag = codegen.Tag.ShouldBeOfType<CallExpression>();
+        tag.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("resolveDynamicComponent");
+        tag.Arguments[0].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("foo");
+        codegen.IsBlock.ShouldBeTrue();
+        result.ShouldUseHelper("resolveDynamicComponent");
+    }
+
+    [Fact]
+    public void DynamicComponent_WithStaticIs_UsesStaticName()
+    {
+        var result = TransformTestHelpers.Transform("<component is=\"foo\"></component>");
+
+        var tag = result.CodegenNode.ShouldBeOfType<VNodeCall>().Tag.ShouldBeOfType<CallExpression>();
+        tag.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("resolveDynamicComponent");
+        var expression = tag.Arguments[0].ShouldBeOfType<SimpleExpressionNode>();
+        expression.Content.ShouldBe("foo");
+        expression.IsStatic.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void UserComponent_CompilesToResolveComponent()
+    {
+        var result = TransformTestHelpers.Transform("<MyComponent></MyComponent>");
+
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Tag.ShouldBe("_component_MyComponent");
+        result.ShouldUseHelper("resolveComponent");
+        result.Components.ShouldContain("MyComponent");
+    }
+
+    [Fact]
+    public void BuiltInComponent_ResolvesToHelperSymbol()
+    {
+        var result = TransformTestHelpers.Transform("<Teleport to=\"#modal\"><div></div></Teleport>");
+
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Teleport");
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/TransformPipelineTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/TransformPipelineTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transform.spec.ts: the transform driver
+// (node/directive transform ordering, replace/remove, helper registration, third-party injection) and the
+// [V01.01.05.02] block-structure (dynamic-children order) invariant.
+public class TransformPipelineTests
+{
+    [Fact]
+    public void Transform_SingleRootElement_ProducesElementBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div></div>");
+
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        codegen.Tag.ShouldBe("\"div\"");
+        codegen.IsBlock.ShouldBeTrue();
+        result.ShouldUseHelper("createElementBlock");
+        result.ShouldUseHelper("openBlock");
+    }
+
+    [Fact]
+    public void Transform_MultipleRoots_ProducesStableFragmentBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div></div><span></span>");
+
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        codegen.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        codegen.ShouldHavePatchFlag(PatchFlags.StableFragment);
+        codegen.IsBlock.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Transform_Interpolation_RegistersToDisplayStringHelper()
+    {
+        var result = TransformTestHelpers.Transform("<div>{{ message }}</div>");
+
+        result.ShouldUseHelper("toDisplayString");
+    }
+
+    [Fact]
+    public void Transform_ThirdPartyNodeTransform_RunsInOrder()
+    {
+        // transform.spec.ts 'context state' / custom nodeTransforms: user transforms run after the preset.
+        var visited = new List<string>();
+        var options = TransformOptions.CreateDom();
+        options.NodeTransforms = new NodeTransform[]
+        {
+            (node, _) =>
+            {
+                if (node is ElementNode element)
+                {
+                    visited.Add(element.Tag);
+                }
+
+                return null;
+            },
+        };
+
+        TransformTestHelpers.Transform("<div><span></span></div>", options);
+
+        visited.ShouldBe(new[] { "div", "span" });
+    }
+
+    [Fact]
+    public void Transform_ReplaceNode_SubstitutesInTree()
+    {
+        // transform.spec.ts 'context.replaceNode': a custom transform swaps a node.
+        var options = TransformOptions.CreateDom();
+        options.NodeTransforms = new NodeTransform[]
+        {
+            (node, context) =>
+            {
+                if (node is ElementNode { Tag: "div" })
+                {
+                    context.ReplaceNode(new TextNode { Content = "replaced", Location = node.Location });
+                }
+
+                return null;
+            },
+        };
+
+        var result = TransformTestHelpers.Transform("<div></div>", options);
+
+        result.SingleChild().ShouldBeOfType<TextNode>().Content.ShouldBe("replaced");
+    }
+
+    [Fact]
+    public void Transform_RemoveNode_DropsFromTree()
+    {
+        // transform.spec.ts 'context.removeNode': a custom transform removes a node.
+        var options = TransformOptions.CreateDom();
+        options.NodeTransforms = new NodeTransform[]
+        {
+            (node, context) =>
+            {
+                if (node is ElementNode { Tag: "span" })
+                {
+                    context.RemoveNode();
+                }
+
+                return null;
+            },
+        };
+
+        var result = TransformTestHelpers.Transform("<div><span></span><b></b></div>", options);
+
+        var div = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var children = div.Children.ShouldBeOfType<SyntaxList<TemplateChildNode>>();
+        children.Count.ShouldBe(1);
+        children[0].ShouldBeOfType<ElementNode>().Tag.ShouldBe("b");
+    }
+
+    [Fact]
+    public void Transform_DynamicChildrenOrder_IsStableAcrossRuns()
+    {
+        // [V01.01.05.02] block-structure invariant: the transformed tree (and its dynamic children) is
+        // deterministic — equal input yields value-equal output, the incremental-generator caching contract.
+        const string template = "<div><span>{{ a }}</span><i v-if=\"ok\"></i><em>{{ b }}</em></div>";
+
+        var first = TransformTestHelpers.Transform(template);
+        var second = TransformTestHelpers.Transform(template);
+
+        first.CodegenNode.ShouldBe(second.CodegenNode);
+        first.Children.ShouldBe(second.Children);
+    }
+
+    [Fact]
+    public void Transform_HelperRegistration_DeduplicatesByReference()
+    {
+        // Two dynamic text children both need toDisplayString but it is registered once.
+        var result = TransformTestHelpers.Transform("<div>{{ a }}{{ b }}</div>");
+
+        result.Helpers.Count(helper => helper.Name == "toDisplayString").ShouldBe(1);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/TransformTestHelpers.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/TransformTestHelpers.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+namespace Assimalign.Vue.Compiler;
+
+/// <summary>
+/// Shared helpers for the transform test corpus: parse a template in DOM mode and run the transform pipeline,
+/// then navigate the resulting code-generation IR. Mirrors the <c>transformWithXxx</c> helpers in vuejs/core's
+/// <c>packages/compiler-core/__tests__/transforms/*.spec.ts</c>.
+/// </summary>
+internal static class TransformTestHelpers
+{
+    /// <summary>Parses <paramref name="source"/> (DOM mode) and transforms it with the default DOM transforms.</summary>
+    public static TransformResult Transform(string source, TransformOptions? options = null)
+    {
+        var root = TemplateParser.Parse(source, ParserOptions.CreateHtml());
+        return Transformer.Transform(root, options ?? TransformOptions.CreateDom());
+    }
+
+    /// <summary>Parses and transforms, collecting reported diagnostics.</summary>
+    public static TransformResult Transform(string source, out List<CompilerError> errors, TransformOptions? options = null)
+    {
+        var collected = new List<CompilerError>();
+        options ??= TransformOptions.CreateDom();
+        options.OnError = collected.Add;
+        var result = Transform(source, options);
+        errors = collected;
+        return result;
+    }
+
+    /// <summary>The single top-level transformed child.</summary>
+    public static TemplateChildNode SingleChild(this TransformResult result)
+        => result.Children.ShouldHaveSingleItem();
+
+    /// <summary>Whether a helper with the given runtime name was registered.</summary>
+    public static bool UsesHelper(this TransformResult result, string name)
+        => result.Helpers.Any(helper => helper.Name == name);
+
+    /// <summary>Asserts a helper with the given runtime name was registered.</summary>
+    public static void ShouldUseHelper(this TransformResult result, string name)
+        => result.UsesHelper(name).ShouldBeTrue($"expected helper '{name}' to be registered");
+
+    /// <summary>The code-generation node of the single top-level child.</summary>
+    public static SyntaxNode RootCodegen(this TransformResult result)
+        => result.CodegenNode.ShouldNotBeNull();
+
+    /// <summary>Asserts the property list contains a property whose static key equals <paramref name="key"/> and returns it.</summary>
+    public static Property Property(this ObjectExpression obj, string key)
+        => obj.Properties.FirstOrDefault(p => p.Key is SimpleExpressionNode { IsStatic: true } k && k.Content == key)
+            .ShouldNotBeNull($"expected property '{key}'");
+
+    /// <summary>The content of a static simple-expression node.</summary>
+    public static string StaticContent(this SyntaxNode node)
+        => node.ShouldBeOfType<SimpleExpressionNode>().Content;
+
+    /// <summary>Asserts a patch flag is present on a vnode call.</summary>
+    public static void ShouldHavePatchFlag(this VNodeCall call, PatchFlags flag)
+    {
+        call.PatchFlag.ShouldNotBeNull();
+        (call.PatchFlag!.Value & flag).ShouldBe(flag);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VBindTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VBindTransformTests.cs
@@ -1,0 +1,90 @@
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vBind.spec.ts: v-bind prop emission,
+// class/style normalization, dynamic-argument FULL_PROPS escalation, and .prop/.attr/.camel modifiers.
+public class VBindTransformTests
+{
+    [Fact]
+    public void VBind_StaticArgument_EmitsProp()
+    {
+        var result = TransformTestHelpers.Transform("<div :id=\"x\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("id").Value.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("x");
+    }
+
+    [Fact]
+    public void VBind_DynamicClass_NormalizesAndFlagsClass()
+    {
+        var result = TransformTestHelpers.Transform("<div :class=\"cls\"></div>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        codegen.ShouldHavePatchFlag(PatchFlags.Class);
+        var classValue = codegen.Props.ShouldBeOfType<ObjectExpression>().Property("class").Value.ShouldBeOfType<CallExpression>();
+        classValue.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("normalizeClass");
+    }
+
+    [Fact]
+    public void VBind_DynamicStyle_NormalizesAndFlagsStyle()
+    {
+        var result = TransformTestHelpers.Transform("<div :style=\"sty\"></div>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        codegen.ShouldHavePatchFlag(PatchFlags.Style);
+        codegen.Props.ShouldBeOfType<ObjectExpression>().Property("style").Value.ShouldBeOfType<CallExpression>()
+            .Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("normalizeStyle");
+    }
+
+    [Fact]
+    public void VBind_CollectsDynamicPropNamesAndFlagsProps()
+    {
+        var result = TransformTestHelpers.Transform("<div :foo=\"x\"></div>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        codegen.ShouldHavePatchFlag(PatchFlags.Props);
+        codegen.DynamicProps.ShouldBe("[\"foo\"]");
+    }
+
+    [Fact]
+    public void VBind_DynamicArgument_EscalatesToFullProps()
+    {
+        var result = TransformTestHelpers.Transform("<div :[key]=\"x\"></div>");
+
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().ShouldHavePatchFlag(PatchFlags.FullProps);
+    }
+
+    [Fact]
+    public void VBind_PropModifier_PrefixesArgumentWithDot()
+    {
+        var result = TransformTestHelpers.Transform("<div :id.prop=\"x\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property(".id").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VBind_CamelModifier_CamelizesStaticArgument()
+    {
+        var result = TransformTestHelpers.Transform("<div :view-box.camel=\"x\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("viewBox").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VBind_ObjectSpread_MergesProps()
+    {
+        // v-bind without argument (v-bind="obj") merges via mergeProps and escalates to FULL_PROPS.
+        var result = TransformTestHelpers.Transform("<div v-bind=\"obj\" id=\"a\"></div>");
+
+        var codegen = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        codegen.ShouldHavePatchFlag(PatchFlags.FullProps);
+        codegen.Props.ShouldBeOfType<CallExpression>().Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("mergeProps");
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VForTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VForTransformTests.cs
@@ -1,0 +1,121 @@
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vFor.spec.ts: the ForNode alias
+// decomposition, the renderList fragment codegen, and keyed/unkeyed fragment classification.
+public class VForTransformTests
+{
+    [Fact]
+    public void VFor_ValueOnly_DecomposesValueAlias()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"item in list\"></div>");
+
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        forNode.Source.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("list");
+        forNode.ValueAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("item");
+        forNode.KeyAlias.ShouldBeNull();
+        forNode.ObjectIndexAlias.ShouldBeNull();
+    }
+
+    [Fact]
+    public void VFor_ValueAndKey_DecomposesTuple()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"(item, index) in list\"></div>");
+
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        forNode.ValueAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("item");
+        forNode.KeyAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("index");
+        forNode.ObjectIndexAlias.ShouldBeNull();
+    }
+
+    [Fact]
+    public void VFor_ValueKeyIndex_DecomposesAllThree()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"(value, key, index) in obj\"></div>");
+
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        forNode.ValueAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("value");
+        forNode.KeyAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("key");
+        forNode.ObjectIndexAlias.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("index");
+    }
+
+    [Fact]
+    public void VFor_OfIterator_IsSupported()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"item of list\"></div>");
+
+        result.SingleChild().ShouldBeOfType<ForNode>()
+            .Source.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("list");
+    }
+
+    [Fact]
+    public void VFor_Unkeyed_CompilesToUnkeyedFragmentBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"item in list\"></div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+
+        var codegen = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+        codegen.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        codegen.IsBlock.ShouldBeTrue();
+        codegen.DisableTracking.ShouldBeTrue();
+        codegen.ShouldHavePatchFlag(PatchFlags.UnkeyedFragment);
+        result.ShouldUseHelper("renderList");
+
+        var renderList = codegen.Children.ShouldBeOfType<CallExpression>();
+        renderList.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("renderList");
+        renderList.Arguments[0].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("list");
+        var iterator = renderList.Arguments[1].ShouldBeOfType<FunctionExpression>();
+        iterator.Parameters[0].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("item");
+    }
+
+    [Fact]
+    public void VFor_Keyed_CompilesToKeyedFragmentBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"item in list\" :key=\"item.id\"></div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+
+        result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>().ShouldHavePatchFlag(PatchFlags.KeyedFragment);
+    }
+
+    [Fact]
+    public void TemplateVFor_MultipleChildren_WrapsInStableFragment()
+    {
+        var result = TransformTestHelpers.Transform("<template v-for=\"i in list\"><div></div><p></p></template>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        forNode.Children.Count.ShouldBe(2);
+
+        var codegen = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+        var renderList = codegen.Children.ShouldBeOfType<CallExpression>();
+        var iterator = renderList.Arguments[1].ShouldBeOfType<FunctionExpression>();
+        iterator.Returns.ShouldBeOfType<VNodeCall>().Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+    }
+
+    [Fact]
+    public void VFor_NoExpression_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-for></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVForNoExpression);
+    }
+
+    [Fact]
+    public void VFor_MalformedExpression_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-for=\"nonsense\"></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVForMalformedExpression);
+    }
+
+    [Fact]
+    public void TemplateVFor_KeyOnChild_ReportsPlacementError()
+    {
+        TransformTestHelpers.Transform("<template v-for=\"i in list\"><div :key=\"i\"></div></template>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVForTemplateKeyPlacement);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VIfTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VIfTransformTests.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vIf.spec.ts: branch grouping into a
+// single IfNode, the conditional-expression codegen, stable per-branch keys, and the diagnostics.
+public class VIfTransformTests
+{
+    [Fact]
+    public void VIf_Single_ProducesIfNodeWithOneBranch()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"ok\"></div>");
+
+        var ifNode = result.SingleChild().ShouldBeOfType<IfNode>();
+        ifNode.Branches.Count.ShouldBe(1);
+        ifNode.Branches[0].Condition.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("ok");
+    }
+
+    [Fact]
+    public void VIf_Single_CompilesToConditionalWithCommentAlternate()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"ok\"></div>");
+        var ifNode = result.SingleChild().ShouldBeOfType<IfNode>();
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        conditional.Test.StaticContent().ShouldBe("ok");
+        var consequent = conditional.Consequent.ShouldBeOfType<VNodeCall>();
+        consequent.IsBlock.ShouldBeTrue();
+        consequent.Props.ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("0");
+        conditional.Alternate.ShouldBeOfType<CallExpression>().Callee
+            .ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("createCommentVNode");
+    }
+
+    [Fact]
+    public void VIfElse_GroupsIntoSingleIfNodeWithTwoBranches()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"a\"></div><p v-else></p>");
+
+        result.Children.Count.ShouldBe(1);
+        var ifNode = result.Children[0].ShouldBeOfType<IfNode>();
+        ifNode.Branches.Count.ShouldBe(2);
+        ifNode.Branches[0].Condition.ShouldNotBeNull();
+        ifNode.Branches[1].Condition.ShouldBeNull();
+    }
+
+    [Fact]
+    public void VIfElse_CompilesToConditionalWithBranchKeys()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"a\"></div><p v-else></p>");
+        var ifNode = result.Children[0].ShouldBeOfType<IfNode>();
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        conditional.Consequent.ShouldBeOfType<VNodeCall>().Props
+            .ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("0");
+        // else branch has no condition, so the alternate is its block directly (key 1).
+        var alternate = conditional.Alternate.ShouldBeOfType<VNodeCall>();
+        alternate.Tag.ShouldBe("\"p\"");
+        alternate.Props.ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("1");
+    }
+
+    [Fact]
+    public void VIfElseIf_ChainsConditionalsWithIncrementingKeys()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"a\"></div><p v-else-if=\"b\"></p><i v-else></i>");
+        var ifNode = result.Children[0].ShouldBeOfType<IfNode>();
+        ifNode.Branches.Count.ShouldBe(3);
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        conditional.Test.StaticContent().ShouldBe("a");
+        var nested = conditional.Alternate.ShouldBeOfType<ConditionalExpression>();
+        nested.Test.StaticContent().ShouldBe("b");
+        nested.Consequent.ShouldBeOfType<VNodeCall>().Props
+            .ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("1");
+        nested.Alternate.ShouldBeOfType<VNodeCall>().Props
+            .ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("2");
+    }
+
+    [Fact]
+    public void TemplateVIf_WithMultipleChildren_CompilesToKeyedFragment()
+    {
+        var result = TransformTestHelpers.Transform("<template v-if=\"ok\"><div></div><p></p></template>");
+        var ifNode = result.SingleChild().ShouldBeOfType<IfNode>();
+        ifNode.Branches[0].IsTemplateIf.ShouldBeTrue();
+        ifNode.Branches[0].Children.Count.ShouldBe(2);
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        var fragment = conditional.Consequent.ShouldBeOfType<VNodeCall>();
+        fragment.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        fragment.ShouldHavePatchFlag(PatchFlags.StableFragment);
+        fragment.Props.ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("0");
+    }
+
+    [Fact]
+    public void VIf_NoExpression_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-if></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVIfNoExpression);
+    }
+
+    [Fact]
+    public void VElse_NoAdjacentIf_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div></div><p v-else></p>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVElseNoAdjacentIf);
+    }
+
+    [Fact]
+    public void VIf_SameKeyOnBranches_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-if=\"a\" key=\"x\"></div><p v-else key=\"x\"></p>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVIfSameKey);
+    }
+
+    [Fact]
+    public void VIf_CommentBetweenBranches_IsAbsorbed()
+    {
+        // vIf.spec.ts 'comment between branches': the comment is moved into the branch, not left dangling.
+        var result = TransformTestHelpers.Transform("<div v-if=\"a\"></div><!--c--><p v-else></p>");
+
+        result.Children.Count.ShouldBe(1);
+        result.Children[0].ShouldBeOfType<IfNode>().Branches.Count.ShouldBe(2);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VModelTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VModelTransformTests.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-dom/__tests__/transforms/vModel.spec.ts: the runtime model
+// directive selected by element and input type, and the component modelValue/onUpdate pair.
+public class VModelTransformTests
+{
+    [Theory]
+    [InlineData("<input v-model=\"text\"/>", "vModelText")]
+    [InlineData("<input type=\"checkbox\" v-model=\"c\"/>", "vModelCheckbox")]
+    [InlineData("<input type=\"radio\" v-model=\"r\"/>", "vModelRadio")]
+    [InlineData("<select v-model=\"s\"></select>", "vModelSelect")]
+    [InlineData("<textarea v-model=\"t\"></textarea>", "vModelText")]
+    [InlineData("<input :type=\"dyn\" v-model=\"d\"/>", "vModelDynamic")]
+    public void VModel_NativeElement_SelectsRuntimeDirectiveByType(string template, string expectedHelper)
+    {
+        var result = TransformTestHelpers.Transform(template);
+
+        result.ShouldUseHelper(expectedHelper);
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().Directives.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VModel_NativeElement_EmitsUpdateHandlerButNotModelValueProp()
+    {
+        var result = TransformTestHelpers.Transform("<input v-model=\"text\"/>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("onUpdate:modelValue").ShouldNotBeNull();
+        // native v-model does not carry the modelValue prop; it is passed as binding.value.
+        props.Properties.Any(p => p.Key is SimpleExpressionNode { Content: "modelValue" }).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void VModel_Component_EmitsModelValueAndUpdatePair()
+    {
+        var result = TransformTestHelpers.Transform("<MyInput v-model=\"value\"></MyInput>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("modelValue").ShouldNotBeNull();
+        props.Property("onUpdate:modelValue").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VModel_ComponentWithArgumentAndModifiers_EmitsNamedModelAndModifiers()
+    {
+        var result = TransformTestHelpers.Transform("<MyInput v-model:title.trim=\"value\"></MyInput>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("title").ShouldNotBeNull();
+        props.Property("onUpdate:title").ShouldNotBeNull();
+        props.Property("titleModifiers").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VModel_OnInvalidElement_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div v-model=\"x\"></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVModelOnInvalidElement);
+    }
+
+    [Fact]
+    public void VModel_OnFileInput_ReportsError()
+    {
+        TransformTestHelpers.Transform("<input type=\"file\" v-model=\"f\"/>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVModelOnFileInputElement);
+    }
+
+    [Fact]
+    public void VModel_MalformedExpression_ReportsError()
+    {
+        TransformTestHelpers.Transform("<input v-model=\"a + b\"/>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVModelMalformedExpression);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VOnTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VOnTransformTests.cs
@@ -1,0 +1,80 @@
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vOn.spec.ts and
+// packages/compiler-dom/__tests__/transforms/vOn.spec.ts: event-name resolution, inline-statement wrapping,
+// and key/system/event-option modifier handling.
+public class VOnTransformTests
+{
+    [Fact]
+    public void VOn_StaticEvent_ResolvesHandlerKey()
+    {
+        var result = TransformTestHelpers.Transform("<div @click=\"handler\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        var handler = props.Property("onClick");
+        handler.Value.ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("handler");
+    }
+
+    [Fact]
+    public void VOn_InlineStatement_WrapsInEventArrow()
+    {
+        var result = TransformTestHelpers.Transform("<div @click=\"count++\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        var compound = props.Property("onClick").Value.ShouldBeOfType<CompoundExpressionNode>();
+        compound.Parts[0].ShouldBe("$event => (");
+    }
+
+    [Fact]
+    public void VOn_SystemModifier_WrapsWithModifiers()
+    {
+        var result = TransformTestHelpers.Transform("<div @click.stop=\"fn\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        var call = props.Property("onClick").Value.ShouldBeOfType<CallExpression>();
+        call.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("withModifiers");
+        call.Arguments[1].ShouldBe("[\"stop\"]");
+        result.ShouldUseHelper("withModifiers");
+    }
+
+    [Fact]
+    public void VOn_KeyModifierOnKeyboardEvent_WrapsWithKeys()
+    {
+        var result = TransformTestHelpers.Transform("<input @keyup.enter=\"fn\"/>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        var call = props.Property("onKeyup").Value.ShouldBeOfType<CallExpression>();
+        call.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("withKeys");
+        call.Arguments[1].ShouldBe("[\"enter\"]");
+    }
+
+    [Fact]
+    public void VOn_EventOptionModifier_AppendsSuffix()
+    {
+        var result = TransformTestHelpers.Transform("<div @click.once=\"fn\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("onClickOnce").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VOn_RightModifier_RemapsToContextmenu()
+    {
+        var result = TransformTestHelpers.Transform("<div @click.right=\"fn\"></div>");
+
+        var props = result.CodegenNode.ShouldBeOfType<VNodeCall>().Props.ShouldBeOfType<ObjectExpression>();
+        props.Property("onContextmenu").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void VOn_NoExpressionAndNoModifiers_ReportsError()
+    {
+        TransformTestHelpers.Transform("<div @click></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVOnNoExpression);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VOnceMemoTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VOnceMemoTransformTests.cs
@@ -1,0 +1,57 @@
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vOnce.spec.ts and vMemo.spec.ts:
+// v-once caches the subtree; v-memo wraps it in withMemo; their interaction with v-for.
+public class VOnceMemoTransformTests
+{
+    [Fact]
+    public void VOnce_CachesSubtreeAndRegistersSetBlockTracking()
+    {
+        var result = TransformTestHelpers.Transform("<div v-once></div>");
+
+        var cache = result.CodegenNode.ShouldBeOfType<CacheExpression>();
+        cache.InVOnce.ShouldBeTrue();
+        cache.NeedPauseTracking.ShouldBeTrue();
+        cache.Value.ShouldBeOfType<VNodeCall>();
+        result.ShouldUseHelper("setBlockTracking");
+        result.Cached.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void VMemo_WrapsSubtreeInWithMemo()
+    {
+        var result = TransformTestHelpers.Transform("<div v-memo=\"[msg]\"></div>");
+
+        var memo = result.CodegenNode.ShouldBeOfType<CallExpression>();
+        memo.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("withMemo");
+        memo.Arguments[0].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("[msg]");
+        var factory = memo.Arguments[1].ShouldBeOfType<FunctionExpression>();
+        factory.Returns.ShouldBeOfType<VNodeCall>().IsBlock.ShouldBeTrue();
+        memo.Arguments[2].ShouldBe("_cache");
+        memo.Arguments[3].ShouldBe("0");
+        result.Cached.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void VMemo_WithVFor_ProducesPerItemMemoLoop()
+    {
+        // vMemo.spec.ts 'on v-for': v-for's renderList iterator memoizes each item (no separate withMemo).
+        var result = TransformTestHelpers.Transform("<div v-for=\"item in list\" v-memo=\"[item]\"></div>");
+
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        var codegen = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+        var renderList = codegen.Children.ShouldBeOfType<CallExpression>();
+        var loop = renderList.Arguments[1].ShouldBeOfType<FunctionExpression>();
+        // the loop takes the aliases plus a trailing _cached parameter and has a block body
+        loop.Parameters[loop.Parameters.Count - 1].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("_cached");
+        loop.Body.ShouldNotBeNull();
+        result.ShouldUseHelper("isMemoSame");
+        result.Cached.Count.ShouldBe(1);
+    }
+}

--- a/libraries/Assimalign.Vue.Compiler/test/VSlotTransformTests.cs
+++ b/libraries/Assimalign.Vue.Compiler/test/VSlotTransformTests.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Compiler;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/vSlot.spec.ts: buildSlots, the
+// SlotFlags fingerprint (STABLE/DYNAMIC/FORWARDED), and the slot-misuse diagnostics.
+public class VSlotTransformTests
+{
+    private static ObjectExpression Slots(TransformResult result)
+    {
+        var children = result.CodegenNode.ShouldBeOfType<VNodeCall>().Children;
+        return children is CallExpression createSlots
+            ? createSlots.Arguments[0].ShouldBeOfType<ObjectExpression>()
+            : children.ShouldBeOfType<ObjectExpression>();
+    }
+
+    private static string SlotFlag(ObjectExpression slots)
+        => slots.Properties.First(p => p.Key is SimpleExpressionNode { Content: "_" }).Value.ShouldBeOfType<SimpleExpressionNode>().Content;
+
+    [Fact]
+    public void NamedTemplateSlot_ProducesStableSlotsObject()
+    {
+        var result = TransformTestHelpers.Transform("<Comp><template #header>title</template></Comp>");
+
+        var slots = Slots(result);
+        slots.Property("header").Value.ShouldBeOfType<FunctionExpression>();
+        SlotFlag(slots).ShouldBe(((int)SlotFlags.Stable).ToString());
+        result.ShouldUseHelper("withCtx");
+    }
+
+    [Fact]
+    public void OnComponentSlot_ProducesDefaultSlotWithProps()
+    {
+        var result = TransformTestHelpers.Transform("<Comp v-slot=\"{ item }\">{{ item }}</Comp>");
+
+        var slots = Slots(result);
+        var defaultSlot = slots.Property("default").Value.ShouldBeOfType<FunctionExpression>();
+        defaultSlot.Parameters.Count.ShouldBe(1);
+        defaultSlot.Parameters[0].ShouldBeOfType<SimpleExpressionNode>().Content.ShouldBe("{ item }");
+    }
+
+    [Fact]
+    public void ConditionalTemplateSlot_ProducesDynamicSlots()
+    {
+        var result = TransformTestHelpers.Transform("<Comp><template #a v-if=\"ok\">x</template></Comp>");
+
+        var codegenChildren = result.CodegenNode.ShouldBeOfType<VNodeCall>().Children;
+        var createSlots = codegenChildren.ShouldBeOfType<CallExpression>();
+        createSlots.Callee.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("createSlots");
+        SlotFlag(createSlots.Arguments[0].ShouldBeOfType<ObjectExpression>()).ShouldBe(((int)SlotFlags.Dynamic).ToString());
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().ShouldHavePatchFlag(PatchFlags.DynamicSlots);
+    }
+
+    [Fact]
+    public void ForwardedSlot_IsFlaggedForwarded()
+    {
+        var result = TransformTestHelpers.Transform("<Comp><slot></slot></Comp>");
+
+        SlotFlag(Slots(result)).ShouldBe(((int)SlotFlags.Forwarded).ToString());
+    }
+
+    [Fact]
+    public void MixedSlotUsage_ReportsError()
+    {
+        TransformTestHelpers.Transform("<Comp v-slot=\"x\"><template #header>h</template></Comp>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVSlotMixedSlotUsage);
+    }
+
+    [Fact]
+    public void DuplicateSlotNames_ReportsError()
+    {
+        TransformTestHelpers.Transform("<Comp><template #a>1</template><template #a>2</template></Comp>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVSlotDuplicateSlotNames);
+    }
+
+    [Fact]
+    public void VSlotOnPlainElement_ReportsMisplacedError()
+    {
+        TransformTestHelpers.Transform("<div v-slot=\"x\"></div>", out var errors);
+
+        errors.ShouldContain(e => e.Code == CompilerErrorCode.XVSlotMisplaced);
+    }
+}


### PR DESCRIPTION
Batch 8A — delegated implementation (Opus 4.8 agent) with design/functionality review. Compiler-only; current main (#121/#122/#123) merged in and the combined result verified.

## What landed

**The transform pipeline [V01.01.05.02, #49]** — the `transform()` port pinned to vuejs/core v3.5.13: ordered node transforms with reverse-order exit callbacks, name-keyed directive transforms, third-party injection via options, `ReplaceNode`/`RemoveNode`, helper/component/directive registration, and the hoist/cache seams #54 will consume. Structural transforms: `v-if` chains grouped into `IfNode` with stable synthetic branch keys, `v-for` → `ForNode` with alias decomposition and keyed/unkeyed/stable fragment classification feeding `renderList` codegen, `v-once`, and `v-memo` (including the v-for interaction). `<component :is>` resolves through `resolveDynamicComponent` exactly per upstream `resolveComponentType`. The block-structure invariant — dynamic-children order stable for a given template — is documented and pinned by a value-equality-across-runs test.

**Directive transforms [V01.01.05.03, #50]** — `v-bind` (class/style normalization, dynamic-arg → `FULL_PROPS`, `dynamicProps` collection, `.prop`/`.attr`/`.camel`), `v-on` (core+DOM merged: `withModifiers`/`withKeys`, `.exact`, event-option suffixes, `click.right` → `onContextmenu`), `v-model` (native input-type/select/dynamic dispatch + component `modelValue`/`onUpdate:` pair), `v-slot` (`buildSlots` with STABLE/DYNAMIC/FORWARDED `SlotFlags` + misuse diagnostics), `v-show`/`v-html`/`v-text`/`v-cloak`, slot outlets, and text-call coalescing. v-pre integrates the parser's existing handling rather than duplicating it.

## The central design decision (reviewed and endorsed)

Upstream mutates the AST in place (`node.codegenNode`, child splicing); our parser AST is immutable records with structural equality — the incremental-caching contract. The port keeps both: codegen results live in a reference-keyed side table on the context, and structural containers use internal working forms frozen into immutable `IfNode`/`ForNode` on consumption. The output is deterministic and value-equatable, pinned by parse-and-transform-twice equality tests.

## Deviations (each documented at the site)

- **Issue-vs-steer conflict resolved per the authority order**: my brief said to leave patch-flag work to #53, but #50's ACs mandate `FULL_PROPS` escalation + `dynamicProps` and #49's mandate fragment classification — inseparable from `buildProps`, so that subset is ported here; element-level patch-flag *refinement* remains #53.
- **DOM error codes carry a +1 offset** after the immovable core catalog (0–52 exact); documented at the enum and pinned by tests.
- **`PatchFlags`/`SlotFlags` linked-source** into the netstandard2.0 compiler (the established seam; both enums are netstandard-clean, and the flag *values* are the compiler↔runtime contract — the build-time assembly never loads beside Shared).
- **v-memo × v-for**: the immutable model exposed an upstream quirk (a dead `withMemo` wrapper + wasted cache slot when both directives share an element); the port coordinates so v-for's per-item memo is the sole memo — same documented v-memo semantics, cleaner output, tested.
- Event-option suffixes stay inline strings (upstream has no shared enum; declined to grow Shared without need).

## Expression-opacity boundary (as briefed)

Expressions ride opaque (upstream non-`prefixIdentifiers` mode); the sole exception is v-for alias decomposition using upstream's own regex-free alias parsing, structured for #51 to replace. Scope-aware handler caching and constant analysis are seamed for #51/#53/#54.

## Verification

- `dotnet build Assimalign.Vuecs.slnx` — 0 warnings, 0 errors.
- **992 tests green** on the merged branch, including **Compiler 227** (79 new; the 148 parser tests untouched). Corpus ported from vuejs/core v3.5.13 transform specs with per-group citations.
- Browser/AOT gates N/A (build-time netstandard2.0 library).

Closes #49
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)