### PR TITLE
feat(compiler): C# expression binding and scope analysis in templates

### DIFF
--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -1,0 +1,101 @@
+# Assimalign.Vue.Syntax.Templates — design
+
+Why the template compiler front end is shaped the way it is, and the deliberate C#/WASM divergences from
+`vuejs/core` v3.5. This document accumulates per feature; today it covers expression binding and scope
+analysis ([V01.01.05.04], issue #51).
+
+## Expression binding and scope analysis (`transformExpression`)
+
+The C# port of `@vue/compiler-core`'s
+[`transforms/transformExpression.ts`](https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-core/src/transforms/transformExpression.ts)
+plus the `BindingTypes` classification from
+[`options.ts`](https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-core/src/options.ts). Where Vue
+parses expression bodies with `@babel/parser`, Vuecs parses them with
+`Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseExpression` — a generator-only dependency added through the
+central build system (`build/Targets/Build.References.Packages.targets`), never referenced by any runtime
+library, so it never reaches the WASM app.
+
+### Pipeline placement and gating
+
+`TransformExpression` is inserted into the node-transform preset immediately before `transformSlotOutlet`,
+exactly where upstream's `getBaseTransformPreset` inserts it under `!__BROWSER__ && prefixIdentifiers`. It runs
+only when `TransformOptions.PrefixIdentifiers` is set; the default pipeline stays byte-for-byte opaque, matching
+Vue's browser build, so every pre-existing transform and test is unaffected.
+
+Scope registration and per-directive expression handling live in the owning transforms, mirroring upstream:
+
+- `VForTransform` rewrites the iterated **source** in the outer scope, then registers the value/key/index
+  aliases before the loop body is traversed and removes them on exit.
+- `VSlotTransform.TrackSlotScopes` registers the slot props for the slot children and removes them on exit.
+- `VOnTransform` processes the handler expression (with `$event`-style locals in scope for inline statements),
+  so ref writes inside handlers unwrap.
+
+All of the above are gated on `PrefixIdentifiers`, matching upstream's `!__BROWSER__ && context.prefixIdentifiers`
+guards.
+
+### The rewrite contract (compiler ↔ codegen ↔ reactivity)
+
+Vue relies on the render context's JavaScript `Proxy` for automatic ref unwrapping. Vuecs has no `Proxy`, so the
+compiler alone decides every access form. Rewriting is always **inline-mode** (the generated render method is a
+single closure over the component), and the table below is the compiler-owned contract with code generation
+([V01.01.05.05]) and the reactivity area's `Ref<T>` API. It is pinned by `ExpressionBindingTests`; a change to
+`Ref<T>.Value` requires a matching change here.
+
+| Classification (`BindingType`) | Read | Write (assignment / `++` / `--`) |
+| --- | --- | --- |
+| template-local (`v-for`/`v-slot` alias in scope) | `name` | `name` |
+| allowed global (`GlobalAllowList`) | `name` | `name` |
+| `SetupReference` | `name.Value` | `name.Value` |
+| `SetupMaybeReference` | `unref(name)` | `name` |
+| `SetupLet` / `SetupConstant` / `SetupReactiveConstant` / `LiteralConstant` | `name` | `name` |
+| `Property` / `PropertyAliased` / `Data` / `Options` | `_ctx.name` (alias resolved for `PropertyAliased`) | same |
+| unresolved | `_ctx.name` | `_ctx.name` |
+
+Key divergences from Vue's JS contract, all forced by C# semantics:
+
+- **`.Value` in read *and* write positions.** Because `Ref<T>.Value` is a settable C# property, `count += 1`,
+  `count++`, and `count = x` on a ref rewrite cleanly to `count.Value …`, replacing Vue's read-time `unref`
+  plus an `isRef(…) ? … .value = … : … = …` assignment guard. This is the direct answer to the acceptance
+  criterion on compound assignment / increment / inline-handler unwrapping.
+- **`_ctx.` member access and bare setup locals** rather than Vue's `$setup.`/`$props.`/`__props.` split — a
+  single inline render closure has the component context in `_ctx` and setup state as locals.
+- **Unresolved identifiers can be an error.** Vue silently emits `_ctx.name` for any unknown identifier because
+  the runtime proxy resolves it. C# cannot: an identifier that is neither a template-local, an allowed global,
+  nor a known binding has no member to bind to. When the component model supplies strict metadata
+  (`BindingMetadata.ReportsUnresolvedIdentifiers`), such an identifier surfaces `XVuecsUnresolvedIdentifier`
+  (code 66 — a Vuecs-specific extension past the upstream and DOM `__EXTEND_POINT__` sentinels) while still
+  emitting the recoverable `_ctx.` fallback. With the default permissive metadata the behavior matches Vue.
+
+### Diagnostics and source mapping
+
+Every processed expression is validated by a Roslyn parse (`consumeFullText`). A syntax error is reported as
+`X_INVALID_EXPRESSION` (numeric parity with upstream), with the offending Roslyn span remapped from
+expression-relative offsets back into template coordinates so [V01.01.05.08] can point at the real file/line/
+column. The upstream message prefix (`Error parsing JavaScript expression: `) is preserved verbatim for parity
+and the Roslyn diagnostic text is appended. Parsing is recoverable — a diagnostic is reported and the original
+node is returned; the transform never throws.
+
+### The global allow-list
+
+`GlobalAllowList` is the C# counterpart of Vue's `isGloballyAllowed` (`@vue/shared` `GLOBALS_ALLOWED`) plus its
+literal allow-list. Vue's entries name JavaScript globals (`Math`, `Date`, `JSON`, `parseInt`, …); Vuecs names
+the common .NET base-class surface a template legitimately reaches (`Math`, `Convert`, `String`, `DateTime`,
+`Enumerable`, the numeric types, the `System` namespace root, …). C# literal keywords (`true`, `false`, `null`,
+`this`) never reach the check because Roslyn tokenizes them as keywords, not identifiers.
+
+### Known simplifications and deferrals (non-goals for [V01.01.05.04])
+
+- **Intra-expression lambda/query shadowing is approximated.** Any name declared anywhere inside an expression
+  (a lambda parameter, a deconstruction designation, a LINQ range variable) is excluded from rewriting
+  everywhere in that expression, rather than tracked per nested scope. This never wrongly rewrites a local; it
+  can under-rewrite a same-named outer reference in the rare case an expression both shadows and separately
+  reads the same name. Template-scope shadowing — the case the acceptance criteria pin — is exact, driven by the
+  `TransformContext` identifier stack.
+- **Inline-handler event parameter.** `$event` is not a legal C# identifier, so a handler body that references
+  the event variable cannot be parsed under prefixing today. The event-variable identifier is a `v-on` /
+  code-generation contract ([V01.01.05.03] / [V01.01.05.05]); handlers that do not reference it (the
+  `count++` / `count += 1` / `count = literal` cases the acceptance criteria call out) unwrap correctly now.
+- **`asParams` validation is lenient.** Alias/prop declaration positions are registered for scope but not
+  hard-validated as expressions, because C# deconstruction forms (`(a, b)`, `var (a, b)`) and JavaScript-style
+  `{ a }` destructures do not all parse as C# expressions; a lenient identifier scan still contributes their
+  names to scope.

--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -27,7 +27,7 @@ Scope registration and per-directive expression handling live in the owning tran
 - `VForTransform` rewrites the iterated **source** in the outer scope, then registers the value/key/index
   aliases before the loop body is traversed and removes them on exit.
 - `VSlotTransform.TrackSlotScopes` registers the slot props for the slot children and removes them on exit.
-- `VOnTransform` processes the handler expression (with `$event`-style locals in scope for inline statements),
+- `VOnTransform` processes the handler expression (inline statements are parsed against the Vuecs event identifier `__event`, the C# spelling of Vue's `$event`),
   so ref writes inside handlers unwrap.
 
 All of the above are gated on `PrefixIdentifiers`, matching upstream's `!__BROWSER__ && context.prefixIdentifiers`
@@ -46,8 +46,9 @@ single closure over the component), and the table below is the compiler-owned co
 | template-local (`v-for`/`v-slot` alias in scope) | `name` | `name` |
 | allowed global (`GlobalAllowList`) | `name` | `name` |
 | `SetupReference` | `name.Value` | `name.Value` |
-| `SetupMaybeReference` | `unref(name)` | `name` |
-| `SetupLet` / `SetupConstant` / `SetupReactiveConstant` / `LiteralConstant` | `name` | `name` |
+| `SetupMaybeReference` | `unref(name)` | `name.Value` (upstream: a write to a const binding is only legal when it is a ref) |
+| `SetupLet` | `unref(name)` | `name` — upstream emits an `isRef`-guarded write, which a C# expression cannot; the helper-backed guarded write is deferred to [V01.01.05.05] |
+| `SetupConstant` / `SetupReactiveConstant` / `LiteralConstant` | `name` | `name` |
 | `Property` / `PropertyAliased` / `Data` / `Options` | `_ctx.name` (alias resolved for `PropertyAliased`) | same |
 | unresolved | `_ctx.name` | `_ctx.name` |
 
@@ -91,10 +92,12 @@ the common .NET base-class surface a template legitimately reaches (`Math`, `Con
   can under-rewrite a same-named outer reference in the rare case an expression both shadows and separately
   reads the same name. Template-scope shadowing — the case the acceptance criteria pin — is exact, driven by the
   `TransformContext` identifier stack.
-- **Inline-handler event parameter.** `$event` is not a legal C# identifier, so a handler body that references
-  the event variable cannot be parsed under prefixing today. The event-variable identifier is a `v-on` /
-  code-generation contract ([V01.01.05.03] / [V01.01.05.05]); handlers that do not reference it (the
-  `count++` / `count += 1` / `count = literal` cases the acceptance criteria call out) unwrap correctly now.
+- **Inline-handler event parameter.** `$event` is not a legal C# identifier, so under prefixing an inline
+  statement is parsed and emitted against the Vuecs spelling `__event`: `VOnTransform` substitutes
+  `$event` → `__event` in the handler content before processing and names the wrapping lambda's parameter
+  `__event`, so `@input="save($event)"` emits `__event => (_ctx.save(__event))`. Template authors keep
+  Vue's `$event`; without prefixing the emitted wrapper keeps `$event` for upstream output parity. Pinned
+  by `ExpressionBindingTests`.
 - **`asParams` validation is lenient.** Alias/prop declaration positions are registered for scope but not
   hard-validated as expressions, because C# deconstruction forms (`(a, b)`, `var (a, b)`) and JavaScript-style
   `{ a }` destructures do not all parse as C# expressions; a lenient identifier scan still contributes their

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Assimalign.Vue.Syntax.Templates.csproj
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Assimalign.Vue.Syntax.Templates.csproj
@@ -27,11 +27,12 @@
     <!-- Roslyn expression parsing ([V01.01.05.04]): the C# analogue of Vue 3.5's @babel/parser dependency
          in transformExpression. Used by the netstandard2.0 compiler front end to parse, validate, and rewrite
          template expressions. The version is centralized in build/Targets/Build.References.Packages.targets
-         (never inline here). This is a generator-only dependency by position, not by PrivateAssets: this
-         library sits build-time-only in the dependency graph (consumed by the codegen generator [V01.01.05.05],
-         which is an analyzer whose Roslyn is provided by the compiler host), so Microsoft.CodeAnalysis never
-         reaches the WASM runtime. The reference flows normally — exactly as Assimalign.Vue.Reactivity.Generators
-         declares it — so that this library's net10.0 test project resolves Roslyn at run time. -->
+         (never inline here). This is a generator-only dependency by graph position, not by
+         PrivateAssets: the library sits build-time-only in the dependency graph (consumed by the codegen
+         generator [V01.01.05.05], whose Roslyn is provided by the compiler host), so Microsoft.CodeAnalysis
+         never reaches the WASM runtime — nothing mechanical enforces that, and the analyzer packaging chain
+         ([V01.01.05.05]) is where the guarantee gets pinned. The reference flows normally so this library's
+         net10.0 test project resolves Roslyn at run time. -->
     <VuecsPackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
   <ItemGroup>

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Assimalign.Vue.Syntax.Templates.csproj
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Assimalign.Vue.Syntax.Templates.csproj
@@ -24,6 +24,17 @@
     <VuecsProjectReference Include="Assimalign.Vue.Syntax" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Roslyn expression parsing ([V01.01.05.04]): the C# analogue of Vue 3.5's @babel/parser dependency
+         in transformExpression. Used by the netstandard2.0 compiler front end to parse, validate, and rewrite
+         template expressions. The version is centralized in build/Targets/Build.References.Packages.targets
+         (never inline here). This is a generator-only dependency by position, not by PrivateAssets: this
+         library sits build-time-only in the dependency graph (consumed by the codegen generator [V01.01.05.05],
+         which is an analyzer whose Roslyn is provided by the compiler host), so Microsoft.CodeAnalysis never
+         reaches the WASM runtime. The reference flows normally — exactly as Assimalign.Vue.Reactivity.Generators
+         declares it — so that this library's net10.0 test project resolves Roslyn at run time. -->
+    <VuecsPackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
     <!-- Linked netstandard2.0 shims ([V01.01.05.09]): IsExternalInit and the required-member attributes
          are authored once in Assimalign.Vue.Syntax and <Compile Include>'d here (still internal) because
          an internal shim in a referenced assembly is not visible to this compilation — each netstandard2.0

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingMetadata.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingMetadata.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The map from a component member name to its <see cref="BindingType"/>, plus the prop-alias table and the
+/// setup-mode flag. The C# port of Vue 3.5's <c>BindingMetadata</c> (<c>@vue/compiler-core</c>
+/// <c>options.ts</c>), produced by the component/setup source model and consumed by expression and scope
+/// analysis ([V01.01.05.04]).
+/// </summary>
+/// <remarks>
+/// This is transform <i>input</i>, not part of the value-equatable transform output, so it is a plain class
+/// rather than a record. It is immutable after construction and safe to share across the single-threaded
+/// transform. <see cref="ReportsUnresolvedIdentifiers"/> is a Vuecs-specific addition with no Vue counterpart:
+/// because C# is statically typed and has no <c>Proxy</c> fallback, a template identifier that is neither a
+/// template-local, an allowed global, nor a known binding cannot silently resolve to a member — the strict
+/// component model sets this flag so such identifiers surface a diagnostic instead of compiling to an invalid
+/// member access.
+/// </remarks>
+public sealed class BindingMetadata
+{
+    private static readonly IReadOnlyDictionary<string, BindingType> EmptyBindings = new Dictionary<string, BindingType>();
+
+    /// <summary>The empty, permissive metadata used when no component model is supplied.</summary>
+    public static readonly BindingMetadata Empty = new();
+
+    private readonly IReadOnlyDictionary<string, BindingType> bindings;
+    private readonly IReadOnlyDictionary<string, string>? propertyAliases;
+
+    /// <summary>Creates binding metadata.</summary>
+    /// <param name="bindings">The member-name to <see cref="BindingType"/> map, or <see langword="null"/> for none.</param>
+    /// <param name="isScriptSetup">
+    /// Whether the bindings come from a <c>&lt;script setup&gt;</c> block (upstream <c>__isScriptSetup</c>).
+    /// </param>
+    /// <param name="reportsUnresolvedIdentifiers">
+    /// Whether an identifier absent from <paramref name="bindings"/>, the template-local scope, and the global
+    /// allow-list should surface a <see cref="CompilerErrorCode.XVuecsUnresolvedIdentifier"/> diagnostic (the
+    /// strict Vuecs mode). Defaults to <see langword="false"/> so partial or absent metadata never spuriously
+    /// errors and the permissive <c>_ctx.</c> fallback (Vue's behavior) is used instead.
+    /// </param>
+    /// <param name="propertyAliases">
+    /// The map from a <see cref="BindingType.PropertyAliased"/> alias to its real prop name (upstream
+    /// <c>__propsAliases</c>), or <see langword="null"/> for none.
+    /// </param>
+    public BindingMetadata(
+        IReadOnlyDictionary<string, BindingType>? bindings = null,
+        bool isScriptSetup = false,
+        bool reportsUnresolvedIdentifiers = false,
+        IReadOnlyDictionary<string, string>? propertyAliases = null)
+    {
+        this.bindings = bindings ?? EmptyBindings;
+        this.propertyAliases = propertyAliases;
+        IsScriptSetup = isScriptSetup;
+        ReportsUnresolvedIdentifiers = reportsUnresolvedIdentifiers;
+    }
+
+    /// <summary>Whether the bindings come from a <c>&lt;script setup&gt;</c> block (upstream <c>__isScriptSetup</c>).</summary>
+    public bool IsScriptSetup { get; }
+
+    /// <summary>
+    /// Whether unresolved identifiers surface a diagnostic (the strict Vuecs mode). No Vue counterpart; see the
+    /// type remarks.
+    /// </summary>
+    public bool ReportsUnresolvedIdentifiers { get; }
+
+    /// <summary>Whether <paramref name="name"/> is a known binding.</summary>
+    /// <param name="name">The identifier name.</param>
+    public bool Contains(string name) => bindings.ContainsKey(name);
+
+    /// <summary>Resolves the <see cref="BindingType"/> of <paramref name="name"/>.</summary>
+    /// <param name="name">The identifier name.</param>
+    /// <param name="type">The resolved binding type when found.</param>
+    /// <returns><see langword="true"/> when <paramref name="name"/> is a known binding.</returns>
+    public bool TryGetBindingType(string name, out BindingType type) => bindings.TryGetValue(name, out type);
+
+    /// <summary>Resolves the real prop name for a <see cref="BindingType.PropertyAliased"/> alias.</summary>
+    /// <param name="name">The alias name.</param>
+    /// <returns>The real prop name, or <see langword="null"/> when no alias is recorded.</returns>
+    public string? GetPropertyAlias(string name)
+        => propertyAliases is not null && propertyAliases.TryGetValue(name, out var real) ? real : null;
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingType.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingType.cs
@@ -1,0 +1,68 @@
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// How a template identifier is bound to its component: the source (data, props, <c>&lt;script setup&gt;</c>
+/// state, options-API members) and, for setup state, whether it is a reactive reference that the compiler must
+/// unwrap. The C# port of Vue 3.5's <c>BindingTypes</c> enum (<c>@vue/compiler-core</c> <c>options.ts</c>).
+/// </summary>
+/// <remarks>
+/// The component/setup source model produces the <see cref="BindingMetadata"/> that maps each member name to
+/// one of these; expression and scope analysis ([V01.01.05.04]) reads it to decide how to rewrite an
+/// identifier for code generation ([V01.01.05.05]). Unlike Vue — which relies on the JavaScript
+/// <c>Proxy</c>-backed render context for automatic ref unwrapping — Vuecs has no runtime proxy, so the
+/// compiler alone decides where a <c>Ref&lt;T&gt;.Value</c> access is inserted, driven by these classifications.
+/// See https://vuejs.org/guide/essentials/reactivity-fundamentals.html#ref-unwrapping-in-templates.
+/// </remarks>
+public enum BindingType
+{
+    /// <summary>A member returned from the options-API <c>data()</c> (upstream <c>DATA</c>).</summary>
+    Data,
+
+    /// <summary>A declared component prop (upstream <c>PROPS</c>).</summary>
+    Property,
+
+    /// <summary>
+    /// A prop accessed through a destructure alias whose real prop name differs (upstream <c>PROPS_ALIASED</c>);
+    /// the real name is resolved through <see cref="BindingMetadata.GetPropertyAlias"/>.
+    /// </summary>
+    PropertyAliased,
+
+    /// <summary>A <c>let</c> binding declared in <c>&lt;script setup&gt;</c> (upstream <c>SETUP_LET</c>).</summary>
+    SetupLet,
+
+    /// <summary>
+    /// A <c>const</c> binding in <c>&lt;script setup&gt;</c> that is provably not a reference — a literal, a
+    /// function, or another non-reactive value (upstream <c>SETUP_CONST</c>). Never unwrapped.
+    /// </summary>
+    SetupConstant,
+
+    /// <summary>
+    /// A <c>const</c> binding initialized from <c>reactive(...)</c> in <c>&lt;script setup&gt;</c> (upstream
+    /// <c>SETUP_REACTIVE_CONST</c>). Reactive but not a reference, so never unwrapped.
+    /// </summary>
+    SetupReactiveConstant,
+
+    /// <summary>
+    /// A <c>&lt;script setup&gt;</c> binding that may or may not be a reference at runtime (upstream
+    /// <c>SETUP_MAYBE_REF</c>); reads are guarded through the <c>unref</c> runtime helper.
+    /// </summary>
+    SetupMaybeReference,
+
+    /// <summary>
+    /// A <c>&lt;script setup&gt;</c> binding that is definitely a <c>Ref&lt;T&gt;</c> (upstream <c>SETUP_REF</c>);
+    /// the compiler inserts <c>.Value</c> in both read and write positions.
+    /// </summary>
+    SetupReference,
+
+    /// <summary>
+    /// A member resolved by the options API (methods, computed, injections) that is not otherwise classified
+    /// (upstream <c>OPTIONS</c>).
+    /// </summary>
+    Options,
+
+    /// <summary>
+    /// A compile-time literal constant, e.g. an inlined enum member (upstream <c>LITERAL_CONST</c>). Never
+    /// unwrapped and eligible for the strongest constant folding.
+    /// </summary>
+    LiteralConstant,
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
@@ -244,7 +244,10 @@ public enum CompilerErrorCode
     /// <summary>
     /// A template identifier resolved to neither a template-local, an allowed global, nor a known component
     /// binding, under strict binding metadata (<see cref="BindingMetadata.ReportsUnresolvedIdentifiers"/>).
-    /// Vuecs-specific; no upstream counterpart.
+    /// Vuecs-specific; no upstream counterpart. Vuecs-only codes live in a reserved band at 1000+ so
+    /// the numeric slots after <see cref="DomExtendPoint"/> stay free for upstream extension enums
+    /// (<c>@vue/compiler-ssr</c>'s <c>SSRErrorCodes</c> continue the chain at 66+ under this type's
+    /// +1 mapping scheme; the server-renderer area [V01.01.07] will claim them).
     /// </summary>
-    XVuecsUnresolvedIdentifier = 66,
+    XVuecsUnresolvedIdentifier = 1000,
 }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
@@ -233,4 +233,18 @@ public enum CompilerErrorCode
 
     /// <summary>The reserved value one past the last defined DOM code (upstream DOM <c>__EXTEND_POINT__</c>).</summary>
     DomExtendPoint = 65,
+
+    // ---- Vuecs-specific expression/scope analysis codes ([V01.01.05.04], no upstream counterpart) ----
+    //
+    // These extend the catalog past both upstream sentinels, exactly as @vue/compiler-dom's DOMErrorCodes
+    // extended core's __EXTEND_POINT__. They have no vuejs/core equivalent because they encode a divergence
+    // C# forces: with no runtime Proxy fallback, a template identifier that resolves to nothing real is an
+    // error the compiler must surface, where Vue would silently emit a _ctx member access.
+
+    /// <summary>
+    /// A template identifier resolved to neither a template-local, an allowed global, nor a known component
+    /// binding, under strict binding metadata (<see cref="BindingMetadata.ReportsUnresolvedIdentifiers"/>).
+    /// Vuecs-specific; no upstream counterpart.
+    /// </summary>
+    XVuecsUnresolvedIdentifier = 66,
 }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerErrorMessages.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerErrorMessages.cs
@@ -107,6 +107,11 @@ internal static class CompilerErrorMessages
             "<Transition> expects exactly one child element or component.",
         [CompilerErrorCode.XIgnoredSideEffectTag] =
             "Tags with side effect (<script> and <style>) are ignored in client component templates.",
+
+        // Vuecs-specific expression/scope analysis messages ([V01.01.05.04]); the offending name is appended.
+        [CompilerErrorCode.XVuecsUnresolvedIdentifier] =
+            "Cannot resolve template identifier against any component binding, template scope variable, or " +
+            "allowed global: ",
     };
 
     /// <summary>Gets the message for <paramref name="code"/>, or an empty string when none is defined.</summary>

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
@@ -144,13 +144,25 @@ internal static class ExpressionProcessor
             // A definite ref: insert .Value in read and write positions (the settable Ref<T>.Value contract).
             BindingType.SetupReference => raw + ".Value",
 
-            // A maybe-ref: guard reads through unref; a write cannot be statically unwrapped, so leave it bare.
+            // A maybe-ref: guard reads through unref; a WRITE unwraps to .Value — upstream rewrites
+            // SETUP_MAYBE_REF to `.value` in assignment/update position because a write to a const
+            // binding is only legal when it is a ref (vuejs/core v3.5 transformExpression.ts
+            // rewriteIdentifier).
             BindingType.SetupMaybeReference => isWriteTarget
+                ? raw + ".Value"
+                : context.HelperString(HelperNames.Unref) + "(" + raw + ")",
+
+            // A let binding may or may not hold a ref: reads guard through unref, matching upstream.
+            // Writes stay bare — upstream emits an `isRef(x) ? x.value = y : x = y` runtime guard,
+            // which is not expressible as a C# expression without a runtime helper; the divergence is
+            // deliberate, recorded in docs/DESIGN.md, and a helper-backed guarded write is deferred to
+            // the codegen work ([V01.01.05.05]).
+            BindingType.SetupLet => isWriteTarget
                 ? raw
                 : context.HelperString(HelperNames.Unref) + "(" + raw + ")",
 
             // Non-reference setup state and literal constants are locals of the render closure: never unwrapped.
-            BindingType.SetupLet or BindingType.SetupConstant or BindingType.SetupReactiveConstant
+            BindingType.SetupConstant or BindingType.SetupReactiveConstant
                 or BindingType.LiteralConstant => raw,
 
             // A destructured prop whose real name differs: resolve through the alias table.
@@ -349,6 +361,20 @@ internal static class ExpressionProcessor
             base.VisitSingleVariableDesignation(node);
         }
 
+        public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
+        {
+            // Locals declared in a multi-statement inline handler (`var next = …;`) are scope
+            // identifiers, mirroring upstream walkIdentifiers' variable-declaration handling.
+            declared.Add(node.Identifier.ValueText);
+            base.VisitVariableDeclarator(node);
+        }
+
+        public override void VisitForEachStatement(ForEachStatementSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitForEachStatement(node);
+        }
+
         public override void VisitFromClause(FromClauseSyntax node)
         {
             declared.Add(node.Identifier.ValueText);
@@ -416,8 +442,31 @@ internal static class ExpressionProcessor
             ObjectCreationExpressionSyntax creation when creation.Type == node => false,
             CastExpressionSyntax cast when cast.Type == node => false,
             TypeArgumentListSyntax => false,
-            _ => true,
+            // The member name in an object initializer (`new Point { X = x }`) names a member of the
+            // constructed type, never a component binding (upstream's walk never rewrites object keys).
+            AssignmentExpressionSyntax initializerAssignment
+                when initializerAssignment.Left == node &&
+                     initializerAssignment.Parent is InitializerExpressionSyntax => false,
+            // The nameof operand is a name, not a value read; rewriting it would change the produced
+            // string.
+            InvocationExpressionSyntax invocation
+                when invocation.Expression == node && node.Identifier.ValueText == "nameof" => false,
+            _ => !IsInsideNameOf(node),
         };
+
+        private static bool IsInsideNameOf(Microsoft.CodeAnalysis.SyntaxNode node)
+        {
+            for (var current = node.Parent; current is not null; current = current.Parent)
+            {
+                if (current is InvocationExpressionSyntax invocation &&
+                    invocation.Expression is IdentifierNameSyntax { Identifier.ValueText: "nameof" })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static bool IsWriteTarget(IdentifierNameSyntax node)
         {

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
@@ -1,0 +1,441 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static Microsoft.CodeAnalysis.CSharpExtensions;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// Parses a template expression with Roslyn, validates it, classifies each referenced identifier against the
+/// template scope and <see cref="BindingMetadata"/>, and rewrites the expression for code generation. The C#
+/// analogue of Vue 3.5's <c>processExpression</c> and <c>rewriteIdentifier</c> (<c>@vue/compiler-core</c>
+/// <c>transforms/transformExpression.ts</c>), with Roslyn (<c>SyntaxFactory.ParseExpression</c>) standing in
+/// for the <c>@babel/parser</c> walk.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Vuecs diverges from Vue where C# semantics require it, and those divergences are the compiler's contract
+/// with code generation ([V01.01.05.05]) and the reactivity area, documented in the feature design notes:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// Vue relies on a runtime <c>Proxy</c> for automatic ref unwrapping; C# has none, so a
+/// <see cref="BindingType.SetupReference"/> is rewritten to a <c>.Value</c> access in <b>both</b> read and
+/// write positions (a settable <c>Ref&lt;T&gt;.Value</c> makes <c>count += 1</c>/<c>count++</c> work directly),
+/// rather than Vue's read-time <c>unref</c> plus an <c>isRef</c> assignment guard.
+/// </item>
+/// <item>
+/// Rewriting is always inline-mode: setup non-reference bindings stay bare (they are locals of the generated
+/// render closure) and every unresolved or component-instance member is prefixed with <c>_ctx.</c>, the render
+/// context bound by code generation.
+/// </item>
+/// <item>
+/// An identifier absent from the scope, the global allow-list, and the binding metadata is prefixed with
+/// <c>_ctx.</c> exactly as Vue does, but additionally surfaces a diagnostic when the metadata is the strict,
+/// component-model-complete form (<see cref="BindingMetadata.ReportsUnresolvedIdentifiers"/>).
+/// </item>
+/// </list>
+/// <para>
+/// Intra-expression lambda/query scopes are handled by conservatively excluding any name declared anywhere in
+/// the expression from rewriting; deeply nested same-name shadowing is therefore approximated (a documented
+/// simplification versus Vue's exact per-scope walk). Template-scope shadowing — the case the acceptance
+/// criteria pin — is exact, driven by the <see cref="TransformContext"/> identifier stack.
+/// </para>
+/// </remarks>
+internal static class ExpressionProcessor
+{
+    private static readonly CSharpParseOptions ParseOptions = new(LanguageVersion.Latest);
+
+    /// <summary>
+    /// Processes <paramref name="node"/>: a no-op when prefixing is disabled, otherwise validates it and, unless
+    /// <paramref name="asParams"/>, rewrites its identifiers (upstream <c>processExpression</c>).
+    /// </summary>
+    /// <param name="node">The expression to process.</param>
+    /// <param name="context">The active transform context.</param>
+    /// <param name="asParams">
+    /// Whether the content is a declaration list (a <c>v-slot</c> prop or <c>v-for</c> alias) rather than a
+    /// referenced expression; declarations are validated but not rewritten, and are registered in scope by the
+    /// owning transform.
+    /// </param>
+    /// <param name="asRawStatements">
+    /// Whether the content is one or more statements (a multi-statement inline <c>v-on</c> handler) rather than a
+    /// single expression.
+    /// </param>
+    public static ExpressionNode ProcessExpression(
+        SimpleExpressionNode node,
+        TransformContext context,
+        bool asParams = false,
+        bool asRawStatements = false)
+    {
+        if (!context.PrefixIdentifiers)
+        {
+            return node;
+        }
+
+        var raw = node.Content;
+        if (raw.Length == 0 || raw.Trim().Length == 0)
+        {
+            return node;
+        }
+
+        // Fast path: a lone identifier (upstream's isSimpleIdentifier branch).
+        if (!asParams && CompilerText.IsSimpleIdentifier(raw))
+        {
+            if (context.IsLocalIdentifier(raw) || GlobalAllowList.IsAllowed(raw))
+            {
+                return node;
+            }
+
+            var rewritten = RewriteIdentifier(raw, context, isWriteTarget: false, node.Location);
+            return rewritten == raw ? node : node with { Content = rewritten };
+        }
+
+        // Full parse: validates the whole text (consumeFullText) and yields a tree to walk.
+        var prefixLength = asRawStatements ? 1 : 0;
+        Microsoft.CodeAnalysis.SyntaxNode parsed = asRawStatements
+            ? SyntaxFactory.ParseStatement("{" + raw + "}", 0, ParseOptions)
+            : SyntaxFactory.ParseExpression(raw, 0, ParseOptions);
+
+        if (TryGetFirstError(parsed, out var errorSpan, out var errorMessage))
+        {
+            context.ReportError(CreateInvalidExpressionError(node, raw, errorSpan, errorMessage, prefixLength));
+            return node;
+        }
+
+        if (asParams)
+        {
+            // Declaration positions are validated above; scope registration is the owning transform's job.
+            return node;
+        }
+
+        var references = CollectReferences(parsed, context, prefixLength);
+        if (references.Count == 0)
+        {
+            return node;
+        }
+
+        return BuildCompound(node, raw, references, context);
+    }
+
+    // ---- identifier classification and rewriting (upstream rewriteIdentifier) ----
+
+    private static string RewriteIdentifier(string raw, TransformContext context, bool isWriteTarget, SourceLocation location)
+    {
+        if (context.BindingMetadata.TryGetBindingType(raw, out var type))
+        {
+            return RewriteBoundIdentifier(raw, type, isWriteTarget, context);
+        }
+
+        if (context.BindingMetadata.ReportsUnresolvedIdentifiers)
+        {
+            var message = CompilerErrorMessages.GetMessage(CompilerErrorCode.XVuecsUnresolvedIdentifier) + "'" + raw + "'.";
+            context.ReportError(new CompilerError(CompilerErrorCode.XVuecsUnresolvedIdentifier, message, location));
+        }
+
+        return "_ctx." + raw;
+    }
+
+    private static string RewriteBoundIdentifier(string raw, BindingType type, bool isWriteTarget, TransformContext context)
+        => type switch
+        {
+            // A definite ref: insert .Value in read and write positions (the settable Ref<T>.Value contract).
+            BindingType.SetupReference => raw + ".Value",
+
+            // A maybe-ref: guard reads through unref; a write cannot be statically unwrapped, so leave it bare.
+            BindingType.SetupMaybeReference => isWriteTarget
+                ? raw
+                : context.HelperString(HelperNames.Unref) + "(" + raw + ")",
+
+            // Non-reference setup state and literal constants are locals of the render closure: never unwrapped.
+            BindingType.SetupLet or BindingType.SetupConstant or BindingType.SetupReactiveConstant
+                or BindingType.LiteralConstant => raw,
+
+            // A destructured prop whose real name differs: resolve through the alias table.
+            BindingType.PropertyAliased => "_ctx." + (context.BindingMetadata.GetPropertyAlias(raw) ?? raw),
+
+            // Props, options-API members, and plain data are component-instance members reached through _ctx.
+            _ => "_ctx." + raw,
+        };
+
+    // ---- reference collection ----
+
+    private static List<ReferencedIdentifier> CollectReferences(
+        Microsoft.CodeAnalysis.SyntaxNode root,
+        TransformContext context,
+        int prefixLength)
+    {
+        var declared = new HashSet<string>();
+        new DeclaredIdentifierWalker(declared).Visit(root);
+
+        var collector = new ReferenceWalker(context, declared, prefixLength);
+        collector.Visit(root);
+        collector.References.Sort(static (left, right) => left.Start.CompareTo(right.Start));
+        return collector.References;
+    }
+
+    private static ExpressionNode BuildCompound(
+        SimpleExpressionNode node,
+        string raw,
+        List<ReferencedIdentifier> references,
+        TransformContext context)
+    {
+        var parts = new List<object>();
+        var cursor = 0;
+        foreach (var reference in references)
+        {
+            var start = Clamp(reference.Start, 0, raw.Length);
+            var length = reference.Length;
+            if (start + length > raw.Length)
+            {
+                length = raw.Length - start;
+            }
+
+            if (length <= 0 || start < cursor)
+            {
+                continue;
+            }
+
+            if (start > cursor)
+            {
+                parts.Add(raw.Substring(cursor, start - cursor));
+            }
+
+            var subLocation = SubLocation(node.Location, raw, start, length);
+            var replacement = RewriteIdentifier(reference.Name, context, reference.IsWriteTarget, subLocation);
+            parts.Add(Ir.SimpleExpression(replacement, false, subLocation));
+            cursor = start + length;
+        }
+
+        if (cursor < raw.Length)
+        {
+            parts.Add(raw.Substring(cursor));
+        }
+
+        if (parts.Count == 1 && parts[0] is SimpleExpressionNode only)
+        {
+            return only;
+        }
+
+        return new CompoundExpressionNode { Parts = new SyntaxList<object>(parts.ToArray()), Location = node.Location };
+    }
+
+    // ---- diagnostics ----
+
+    private static bool TryGetFirstError(
+        Microsoft.CodeAnalysis.SyntaxNode node,
+        out Microsoft.CodeAnalysis.Text.TextSpan span,
+        out string message)
+    {
+        foreach (var diagnostic in node.GetDiagnostics())
+        {
+            if (diagnostic.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            {
+                span = diagnostic.Location.SourceSpan;
+                message = diagnostic.GetMessage(CultureInfo.InvariantCulture);
+                return true;
+            }
+        }
+
+        span = default;
+        message = string.Empty;
+        return false;
+    }
+
+    private static CompilerError CreateInvalidExpressionError(
+        SimpleExpressionNode node,
+        string raw,
+        Microsoft.CodeAnalysis.Text.TextSpan errorSpan,
+        string errorMessage,
+        int prefixLength)
+    {
+        var start = Clamp(errorSpan.Start - prefixLength, 0, raw.Length);
+        var length = errorSpan.Length;
+        if (start + length > raw.Length)
+        {
+            length = raw.Length - start;
+        }
+
+        if (length < 0)
+        {
+            length = 0;
+        }
+
+        var location = SubLocation(node.Location, raw, start, length);
+        var message = CompilerErrorMessages.GetMessage(CompilerErrorCode.XInvalidExpression) + errorMessage;
+        return new CompilerError(CompilerErrorCode.XInvalidExpression, message, location);
+    }
+
+    // ---- position mapping (upstream advancePositionWithClone) ----
+
+    private static SourceLocation SubLocation(SourceLocation expressionLocation, string source, int offset, int length)
+    {
+        var start = Advance(expressionLocation.Start, source, 0, offset);
+        var end = Advance(start, source, offset, length);
+        var slice = offset >= 0 && offset + length <= source.Length
+            ? source.Substring(offset, length)
+            : string.Empty;
+        return new SourceLocation(start, end, slice);
+    }
+
+    private static Position Advance(Position from, string source, int start, int count)
+    {
+        var line = from.Line;
+        var lastNewLine = -1;
+        var end = System.Math.Min(source.Length, start + count);
+        for (var index = start; index < end; index++)
+        {
+            if (source[index] == '\n')
+            {
+                line++;
+                lastNewLine = index;
+            }
+        }
+
+        var column = lastNewLine == -1 ? from.Column + count : end - lastNewLine;
+        return new Position(from.Offset + count, line, column);
+    }
+
+    private static int Clamp(int value, int min, int max) => value < min ? min : value > max ? max : value;
+
+    // ---- referenced identifier ----
+
+    private readonly struct ReferencedIdentifier
+    {
+        public ReferencedIdentifier(string name, int start, int length, bool isWriteTarget)
+        {
+            Name = name;
+            Start = start;
+            Length = length;
+            IsWriteTarget = isWriteTarget;
+        }
+
+        public string Name { get; }
+
+        public int Start { get; }
+
+        public int Length { get; }
+
+        public bool IsWriteTarget { get; }
+    }
+
+    // ---- Roslyn walkers ----
+
+    // Collects identifiers declared inside the expression (lambda parameters, deconstruction designations, LINQ
+    // range variables) so they are treated as locals, not references. Conservative: a name declared in any
+    // nested scope is excluded everywhere within the expression.
+    private sealed class DeclaredIdentifierWalker : CSharpSyntaxWalker
+    {
+        private readonly HashSet<string> declared;
+
+        public DeclaredIdentifierWalker(HashSet<string> declared) => this.declared = declared;
+
+        public override void VisitParameter(ParameterSyntax node)
+        {
+            var name = node.Identifier.ValueText;
+            if (name.Length > 0)
+            {
+                declared.Add(name);
+            }
+
+            base.VisitParameter(node);
+        }
+
+        public override void VisitSingleVariableDesignation(SingleVariableDesignationSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitSingleVariableDesignation(node);
+        }
+
+        public override void VisitFromClause(FromClauseSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitFromClause(node);
+        }
+
+        public override void VisitLetClause(LetClauseSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitLetClause(node);
+        }
+
+        public override void VisitJoinClause(JoinClauseSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitJoinClause(node);
+        }
+
+        public override void VisitQueryContinuation(QueryContinuationSyntax node)
+        {
+            declared.Add(node.Identifier.ValueText);
+            base.VisitQueryContinuation(node);
+        }
+    }
+
+    // Collects the identifiers to rewrite: referenced positions that are not member names, type positions,
+    // locally declared names, template-scope locals, or allowed globals.
+    private sealed class ReferenceWalker : CSharpSyntaxWalker
+    {
+        private readonly TransformContext context;
+        private readonly HashSet<string> declared;
+        private readonly int prefixLength;
+
+        public ReferenceWalker(TransformContext context, HashSet<string> declared, int prefixLength)
+        {
+            this.context = context;
+            this.declared = declared;
+            this.prefixLength = prefixLength;
+        }
+
+        public List<ReferencedIdentifier> References { get; } = new();
+
+        public override void VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            var name = node.Identifier.ValueText;
+            if (IsReferencePosition(node) &&
+                !declared.Contains(name) &&
+                !context.IsLocalIdentifier(name) &&
+                !GlobalAllowList.IsAllowed(name))
+            {
+                var span = node.Span;
+                References.Add(new ReferencedIdentifier(name, span.Start - prefixLength, span.Length, IsWriteTarget(node)));
+            }
+
+            base.VisitIdentifierName(node);
+        }
+
+        private static bool IsReferencePosition(IdentifierNameSyntax node) => node.Parent switch
+        {
+            MemberAccessExpressionSyntax memberAccess when memberAccess.Name == node => false,
+            MemberBindingExpressionSyntax memberBinding when memberBinding.Name == node => false,
+            QualifiedNameSyntax qualified when qualified.Right == node => false,
+            NameEqualsSyntax => false,
+            NameColonSyntax => false,
+            ObjectCreationExpressionSyntax creation when creation.Type == node => false,
+            CastExpressionSyntax cast when cast.Type == node => false,
+            TypeArgumentListSyntax => false,
+            _ => true,
+        };
+
+        private static bool IsWriteTarget(IdentifierNameSyntax node)
+        {
+            switch (node.Parent)
+            {
+                case AssignmentExpressionSyntax assignment when assignment.Left == node:
+                    return true;
+                case PrefixUnaryExpressionSyntax prefix
+                    when prefix.Operand == node &&
+                         (prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression)):
+                    return true;
+                case PostfixUnaryExpressionSyntax postfix
+                    when postfix.Operand == node &&
+                         (postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression)):
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/GlobalAllowList.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/GlobalAllowList.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The identifiers that expression rewriting leaves untouched: neither prefixed with the render context nor
+/// reported as unresolved. The C# analogue of Vue 3.5's <c>isGloballyAllowed</c> plus the literal allow-list
+/// used by <c>processExpression</c> (<c>@vue/compiler-core</c> <c>utils.ts</c>/<c>transformExpression.ts</c>,
+/// backed by <c>@vue/shared</c>'s <c>GLOBALS_ALLOWED</c>).
+/// </summary>
+/// <remarks>
+/// Vue's list names the JavaScript globals a template may reference (<c>Math</c>, <c>Date</c>, <c>JSON</c>,
+/// <c>parseInt</c>, …). Because Vuecs expressions are C#, this is the corresponding common .NET base-class
+/// surface a template legitimately reaches for. It is a Vuecs runtime-contract choice, documented in the
+/// feature design notes; C# literal keywords (<c>true</c>, <c>false</c>, <c>null</c>, <c>this</c>) never reach
+/// this check because Roslyn tokenizes them as keywords, not identifiers.
+/// </remarks>
+internal static class GlobalAllowList
+{
+    private static readonly HashSet<string> Allowed = new()
+    {
+        // Numeric and conversion helpers.
+        "Math", "Convert", "Number", "BigInteger",
+        "Byte", "SByte", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64",
+        "Single", "Double", "Decimal", "Boolean", "Char",
+
+        // Text.
+        "String", "StringComparison", "StringComparer",
+
+        // Time.
+        "DateTime", "DateTimeOffset", "DateOnly", "TimeOnly", "TimeSpan", "DayOfWeek",
+
+        // Collections and LINQ entry points a template expression commonly reaches for.
+        "Array", "Enumerable", "Comparer", "EqualityComparer",
+
+        // Identity and formatting.
+        "Guid", "Uri", "Object", "Nullable",
+
+        // Namespace roots for fully qualified access such as System.Math.PI.
+        "System",
+
+        // Runtime and culture surfaces.
+        "Environment", "CultureInfo",
+    };
+
+    /// <summary>Whether <paramref name="name"/> is a global that must not be prefixed or reported.</summary>
+    /// <param name="name">The identifier name.</param>
+    public static bool IsAllowed(string name) => Allowed.Contains(name);
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/IdentifierExtraction.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/IdentifierExtraction.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using static Microsoft.CodeAnalysis.CSharpExtensions;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// Extracts the identifier names an alias expression <i>declares</i> — the value/key/index of a <c>v-for</c>
+/// and the destructured props of a <c>v-slot</c> — so the transform can register them in the template scope.
+/// The C# analogue of the parameter walk Vue 3.5 performs in <c>processExpression(..., asParams = true)</c>
+/// and feeds to <c>addIdentifiers</c> (<c>@vue/compiler-core</c> <c>transformExpression.ts</c>/<c>babelUtils.ts</c>).
+/// </summary>
+/// <remarks>
+/// Because template aliases are C#, this handles the C# binding forms — a plain identifier (<c>item</c>), a
+/// tuple (<c>(value, index)</c>), and a deconstruction designation (<c>var (a, b)</c>) — and falls back to a
+/// lenient identifier-token scan for shapes Roslyn cannot parse as an expression (for example a JavaScript-style
+/// <c>{ a, b }</c> destructure), so a malformed alias still contributes names to the scope rather than throwing.
+/// </remarks>
+internal static class IdentifierExtraction
+{
+    /// <summary>Collects the identifier names <paramref name="content"/> declares.</summary>
+    /// <param name="content">The alias expression text.</param>
+    public static IReadOnlyList<string> CollectDeclaredIdentifiers(string content)
+    {
+        var names = new List<string>();
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return names;
+        }
+
+        var expression = SyntaxFactory.ParseExpression(content);
+        if (!HasError(expression))
+        {
+            CollectFromDesignationOrExpression(expression, names);
+            if (names.Count > 0)
+            {
+                return names;
+            }
+        }
+
+        // Lenient fallback: gather identifier tokens that are not member accesses (`a.b` contributes only `a`).
+        ScanTokens(content, names);
+        return names;
+    }
+
+    private static void CollectFromDesignationOrExpression(ExpressionSyntax expression, List<string> names)
+    {
+        switch (expression)
+        {
+            case IdentifierNameSyntax identifier:
+                AddName(names, identifier.Identifier.ValueText);
+                break;
+            case ParenthesizedExpressionSyntax parenthesized:
+                CollectFromDesignationOrExpression(parenthesized.Expression, names);
+                break;
+            case TupleExpressionSyntax tuple:
+                foreach (var argument in tuple.Arguments)
+                {
+                    CollectFromDesignationOrExpression(argument.Expression, names);
+                }
+
+                break;
+            case DeclarationExpressionSyntax declaration:
+                CollectFromDesignation(declaration.Designation, names);
+                break;
+        }
+    }
+
+    private static void CollectFromDesignation(VariableDesignationSyntax designation, List<string> names)
+    {
+        switch (designation)
+        {
+            case SingleVariableDesignationSyntax single:
+                AddName(names, single.Identifier.ValueText);
+                break;
+            case ParenthesizedVariableDesignationSyntax parenthesized:
+                foreach (var nested in parenthesized.Variables)
+                {
+                    CollectFromDesignation(nested, names);
+                }
+
+                break;
+        }
+    }
+
+    private static void ScanTokens(string content, List<string> names)
+    {
+        var previousWasDot = false;
+        foreach (var token in SyntaxFactory.ParseTokens(content))
+        {
+            if (token.IsKind(SyntaxKind.IdentifierToken))
+            {
+                if (!previousWasDot)
+                {
+                    AddName(names, token.ValueText);
+                }
+
+                previousWasDot = false;
+            }
+            else
+            {
+                previousWasDot = token.IsKind(SyntaxKind.DotToken);
+            }
+        }
+    }
+
+    private static void AddName(List<string> names, string name)
+    {
+        if (name.Length > 0 && !names.Contains(name))
+        {
+            names.Add(name);
+        }
+    }
+
+    private static bool HasError(ExpressionSyntax node)
+    {
+        foreach (var diagnostic in node.GetDiagnostics())
+        {
+            if (diagnostic.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/TransformExpression.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/TransformExpression.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The expression node transform: rewrites the identifiers inside interpolations and element directive
+/// expressions and arguments against the template scope and binding metadata. The C# port of Vue 3.5's
+/// <c>transformExpression</c> (<c>@vue/compiler-core</c> <c>transforms/transformExpression.ts</c>).
+/// </summary>
+/// <remarks>
+/// Only installed in the pipeline when <see cref="TransformOptions.PrefixIdentifiers"/> is set, mirroring
+/// upstream's <c>!__BROWSER__ &amp;&amp; prefixIdentifiers</c> gate; the default opaque-expression pipeline is
+/// unchanged. Like upstream it skips <c>v-for</c> (its source and aliases are handled by
+/// <see cref="VForTransform"/>) and the expression of a <c>v-on</c> that has an argument (handled by
+/// <see cref="VOnTransform"/>); <c>v-slot</c> expressions are validated as parameter declarations.
+/// </remarks>
+internal static class TransformExpression
+{
+    /// <summary>The node transform (work happens on entry, before children are traversed).</summary>
+    public static Action? Transform(TemplateSyntaxNode node, TransformContext context)
+    {
+        switch (node)
+        {
+            case InterpolationNode interpolation when interpolation.Content is SimpleExpressionNode content:
+                var processed = ExpressionProcessor.ProcessExpression(content, context);
+                if (!ReferenceEquals(processed, content))
+                {
+                    context.ReplaceNode(interpolation with { Content = processed });
+                }
+
+                break;
+            case ElementNode element:
+                RewriteElementDirectives(element, context);
+                break;
+        }
+
+        return null;
+    }
+
+    private static void RewriteElementDirectives(ElementNode element, TransformContext context)
+    {
+        var properties = element.Properties;
+        List<PropertyNode>? rewritten = null;
+
+        for (var index = 0; index < properties.Count; index++)
+        {
+            var property = properties[index];
+            if (property is not DirectiveNode directive || directive.Name == "for")
+            {
+                continue;
+            }
+
+            var newDirective = directive;
+
+            // Rewrite the expression, except a v-on with an argument (its handler is processed by transformOn).
+            if (directive.Expression is SimpleExpressionNode expression &&
+                !(directive.Name == "on" && directive.Argument is not null))
+            {
+                var processedExpression = ExpressionProcessor.ProcessExpression(
+                    expression,
+                    context,
+                    asParams: directive.Name == "slot");
+                if (!ReferenceEquals(processedExpression, expression))
+                {
+                    newDirective = newDirective with { Expression = processedExpression };
+                }
+            }
+
+            // Rewrite a dynamic argument (upstream processes non-static SIMPLE_EXPRESSION args).
+            if (directive.Argument is SimpleExpressionNode { IsStatic: false } argument)
+            {
+                var processedArgument = ExpressionProcessor.ProcessExpression(argument, context);
+                if (!ReferenceEquals(processedArgument, argument))
+                {
+                    newDirective = newDirective with { Argument = processedArgument };
+                }
+            }
+
+            if (!ReferenceEquals(newDirective, directive))
+            {
+                rewritten ??= NewPropertyList(properties);
+                rewritten[index] = newDirective;
+            }
+        }
+
+        if (rewritten is not null)
+        {
+            context.ReplaceNode(element with { Properties = new SyntaxList<PropertyNode>(rewritten.ToArray()) });
+        }
+    }
+
+    private static List<PropertyNode> NewPropertyList(SyntaxList<PropertyNode> properties)
+    {
+        var list = new List<PropertyNode>(properties.Count);
+        foreach (var property in properties)
+        {
+            list.Add(property);
+        }
+
+        return list;
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VForTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VForTransform.cs
@@ -33,6 +33,13 @@ internal static class VForTransform
             return null;
         }
 
+        // The iterated source is evaluated in the outer scope, so rewrite it before the aliases enter scope
+        // (upstream processExpression(source) precedes addIdentifiers of value/key/index).
+        if (context.PrefixIdentifiers && parseResult.Source is SimpleExpressionNode sourceExpression)
+        {
+            parseResult = parseResult with { Source = ExpressionProcessor.ProcessExpression(sourceExpression, context) };
+        }
+
         var workingFor = new WorkingFor
         {
             Source = parseResult.Source,
@@ -67,13 +74,61 @@ internal static class VForTransform
         context.ReplaceNode(workingFor);
         context.ScopeVFor++;
 
+        // Register the value/key/index aliases so the loop body's expressions treat them as template-locals
+        // (upstream addIdentifiers, gated on prefixIdentifiers). They are declarations, never rewritten.
+        if (context.PrefixIdentifiers)
+        {
+            AddAliasIdentifiers(context, parseResult);
+        }
+
         var onExit = ProcessCodegen(element, directive, context, workingFor, parseResult, isTemplate);
 
         return () =>
         {
             context.ScopeVFor--;
+            if (context.PrefixIdentifiers)
+            {
+                RemoveAliasIdentifiers(context, parseResult);
+            }
+
             onExit?.Invoke();
         };
+    }
+
+    private static void AddAliasIdentifiers(TransformContext context, ForParseResult parseResult)
+    {
+        if (parseResult.Value is not null)
+        {
+            context.AddIdentifiers(parseResult.Value);
+        }
+
+        if (parseResult.Key is not null)
+        {
+            context.AddIdentifiers(parseResult.Key);
+        }
+
+        if (parseResult.Index is not null)
+        {
+            context.AddIdentifiers(parseResult.Index);
+        }
+    }
+
+    private static void RemoveAliasIdentifiers(TransformContext context, ForParseResult parseResult)
+    {
+        if (parseResult.Value is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Value);
+        }
+
+        if (parseResult.Key is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Key);
+        }
+
+        if (parseResult.Index is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Index);
+        }
     }
 
     private static Action ProcessCodegen(

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VIfTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VIfTransform.cs
@@ -63,7 +63,7 @@ internal static class VIfTransform
 
         if (directive.Name == "if")
         {
-            var branch = CreateIfBranch(element, directive);
+            var branch = CreateIfBranch(element, directive, context);
             var workingIf = new WorkingIf { Location = element.Location };
             workingIf.Branches.Add(branch);
             context.ReplaceNode(workingIf);
@@ -107,7 +107,7 @@ internal static class VIfTransform
                 }
 
                 context.RemoveNode();
-                var branch = CreateIfBranch(element, directive);
+                var branch = CreateIfBranch(element, directive, context);
                 if (comments.Count > 0 && !IsTransitionParent(context.Parent))
                 {
                     branch.Children.InsertRange(0, comments);
@@ -142,13 +142,23 @@ internal static class VIfTransform
         return null;
     }
 
-    private static WorkingIfBranch CreateIfBranch(ElementNode element, DirectiveNode directive)
+    private static WorkingIfBranch CreateIfBranch(ElementNode element, DirectiveNode directive, TransformContext context)
     {
+        // The structural v-if transform runs before TransformExpression and consumes the directive, so
+        // the condition must be rewritten here — upstream processIf calls processExpression(dir.exp)
+        // under prefixIdentifiers for exactly this reason (vuejs/core v3.5 compiler-core
+        // transforms/vIf.ts).
+        var condition = directive.Name == "else" ? null : directive.Expression;
+        if (context.PrefixIdentifiers && condition is SimpleExpressionNode simpleCondition)
+        {
+            condition = ExpressionProcessor.ProcessExpression(simpleCondition, context);
+        }
+
         var isTemplateIf = element.ElementType == ElementType.Template;
         var branch = new WorkingIfBranch
         {
             Location = element.Location,
-            Condition = directive.Name == "else" ? null : directive.Expression,
+            Condition = condition,
             UserKey = TransformUtilities.FindProperty(element, "key"),
             IsTemplateIf = isTemplateIf,
         };

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
@@ -115,11 +115,30 @@ internal static class VOnTransform
             var isInlineStatement = !(isMemberExpression || ExpressionShape.IsFunctionExpression(expression));
             var hasMultipleStatements = expression.Content.IndexOf(';') >= 0;
 
+            // Rewrite the handler's identifiers, with $event in scope for an inline statement so its
+            // assignments unwrap refs (upstream transformOn: addIdentifiers($event) around processExpression).
+            ExpressionNode processedExpression = expression;
+            if (context.PrefixIdentifiers)
+            {
+                if (isInlineStatement)
+                {
+                    context.AddIdentifiers("$event");
+                }
+
+                processedExpression = ExpressionProcessor.ProcessExpression(expression, context, asRawStatements: hasMultipleStatements);
+
+                if (isInlineStatement)
+                {
+                    context.RemoveIdentifiers("$event");
+                }
+            }
+
+            handler = processedExpression;
             if (isInlineStatement || (shouldCache && isMemberExpression))
             {
                 handler = Ir.CompoundExpression(
                     (isInlineStatement ? "$event" : "(...args)") + " => " + (hasMultipleStatements ? "{" : "("),
-                    expression,
+                    processedExpression,
                     hasMultipleStatements ? "}" : ")");
             }
         }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
@@ -115,21 +115,30 @@ internal static class VOnTransform
             var isInlineStatement = !(isMemberExpression || ExpressionShape.IsFunctionExpression(expression));
             var hasMultipleStatements = expression.Content.IndexOf(';') >= 0;
 
-            // Rewrite the handler's identifiers, with $event in scope for an inline statement so its
-            // assignments unwrap refs (upstream transformOn: addIdentifiers($event) around processExpression).
+            // Rewrite the handler's identifiers, with the event variable in scope for an inline
+            // statement so its assignments unwrap refs (upstream transformOn: addIdentifiers($event)
+            // around processExpression). `$event` is not a legal C# identifier, so under prefixing the
+            // inline statement is parsed against the Vuecs spelling `__event` — the parameter name the
+            // wrapping lambda emits below. Template authors keep Vue's `$event`; the substitution is
+            // the documented C# divergence (docs/DESIGN.md).
             ExpressionNode processedExpression = expression;
             if (context.PrefixIdentifiers)
             {
                 if (isInlineStatement)
                 {
-                    context.AddIdentifiers("$event");
+                    if (expression.Content.Contains("$event"))
+                    {
+                        expression = expression with { Content = expression.Content.Replace("$event", "__event") };
+                    }
+
+                    context.AddIdentifiers("__event");
                 }
 
                 processedExpression = ExpressionProcessor.ProcessExpression(expression, context, asRawStatements: hasMultipleStatements);
 
                 if (isInlineStatement)
                 {
-                    context.RemoveIdentifiers("$event");
+                    context.RemoveIdentifiers("__event");
                 }
             }
 
@@ -137,7 +146,7 @@ internal static class VOnTransform
             if (isInlineStatement || (shouldCache && isMemberExpression))
             {
                 handler = Ir.CompoundExpression(
-                    (isInlineStatement ? "$event" : "(...args)") + " => " + (hasMultipleStatements ? "{" : "("),
+                    (isInlineStatement ? (context.PrefixIdentifiers ? "__event" : "$event") : "(...args)") + " => " + (hasMultipleStatements ? "{" : "("),
                     processedExpression,
                     hasMultipleStatements ? "}" : ")");
             }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VSlotTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VSlotTransform.cs
@@ -25,7 +25,7 @@ internal static class VSlotTransform
     public static Action? TrackSlotScopes(TemplateSyntaxNode node, TransformContext context)
     {
         if (node is ElementNode { ElementType: ElementType.Component or ElementType.Template } element &&
-            TransformUtilities.FindDirective(element, "slot") is { } slotDirective)
+            TransformUtilities.FindDirective(element, "slot", allowEmpty: true) is { } slotDirective)
         {
             // Register the slot props so the slot children's expressions treat them as template-locals
             // (upstream addIdentifiers of the slot exp, gated on prefixIdentifiers).
@@ -35,9 +35,29 @@ internal static class VSlotTransform
                 context.AddIdentifiers(slotProperties);
             }
 
+            // A dynamic slot's v-for aliases are registered here too: the structural-directive factory
+            // deliberately skips template-with-v-slot nodes, so no other transform sees this v-for —
+            // the C# port of trackVForSlotScopes (vuejs/core v3.5 compiler-core transforms/vSlot.ts).
+            ForParseResult? forAliases = null;
+            if (context.PrefixIdentifiers &&
+                element.ElementType == ElementType.Template &&
+                TransformUtilities.FindDirective(element, "for") is { Expression: SimpleExpressionNode forExpression })
+            {
+                forAliases = ForExpressionParser.Parse(forExpression);
+                if (forAliases is not null)
+                {
+                    AddForAliasIdentifiers(forAliases, context);
+                }
+            }
+
             context.ScopeVSlot++;
             return () =>
             {
+                if (forAliases is not null)
+                {
+                    RemoveForAliasIdentifiers(forAliases, context);
+                }
+
                 if (context.PrefixIdentifiers && slotProperties is not null)
                 {
                     context.RemoveIdentifiers(slotProperties);
@@ -48,6 +68,42 @@ internal static class VSlotTransform
         }
 
         return null;
+    }
+
+    private static void AddForAliasIdentifiers(ForParseResult parseResult, TransformContext context)
+    {
+        if (parseResult.Value is not null)
+        {
+            context.AddIdentifiers(parseResult.Value);
+        }
+
+        if (parseResult.Key is not null)
+        {
+            context.AddIdentifiers(parseResult.Key);
+        }
+
+        if (parseResult.Index is not null)
+        {
+            context.AddIdentifiers(parseResult.Index);
+        }
+    }
+
+    private static void RemoveForAliasIdentifiers(ForParseResult parseResult, TransformContext context)
+    {
+        if (parseResult.Value is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Value);
+        }
+
+        if (parseResult.Key is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Key);
+        }
+
+        if (parseResult.Index is not null)
+        {
+            context.RemoveIdentifiers(parseResult.Index);
+        }
     }
 
     /// <summary>Compiles a component's slots into a slots object (upstream <c>buildSlots</c>).</summary>
@@ -179,6 +235,13 @@ internal static class VSlotTransform
                     : null;
                 if (parseResult is not null)
                 {
+                    if (context.PrefixIdentifiers && parseResult.Source is SimpleExpressionNode sourceExpression)
+                    {
+                        // Upstream finalizes a slot v-for's parse result with processExpression under
+                        // prefixIdentifiers (vSlot.ts buildSlots); mirror VForTransform's source rewrite.
+                        parseResult = parseResult with { Source = ExpressionProcessor.ProcessExpression(sourceExpression, context) };
+                    }
+
                     dynamicSlots.Add(Ir.CallExpression(
                         context.Helper(HelperNames.RenderList),
                         new object[]

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VSlotTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VSlotTransform.cs
@@ -25,10 +25,26 @@ internal static class VSlotTransform
     public static Action? TrackSlotScopes(TemplateSyntaxNode node, TransformContext context)
     {
         if (node is ElementNode { ElementType: ElementType.Component or ElementType.Template } element &&
-            TransformUtilities.FindDirective(element, "slot") is not null)
+            TransformUtilities.FindDirective(element, "slot") is { } slotDirective)
         {
+            // Register the slot props so the slot children's expressions treat them as template-locals
+            // (upstream addIdentifiers of the slot exp, gated on prefixIdentifiers).
+            var slotProperties = slotDirective.Expression;
+            if (context.PrefixIdentifiers && slotProperties is not null)
+            {
+                context.AddIdentifiers(slotProperties);
+            }
+
             context.ScopeVSlot++;
-            return () => context.ScopeVSlot--;
+            return () =>
+            {
+                if (context.PrefixIdentifiers && slotProperties is not null)
+                {
+                    context.RemoveIdentifiers(slotProperties);
+                }
+
+                context.ScopeVSlot--;
+            };
         }
 
         return null;

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
@@ -27,6 +27,7 @@ public sealed class TransformContext
     private readonly HashSet<TemplateSyntaxNode> seenOnce = new(ReferenceComparer.Instance);
     private readonly HashSet<TemplateSyntaxNode> seenMemo = new(ReferenceComparer.Instance);
     private readonly Dictionary<TemplateSyntaxNode, RuntimeHelper> directiveRuntime = new(ReferenceComparer.Instance);
+    private readonly Dictionary<string, int> identifiers = new();
 
     internal TransformContext(
         RootNode root,
@@ -40,6 +41,8 @@ public sealed class TransformContext
         IsBuiltInComponent = options.IsBuiltInComponent;
         IsCustomElement = options.IsCustomElement;
         CacheHandlers = options.CacheHandlers;
+        PrefixIdentifiers = options.PrefixIdentifiers;
+        BindingMetadata = options.BindingMetadata ?? BindingMetadata.Empty;
         InSSR = options.InSSR;
         Ssr = options.Ssr;
         Slotted = options.Slotted;
@@ -70,10 +73,17 @@ public sealed class TransformContext
     public bool CacheHandlers { get; }
 
     /// <summary>
-    /// Whether identifier prefixing is enabled. Always <see langword="false"/> in this build; expression and
-    /// scope analysis is [V01.01.05.04].
+    /// Whether identifier prefixing and scope analysis is enabled (upstream <c>prefixIdentifiers</c>). When
+    /// <see langword="false"/> expression bodies stay opaque, matching Vue's browser build; when
+    /// <see langword="true"/> the <see cref="TransformExpression"/> pass rewrites identifiers ([V01.01.05.04]).
     /// </summary>
-    public bool PrefixIdentifiers => false;
+    public bool PrefixIdentifiers { get; }
+
+    /// <summary>
+    /// The component binding classifications expression rewriting resolves identifiers against (upstream
+    /// <c>bindingMetadata</c>). Defaults to <see cref="BindingMetadata.Empty"/>.
+    /// </summary>
+    public BindingMetadata BindingMetadata { get; }
 
     /// <summary>Whether this is a nested SSR slot compilation.</summary>
     public bool InSSR { get; }
@@ -118,6 +128,69 @@ public sealed class TransformContext
     /// <summary>Reports a transform diagnostic (never throws; recoverable), matching upstream's <c>onError</c>.</summary>
     /// <param name="error">The diagnostic to report.</param>
     public void ReportError(CompilerError error) => onError?.Invoke(error);
+
+    // ---- template-local identifier scope (upstream context.identifiers / addIdentifiers / removeIdentifiers) ----
+
+    /// <summary>
+    /// Whether <paramref name="name"/> is currently a template-local (a <c>v-for</c> alias or <c>v-slot</c> prop
+    /// in scope). Such identifiers shadow bindings and are never prefixed or unwrapped (upstream reads
+    /// <c>context.identifiers</c>).
+    /// </summary>
+    /// <param name="name">The identifier name.</param>
+    public bool IsLocalIdentifier(string name) => identifiers.TryGetValue(name, out var count) && count > 0;
+
+    /// <summary>Pushes <paramref name="name"/> onto the local scope (upstream <c>addIdentifiers</c>).</summary>
+    /// <param name="name">The identifier name.</param>
+    public void AddIdentifiers(string name)
+    {
+        identifiers.TryGetValue(name, out var count);
+        identifiers[name] = count + 1;
+    }
+
+    /// <summary>
+    /// Pushes the identifiers <paramref name="expression"/> declares onto the local scope — a plain alias, a
+    /// tuple, or a deconstruction (upstream <c>addIdentifiers</c> over an expression's declared identifiers).
+    /// </summary>
+    /// <param name="expression">The alias or slot-prop expression.</param>
+    public void AddIdentifiers(ExpressionNode expression)
+    {
+        foreach (var name in DeclaredIdentifiersOf(expression))
+        {
+            AddIdentifiers(name);
+        }
+    }
+
+    /// <summary>Pops <paramref name="name"/> from the local scope (upstream <c>removeIdentifiers</c>).</summary>
+    /// <param name="name">The identifier name.</param>
+    public void RemoveIdentifiers(string name)
+    {
+        if (identifiers.TryGetValue(name, out var count))
+        {
+            if (count <= 1)
+            {
+                identifiers.Remove(name);
+            }
+            else
+            {
+                identifiers[name] = count - 1;
+            }
+        }
+    }
+
+    /// <summary>Pops the identifiers <paramref name="expression"/> declares (upstream <c>removeIdentifiers</c>).</summary>
+    /// <param name="expression">The alias or slot-prop expression.</param>
+    public void RemoveIdentifiers(ExpressionNode expression)
+    {
+        foreach (var name in DeclaredIdentifiersOf(expression))
+        {
+            RemoveIdentifiers(name);
+        }
+    }
+
+    private static IReadOnlyList<string> DeclaredIdentifiersOf(ExpressionNode expression)
+        => expression is SimpleExpressionNode simple
+            ? IdentifierExtraction.CollectDeclaredIdentifiers(simple.Content)
+            : System.Array.Empty<string>();
 
     // ---- helper / component / directive registration ----
 

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
@@ -37,6 +37,21 @@ public sealed class TransformOptions
     public Action<CompilerError>? OnError { get; set; }
 
     /// <summary>
+    /// Whether the expression and scope analysis pass runs (upstream <c>prefixIdentifiers</c>). Defaults to
+    /// <see langword="false"/>, keeping expression bodies opaque like Vue's browser build; set it, together with
+    /// <see cref="BindingMetadata"/>, to enable identifier classification and <c>Ref&lt;T&gt;</c> unwrapping
+    /// ([V01.01.05.04]).
+    /// </summary>
+    public bool PrefixIdentifiers { get; set; }
+
+    /// <summary>
+    /// The component binding classifications expression rewriting resolves identifiers against (upstream
+    /// <c>bindingMetadata</c>), produced by the component/setup source model. Defaults to
+    /// <see cref="BindingMetadata.Empty"/> and is only consulted when <see cref="PrefixIdentifiers"/> is set.
+    /// </summary>
+    public BindingMetadata? BindingMetadata { get; set; }
+
+    /// <summary>
     /// Whether static event handlers are cached so blocks are not invalidated (upstream <c>cacheHandlers</c>).
     /// Defaults to <see langword="false"/>.
     /// </summary>

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/Transformer.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/Transformer.cs
@@ -46,8 +46,9 @@ public static class Transformer
             context.CachedSlots);
     }
 
-    // The base preset order: structural transforms, then slot outlet, then element, then slot-scope tracking,
-    // then text. Expression transforms ([V01.01.05.04]) slot in before transformSlotOutlet when added.
+    // The base preset order: structural transforms, then (when prefixing) expression rewriting, then slot
+    // outlet, element, slot-scope tracking, and text. transformExpression slots in before transformSlotOutlet,
+    // exactly as upstream inserts it in getBaseTransformPreset when !__BROWSER__ && prefixIdentifiers.
     private static IReadOnlyList<NodeTransform> BuildNodeTransforms(TransformOptions options)
     {
         var transforms = new List<NodeTransform>
@@ -56,11 +57,17 @@ public static class Transformer
             VIfTransform.Transform,
             VMemoTransform.Transform,
             VForTransform.Transform,
-            TransformSlotOutlet.Transform,
-            TransformElement.Transform,
-            VSlotTransform.TrackSlotScopes,
-            TransformText.Transform,
         };
+
+        if (options.PrefixIdentifiers)
+        {
+            transforms.Add(TransformExpression.Transform);
+        }
+
+        transforms.Add(TransformSlotOutlet.Transform);
+        transforms.Add(TransformElement.Transform);
+        transforms.Add(VSlotTransform.TrackSlotScopes);
+        transforms.Add(TransformText.Transform);
         transforms.AddRange(options.NodeTransforms);
         return transforms;
     }

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
@@ -1,0 +1,501 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+// Ported from vuejs/core packages/compiler-core/__tests__/transforms/transformExpression.spec.ts: identifier
+// prefixing, binding-metadata classification, ref unwrapping, v-for/v-slot scope, and expression validation.
+// Vuecs divergences (C# .Value unwrapping in read and write positions, _ctx member access, the strict
+// unresolved-identifier diagnostic) are pinned here and documented in
+// libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md.
+public class ExpressionBindingTests
+{
+    // ---- interpolation identifier rewriting ----
+
+    [Fact]
+    public void ProcessExpression_ComponentDataMember_PrefixesWithContext()
+    {
+        // Unknown-source members resolve to _ctx.<name>, mirroring Vue's default _ctx prefix.
+        SingleInterpolation("{{ message }}", Bindings(("message", BindingType.Data)))
+            .ShouldBe("_ctx.message");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupReference_InsertsValueAccessor()
+    {
+        // upstream SETUP_REF -> `foo.value`; Vuecs uses the C# settable Ref<T>.Value.
+        SingleInterpolation("{{ count }}", Bindings(("count", BindingType.SetupReference)))
+            .ShouldBe("count.Value");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupConstant_StaysBare()
+    {
+        // upstream SETUP_CONST in inline mode returns the raw name (a render-closure local); never unwrapped.
+        SingleInterpolation("{{ total }}", Bindings(("total", BindingType.SetupConstant)))
+            .ShouldBe("total");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupMaybeReference_GuardsReadWithUnref()
+    {
+        // upstream SETUP_MAYBE_REF read -> `unref(x)`.
+        SingleInterpolation("{{ maybe }}", Bindings(("maybe", BindingType.SetupMaybeReference)))
+            .ShouldBe("_unref(maybe)");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupMaybeReference_RegistersUnrefHelper()
+    {
+        var result = TransformPrefixed("<div>{{ maybe }}</div>", Bindings(("maybe", BindingType.SetupMaybeReference)), out _);
+        result.UsesHelper("unref").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ProcessExpression_PropertyBinding_PrefixesWithContext()
+    {
+        SingleInterpolation("{{ title }}", Bindings(("title", BindingType.Property)))
+            .ShouldBe("_ctx.title");
+    }
+
+    [Fact]
+    public void ProcessExpression_AliasedProperty_ResolvesRealPropertyName()
+    {
+        var metadata = new BindingMetadata(
+            new Dictionary<string, BindingType> { ["alias"] = BindingType.PropertyAliased },
+            propertyAliases: new Dictionary<string, string> { ["alias"] = "realProperty" });
+
+        SingleInterpolation("{{ alias }}", metadata).ShouldBe("_ctx.realProperty");
+    }
+
+    [Fact]
+    public void ProcessExpression_MemberExpression_RewritesOnlyTheRoot()
+    {
+        // `user.name`: only the root identifier is a reference; `name` is a member and stays literal.
+        SingleInterpolation("{{ user.name }}", Bindings(("user", BindingType.Data)))
+            .ShouldBe("_ctx.user.name");
+    }
+
+    [Fact]
+    public void ProcessExpression_ReferenceInMemberReceiver_UnwrapsThenAccessesMember()
+    {
+        // A ref used as a member-access receiver unwraps first: `user.Name` -> `user.Value.Name`.
+        SingleInterpolation("{{ user.Name }}", Bindings(("user", BindingType.SetupReference)))
+            .ShouldBe("user.Value.Name");
+    }
+
+    [Fact]
+    public void ProcessExpression_ReferenceInElementAccess_UnwrapsReceiverOnly()
+    {
+        // A ref used as an indexer receiver unwraps; the literal index is untouched.
+        SingleInterpolation("{{ items[0] }}", Bindings(("items", BindingType.SetupReference)))
+            .ShouldBe("items.Value[0]");
+    }
+
+    [Fact]
+    public void ProcessExpression_LambdaParameter_IsExcludedFromRewriting()
+    {
+        // A lambda parameter is a local of the expression: `x` stays bare, `list` resolves through _ctx.
+        SingleInterpolation("{{ list.Where(x => x.Active) }}", Bindings(("list", BindingType.Data)))
+            .ShouldBe("_ctx.list.Where(x => x.Active)");
+    }
+
+    [Fact]
+    public void ProcessExpression_AllowedGlobal_IsNeverRewritten()
+    {
+        // Math is an allowed global; a and b are members. Mirrors upstream isGloballyAllowed skipping.
+        SingleInterpolation("{{ Math.Max(a, b) }}", Bindings(("a", BindingType.Data), ("b", BindingType.Data)))
+            .ShouldBe("Math.Max(_ctx.a, _ctx.b)");
+    }
+
+    [Fact]
+    public void ProcessExpression_BinaryExpression_RewritesEachOperand()
+    {
+        SingleInterpolation(
+            "{{ count + step }}",
+            Bindings(("count", BindingType.SetupReference), ("step", BindingType.Data)))
+            .ShouldBe("count.Value + _ctx.step");
+    }
+
+    [Fact]
+    public void ProcessExpression_PrefixingDisabled_LeavesExpressionOpaque()
+    {
+        // Without PrefixIdentifiers the pipeline matches Vue's browser build: expression bodies are untouched.
+        var interpolation = TransformTestHelpers.Transform("{{ count }}").SingleChild().ShouldBeOfType<InterpolationNode>();
+        Flatten(interpolation.Content).ShouldBe("count");
+    }
+
+    // ---- ref unwrapping in write positions (v-on inline handlers) ----
+
+    [Fact]
+    public void ProcessExpression_IncrementOnReference_UnwrapsWriteTarget()
+    {
+        // upstream: `count++` on a ref becomes `count.value++` inside the inline handler.
+        HandlerBody("<button @click=\"count++\"></button>", Bindings(("count", BindingType.SetupReference)))
+            .ShouldBe("$event => (count.Value++)");
+    }
+
+    [Fact]
+    public void ProcessExpression_CompoundAssignmentOnReference_UnwrapsWriteTarget()
+    {
+        HandlerBody("<button @click=\"count += 1\"></button>", Bindings(("count", BindingType.SetupReference)))
+            .ShouldBe("$event => (count.Value += 1)");
+    }
+
+    [Fact]
+    public void ProcessExpression_SimpleAssignmentOnReference_UnwrapsWriteTarget()
+    {
+        HandlerBody("<button @click=\"count = 5\"></button>", Bindings(("count", BindingType.SetupReference)))
+            .ShouldBe("$event => (count.Value = 5)");
+    }
+
+    [Fact]
+    public void ProcessExpression_NonReferenceAssignment_IsNeverUnwrapped()
+    {
+        // A data member assigned in a handler resolves through _ctx and gains no .Value.
+        HandlerBody("<button @click=\"open = true\"></button>", Bindings(("open", BindingType.Data)))
+            .ShouldBe("$event => (_ctx.open = true)");
+    }
+
+    [Fact]
+    public void ProcessExpression_MethodHandler_ResolvesWithoutInlineWrapper()
+    {
+        // A bare member handler is a method reference, not an inline statement: no $event wrapper.
+        HandlerValue("<button @click=\"submit\"></button>", Bindings(("submit", BindingType.Options)))
+            .ShouldBe("_ctx.submit");
+    }
+
+    // ---- v-bind and v-model expressions ----
+
+    [Fact]
+    public void ProcessExpression_VBindReference_UnwrapsBoundValue()
+    {
+        var result = TransformPrefixed("<div :id=\"itemId\"></div>", Bindings(("itemId", BindingType.SetupReference)), out _);
+        Flatten(PropertyValue(result, "id")).ShouldBe("itemId.Value");
+    }
+
+    [Fact]
+    public void ProcessExpression_VModelReference_UnwrapsModelValue()
+    {
+        // The v-model expression is rewritten by transformExpression before the model directive consumes it.
+        var result = TransformPrefixed("<input v-model=\"name\"/>", Bindings(("name", BindingType.SetupReference)), out _);
+        FlattenProps(result).ShouldContain("name.Value");
+    }
+
+    [Fact]
+    public void ProcessExpression_DynamicArgument_IsRewritten()
+    {
+        // A dynamic v-bind argument (`:[key]`) is a non-static expression and is rewritten too.
+        var result = TransformPrefixed("<div :[key]=\"value\"></div>", Bindings(("key", BindingType.Data), ("value", BindingType.Data)), out _);
+        var props = FlattenProps(result);
+        props.ShouldContain("_ctx.key");
+        props.ShouldContain("_ctx.value");
+    }
+
+    // ---- v-for / v-slot scope and shadowing ----
+
+    [Fact]
+    public void ProcessExpression_VForAlias_ShadowsComponentMember()
+    {
+        // `item` is a component member but the v-for alias shadows it inside the loop; the sibling does not.
+        var interpolations = Interpolations(
+            "<div><span v-for=\"item in list\">{{ item }}</span><b>{{ item }}</b></div>",
+            Bindings(("item", BindingType.Data), ("list", BindingType.Data)));
+
+        interpolations.ShouldBe(new[] { "item", "_ctx.item" });
+    }
+
+    [Fact]
+    public void ProcessExpression_VForKeyAndIndexAliases_AreExcludedFromPrefixing()
+    {
+        // (value, key, index) aliases all enter scope and stay bare.
+        SingleInterpolation(
+            "<div v-for=\"(value, key, index) in map\">{{ value }}-{{ key }}-{{ index }}</div>",
+            Bindings(("map", BindingType.Data)),
+            join: true)
+            .ShouldBe("value-key-index");
+    }
+
+    [Fact]
+    public void ProcessExpression_NestedVForSameAlias_ShadowsAndRestoresOuter()
+    {
+        // Inner `a` shadows outer `a`; after the inner loop pops, the outer alias is still in scope (ref-count).
+        var interpolations = Interpolations(
+            "<div v-for=\"a in xs\"><i v-for=\"a in a\">{{ a }}</i>{{ a }}</div>",
+            Bindings(("a", BindingType.Data), ("xs", BindingType.Data)));
+
+        interpolations.ShouldBe(new[] { "a", "a" });
+    }
+
+    [Fact]
+    public void ProcessExpression_VForSource_IsRewrittenInOuterScope()
+    {
+        // The iterated source is evaluated before the aliases exist, so a ref source unwraps normally.
+        var result = TransformPrefixed(
+            "<div v-for=\"item in items\">{{ item }}</div>",
+            Bindings(("items", BindingType.SetupReference)),
+            out _);
+
+        FlattenTree(result.RootCodegen()).ShouldContain("items.Value");
+    }
+
+    [Fact]
+    public void ProcessExpression_VSlotProperties_AreInScopeForSlotChildren()
+    {
+        // `slotProperties` is introduced by v-slot and is a template-local inside the slot content.
+        SingleInterpolation(
+            "<Comp v-slot=\"slotProperties\"><span>{{ slotProperties }}</span></Comp>",
+            BindingMetadata.Empty)
+            .ShouldBe("slotProperties");
+    }
+
+    [Fact]
+    public void ProcessExpression_VSlotDestructuredProperties_EnterScope()
+    {
+        // A destructured slot prop contributes each name to scope (lenient extraction).
+        SingleInterpolation(
+            "<Comp v-slot=\"{ row }\"><span>{{ row }}</span></Comp>",
+            Bindings(("row", BindingType.Data)))
+            .ShouldBe("row");
+    }
+
+    // ---- expression validation and diagnostics ----
+
+    [Fact]
+    public void ProcessExpression_MalformedExpression_ReportsInvalidExpression()
+    {
+        TransformPrefixed("<div>{{ a + }}</div>", Bindings(("a", BindingType.Data)), out var errors);
+
+        var error = errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe(CompilerErrorCode.XInvalidExpression);
+        error.Message.ShouldStartWith("Error parsing JavaScript expression:");
+    }
+
+    [Fact]
+    public void ProcessExpression_MalformedExpression_RemapsLocationIntoTemplate()
+    {
+        const string source = "<div>{{ a + }}</div>";
+
+        // The content's template offset, taken from an opaque (non-prefixed) parse of the same input.
+        var opaque = TransformTestHelpers.Transform(source);
+        var vnode = opaque.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var interpolation = vnode.Children.ShouldBeOfType<InterpolationNode>();
+        var expressionStart = interpolation.Content.Location.Start.Offset;
+
+        TransformPrefixed(source, Bindings(("a", BindingType.Data)), out var errors);
+
+        // The reported offset is in template coordinates (>= the expression start), not sub-expression-relative.
+        errors.ShouldHaveSingleItem().Location.Start.Offset.ShouldBeGreaterThanOrEqualTo(expressionStart);
+    }
+
+    [Fact]
+    public void ProcessExpression_MalformedExpression_IsRecoverableNotThrown()
+    {
+        // Parsing is recoverable: a diagnostic is reported and the transform still completes.
+        Should.NotThrow(() => TransformPrefixed("<div>{{ )( }}</div>", BindingMetadata.Empty, out _));
+    }
+
+    [Fact]
+    public void ProcessExpression_OpaqueModeMalformedExpression_IsNotValidated()
+    {
+        // Without prefixing there is no Roslyn validation, matching Vue's browser build.
+        TransformTestHelpers.Transform("<div>{{ a + }}</div>", out var errors);
+        errors.ShouldBeEmpty();
+    }
+
+    // ---- strict unresolved-identifier diagnostic (Vuecs-specific) ----
+
+    [Fact]
+    public void ProcessExpression_UnknownIdentifierUnderStrictMetadata_ReportsUnresolved()
+    {
+        var metadata = new BindingMetadata(
+            new Dictionary<string, BindingType> { ["known"] = BindingType.Data },
+            reportsUnresolvedIdentifiers: true);
+
+        TransformPrefixed("<div>{{ mystery }}</div>", metadata, out var errors);
+
+        errors.ShouldHaveSingleItem().Code.ShouldBe(CompilerErrorCode.XVuecsUnresolvedIdentifier);
+    }
+
+    [Fact]
+    public void ProcessExpression_UnknownIdentifierUnderPermissiveMetadata_FallsBackToContext()
+    {
+        // Default (non-strict) metadata never errors: unknown identifiers use the _ctx fallback like Vue.
+        var result = TransformPrefixed("<div>{{ mystery }}</div>", BindingMetadata.Empty, out var errors);
+        errors.ShouldBeEmpty();
+        FlattenTree(result.RootCodegen()).ShouldContain("_ctx.mystery");
+    }
+
+    [Fact]
+    public void ProcessExpression_UnknownIdentifierUnderStrictMetadata_StillEmitsContextAccess()
+    {
+        // The diagnostic is recoverable: a _ctx access is still emitted so later stages see a valid tree.
+        var metadata = new BindingMetadata(
+            new Dictionary<string, BindingType>(),
+            reportsUnresolvedIdentifiers: true);
+
+        var result = TransformPrefixed("<div>{{ mystery }}</div>", metadata, out _);
+        FlattenTree(result.RootCodegen()).ShouldContain("_ctx.mystery");
+    }
+
+    // ---- incremental-caching contract ----
+
+    [Fact]
+    public void ProcessExpression_EqualInput_ProducesValueEqualRewrittenExpression()
+    {
+        var metadata = Bindings(("count", BindingType.SetupReference), ("step", BindingType.Data));
+
+        var first = FirstInterpolationContent("<div>{{ count + step }}</div>", metadata);
+        var second = FirstInterpolationContent("<div>{{ count + step }}</div>", metadata);
+
+        first.ShouldBe(second);
+    }
+
+    // ---- helpers ----
+
+    private static BindingMetadata Bindings(params (string Name, BindingType Type)[] entries)
+    {
+        var map = new Dictionary<string, BindingType>();
+        foreach (var (name, type) in entries)
+        {
+            map[name] = type;
+        }
+
+        return new BindingMetadata(map, isScriptSetup: true);
+    }
+
+    private static TransformResult TransformPrefixed(string source, BindingMetadata metadata, out List<CompilerError> errors)
+    {
+        var collected = new List<CompilerError>();
+        var options = TransformOptions.CreateDom();
+        options.PrefixIdentifiers = true;
+        options.BindingMetadata = metadata;
+        options.OnError = collected.Add;
+        var result = TransformTestHelpers.Transform(source, options);
+        errors = collected;
+        return result;
+    }
+
+    private static List<string> Interpolations(string source, BindingMetadata metadata)
+    {
+        var collected = new List<string>();
+        var options = TransformOptions.CreateDom();
+        options.PrefixIdentifiers = true;
+        options.BindingMetadata = metadata;
+        options.NodeTransforms = new NodeTransform[]
+        {
+            (node, _) =>
+            {
+                if (node is InterpolationNode interpolation)
+                {
+                    collected.Add(Flatten(interpolation.Content));
+                }
+
+                return null;
+            },
+        };
+        TransformTestHelpers.Transform(source, options);
+        return collected;
+    }
+
+    private static string SingleInterpolation(string source, BindingMetadata metadata, bool join = false)
+    {
+        var interpolations = Interpolations(source, metadata);
+        return join ? string.Join("-", interpolations) : interpolations.Single();
+    }
+
+    private static ExpressionNode FirstInterpolationContent(string source, BindingMetadata metadata)
+    {
+        ExpressionNode? content = null;
+        var options = TransformOptions.CreateDom();
+        options.PrefixIdentifiers = true;
+        options.BindingMetadata = metadata;
+        options.NodeTransforms = new NodeTransform[]
+        {
+            (node, _) =>
+            {
+                if (content is null && node is InterpolationNode interpolation)
+                {
+                    content = interpolation.Content;
+                }
+
+                return null;
+            },
+        };
+        TransformTestHelpers.Transform(source, options);
+        return content.ShouldNotBeNull();
+    }
+
+    private static string HandlerValue(string source, BindingMetadata metadata)
+    {
+        var result = TransformPrefixed(source, metadata, out _);
+        return Flatten(PropertyValue(result, "onClick"));
+    }
+
+    private static string HandlerBody(string source, BindingMetadata metadata) => HandlerValue(source, metadata);
+
+    private static object PropertyValue(TransformResult result, string key)
+    {
+        var vnode = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var properties = vnode.Props.ShouldBeOfType<ObjectExpression>();
+        var property = properties.Properties.First(p => p.Key is SimpleExpressionNode s && s.Content == key);
+        return property.Value;
+    }
+
+    private static string FlattenProps(TransformResult result)
+    {
+        var vnode = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        return vnode.Props is null ? string.Empty : FlattenTree(vnode.Props);
+    }
+
+    // Concatenates a rewritten expression back to source text for assertion.
+    private static string Flatten(object? part) => part switch
+    {
+        null => string.Empty,
+        string text => text,
+        SimpleExpressionNode expression => expression.Content,
+        CompoundExpressionNode compound => string.Concat(compound.Parts.Select(Flatten)),
+        RuntimeHelper helper => "_" + helper.Name,
+        InterpolationNode interpolation => Flatten(interpolation.Content),
+        TextNode text => text.Content,
+        _ => throw new InvalidOperationException("Unexpected expression part: " + part.GetType().Name),
+    };
+
+    // Stringifies an arbitrary code-generation node loosely, for containment assertions over built props.
+    private static string FlattenTree(object? node) => node switch
+    {
+        null => string.Empty,
+        string text => text,
+        SimpleExpressionNode expression => expression.Content,
+        CompoundExpressionNode compound => string.Concat(compound.Parts.Select(FlattenTree)),
+        RuntimeHelper helper => "_" + helper.Name,
+        InterpolationNode interpolation => FlattenTree(interpolation.Content),
+        TextNode text => text.Content,
+        ObjectExpression obj => "{" + string.Join(",", obj.Properties.Select(p => FlattenTree(p.Key) + ":" + FlattenTree(p.Value))) + "}",
+        ArrayExpression array => "[" + string.Join(",", array.Elements.Select(FlattenTree)) + "]",
+        CallExpression call => FlattenTree(call.Callee) + "(" + string.Join(",", call.Arguments.Select(FlattenTree)) + ")",
+        VNodeCall vnode => FlattenVNode(vnode),
+        _ => node.ToString() ?? string.Empty,
+    };
+
+    private static string FlattenVNode(VNodeCall vnode)
+    {
+        var parts = new List<string> { FlattenTree(vnode.Tag) };
+        if (vnode.Props is not null)
+        {
+            parts.Add(FlattenTree(vnode.Props));
+        }
+
+        if (vnode.Children is not null)
+        {
+            parts.Add(FlattenTree(vnode.Children));
+        }
+
+        return string.Join(",", parts);
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
@@ -137,21 +137,21 @@ public class ExpressionBindingTests
     {
         // upstream: `count++` on a ref becomes `count.value++` inside the inline handler.
         HandlerBody("<button @click=\"count++\"></button>", Bindings(("count", BindingType.SetupReference)))
-            .ShouldBe("$event => (count.Value++)");
+            .ShouldBe("__event => (count.Value++)");
     }
 
     [Fact]
     public void ProcessExpression_CompoundAssignmentOnReference_UnwrapsWriteTarget()
     {
         HandlerBody("<button @click=\"count += 1\"></button>", Bindings(("count", BindingType.SetupReference)))
-            .ShouldBe("$event => (count.Value += 1)");
+            .ShouldBe("__event => (count.Value += 1)");
     }
 
     [Fact]
     public void ProcessExpression_SimpleAssignmentOnReference_UnwrapsWriteTarget()
     {
         HandlerBody("<button @click=\"count = 5\"></button>", Bindings(("count", BindingType.SetupReference)))
-            .ShouldBe("$event => (count.Value = 5)");
+            .ShouldBe("__event => (count.Value = 5)");
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ExpressionBindingTests
     {
         // A data member assigned in a handler resolves through _ctx and gains no .Value.
         HandlerBody("<button @click=\"open = true\"></button>", Bindings(("open", BindingType.Data)))
-            .ShouldBe("$event => (_ctx.open = true)");
+            .ShouldBe("__event => (_ctx.open = true)");
     }
 
     [Fact]
@@ -354,6 +354,139 @@ public class ExpressionBindingTests
         var second = FirstInterpolationContent("<div>{{ count + step }}</div>", metadata);
 
         first.ShouldBe(second);
+    }
+
+    // ---- structural-directive expression sites (vIf.ts processIf, vSlot.ts trackVForSlotScopes) ----
+
+    [Fact]
+    public void ProcessExpression_VIfCondition_RewritesUnderPrefixing()
+    {
+        // Upstream processIf runs processExpression on dir.exp under prefixIdentifiers because vIf is a
+        // structural transform applied before transformExpression (vuejs/core v3.5 transforms/vIf.ts).
+        var result = TransformPrefixed(
+            "<span v-if=\"visible\">a</span><span v-else-if=\"other\">b</span>",
+            Bindings(("visible", BindingType.SetupReference), ("other", BindingType.Data)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var ifNode = result.Children[0].ShouldBeOfType<IfNode>();
+        Flatten(ifNode.Branches[0].Condition).ShouldBe("visible.Value");
+        Flatten(ifNode.Branches[1].Condition).ShouldBe("_ctx.other");
+    }
+
+    [Fact]
+    public void ProcessExpression_TemplateVForSlot_AliasStaysLocalAndSourceRewrites()
+    {
+        // The structural-directive factory skips template-with-v-slot, so trackVForSlotScopes registers
+        // the v-for aliases and buildSlots processes the source (vuejs/core v3.5 transforms/vSlot.ts).
+        var result = TransformPrefixed(
+            "<Comp><template v-for=\"item in items\" v-slot:row><span>{{ item }}</span></template></Comp>",
+            Bindings(("items", BindingType.Data)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var flattened = FlattenTree(result.RootCodegen());
+        flattened.ShouldContain("_ctx.items");
+        flattened.ShouldNotContain("_ctx.item)");
+        SingleInterpolation(
+            "<Comp><template v-for=\"item in items\" v-slot:row><span>{{ item }}</span></template></Comp>",
+            Bindings(("items", BindingType.Data)))
+            .ShouldBe("item");
+    }
+
+    // ---- write-position unwrapping (upstream rewriteIdentifier assignment/update handling) ----
+
+    [Fact]
+    public void ProcessExpression_MaybeReferenceWrite_UnwrapsToValue()
+    {
+        // upstream SETUP_MAYBE_REF in assignment position -> `.value`: a write to a const binding is
+        // only legal when it is a ref (transformExpression.ts rewriteIdentifier).
+        SingleInterpolation("{{ maybe = 1 }}", Bindings(("maybe", BindingType.SetupMaybeReference)))
+            .ShouldBe("maybe.Value = 1");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupLetRead_GuardsWithUnref()
+    {
+        // upstream SETUP_LET read -> `unref(x)`; the guarded write stays bare (documented divergence,
+        // docs/DESIGN.md).
+        SingleInterpolation("{{ letBinding }}", Bindings(("letBinding", BindingType.SetupLet)))
+            .ShouldBe("_unref(letBinding)");
+    }
+
+    [Fact]
+    public void ProcessExpression_SetupLetWrite_StaysBare()
+    {
+        SingleInterpolation("{{ letBinding = 1 }}", Bindings(("letBinding", BindingType.SetupLet)))
+            .ShouldBe("letBinding = 1");
+    }
+
+    // ---- statement-mode locals, object members, and nameof ----
+
+    [Fact]
+    public void ProcessExpression_StatementHandlerLocal_IsNotPrefixed()
+    {
+        // A local declared in a multi-statement handler is a scope identifier, mirroring upstream
+        // walkIdentifiers' variable-declaration handling.
+        var result = TransformPrefixed(
+            "<button @click=\"var next = count + 1; total = next;\"></button>",
+            Bindings(("count", BindingType.SetupReference), ("total", BindingType.Data)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var flattened = FlattenTree(result.RootCodegen());
+        flattened.ShouldContain("var next = count.Value + 1");
+        flattened.ShouldContain("_ctx.total = next");
+        flattened.ShouldNotContain("_ctx.next");
+    }
+
+    [Fact]
+    public void ProcessExpression_ObjectInitializerMemberNames_AreNotRewritten()
+    {
+        // `new Point { X = x }`: X names a member of the constructed type; only x is a reference.
+        var result = TransformPrefixed(
+            "<div :data-point=\"new Point { X = x, Y = y }\"></div>",
+            Bindings(("x", BindingType.Data), ("y", BindingType.Data)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var flattened = FlattenTree(result.RootCodegen());
+        flattened.ShouldContain("X = _ctx.x");
+        flattened.ShouldContain("Y = _ctx.y");
+        flattened.ShouldNotContain("_ctx.X", Case.Sensitive);
+    }
+
+    [Fact]
+    public void ProcessExpression_NameOf_IsNotRewritten()
+    {
+        // The nameof operand is a name, not a value read; rewriting it would change the produced string.
+        var result = TransformPrefixed(
+            "<div :title=\"nameof(count)\"></div>",
+            Bindings(("count", BindingType.SetupReference)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var flattened = FlattenTree(result.RootCodegen());
+        flattened.ShouldContain("nameof(count)");
+        flattened.ShouldNotContain("_ctx.nameof");
+        flattened.ShouldNotContain("count.Value");
+    }
+
+    // ---- the Vuecs event identifier (docs/DESIGN.md: template $event <-> C# __event) ----
+
+    [Fact]
+    public void ProcessExpression_EventVariable_SubstitutesLegalIdentifierUnderPrefixing()
+    {
+        var result = TransformPrefixed(
+            "<button @click=\"save($event)\"></button>",
+            Bindings(("save", BindingType.SetupConstant)),
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var flattened = FlattenTree(result.RootCodegen());
+        flattened.ShouldContain("__event => ");
+        flattened.ShouldContain("save(__event)");
+        flattened.ShouldNotContain("$event");
     }
 
     // ---- helpers ----


### PR DESCRIPTION
## Summary

The C# port of Vue 3.5's `transformExpression` (`@vue/compiler-core` `transforms/transformExpression.ts` + `BindingTypes`): template expressions are Roslyn-parsed, every identifier is classified against binding metadata and the template scope stack (v-for aliases, v-slot props, inline-handler locals), and references are rewritten for the render closure — `SetupReference` → `name.Value` in read **and** write positions, `SetupMaybeReference`/`SetupLet` reads through `unref(...)`, everything else through `_ctx.`. Where upstream uses `@babel/parser`, Vuecs uses `Microsoft.CodeAnalysis.CSharp` (a build-time-only dependency; the library never reaches the WASM runtime).

**Stacked on PR #126** — base is `feature/V01.01.12.09-structure-refactor`; merge #126 first and this retargets to `main` automatically.

Initial implementation was delegated to Claude Opus 4.8, then adversarially reviewed; the review pass closed one blocker and six further findings in the follow-up commit (see Changes).

## Type of change

- [x] `feat` — new feature

## Changes

- `TransformExpression` node transform (gated on `PrefixIdentifiers`, inserted per upstream preset order), `ExpressionProcessor` (the `processExpression`/`rewriteIdentifier` port with a scope-aware Roslyn identifier walker and template-offset error remapping), `BindingType`/`BindingMetadata`, and the `TransformContext` identifier stack driven by `VForTransform`, `VSlotTransform`, and `VOnTransform`.
- Review corrections: `v-if`/`v-else-if` conditions are rewritten (upstream `processIf` parity — the structural transform consumes them before `transformExpression` runs); the `trackVForSlotScopes` port registers a dynamic slot template's v-for aliases and processes its source; maybe-ref **writes** unwrap to `.Value` (upstream: a write to a const binding is only legal when it is a ref); statement-handler locals, object-initializer member names, and `nameof` operands are never `_ctx.`-prefixed.
- The template event variable contract: authors write Vue's `$event`; under prefixing it maps to the C# spelling `__event` (also the wrapping lambda's parameter). Documented in the library's `docs/DESIGN.md` together with the deliberate divergences (SetupLet guarded writes deferred to [V01.01.05.05], conservative intra-expression shadowing).
- `XVuecsUnresolvedIdentifier` (the Vuecs-only strict-metadata diagnostic) lives in a reserved 1000+ band so the 66+ slots stay free for the upstream `compiler-ssr` extension chain ([V01.01.07]).
- 45 new tests (Templates suite 233 → 278), each pinning the upstream contract or the documented Vuecs divergence.

## Verification

- `dotnet build Assimalign.Vuecs.slnx -warnaserror` — 0 warnings, 0 errors (WASM example included).
- Syntax cluster fully green: 278 Templates + 60 SingleFileComponent + 17 base + 7 scaffold tests.
- Multi-lens adversarial review with skeptic verification; every confirmed finding fixed and pinned by a test in `012a686`.

## Work items resolved

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
