### PR TITLE
test(compiler): pin patch-flag inference and block emission

### DIFF
--- a/libraries/Assimalign.Vue.Syntax.Templates/src/CodeGeneration/VNodeCall.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/CodeGeneration/VNodeCall.cs
@@ -9,9 +9,10 @@ namespace Assimalign.Vue.Syntax.Templates;
 /// </summary>
 /// <remarks>
 /// The <see cref="PatchFlag"/> and <see cref="DynamicProps"/> fields are populated by prop analysis
-/// ([V01.01.05.03]); the full element-level patch-flag inference (class/style/text elision) is refined by
-/// [V01.01.05.06]. This node deliberately carries every field those stages fill so downstream passes never
-/// reshape it.
+/// ([V01.01.05.03]) and the element-level patch-flag inference and block-emission decisions ([V01.01.05.06]);
+/// <see cref="IsBlock"/> and <see cref="DisableTracking"/> record whether this vnode opens an optimization
+/// block and whether its block tracking is suppressed. This node deliberately carries every field those
+/// stages fill so downstream passes never reshape it.
 /// </remarks>
 public sealed record VNodeCall : TemplateSyntaxNode
 {

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/TransformElement.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/TransformElement.cs
@@ -15,7 +15,9 @@ namespace Assimalign.Vue.Syntax.Templates;
 /// <remarks>
 /// The patch-flag analysis in <see cref="BuildProps"/> is ported here because it is inseparable from prop
 /// building and because [V01.01.05.03] requires the <c>FULL_PROPS</c> escalation and the <c>dynamicProps</c>
-/// list. The full element-level patch-flag refinement (static class/style elision, text) is [V01.01.05.06].
+/// list. The element-level patch-flag refinement it drives — static class/style elision, the <c>TEXT</c> flag
+/// for a single dynamic text child, and the block-emission decisions stamped onto the resulting
+/// <see cref="VNodeCall"/> (<c>shouldUseBlock</c>) — landed in [V01.01.05.06].
 /// </remarks>
 internal static class TransformElement
 {

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/BlockTreeEmissionTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/BlockTreeEmissionTests.cs
@@ -1,0 +1,214 @@
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+// [V01.01.05.06] block-tree emission. Ported from vuejs/core
+// packages/compiler-core/__tests__/transforms/{vFor,vIf}.spec.ts and the "tree flattening" section of
+// https://vuejs.org/guide/extras/rendering-mechanism.html. Pins which vnodes open an optimization block
+// (openBlock + createElementBlock/createBlock), how v-if branches and v-for fragments become blocks, and
+// where block tracking is disabled — the compiler half of the compiler-informed VDOM contract.
+public class BlockTreeEmissionTests
+{
+    // ---- the template root opens a block ----
+
+    [Fact]
+    public void SingleRootElement_OpensBlockWithTrackingEnabled()
+    {
+        var result = TransformTestHelpers.Transform("<div></div>");
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+
+        codegen.IsBlock.ShouldBeTrue();
+        codegen.DisableTracking.ShouldBeFalse();
+        result.ShouldUseHelper("openBlock");
+        result.ShouldUseHelper("createElementBlock");
+    }
+
+    [Fact]
+    public void SingleRootComponent_OpensBlockViaCreateBlock()
+    {
+        var result = TransformTestHelpers.Transform("<Comp></Comp>");
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+
+        codegen.IsBlock.ShouldBeTrue();
+        codegen.IsComponent.ShouldBeTrue();
+        result.ShouldUseHelper("openBlock");
+        result.ShouldUseHelper("createBlock");
+    }
+
+    // ---- nested elements do NOT open blocks; they are collected by the enclosing block at runtime ----
+
+    [Fact]
+    public void NestedDynamicElement_DoesNotOpenBlockButKeepsItsPatchFlag()
+    {
+        // Only block roots open blocks; a nested dynamic element stays a plain (element) vnode carrying its
+        // patch flag, to be collected into the parent block's dynamicChildren at runtime.
+        var result = TransformTestHelpers.Transform("<div><span :id=\"x\"></span></div>");
+        var root = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var children = root.Children.ShouldBeOfType<SyntaxList<TemplateChildNode>>();
+
+        var span = result.GetCodegenNode(children[0]).ShouldBeOfType<VNodeCall>();
+        span.IsBlock.ShouldBeFalse();
+        span.ShouldHavePatchFlag(PatchFlags.Props);
+        span.DynamicProps.ShouldBe("[\"id\"]");
+    }
+
+    [Fact]
+    public void FullyStaticSubtree_HasNeitherBlockNorFlagBelowTheRoot()
+    {
+        var result = TransformTestHelpers.Transform("<div><span></span></div>");
+        var root = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var children = root.Children.ShouldBeOfType<SyntaxList<TemplateChildNode>>();
+
+        var span = result.GetCodegenNode(children[0]).ShouldBeOfType<VNodeCall>();
+        span.IsBlock.ShouldBeFalse();
+        span.PatchFlag.ShouldBeNull();
+    }
+
+    // ---- svg/foreignObject open a block boundary even when nested ----
+
+    [Fact]
+    public void NestedSvg_OpensItsOwnBlockBoundary()
+    {
+        // transformElement.ts forces a block for svg/foreignObject/math because their namespace boundary breaks
+        // the flat dynamicChildren assumption of the enclosing block.
+        var result = TransformTestHelpers.Transform("<div><svg></svg></div>");
+        var root = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+        var children = root.Children.ShouldBeOfType<SyntaxList<TemplateChildNode>>();
+
+        var svg = result.GetCodegenNode(children[0]).ShouldBeOfType<VNodeCall>();
+        svg.IsBlock.ShouldBeTrue();
+    }
+
+    // ---- multi-root templates emit a stable fragment block ----
+
+    [Fact]
+    public void MultiRoot_EmitsStableFragmentBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div></div><span></span>");
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+
+        codegen.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        codegen.IsBlock.ShouldBeTrue();
+        codegen.DisableTracking.ShouldBeFalse();
+        codegen.ShouldHavePatchFlag(PatchFlags.StableFragment);
+    }
+
+    // ---- v-if: each branch is its own block with a stable synthetic key ----
+
+    [Fact]
+    public void VIfBranch_OpensBlockWithTrackingEnabled()
+    {
+        var result = TransformTestHelpers.Transform("<div v-if=\"ok\"></div>");
+        var ifNode = result.SingleChild().ShouldBeOfType<IfNode>();
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        var branchBlock = conditional.Consequent.ShouldBeOfType<VNodeCall>();
+        branchBlock.IsBlock.ShouldBeTrue();
+        branchBlock.DisableTracking.ShouldBeFalse();
+        branchBlock.Props.ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("0");
+    }
+
+    // ---- v-for: a fragment block whose tracking is disabled when the source is dynamic ----
+
+    [Fact]
+    public void VForFragment_OpensBlockAndDisablesTracking()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"i in list\">{{ i }}</div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        var fragment = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+
+        fragment.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        fragment.IsBlock.ShouldBeTrue();
+        // A v-for's item count and identity can change, so the fragment does not collect a stable child list.
+        fragment.DisableTracking.ShouldBeTrue();
+        fragment.ShouldHavePatchFlag(PatchFlags.UnkeyedFragment);
+    }
+
+    [Fact]
+    public void VForLoopItem_BecomesABlockWhenSourceIsDynamic()
+    {
+        // vFor.spec.ts: the per-item vnode is forced into a block so each item roots its own dynamicChildren.
+        var result = TransformTestHelpers.Transform("<div v-for=\"i in list\">{{ i }}</div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        var fragment = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+
+        var renderList = fragment.Children.ShouldBeOfType<CallExpression>();
+        var iterator = renderList.Arguments[1].ShouldBeOfType<FunctionExpression>();
+        var itemBlock = iterator.Returns.ShouldBeOfType<VNodeCall>();
+        itemBlock.Tag.ShouldBe("\"div\"");
+        itemBlock.IsBlock.ShouldBeTrue();
+        itemBlock.ShouldHavePatchFlag(PatchFlags.Text);
+    }
+
+    [Fact]
+    public void KeyedVFor_FlagsKeyedFragment()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"i in list\" :key=\"i.id\"></div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+
+        result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>().ShouldHavePatchFlag(PatchFlags.KeyedFragment);
+    }
+
+    [Fact]
+    public void TemplateVFor_InnerWrapper_IsAStableFragment()
+    {
+        // The outer renderList fragment is unkeyed/dynamic, but each iteration's multi-child wrapper has a
+        // fixed child order => STABLE_FRAGMENT.
+        var result = TransformTestHelpers.Transform("<template v-for=\"i in list\"><div></div><p></p></template>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        var fragment = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+
+        fragment.ShouldHavePatchFlag(PatchFlags.UnkeyedFragment);
+        var iterator = fragment.Children.ShouldBeOfType<CallExpression>().Arguments[1].ShouldBeOfType<FunctionExpression>();
+        var wrapper = iterator.Returns.ShouldBeOfType<VNodeCall>();
+        wrapper.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        wrapper.IsBlock.ShouldBeTrue();
+        wrapper.ShouldHavePatchFlag(PatchFlags.StableFragment);
+    }
+
+    // ---- v-if / v-for interplay ----
+
+    [Fact]
+    public void VForContainingVIf_NestsAConditionalInsideTheItemBlock()
+    {
+        var result = TransformTestHelpers.Transform("<div v-for=\"i in list\"><span v-if=\"i.ok\"></span></div>");
+        var forNode = result.SingleChild().ShouldBeOfType<ForNode>();
+        var fragment = result.GetCodegenNode(forNode).ShouldBeOfType<VNodeCall>();
+
+        fragment.ShouldHavePatchFlag(PatchFlags.UnkeyedFragment);
+        fragment.DisableTracking.ShouldBeTrue();
+
+        var iterator = fragment.Children.ShouldBeOfType<CallExpression>().Arguments[1].ShouldBeOfType<FunctionExpression>();
+        var itemBlock = iterator.Returns.ShouldBeOfType<VNodeCall>();
+        itemBlock.Tag.ShouldBe("\"div\"");
+        itemBlock.IsBlock.ShouldBeTrue();
+
+        // The item's child is the v-if, folded into an IfNode whose codegen is the branch conditional.
+        var itemChildren = itemBlock.Children.ShouldBeOfType<SyntaxList<TemplateChildNode>>();
+        var innerIf = itemChildren[0].ShouldBeOfType<IfNode>();
+        var conditional = result.GetCodegenNode(innerIf).ShouldBeOfType<ConditionalExpression>();
+        conditional.Test.StaticContent().ShouldBe("i.ok");
+        conditional.Consequent.ShouldBeOfType<VNodeCall>().IsBlock.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void VIfBranchContainingVFor_UsesTheForFragmentAsTheBranchBlock()
+    {
+        // When a branch's only child is a v-for, upstream injects the branch key into the v-for fragment
+        // instead of adding a wrapper — the fragment itself becomes the branch block.
+        var result = TransformTestHelpers.Transform("<template v-if=\"ok\"><div v-for=\"i in list\"></div></template>");
+        var ifNode = result.SingleChild().ShouldBeOfType<IfNode>();
+
+        var conditional = result.GetCodegenNode(ifNode).ShouldBeOfType<ConditionalExpression>();
+        var branchBlock = conditional.Consequent.ShouldBeOfType<VNodeCall>();
+        branchBlock.Tag.ShouldBeOfType<RuntimeHelper>().Name.ShouldBe("Fragment");
+        branchBlock.IsBlock.ShouldBeTrue();
+        branchBlock.DisableTracking.ShouldBeTrue();
+        branchBlock.ShouldHavePatchFlag(PatchFlags.UnkeyedFragment);
+        branchBlock.Props.ShouldBeOfType<ObjectExpression>().Property("key").Value.StaticContent().ShouldBe("0");
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/PatchFlagInferenceTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/PatchFlagInferenceTests.cs
@@ -1,0 +1,239 @@
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+// [V01.01.05.06] patch-flag inference. Ported from vuejs/core
+// packages/compiler-core/__tests__/transforms/{transformElement,vBind,vOn}.spec.ts and pinned against the
+// vuejs/core v3.5 template-explorer output for each template. Every expected numeric value is the exact
+// PatchFlags bit combination @vue/shared emits and the runtime diff consumes; the enum lives once in
+// Assimalign.Vue.Shared (see Assimalign.Vue.Shared.Tests.PatchFlagsParityTests for the bit-for-bit table),
+// so these tests are the compiler-side half of that shared-constants contract.
+public class PatchFlagInferenceTests
+{
+    private static VNodeCall RootVNode(string source)
+        => TransformTestHelpers.Transform(source).RootCodegen().ShouldBeOfType<VNodeCall>();
+
+    // ---- TEXT (1 << 0) ----
+
+    [Fact]
+    public void DynamicTextChild_FlagsTextOnly()
+    {
+        // transformElement.ts: a single interpolation/compound child with NOT_CONSTANT value => TEXT.
+        var codegen = RootVNode("<div>{{ message }}</div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.Text);
+        ((int)codegen.PatchFlag!.Value).ShouldBe(1);
+    }
+
+    [Fact]
+    public void StaticTextChild_HasNoPatchFlag()
+    {
+        // A plain text child can never change, so no flag is emitted (the vnode carries the text directly).
+        var codegen = RootVNode("<div>hello</div>");
+
+        codegen.PatchFlag.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DynamicTextChildWithDynamicClass_CombinesClassAndText()
+    {
+        // Flags are a bitset: :class => CLASS, {{ x }} => TEXT, combined = 2 | 1 = 3.
+        var codegen = RootVNode("<div :class=\"cls\">{{ message }}</div>");
+
+        codegen.ShouldHavePatchFlag(PatchFlags.Class);
+        codegen.ShouldHavePatchFlag(PatchFlags.Text);
+        ((int)codegen.PatchFlag!.Value).ShouldBe((int)(PatchFlags.Class | PatchFlags.Text));
+        ((int)codegen.PatchFlag!.Value).ShouldBe(3);
+    }
+
+    // ---- static prop elision ----
+
+    [Fact]
+    public void OnlyStaticAttributes_EmitNoPatchFlag()
+    {
+        // buildProps only runs analyzePatchFlag on directive-produced props; static attributes never flag.
+        var codegen = RootVNode("<div class=\"a\" style=\"color:red\" id=\"x\"></div>");
+
+        codegen.PatchFlag.ShouldBeNull();
+    }
+
+    // ---- PROPS (1 << 3) and the dynamicProps list ----
+
+    [Fact]
+    public void DynamicProps_CollectsExactNamesInSourceOrder()
+    {
+        // vBind.spec.ts: non-class/style dynamic bindings => PROPS with an ordered dynamicProps name list.
+        var codegen = RootVNode("<div :foo=\"a\" :bar=\"b\"></div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.Props);
+        codegen.DynamicProps.ShouldBe("[\"foo\", \"bar\"]");
+    }
+
+    [Fact]
+    public void KeyBinding_IsNeverCollectedAsDynamicProp()
+    {
+        // analyzePatchFlag skips `key`: the diff handles keys structurally, not as a patched prop.
+        var codegen = RootVNode("<div :key=\"k\" :foo=\"a\"></div>");
+
+        codegen.DynamicProps.ShouldBe("[\"foo\"]");
+    }
+
+    // ---- FULL_PROPS (1 << 4): replaces CLASS/STYLE/PROPS ----
+
+    [Fact]
+    public void DynamicArgument_EscalatesToFullPropsAndReplacesFinerFlags()
+    {
+        // A dynamic v-bind argument makes the prop keys themselves dynamic; upstream sets FULL_PROPS *instead*
+        // of CLASS/STYLE/PROPS (the else-branch in buildProps is skipped entirely when hasDynamicKeys).
+        var codegen = RootVNode("<div :[key]=\"v\" :class=\"c\" :style=\"s\" :foo=\"f\"></div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.FullProps);
+        ((int)codegen.PatchFlag!.Value).ShouldBe(16);
+        (codegen.PatchFlag!.Value & PatchFlags.Class).ShouldBe((PatchFlags)0);
+        (codegen.PatchFlag!.Value & PatchFlags.Style).ShouldBe((PatchFlags)0);
+        (codegen.PatchFlag!.Value & PatchFlags.Props).ShouldBe((PatchFlags)0);
+    }
+
+    [Fact]
+    public void ObjectSpreadVBind_EscalatesToFullProps()
+    {
+        // v-bind="obj" merges an object whose keys are unknown at compile time => FULL_PROPS.
+        var codegen = RootVNode("<div v-bind=\"obj\" :class=\"c\"></div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.FullProps);
+    }
+
+    // ---- NEED_HYDRATION (1 << 5) ----
+
+    [Fact]
+    public void NonClickEventListener_FlagsNeedHydration()
+    {
+        // transformElement.ts: a non-click, non-reserved event binding needs its listener attached during
+        // hydration even when nothing else changes. The handler name is also a dynamic prop (no cacheHandlers),
+        // so the flag is PROPS | NEED_HYDRATION = 8 | 32 = 40.
+        var codegen = RootVNode("<div @foo=\"bar\"></div>");
+
+        codegen.ShouldHavePatchFlag(PatchFlags.NeedHydration);
+        codegen.ShouldHavePatchFlag(PatchFlags.Props);
+        ((int)codegen.PatchFlag!.Value).ShouldBe((int)(PatchFlags.Props | PatchFlags.NeedHydration));
+        ((int)codegen.PatchFlag!.Value).ShouldBe(40);
+        codegen.DynamicProps.ShouldBe("[\"onFoo\"]");
+    }
+
+    [Fact]
+    public void ClickEventListener_OmitsNeedHydration()
+    {
+        // onClick is deliberately excluded from NEED_HYDRATION: hydration gives click a dedicated fast path.
+        var codegen = RootVNode("<button @click=\"onClick\"></button>");
+
+        (codegen.PatchFlag!.Value & PatchFlags.NeedHydration).ShouldBe((PatchFlags)0);
+        codegen.PatchFlag.ShouldBe(PatchFlags.Props);
+        codegen.DynamicProps.ShouldBe("[\"onClick\"]");
+    }
+
+    // ---- NEED_PATCH (1 << 9) ----
+
+    [Fact]
+    public void TemplateReferenceOnly_FlagsNeedPatch()
+    {
+        // A ref with no dynamic props still needs runtime work (assigning the ref), so NEED_PATCH is emitted.
+        var codegen = RootVNode("<div ref=\"root\"></div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.NeedPatch);
+        ((int)codegen.PatchFlag!.Value).ShouldBe(512);
+    }
+
+    [Fact]
+    public void RuntimeCustomDirectiveOnly_FlagsNeedPatchAndResolvesDirective()
+    {
+        // A user directive with no other dynamic bindings => NEED_PATCH, plus a resolveDirective registration.
+        var result = TransformTestHelpers.Transform("<div v-custom=\"x\"></div>");
+        var codegen = result.RootCodegen().ShouldBeOfType<VNodeCall>();
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.NeedPatch);
+        result.ShouldUseHelper("resolveDirective");
+        result.ShouldUseHelper("withDirectives");
+        result.Directives.ShouldContain("custom");
+    }
+
+    [Fact]
+    public void NeedPatchIsSuppressed_WhenElementAlreadyHasDynamicProps()
+    {
+        // NEED_PATCH only fills the gap when patchFlag is otherwise 0 (or NEED_HYDRATION): a ref alongside a
+        // dynamic prop rides the PROPS diff instead of adding NEED_PATCH.
+        var codegen = RootVNode("<div ref=\"root\" :foo=\"a\"></div>");
+
+        codegen.PatchFlag.ShouldBe(PatchFlags.Props);
+        (codegen.PatchFlag!.Value & PatchFlags.NeedPatch).ShouldBe((PatchFlags)0);
+    }
+
+    // ---- component class/style as dynamic props ----
+
+    [Fact]
+    public void Component_TreatsDynamicClassAndStyleAsRegularProps()
+    {
+        // For a component, class/style are ordinary props (not element attributes), so they escalate PROPS and
+        // land in dynamicProps rather than setting the CLASS/STYLE bits.
+        var codegen = RootVNode("<Comp :class=\"c\" :style=\"s\" :foo=\"f\"></Comp>");
+
+        codegen.IsComponent.ShouldBeTrue();
+        codegen.PatchFlag.ShouldBe(PatchFlags.Props);
+        (codegen.PatchFlag!.Value & PatchFlags.Class).ShouldBe((PatchFlags)0);
+        (codegen.PatchFlag!.Value & PatchFlags.Style).ShouldBe((PatchFlags)0);
+        codegen.DynamicProps.ShouldBe("[\"class\", \"style\", \"foo\"]");
+    }
+
+    // ---- DYNAMIC_SLOTS (1 << 10) ----
+
+    [Fact]
+    public void DynamicSlotName_FlagsDynamicSlots()
+    {
+        // buildSlots: a non-static slot name forces the component's slots dynamic (DYNAMIC_SLOTS).
+        var codegen = RootVNode("<Comp><template #[name]>x</template></Comp>");
+
+        codegen.ShouldHavePatchFlag(PatchFlags.DynamicSlots);
+    }
+
+    // ---- numeric parity centrepiece ----
+
+    // Each row is the exact patchFlag the vuejs/core v3.5 template-explorer stamps for the template (base
+    // compiler options: no prefixIdentifiers, no cacheHandlers). This is the compiler-side mirror of
+    // Assimalign.Vue.Shared.Tests.PatchFlagsParityTests — same numbers, produced by inference rather than by
+    // reading the enum, so a divergence in either the enum or the inference is caught.
+    [Theory]
+    [InlineData("<div>{{ x }}</div>", 1)]                    // TEXT
+    [InlineData("<div :class=\"c\"></div>", 2)]              // CLASS
+    [InlineData("<div :style=\"s\"></div>", 4)]              // STYLE
+    [InlineData("<div :foo=\"f\"></div>", 8)]                // PROPS
+    [InlineData("<div :[k]=\"v\"></div>", 16)]               // FULL_PROPS
+    [InlineData("<div @foo=\"bar\"></div>", 40)]             // PROPS | NEED_HYDRATION
+    [InlineData("<div ref=\"r\"></div>", 512)]               // NEED_PATCH
+    [InlineData("<div :class=\"c\">{{ x }}</div>", 3)]       // CLASS | TEXT
+    public void EmittedPatchFlag_IsBitIdenticalToUpstream(string template, int expected)
+    {
+        var codegen = RootVNode(template);
+
+        ((int)codegen.PatchFlag!.Value).ShouldBe(expected);
+    }
+
+    // ---- caching contract: equal input yields value-equal flags ----
+
+    [Fact]
+    public void PatchFlagInference_IsDeterministic()
+    {
+        // The incremental-generator caching contract: identical templates yield value-equal codegen (flags,
+        // dynamicProps, and all).
+        const string template = "<div :class=\"c\" :foo=\"a\" @bar=\"h\">{{ x }}</div>";
+
+        var first = RootVNode(template);
+        var second = RootVNode(template);
+
+        first.ShouldBe(second);
+        first.PatchFlag.ShouldBe(second.PatchFlag);
+        first.DynamicProps.ShouldBe(second.DynamicProps);
+    }
+}


### PR DESCRIPTION
## Summary

Audit outcome for [V01.01.05.06]: patch-flag inference and block-tree emission were **already a complete, faithful port** of Vue 3.5's `transformElement`/`vIf`/`vFor` semantics, landed with the transform pipeline ([V01.01.05.02]/[V01.01.05.03]) and carried intact through the structure refactor. What the item still owed — and what this PR delivers — is the test corpus that locks the contract down: 37 tests pinning the exact numeric `PatchFlags` and block shapes the Vue 3.5 template explorer emits for the same templates, plus doc-comment refreshes on the two types that still described this work as future.

**Stacked on PR #126** — base is `feature/V01.01.12.09-structure-refactor`; merge #126 first and this retargets to `main` automatically.

Initial implementation was delegated to Claude Opus 4.8; the subsequent adversarial review confirmed the corpus against upstream with no findings.

## Type of change

- [x] `test` — tests only
- [x] `docs` — documentation only (XML doc refreshes in `TransformElement`/`VNodeCall`)

## Changes

- `PatchFlagInferenceTests`: TEXT / CLASS / STYLE / PROPS with ordered `dynamicProps`, FULL_PROPS escalation (dynamic keys, `v-bind` object spread), NEED_HYDRATION (non-click listeners, `onClick` omitted), NEED_PATCH (`ref`/runtime-directive, suppressed when other dynamic props exist), component class/style as dynamic props, DYNAMIC_SLOTS, plus a numeric-parity theory bit-identical to `Assimalign.Vue.Shared`'s `PatchFlagsParityTests` — the compiler half of the shared-constants contract.
- `BlockTreeEmissionTests`: root element/component blocks, the svg block boundary, multi-root STABLE_FRAGMENT, per-branch v-if blocks with stable synthetic keys, v-for KEYED/UNKEYED/STABLE fragments with `DisableTracking`, and v-if/v-for interplay in both directions — the `openBlock`/`createElementBlock`/`createBlock` bookkeeping.
- Every test references its `vuejs/core` source (`transformElement`/`vBind`/`vOn`/`vFor`/`vIf` spec files) so a future divergence is caught, not enshrined.

## Verification

- `dotnet build Assimalign.Vuecs.slnx -warnaserror` — 0 warnings, 0 errors.
- Templates suite 233 → 270 green at this branch tip; full syntax cluster green.

## Work items resolved

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
