### PR TITLE
feat(compiler): static caching and stringification — the cacheStatic/stringifyStatic port

### DIFF
--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
@@ -182,6 +182,10 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             var transformOptions = TransformOptions.CreateDom();
             transformOptions.PrefixIdentifiers = true;
             transformOptions.BindingMetadata = bindingMetadata;
+            // Static caching and stringification ([V01.01.05.07]): fully static subtrees are cached and long
+            // static runs collapse to innerHTML string inserts, cutting per-node JS-interop round-trips on
+            // WASM. Deterministic and value-equatable, so the incremental-generator cache is preserved.
+            transformOptions.HoistStatic = true;
             // CacheHandlers stays off: the upstream cached member-expression wrapper `(...args) => ...`
             // has no C# spelling yet; handler caching is runtime-binding follow-up work. v-once caching
             // is independent of this switch and fully emitted.

--- a/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentGeneratorTests.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentGeneratorTests.cs
@@ -208,6 +208,41 @@ namespace Demo
             reason => reason == IncrementalStepRunReason.Cached);
     }
 
+    private const string StaticContentSource =
+        "@template {\n" +
+        "    <section><span>static</span></section>\n" +
+        "}\n";
+
+    [Fact]
+    public void StaticSubtree_CompilesToCachedRender_WithCacheSlot()
+    {
+        // [V01.01.05.07] end to end: a fully static nested subtree caches into a render cache slot, marked
+        // PatchFlags.Cached (-1), so the runtime diff skips it. The composition root enables HoistStatic.
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Static.viu", StaticContentSource, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Static.SingleFileComponent.g.cs");
+        generated.ShouldContain("internal const int RenderCacheSize = 1;");
+        generated.ShouldContain("(_cache[0] ??= _createElementVNode(\"span\", null, \"static\", -1 /* CACHED */))");
+    }
+
+    [Fact]
+    public void StaticCaching_DoesNotBreakIncrementalCache()
+    {
+        // The regression the work item guards: enabling static caching keeps the model step strictly Cached
+        // across identical runs (deterministic, value-equatable transform output).
+        var file = new InMemoryAdditionalText($"{ProjectDirectory}/Static.viu", StaticContentSource);
+        var compilation = GeneratorTestHarness.CreateCompilation();
+        var driver = GeneratorTestHarness.CreateDriver(
+            ImmutableArray.Create<AdditionalText>(file), RootNamespace, ProjectDirectory);
+
+        driver = driver.RunGenerators(compilation);
+        driver = driver.RunGenerators(compilation);
+
+        ModelStepReasons(driver).ShouldAllBe(
+            reason => reason == IncrementalStepRunReason.Cached);
+    }
+
     [Fact]
     public void UnrelatedCompilationEdit_DoesNotReRunGeneration()
     {

--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -205,3 +205,80 @@ is snapshot + Roslyn parse-validity tests.
   independent and fully emitted.
 - **v-slot destructuring and tuple v-for aliases** (`#item="{ label }"`, `(a, b) in pairs`) emit
   verbatim and are not valid C# lambda parameters; they are follow-up expression-binding work.
+
+## Static caching and stringification (`cacheStatic` / `stringifyStatic`)
+
+The C# port of Vue 3.5's static optimization ([V01.01.05.07], issue #54): `@vue/compiler-core`'s
+[`transforms/cacheStatic.ts`](https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-core/src/transforms/cacheStatic.ts)
+(the successor to `hoistStatic`) and `@vue/compiler-dom`'s
+[`transforms/stringifyStatic.ts`](https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-dom/src/transforms/stringifyStatic.ts).
+`StaticCache.Cache` runs from `Transformer.Transform` — after the traversal, before `CreateRootCodegen` —
+only when `TransformOptions.HoistStatic` is set (the composition-root generator sets it; the default
+pipeline stays unoptimized, which is the acceptance criteria's debugging opt-out). This matters more on
+WASM than upstream (PLAN.md founding decision #4): every vnode not created and every patch visit skipped is
+a `JSImport` marshaling round-trip avoided, so a stringified 20-node run replaces 20+ interop calls with one
+`insertStaticContent`.
+
+### The constant analysis (`getConstantType`)
+
+`ConstantAnalysis.GetConstantType(node, context)` is the full port of upstream `getConstantType`: an element
+is constant only when its generated props, every child, and every `v-bind` expression are constant, and it
+carries no patch flag and is not a block. `NOT_CONSTANT` from any of them poisons the ancestor, so refs
+(`NEED_PATCH`), runtime directives, dynamic keys (which force a block), and dynamic children/props are never
+static — exactly the eligibility the issue pins. Levels are memoized per element in
+`TransformContext.ConstantCache`. Because Vuecs keeps expression bodies opaque, an interpolation or dynamic
+`v-bind` value is never above `NOT_CONSTANT`; only static text, static attributes, and compiler-injected
+literal constants (`v-if` branch keys, `v-model` modifier objects) reach the higher levels. As upstream
+does, a fully static `svg`/`foreignObject`/`math` block is demoted back to a plain vnode as a side effect of
+the analysis. The context-free `GetConstantType(node)` overload (parser-stamped levels only) still backs the
+patch-flag pass, unchanged.
+
+### Caching and marking
+
+Each fully static (`>= CAN_CACHE`) subtree is marked `PatchFlags.Cached` (`-1`, the v3.5 `CACHED` spelling
+of the old `HOISTED`) so the runtime diff skips it, then wrapped in a render-cache slot via `context.Cache`
+(reusing the same `_cache[n]` seam and `??=` emission v-once already uses). An element whose subtree is
+dynamic but whose props are static gets its props cached the same way. **Clone-on-insert is the runtime's
+responsibility**: the compiler emits the `CACHED` marker and the `createStaticVNode` payload; the runtime's
+DOM adapter clones a cached/static vnode when inserting it into more than one tree (the runtime-area
+contract referenced by `createStaticVNode`/`insertStaticContent`).
+
+### Stringification (`stringifyStatic`)
+
+After the walk, `StaticStringifier.Run` scans a container's children for the largest contiguous run of
+cached, stringifiable siblings and — at or above the upstream thresholds — collapses it into a single
+`createStaticVNode(html, nodeCount)` whose serialized HTML the runtime applies via one `innerHTML`. The
+thresholds are pinned numerically to upstream `StringifyThresholds`:
+
+| Threshold | Value | Meaning |
+| --- | --- | --- |
+| `NODE_COUNT` | 20 | consecutive stringifiable nodes |
+| `ELEMENT_WITH_BINDING_COUNT` | 5 | consecutive elements carrying attribute bindings |
+
+Serialization reuses the compiler's existing HTML knowledge: `escapeHtml` (the `@vue/shared` port: `"`, `&`,
+`'`, `<`, `>`) so the string round-trips through `innerHTML` to the same DOM (WHATWG fragment serialization),
+`CompilerDomKnowledge.IsVoidTag` to omit end tags for void elements, and `IsKnownHtmlAttribute`/
+`IsKnownSvgAttribute` plus the `data-`/`aria-` rule for `isStringifiableAttr`. Table-section tags
+(`caption,thead,tr,th,tbody,td,tfoot,colgroup,col`) never stringify (innerHTML would reparent them).
+
+### JavaScript → C# / AOT divergences
+
+Each is deliberate, forced by the no-dynamic-codegen rule or the immutable-AST model, and pinned by
+`StaticCacheTests` (the *chosen* behavior, per the deviations rule).
+
+| Upstream behavior | Vuecs behavior | Why |
+| --- | --- | --- |
+| `context.cache` (vnode subtrees, per-instance `_cache`) **and** `context.hoist` (props objects, per-type module `_hoisted_N` consts) | both route through the per-instance `_cache` seam | the C# generator model owns the render method and has no module-const scope without a new emitter↔generator field contract; each value is still created once per instance and reused across all re-renders — the interop-reduction goal. `context.Hoist`/`result.Hoists` stay reserved for a future per-type static-field seam. |
+| constant interpolations / constant `v-bind` values evaluated with `new Function` | not evaluated; `AnalyzeNode` bails on any non-text/comment/element content and on any binding | dynamic code generation is forbidden (AOT). In the opaque-expression model no interpolation or `v-bind` is ever constant, so a stringifiable cached subtree only ever holds static text, comments, and static attributes — the eval branches are unreachable. |
+| whole-children-array cache (`cachedAsArray`) and `TEXT_CALL` caching | omitted; each eligible static sibling caches individually | a fully static text run is a single `TextNode` folded into its element's cached subtree, so `TEXT_CALL` caching is unreachable; skipping `cachedAsArray` avoids reconstructing frozen immutable children arrays and means only upstream's non-`isParentCached` stringify path is needed. |
+| `stringifyStatic` runs on every container (element, root, `v-for`/`v-if` bodies) | runs on a template root's children and a plain element's children | those are the two containers with clean immutable write-back; static descendants inside `v-if`/`v-for` bodies are still cached, just not stringified (a per-iteration run rarely reaches 20 nodes anyway). |
+| after merging, `context.cached` is spliced and trailing cache indices decremented | merged nodes' cache slots stay reserved-but-unused | `CacheExpression.Index` is immutable; leaving the slots reserved keeps the record immutable and the output deterministic, at the cost of a marginally larger `_cache`. |
+| `isKnownMathMLAttr` | MathML attributes are never stringifiable | the Vuecs shared DOM knowledge has no MathML known-attribute table; MathML static content still caches, it just does not fold into an innerHTML string. |
+
+### Non-goals ([V01.01.05.07])
+
+- Per-component-type static fields (the pre-3.5 `_hoisted_N` module consts). All static optimization routes
+  through per-instance `_cache`; a static-field emission seam through the generator is deferred.
+- Stringification of `v-for`/`v-if` body runs, and of runs interleaved with `TextCall` text (see above).
+- Constant-expression evaluation for stringifying constant interpolations / `:bind="1"` (needs an evaluator
+  Vuecs deliberately does not have).

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerDomKnowledge.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerDomKnowledge.cs
@@ -19,6 +19,8 @@ internal static class CompilerDomKnowledge
     private static readonly HashSet<string> SvgTagSet = Build(DomKnowledgeData.SvgTags, StringComparer.Ordinal);
     private static readonly HashSet<string> MathTagSet = Build(DomKnowledgeData.MathTags, StringComparer.Ordinal);
     private static readonly HashSet<string> VoidTagSet = Build(DomKnowledgeData.VoidTags, StringComparer.OrdinalIgnoreCase);
+    private static readonly HashSet<string> KnownHtmlAttributeSet = Build(DomKnowledgeData.KnownHtmlAttributes, StringComparer.Ordinal);
+    private static readonly HashSet<string> KnownSvgAttributeSet = Build(DomKnowledgeData.KnownSvgAttributes, StringComparer.Ordinal);
 
     /// <summary>Whether <paramref name="tag"/> is a known HTML element (upstream <c>isHTMLTag</c>).</summary>
     /// <param name="tag">The tag name (matched case-insensitively).</param>
@@ -39,6 +41,14 @@ internal static class CompilerDomKnowledge
     /// <summary>Whether <paramref name="tag"/> is a native HTML/SVG/MathML element (upstream <c>isNativeTag</c>).</summary>
     /// <param name="tag">The tag name.</param>
     public static bool IsNativeTag(string tag) => IsHtmlTag(tag) || IsSvgTag(tag) || IsMathMLTag(tag);
+
+    /// <summary>Whether <paramref name="attributeName"/> is a known HTML attribute (upstream <c>isKnownHtmlAttr</c>).</summary>
+    /// <param name="attributeName">The attribute name (matched case-sensitively, as upstream).</param>
+    public static bool IsKnownHtmlAttribute(string attributeName) => KnownHtmlAttributeSet.Contains(attributeName);
+
+    /// <summary>Whether <paramref name="attributeName"/> is a known SVG attribute (upstream <c>isKnownSvgAttr</c>).</summary>
+    /// <param name="attributeName">The attribute name (matched case-sensitively, as upstream).</param>
+    public static bool IsKnownSvgAttribute(string attributeName) => KnownSvgAttributeSet.Contains(attributeName);
 
     private static HashSet<string> Build(string list, StringComparer comparer)
     {

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ConstantAnalysis.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ConstantAnalysis.cs
@@ -1,20 +1,37 @@
 namespace Assimalign.Vue.Syntax.Templates;
 
 /// <summary>
-/// The reduced constant-type analysis the transform pipeline needs — an opaque-expression subset of Vue
-/// 3.5's <c>getConstantType</c> (<c>@vue/compiler-core</c> <c>transforms/cacheStatic.ts</c>).
+/// The constant-type analysis that drives static caching and stringification — the C# port of Vue 3.5's
+/// <c>getConstantType</c> family (<c>@vue/compiler-core</c>
+/// <see href="https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-core/src/transforms/cacheStatic.ts">transforms/cacheStatic.ts</see>).
 /// </summary>
 /// <remarks>
-/// Because this stage keeps expression bodies opaque (upstream's non-<c>prefixIdentifiers</c> mode), the
-/// analysis reads the <see cref="ConstantType"/> the parser stamped on each <see cref="SimpleExpressionNode"/>
-/// rather than walking a JavaScript AST. The full element-subtree constant analysis that drives static
-/// hoisting is deferred to [V01.01.05.07]; element nodes therefore report
-/// <see cref="ConstantType.NotConstant"/> here. Only the expression/text cases matter for the patch-flag and
-/// text-vnode decisions made in [V01.01.05.02]/[V01.01.05.03].
+/// <para>
+/// Two overloads exist. The context-free <see cref="GetConstantType(TemplateSyntaxNode)"/> reads the
+/// <see cref="ConstantType"/> the parser stamped on each <see cref="SimpleExpressionNode"/> and is what the
+/// patch-flag inference in <see cref="TransformElement"/> uses; it treats element/container nodes as
+/// <see cref="ConstantType.NotConstant"/> because it cannot see their code-generation nodes. The
+/// context-aware <see cref="GetConstantType(TemplateSyntaxNode, TransformContext)"/> is the full subtree
+/// analysis the static-caching walk ([V01.01.05.07]) uses: it resolves an element's
+/// <see cref="VNodeCall"/> through the transform side table, propagates <see cref="ConstantType.NotConstant"/>
+/// from any non-constant child, prop, or <c>v-bind</c> expression, memoizes each element's level in
+/// <see cref="TransformContext.ConstantCache"/>, and — matching upstream — demotes a fully static
+/// <c>svg</c>/<c>foreignObject</c>/<c>math</c> block back to a plain vnode as a side effect.
+/// </para>
+/// <para>
+/// Because Vuecs keeps expression bodies opaque (upstream's non-<c>prefixIdentifiers</c> mode), an
+/// interpolation or a dynamic <c>v-bind</c> value is never classified above
+/// <see cref="ConstantType.NotConstant"/>; only static text, static attributes, and compiler-injected
+/// literal constants (<c>v-if</c> branch keys, <c>v-model</c> modifier objects) reach the higher levels.
+/// </para>
 /// </remarks>
 internal static class ConstantAnalysis
 {
-    /// <summary>Returns the static-ness level of <paramref name="node"/> (upstream <c>getConstantType</c>, reduced).</summary>
+    /// <summary>
+    /// Returns the static-ness level of <paramref name="node"/> without a transform context (upstream
+    /// <c>getConstantType</c> reduced to the cases the patch-flag pass needs). Element and container nodes
+    /// report <see cref="ConstantType.NotConstant"/>; use the context-aware overload for subtree analysis.
+    /// </summary>
     /// <param name="node">The node to analyze.</param>
     public static ConstantType GetConstantType(TemplateSyntaxNode node)
     {
@@ -54,8 +71,231 @@ internal static class ConstantAnalysis
 
                 return result;
             default:
-                // Element / container constant analysis (for static hoisting) is [V01.01.05.07]'s job.
+                // Element / container constant analysis needs the code-generation side table — see the
+                // context-aware overload below.
                 return ConstantType.NotConstant;
         }
     }
+
+    /// <summary>
+    /// Returns the static-ness level of <paramref name="node"/>, resolving elements' code-generation nodes
+    /// through <paramref name="context"/> — the full port of upstream <c>getConstantType</c>. Memoized in
+    /// <see cref="TransformContext.ConstantCache"/>.
+    /// </summary>
+    /// <param name="node">The node to analyze.</param>
+    /// <param name="context">The transform context (side table, constant cache, helper registration).</param>
+    public static ConstantType GetConstantType(TemplateSyntaxNode node, TransformContext context)
+    {
+        switch (node)
+        {
+            case ElementNode element:
+                return GetElementConstantType(element, context);
+            case CommentNode:
+                return ConstantType.CanStringify;
+            case IfNode or WorkingIf or ForNode or WorkingFor or IfBranchNode or WorkingIfBranch:
+                return ConstantType.NotConstant;
+            case CacheExpression:
+                return ConstantType.CanCache;
+            default:
+                // Simple expression, text, interpolation, text call, compound: these never contain an
+                // element, so the context-free overload is exact.
+                return GetConstantType(node);
+        }
+    }
+
+    private static ConstantType GetElementConstantType(ElementNode element, TransformContext context)
+    {
+        if (element.ElementType != ElementType.Element)
+        {
+            return ConstantType.NotConstant;
+        }
+
+        if (context.ConstantCache.TryGetValue(element, out var cached))
+        {
+            return cached;
+        }
+
+        if (context.GetCodegenNode(element) is not VNodeCall codegenNode)
+        {
+            return ConstantType.NotConstant;
+        }
+
+        // A block (a v-for fragment, a component-conditioned block, etc.) is never constant, except the
+        // svg/foreignObject/math elements the DOM transform makes blocks for namespace tracking — those are
+        // demoted below when they turn out static.
+        if (codegenNode.IsBlock &&
+            element.Tag != "svg" && element.Tag != "foreignObject" && element.Tag != "math")
+        {
+            return ConstantType.NotConstant;
+        }
+
+        if (codegenNode.PatchFlag is not null)
+        {
+            // The element has a patch flag, so it is not constant.
+            context.ConstantCache[element] = ConstantType.NotConstant;
+            return ConstantType.NotConstant;
+        }
+
+        var returnType = ConstantType.CanStringify;
+
+        // 1. Even with no patch flag the generated props can carry non-hoistable expressions (compiler
+        // injected keys, cached handlers), so always check them.
+        var generatedPropsType = GetGeneratedPropsConstantType(element, context);
+        if (generatedPropsType == ConstantType.NotConstant)
+        {
+            context.ConstantCache[element] = ConstantType.NotConstant;
+            return ConstantType.NotConstant;
+        }
+
+        if (generatedPropsType < returnType)
+        {
+            returnType = generatedPropsType;
+        }
+
+        // 2. Its children.
+        foreach (var child in element.Children)
+        {
+            var childType = GetConstantType(child, context);
+            if (childType == ConstantType.NotConstant)
+            {
+                context.ConstantCache[element] = ConstantType.NotConstant;
+                return ConstantType.NotConstant;
+            }
+
+            if (childType < returnType)
+            {
+                returnType = childType;
+            }
+        }
+
+        // 3. Above CAN_SKIP_PATCH, check whether any v-bind expression lowers the type.
+        if (returnType > ConstantType.CanSkipPatch)
+        {
+            foreach (var property in element.Properties)
+            {
+                if (property is DirectiveNode { Name: "bind" } directive && directive.Expression is not null)
+                {
+                    var expressionType = GetConstantType(directive.Expression, context);
+                    if (expressionType == ConstantType.NotConstant)
+                    {
+                        context.ConstantCache[element] = ConstantType.NotConstant;
+                        return ConstantType.NotConstant;
+                    }
+
+                    if (expressionType < returnType)
+                    {
+                        returnType = expressionType;
+                    }
+                }
+            }
+        }
+
+        // Only svg/foreignObject/math reach here as blocks; a static one needs no block because there are no
+        // nested updates, so demote it — but bail if it carries a custom directive.
+        if (codegenNode.IsBlock)
+        {
+            foreach (var property in element.Properties)
+            {
+                if (property is DirectiveNode)
+                {
+                    context.ConstantCache[element] = ConstantType.NotConstant;
+                    return ConstantType.NotConstant;
+                }
+            }
+
+            context.RemoveHelper(HelperNames.OpenBlock);
+            context.RemoveHelper(TransformContext.GetVNodeBlockHelper(context.InSSR, codegenNode.IsComponent));
+            context.SetCodegenNode(element, codegenNode with { IsBlock = false });
+            context.Helper(TransformContext.GetVNodeHelper(context.InSSR, codegenNode.IsComponent));
+        }
+
+        context.ConstantCache[element] = returnType;
+        return returnType;
+    }
+
+    /// <summary>
+    /// The constant-type of an element's generated props object (upstream <c>getGeneratedPropsConstantType</c>):
+    /// every key and value must be constant, and helper-wrapped values (<c>normalizeClass</c>, …) are
+    /// unwrapped to their argument's constant-type.
+    /// </summary>
+    /// <param name="element">The element whose <see cref="VNodeCall.Props"/> is analyzed.</param>
+    /// <param name="context">The transform context.</param>
+    public static ConstantType GetGeneratedPropsConstantType(ElementNode element, TransformContext context)
+    {
+        var returnType = ConstantType.CanStringify;
+        if (context.GetCodegenNode(element) is not VNodeCall { Props: ObjectExpression properties })
+        {
+            return returnType;
+        }
+
+        foreach (var property in properties.Properties)
+        {
+            var keyType = GetConstantType(property.Key, context);
+            if (keyType == ConstantType.NotConstant)
+            {
+                return ConstantType.NotConstant;
+            }
+
+            if (keyType < returnType)
+            {
+                returnType = keyType;
+            }
+
+            ConstantType valueType;
+            if (property.Value is SimpleExpressionNode)
+            {
+                valueType = GetConstantType(property.Value, context);
+            }
+            else if (property.Value is CallExpression call)
+            {
+                // Some helper calls can be hoisted (e.g. the compiler-generated normalizeProps for a
+                // pre-normalized class); respect the constant-type of the helper's argument.
+                valueType = GetConstantTypeOfHelperCall(call, context);
+            }
+            else
+            {
+                valueType = ConstantType.NotConstant;
+            }
+
+            if (valueType == ConstantType.NotConstant)
+            {
+                return ConstantType.NotConstant;
+            }
+
+            if (valueType < returnType)
+            {
+                returnType = valueType;
+            }
+        }
+
+        return returnType;
+    }
+
+    private static ConstantType GetConstantTypeOfHelperCall(CallExpression call, TransformContext context)
+    {
+        if (call.Callee is RuntimeHelper helper && IsHoistableHelper(helper) && call.Arguments.Count > 0)
+        {
+            var argument = call.Arguments[0];
+            if (argument is SimpleExpressionNode simple)
+            {
+                return GetConstantType(simple, context);
+            }
+
+            if (argument is CallExpression nested)
+            {
+                // Nested helper call, e.g. normalizeProps(guardReactiveProps(exp)).
+                return GetConstantTypeOfHelperCall(nested, context);
+            }
+        }
+
+        return ConstantType.NotConstant;
+    }
+
+    // Upstream allowHoistedHelperSet: the pure prop-normalization helpers whose result is constant when
+    // their argument is (@vue/compiler-core cacheStatic.ts).
+    private static bool IsHoistableHelper(RuntimeHelper helper)
+        => helper == HelperNames.NormalizeClass ||
+           helper == HelperNames.NormalizeStyle ||
+           helper == HelperNames.NormalizeProps ||
+           helper == HelperNames.GuardReactiveProps;
 }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/StaticCache.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/StaticCache.cs
@@ -1,0 +1,183 @@
+using System.Collections.Generic;
+
+using Assimalign.Vue.Shared;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The static-caching pass — the C# port of Vue 3.5's <c>cacheStatic</c> (<c>@vue/compiler-core</c>
+/// <see href="https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-core/src/transforms/cacheStatic.ts">transforms/cacheStatic.ts</see>,
+/// the successor to <c>hoistStatic</c>). It runs once after the transform traversal and before the root
+/// code-generation node is built: it walks the tree, and every fully static subtree at or above
+/// <see cref="ConstantType.CanCache"/> is marked <see cref="PatchFlags.Cached"/> (so the runtime diff skips
+/// it) and wrapped in a render-cache slot (created once per instance, reused across re-renders); an element
+/// whose children are dynamic but whose props are static gets its props cached the same way. On WASM each
+/// avoided vnode creation and patch visit is a JS-interop round-trip saved, which is why this is a primary
+/// optimization here. The DOM stringification pass (<see cref="StaticStringifier"/>) then runs over the same
+/// children.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberate divergences from upstream, pinned by tests (see <c>docs/DESIGN.md</c>):
+/// </para>
+/// <list type="bullet">
+/// <item>Upstream splits static optimization between <c>context.cache</c> (vnode subtrees, per-instance
+/// <c>_cache</c>) and <c>context.hoist</c> (props objects, per-type module consts). Vuecs routes both through
+/// the per-instance <c>_cache</c> seam the emitter already implements, because the C# generator model has no
+/// module-const scope without a new field-emission contract; each value is still created once per instance
+/// and reused across re-renders.</item>
+/// <item>The whole-children-array cache (upstream <c>cachedAsArray</c>) and <c>TEXT_CALL</c> caching are
+/// omitted; each eligible static sibling is cached individually. A fully static text run is a single
+/// <see cref="TextNode"/> folded into its element's cached subtree, so the <c>TEXT_CALL</c> path is
+/// unreachable in practice.</item>
+/// </list>
+/// </remarks>
+internal static class StaticCache
+{
+    /// <summary>Runs the static-caching walk over <paramref name="root"/> (upstream <c>cacheStatic</c>).</summary>
+    /// <param name="root">The transformed template root.</param>
+    /// <param name="context">The transform context.</param>
+    public static void Cache(RootNode root, TransformContext context)
+    {
+        // The root itself is never cached: a single root element may receive parent fallthrough attributes,
+        // so upstream passes doNotHoistNode for it (isSingleElementRoot).
+        Walk(root, context, IsSingleElementRoot(root, context));
+    }
+
+    private static bool IsSingleElementRoot(RootNode root, TransformContext context)
+    {
+        var children = context.WorkingChildrenOf(root, root.Children);
+        return children.Count == 1 &&
+               children[0] is ElementNode { ElementType: not ElementType.Slot };
+    }
+
+    private static void Walk(TemplateSyntaxNode node, TransformContext context, bool doNotHoistNode)
+    {
+        var children = ChildrenOf(node, context);
+        if (children is null)
+        {
+            return;
+        }
+
+        var toCache = new List<ElementNode>();
+        foreach (var child in children)
+        {
+            // Only plain elements are eligible for caching (upstream also caches text calls; see the type
+            // remarks for why that path is unreachable in Vuecs).
+            if (child is ElementNode { ElementType: ElementType.Element } element)
+            {
+                var constantType = doNotHoistNode
+                    ? ConstantType.NotConstant
+                    : ConstantAnalysis.GetConstantType(element, context);
+                if (constantType > ConstantType.NotConstant)
+                {
+                    if (constantType >= ConstantType.CanCache)
+                    {
+                        if (context.GetCodegenNode(element) is VNodeCall codegenNode)
+                        {
+                            context.SetCodegenNode(element, codegenNode with { PatchFlag = PatchFlags.Cached });
+                        }
+
+                        toCache.Add(element);
+                        continue;
+                    }
+                }
+                else
+                {
+                    // The element may have dynamic children, but its props can still be eligible for caching.
+                    if (context.GetCodegenNode(element) is VNodeCall { Props: { } props } codegenNode)
+                    {
+                        var flag = codegenNode.PatchFlag;
+                        if ((flag is null or PatchFlags.NeedPatch or PatchFlags.Text) &&
+                            ConstantAnalysis.GetGeneratedPropsConstantType(element, context) >= ConstantType.CanCache)
+                        {
+                            context.SetCodegenNode(element, codegenNode with { Props = context.Cache(props) });
+                        }
+                    }
+                }
+            }
+
+            // Walk further (caching descendants inside components/loops/conditionals via the side table).
+            switch (child)
+            {
+                case ElementNode descendant:
+                    var isComponent = descendant.ElementType == ElementType.Component;
+                    if (isComponent)
+                    {
+                        context.ScopeVSlot++;
+                    }
+
+                    Walk(descendant, context, doNotHoistNode: false);
+                    if (isComponent)
+                    {
+                        context.ScopeVSlot--;
+                    }
+
+                    break;
+                case WorkingFor workingFor:
+                    // A single v-for child stays a block, so do not hoist it.
+                    Walk(workingFor, context, doNotHoistNode: workingFor.Children.Count == 1);
+                    break;
+                case ForNode forNode:
+                    Walk(forNode, context, doNotHoistNode: forNode.Children.Count == 1);
+                    break;
+                case WorkingIf workingIf:
+                    foreach (var branch in workingIf.Branches)
+                    {
+                        Walk(branch, context, doNotHoistNode: branch.Children.Count == 1);
+                    }
+
+                    break;
+                case IfNode ifNode:
+                    foreach (var branch in ifNode.Branches)
+                    {
+                        Walk(branch, context, doNotHoistNode: branch.Children.Count == 1);
+                    }
+
+                    break;
+            }
+        }
+
+        // Cache each eligible static subtree into its own render-cache slot: child.codegenNode = cache(...).
+        foreach (var element in toCache)
+        {
+            if (context.GetCodegenNode(element) is { } codegenNode)
+            {
+                context.SetCodegenNode(element, context.Cache(codegenNode));
+            }
+        }
+
+        // The DOM stringification hook (upstream context.transformHoist), gated to non-SSR: contiguous
+        // stringifiable cached runs above the thresholds collapse into a single static vnode.
+        if (toCache.Count > 0 && !context.Ssr && !context.InSSR)
+        {
+            StaticStringifier.Run(node, context);
+        }
+    }
+
+    // The list of children to walk. Root/element/working-for/working-if-branch expose their mutable working
+    // children (shared with code generation through the side table / CreateRootCodegen); the frozen forms are
+    // materialized read-only for caching-only recursion.
+    private static IReadOnlyList<TemplateSyntaxNode>? ChildrenOf(TemplateSyntaxNode node, TransformContext context)
+        => node switch
+        {
+            RootNode root => context.WorkingChildrenOf(root, root.Children),
+            ElementNode element => context.WorkingChildrenOf(element, element.Children),
+            WorkingFor workingFor => workingFor.Children,
+            WorkingIfBranch workingIfBranch => workingIfBranch.Children,
+            ForNode forNode => Materialize(forNode.Children),
+            IfBranchNode ifBranch => Materialize(ifBranch.Children),
+            _ => null,
+        };
+
+    private static List<TemplateSyntaxNode> Materialize(SyntaxList<TemplateChildNode> children)
+    {
+        var list = new List<TemplateSyntaxNode>(children.Count);
+        foreach (var child in children)
+        {
+            list.Add(child);
+        }
+
+        return list;
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/StaticStringifier.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/StaticStringifier.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The DOM static-stringification pass — the C# port of Vue 3.5's <c>stringifyStatic</c>
+/// (<c>@vue/compiler-dom</c>
+/// <see href="https://github.com/vuejs/core/blob/v3.5.13/packages/compiler-dom/src/transforms/stringifyStatic.ts">transforms/stringifyStatic.ts</see>,
+/// upstream's <c>HoistTransform</c>). It runs at the end of the static-caching walk over a node's children:
+/// contiguous runs of cached, stringifiable static siblings that reach the upstream thresholds
+/// (<see cref="NodeCountThreshold"/> nodes, or <see cref="ElementWithBindingCountThreshold"/> elements with
+/// attribute bindings) collapse into a single <c>createStaticVNode(html, nodeCount)</c> call carrying the
+/// serialized HTML, which the runtime inserts via one <c>innerHTML</c> assignment instead of creating each
+/// vnode across the JS-interop boundary. This is the founding-decision-#4 interop reducer: every avoided
+/// node is a marshaling round-trip saved on WASM.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberate divergences from upstream, all AOT- and immutability-driven and pinned by tests
+/// (see <c>docs/DESIGN.md</c>):
+/// </para>
+/// <list type="bullet">
+/// <item>No constant-expression evaluation. Upstream evaluates constant interpolations and constant
+/// <c>v-bind</c> values with <c>new Function</c>; that is forbidden by the no-dynamic-codegen rule, and in
+/// Vuecs's opaque-expression model no interpolation or dynamic binding is ever classified constant, so a
+/// stringifiable cached subtree only ever contains static text, comments, and static attributes.
+/// <see cref="AnalyzeNode"/> bails on anything else.</item>
+/// <item>Only runs on a template root's children and a plain element's children (the two containers with
+/// clean immutable write-back). Static descendants inside <c>v-if</c>/<c>v-for</c> bodies are still cached,
+/// just not stringified.</item>
+/// <item>Merged cache slots stay reserved-but-unused rather than being compacted (upstream splices
+/// <c>context.cached</c> and re-indexes), which keeps <see cref="CacheExpression"/> immutable.</item>
+/// </list>
+/// </remarks>
+internal static class StaticStringifier
+{
+    // upstream StringifyThresholds (@vue/compiler-dom stringifyStatic.ts):
+    //   NODE_COUNT = 20, ELEMENT_WITH_BINDING_COUNT = 5.
+    private const int NodeCountThreshold = 20;
+    private const int ElementWithBindingCountThreshold = 5;
+
+    // upstream isNonStringifiable makeMap: table-section tags that innerHTML would reparent, so they are
+    // never stringified.
+    private static readonly HashSet<string> NonStringifiableTags = new(StringComparer.Ordinal)
+    {
+        "caption", "thead", "tr", "th", "tbody", "td", "tfoot", "colgroup", "col",
+    };
+
+    /// <summary>
+    /// Stringifies eligible contiguous cached-static runs among <paramref name="node"/>'s children (the
+    /// upstream <c>transformHoist</c> invocation at the tail of <c>walk</c>). Bails for slot content, and
+    /// only rewrites a <see cref="RootNode"/>'s working children or a plain element's
+    /// <see cref="VNodeCall"/> children.
+    /// </summary>
+    /// <param name="node">The container whose children were just cached.</param>
+    /// <param name="context">The transform context.</param>
+    public static void Run(TemplateSyntaxNode node, TransformContext context)
+    {
+        // Bail stringification for slot content (upstream: if (context.scopes.vSlot > 0) return).
+        if (context.ScopeVSlot > 0)
+        {
+            return;
+        }
+
+        if (node is RootNode root)
+        {
+            // The root's working children are the same list CreateRootCodegen freezes afterwards, so an
+            // in-place edit is reflected.
+            StringifyChildren(context.WorkingChildrenOf(root, root.Children), context);
+        }
+        else if (node is ElementNode element &&
+                 context.GetCodegenNode(element) is VNodeCall { Children: SyntaxList<TemplateChildNode> frozenChildren } vnode)
+        {
+            var children = new List<TemplateSyntaxNode>(frozenChildren.Count);
+            foreach (var child in frozenChildren)
+            {
+                children.Add(child);
+            }
+
+            var originalCount = children.Count;
+            StringifyChildren(children, context);
+            if (children.Count != originalCount)
+            {
+                var updated = new TemplateChildNode[children.Count];
+                for (var index = 0; index < children.Count; index++)
+                {
+                    updated[index] = (TemplateChildNode)children[index];
+                }
+
+                context.SetCodegenNode(element, vnode with { Children = new SyntaxList<TemplateChildNode>(updated) });
+            }
+        }
+    }
+
+    // Port of the stringifyStatic body: scan for the largest contiguous chunk of stringifiable cached
+    // siblings, and collapse it once the thresholds are met.
+    private static void StringifyChildren(List<TemplateSyntaxNode> children, TransformContext context)
+    {
+        var nodeCount = 0;
+        var elementWithBindingCount = 0;
+        var currentChunk = new List<ElementNode>();
+
+        var index = 0;
+        for (; index < children.Count; index++)
+        {
+            if (GetCachedElement(children[index], context) is { } element &&
+                AnalyzeNode(element) is { } analyzed)
+            {
+                nodeCount += analyzed.NodeCount;
+                elementWithBindingCount += analyzed.ElementWithBindingCount;
+                currentChunk.Add(element);
+                continue;
+            }
+
+            index -= StringifyCurrentChunk(children, index, nodeCount, elementWithBindingCount, currentChunk, context);
+            nodeCount = 0;
+            elementWithBindingCount = 0;
+            currentChunk.Clear();
+        }
+
+        StringifyCurrentChunk(children, index, nodeCount, elementWithBindingCount, currentChunk, context);
+    }
+
+    private static int StringifyCurrentChunk(
+        List<TemplateSyntaxNode> children,
+        int currentIndex,
+        int nodeCount,
+        int elementWithBindingCount,
+        List<ElementNode> currentChunk,
+        TransformContext context)
+    {
+        if (nodeCount < NodeCountThreshold && elementWithBindingCount < ElementWithBindingCountThreshold)
+        {
+            return 0;
+        }
+
+        var html = new StringBuilder();
+        foreach (var element in currentChunk)
+        {
+            StringifyNode(html, element, context);
+        }
+
+        // createStaticVNode(html, nodeCount): the html rides as a static simple expression so the emitter
+        // writes it as a C#-escaped string literal; the count rides as a raw integer literal string.
+        var staticCall = Ir.CallExpression(
+            context.Helper(HelperNames.CreateStatic),
+            new object[]
+            {
+                Ir.SimpleExpression(html.ToString(), isStatic: true),
+                currentChunk.Count.ToString(CultureInfo.InvariantCulture),
+            });
+
+        var deleteCount = currentChunk.Count - 1;
+
+        // Replace the first chunk node's cache value with the static call; the node stays in the list and its
+        // cache slot now yields the single static vnode.
+        if (context.GetCodegenNode(currentChunk[0]) is CacheExpression firstCache)
+        {
+            context.SetCodegenNode(currentChunk[0], firstCache with { Value = staticCall });
+        }
+
+        if (currentChunk.Count > 1)
+        {
+            // Remove the merged nodes (all but the first) from the children list.
+            children.RemoveRange(currentIndex - currentChunk.Count + 1, deleteCount);
+
+            // Upstream also compacts context.cached and re-indexes trailing cache expressions; Vuecs leaves
+            // the merged slots reserved-but-unused to keep CacheExpression immutable (see docs/DESIGN.md).
+        }
+
+        return deleteCount;
+    }
+
+    private static ElementNode? GetCachedElement(TemplateSyntaxNode node, TransformContext context)
+        => node is ElementNode { ElementType: ElementType.Element } element &&
+           context.GetCodegenNode(element) is CacheExpression
+            ? element
+            : null;
+
+    /// <summary>
+    /// Analyzes a cached element (upstream <c>analyzeNode</c>): returns the node count and the count of
+    /// elements carrying bindings inside it, or <see langword="null"/> when it is not stringifiable.
+    /// </summary>
+    private static (int NodeCount, int ElementWithBindingCount)? AnalyzeNode(ElementNode node)
+    {
+        if (NonStringifiableTags.Contains(node.Tag))
+        {
+            return null;
+        }
+
+        var nodeCount = 1;
+        var elementWithBindingCount = node.Properties.Count > 0 ? 1 : 0;
+        return WalkStringifiable(node, ref nodeCount, ref elementWithBindingCount)
+            ? (nodeCount, elementWithBindingCount)
+            : null;
+    }
+
+    private static bool WalkStringifiable(ElementNode node, ref int nodeCount, ref int elementWithBindingCount)
+    {
+        var isOptionTag = node.Tag == "option" && node.Namespace == ElementNamespace.Html;
+        foreach (var property in node.Properties)
+        {
+            // Bail on a non-stringifiable plain attribute.
+            if (property is AttributeNode attribute && !IsStringifiableAttribute(attribute.Name, node.Namespace))
+            {
+                return false;
+            }
+
+            if (property is DirectiveNode { Name: "bind" } directive)
+            {
+                // Bail on a dynamic/compound argument, or a static argument that is not a stringifiable attr.
+                if (directive.Argument is CompoundExpressionNode ||
+                    (directive.Argument is SimpleExpressionNode { IsStatic: true } argument &&
+                     !IsStringifiableAttribute(argument.Content, node.Namespace)))
+                {
+                    return false;
+                }
+
+                // Bail on a compound or non-stringifiable-constant expression. In Vuecs's opaque model an
+                // ordinary v-bind expression is never CAN_STRINGIFY, so every real binding bails here.
+                if (directive.Expression is CompoundExpressionNode ||
+                    (directive.Expression is SimpleExpressionNode expression &&
+                     expression.ConstantType < ConstantType.CanStringify))
+                {
+                    return false;
+                }
+
+                // <option :value="1"> cannot be safely stringified.
+                if (isOptionTag &&
+                    TransformUtilities.IsStaticArgumentOf(directive.Argument, "value") &&
+                    directive.Expression is SimpleExpressionNode { IsStatic: false })
+                {
+                    return false;
+                }
+            }
+        }
+
+        foreach (var child in node.Children)
+        {
+            nodeCount++;
+            if (child is ElementNode childElement)
+            {
+                if (childElement.Properties.Count > 0)
+                {
+                    elementWithBindingCount++;
+                }
+
+                if (!WalkStringifiable(childElement, ref nodeCount, ref elementWithBindingCount))
+                {
+                    return false;
+                }
+            }
+            else if (child is not (TextNode or CommentNode))
+            {
+                // Interpolations/compounds would need constant evaluation Vuecs does not do (AOT); such
+                // content never reaches a cached element, but bail defensively rather than drop it.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void StringifyNode(StringBuilder builder, TemplateSyntaxNode node, TransformContext context)
+    {
+        switch (node)
+        {
+            case ElementNode element:
+                StringifyElement(builder, element, context);
+                break;
+            case TextNode text:
+                EscapeHtml(builder, text.Content);
+                break;
+            case CommentNode comment:
+                builder.Append("<!--");
+                EscapeHtml(builder, comment.Content);
+                builder.Append("-->");
+                break;
+            default:
+                // Unreachable: AnalyzeNode bails on any child that is not an element/text/comment.
+                throw new InvalidOperationException(
+                    $"Cannot stringify a '{node.NodeType}' node without constant evaluation.");
+        }
+    }
+
+    private static void StringifyElement(StringBuilder builder, ElementNode node, TransformContext context)
+    {
+        builder.Append('<').Append(node.Tag);
+        foreach (var property in node.Properties)
+        {
+            if (property is AttributeNode attribute)
+            {
+                builder.Append(' ').Append(attribute.Name);
+                if (attribute.Value is not null)
+                {
+                    builder.Append("=\"");
+                    EscapeHtml(builder, attribute.Value.Content);
+                    builder.Append('"');
+                }
+            }
+
+            // A DirectiveNode is unreachable on a cached, stringifiable element: AnalyzeNode bails on any
+            // binding whose value is not a stringifiable constant, and Vuecs never classifies an opaque
+            // v-bind/v-html/v-text expression as constant (no constant evaluation). See docs/DESIGN.md.
+        }
+
+        if (context.ScopeId is not null)
+        {
+            builder.Append(' ').Append(context.ScopeId);
+        }
+
+        builder.Append('>');
+        foreach (var child in node.Children)
+        {
+            StringifyNode(builder, child, context);
+        }
+
+        if (!CompilerDomKnowledge.IsVoidTag(node.Tag))
+        {
+            builder.Append("</").Append(node.Tag).Append('>');
+        }
+    }
+
+    // Port of @vue/shared escapeHtml (packages/shared/src/escapeHtml.ts): escapes " & ' < > so the
+    // serialized string round-trips through innerHTML to the same DOM. Applied to text, comment, and
+    // attribute-value content, matching upstream's stringifyNode/stringifyElement.
+    private static void EscapeHtml(StringBuilder builder, string value)
+    {
+        foreach (var character in value)
+        {
+            switch (character)
+            {
+                case '"':
+                    builder.Append("&quot;");
+                    break;
+                case '&':
+                    builder.Append("&amp;");
+                    break;
+                case '\'':
+                    builder.Append("&#39;");
+                    break;
+                case '<':
+                    builder.Append("&lt;");
+                    break;
+                case '>':
+                    builder.Append("&gt;");
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+    }
+
+    // Port of isStringifiableAttr: a known attribute for the element's namespace, or a data-/aria- attribute.
+    // MathML has no known-attribute table in the Vuecs shared DOM knowledge, so it is conservatively
+    // non-stringifiable (the element still caches). See docs/DESIGN.md.
+    private static bool IsStringifiableAttribute(string name, ElementNamespace ns)
+    {
+        var known = ns switch
+        {
+            ElementNamespace.Html => CompilerDomKnowledge.IsKnownHtmlAttribute(name),
+            ElementNamespace.Svg => CompilerDomKnowledge.IsKnownSvgAttribute(name),
+            _ => false,
+        };
+
+        return known ||
+               name.StartsWith("data-", StringComparison.Ordinal) ||
+               name.StartsWith("aria-", StringComparison.Ordinal);
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
@@ -28,6 +28,7 @@ public sealed class TransformContext
     private readonly HashSet<TemplateSyntaxNode> seenMemo = new(ReferenceComparer.Instance);
     private readonly Dictionary<TemplateSyntaxNode, RuntimeHelper> directiveRuntime = new(ReferenceComparer.Instance);
     private readonly Dictionary<string, int> identifiers = new();
+    private readonly Dictionary<TemplateSyntaxNode, ConstantType> constantCache = new(ReferenceComparer.Instance);
 
     internal TransformContext(
         RootNode root,
@@ -416,6 +417,11 @@ public sealed class TransformContext
     internal HashSet<TemplateSyntaxNode> SeenOnce => seenOnce;
 
     internal HashSet<TemplateSyntaxNode> SeenMemo => seenMemo;
+
+    // The memoization table for the static-caching pass's element constant analysis (upstream
+    // context.constantCache, @vue/compiler-core transforms/cacheStatic.ts). Keyed by node reference so a
+    // subtree's constant type is computed once; [V01.01.05.07] populates it.
+    internal Dictionary<TemplateSyntaxNode, ConstantType> ConstantCache => constantCache;
 
     // The C# analogue of upstream's directiveImportMap: records the runtime helper a directive transform
     // requested, so the element transform can emit a helper reference instead of a resolveDirective call.

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/Transformer.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/Transformer.cs
@@ -30,7 +30,13 @@ public static class Transformer
         var context = new TransformContext(root, nodeTransforms, directiveTransforms, options);
 
         TransformTraversal.TraverseNode(root, context);
-        // The static-hoisting/caching pass ([V01.01.05.07]) would run here when options.HoistStatic is set.
+        if (options.HoistStatic)
+        {
+            // The static-caching/stringification pass ([V01.01.05.07]): cache fully static subtrees
+            // (marking them PatchFlags.Cached) and collapse contiguous static runs into stringified static
+            // vnodes, before the root code-generation node is built (upstream runs cacheStatic here).
+            StaticCache.Cache(root, context);
+        }
 
         var rootChildren = context.WorkingChildrenOf(root, root.Children);
         var codegenNode = CreateRootCodegen(context, rootChildren);

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/StaticCacheTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/StaticCacheTests.cs
@@ -1,0 +1,385 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis.CSharp;
+
+using Assimalign.Vue.Shared;
+
+using Shouldly;
+
+using Xunit;
+
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// Tests for the static-caching walk (<see cref="StaticCache"/>) and the DOM stringification pass
+/// (<see cref="StaticStringifier"/>) — [V01.01.05.07], the C# port of Vue 3.5's
+/// <c>@vue/compiler-core</c> <c>cacheStatic.ts</c> and <c>@vue/compiler-dom</c> <c>stringifyStatic.ts</c>.
+/// The corpus pins upstream eligibility (what caches vs what does not: dynamic keys, refs, runtime
+/// directives, component boundaries), the numeric stringification thresholds (20 nodes / 5 elements with
+/// bindings), WHATWG fragment-escaping of the serialized HTML, void-tag serialization, the opt-out flag,
+/// and the value-equatable/deterministic output the incremental generator relies on.
+/// </summary>
+public class StaticCacheTests
+{
+    // ---- eligibility: what caches ----
+
+    [Fact]
+    public void StaticSubtree_IsCachedAndMarkedCached()
+    {
+        // A fully static nested element is cached (created once, reused) and marked PatchFlags.Cached so the
+        // runtime diff skips it. The root element itself is never cached (parent fallthrough attributes).
+        var result = Transform("<div><span>static</span></div>");
+
+        var cachedSpan = ChildCodegen(result, 0).ShouldBeOfType<CacheExpression>();
+        var vnode = cachedSpan.Value.ShouldBeOfType<VNodeCall>();
+        vnode.PatchFlag.ShouldBe(PatchFlags.Cached);
+        result.Cached.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RootElement_ItselfIsNeverCached()
+    {
+        // isSingleElementRoot: the single root element may receive fallthrough attributes, so it stays a
+        // live block even when fully static.
+        var result = Transform("<div><span>static</span></div>");
+
+        result.CodegenNode.ShouldBeOfType<VNodeCall>().IsBlock.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StaticProps_OnDynamicChildElement_AreCached()
+    {
+        // The element has a dynamic child (TEXT flag) so its subtree is not cached, but its static props
+        // object is (upstream hoists it; Vuecs caches it — see docs/DESIGN.md). The root element's own props
+        // are eligible even though the root vnode is not.
+        var result = Transform("<div class=\"card\">{{ msg }}</div>", prefixIdentifiers: true);
+
+        var vnode = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        vnode.PatchFlag.ShouldBe(PatchFlags.Text);
+        vnode.Props.ShouldBeOfType<CacheExpression>();
+        result.Cached.Count.ShouldBe(1);
+    }
+
+    // ---- eligibility: what does NOT cache ----
+
+    [Fact]
+    public void DynamicKey_IsNeverTreatedAsStatic()
+    {
+        // A :key makes the element a block; a block (that is not svg/foreignObject/math) is never constant.
+        var result = Transform("<div><span :key=\"k\">x</span></div>", prefixIdentifiers: true);
+
+        ChildCodegen(result, 0).ShouldBeOfType<VNodeCall>().IsBlock.ShouldBeTrue();
+        result.Cached.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void TemplateReference_IsNeverTreatedAsStaticSubtree()
+    {
+        // A ref emits NEED_PATCH, so the subtree is not cached (the ref must run every mount).
+        var result = Transform("<div><span ref=\"r\">x</span></div>");
+
+        var codegen = ChildCodegen(result, 0);
+        codegen.ShouldBeOfType<VNodeCall>().PatchFlag.ShouldBe(PatchFlags.NeedPatch);
+    }
+
+    [Fact]
+    public void RuntimeDirective_IsNeverTreatedAsStaticSubtree()
+    {
+        // A custom directive forces runtime work (NEED_PATCH + withDirectives), so the subtree is not cached.
+        var result = Transform("<div><span v-custom=\"x\">y</span></div>", prefixIdentifiers: true);
+
+        ChildCodegen(result, 0).ShouldNotBeOfType<CacheExpression>();
+    }
+
+    [Fact]
+    public void ComponentBoundary_IsNotCachedAsElement()
+    {
+        // A component is not a plain element, so it is never cached as a static subtree.
+        var result = Transform("<div><Comp></Comp></div>");
+
+        ChildCodegen(result, 0).ShouldBeOfType<VNodeCall>().IsComponent.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DynamicChild_PreventsSubtreeCaching()
+    {
+        // An interpolation child poisons the parent's constant type, so the parent is not cached.
+        var result = Transform("<div><span>{{ dynamic }}</span></div>", prefixIdentifiers: true);
+
+        ChildCodegen(result, 0).ShouldBeOfType<VNodeCall>().PatchFlag.ShouldBe(PatchFlags.Text);
+        result.Cached.Count.ShouldBe(0);
+    }
+
+    // ---- the opt-out flag ----
+
+    [Fact]
+    public void HoistStaticOff_CachesNothing()
+    {
+        // The debugging opt-out: with HoistStatic off, the identical template produces no caches, and the
+        // vnode structure is otherwise identical (same span vnode, just uncached) — so optimized and
+        // unoptimized render the same tree.
+        var optimized = Emit("<div><span>static</span></div>", hoistStatic: true);
+        var unoptimized = Emit("<div><span>static</span></div>", hoistStatic: false);
+
+        optimized.Code.ShouldContain("_cache[0] ??=");
+        optimized.Code.ShouldContain("-1 /* CACHED */");
+        unoptimized.Code.ShouldNotContain("_cache");
+        unoptimized.Code.ShouldNotContain("CACHED");
+        unoptimized.CacheSlotCount.ShouldBe(0);
+    }
+
+    // ---- stringification thresholds (upstream 20 nodes / 5 elements-with-bindings) ----
+
+    [Fact]
+    public void ContiguousStaticRun_AtNodeThreshold_CollapsesToOneStaticVNode()
+    {
+        // 20 contiguous static nodes reach StringifyThresholds.NODE_COUNT and collapse into a single
+        // createStaticVNode carrying the serialized HTML, created once (per the run-count pin below).
+        var code = Emit(Wrapped("<div></div>", 20)).Code;
+
+        StaticVNodeCount(code).ShouldBe(1);
+        code.ShouldContain("_createStaticVNode(");
+        code.ShouldContain(", 20)");
+    }
+
+    [Fact]
+    public void JustBelowNodeThreshold_DoesNotStringify()
+    {
+        // 19 nodes stay below NODE_COUNT (and below ELEMENT_WITH_BINDING_COUNT), so no stringification —
+        // each element is still individually cached instead.
+        var result = TransformSource(Wrapped("<div></div>", 19));
+        var code = RenderFunctionEmitter.Emit(result).Code;
+
+        code.ShouldNotContain("_createStaticVNode");
+        result.Cached.Count.ShouldBe(19);
+    }
+
+    [Fact]
+    public void FiveElementsWithBindings_ReachBindingThreshold_AndStringify()
+    {
+        // 5 elements each carrying an attribute binding reach StringifyThresholds.ELEMENT_WITH_BINDING_COUNT
+        // even though the node count (5) is well under NODE_COUNT.
+        var code = Emit(Wrapped("<div id=\"x\"></div>", 5)).Code;
+
+        StaticVNodeCount(code).ShouldBe(1);
+        code.ShouldContain(", 5)");
+    }
+
+    [Fact]
+    public void FourElementsWithBindings_StayBelowBindingThreshold()
+    {
+        // 4 elements with bindings is under the threshold; nothing stringifies.
+        Emit(Wrapped("<div id=\"x\"></div>", 4)).Code.ShouldNotContain("_createStaticVNode");
+    }
+
+    [Fact]
+    public void StringifiedRun_SerializesExactlyOnce()
+    {
+        // The run-count pin: a collapsed run produces exactly one static vnode, cached in one slot — the
+        // whole run marshals across the interop boundary once, not per node.
+        var result = TransformSource(Wrapped("<p>x</p>", 20));
+        var code = RenderFunctionEmitter.Emit(result).Code;
+
+        StaticVNodeCount(code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void MergedCacheSlots_StayReserved_NotCompacted()
+    {
+        // Documented divergence: after merging a run, the merged nodes' cache slots stay reserved rather
+        // than being compacted and re-indexed (which would require mutating immutable CacheExpressions).
+        var result = TransformSource(Wrapped("<div></div>", 20));
+
+        result.Cached.Count.ShouldBe(20);
+    }
+
+    // ---- serialization: escaping and void tags (WHATWG fragment serialization) ----
+
+    [Fact]
+    public void SerializedHtml_EscapesMarkupSensitiveCharacters()
+    {
+        // escapeHtml parity (@vue/shared): & < > " ' are escaped so the innerHTML round-trips to the same
+        // DOM as node-by-node creation.
+        var code = Emit(Wrapped("<i>a &amp; b &lt; c</i>", 20)).Code;
+
+        code.ShouldContain("a &amp; b &lt; c");
+    }
+
+    [Fact]
+    public void SerializedHtml_OmitsClosingTagForVoidElements()
+    {
+        // Void elements serialize with no end tag (upstream isVoidTag).
+        var code = Emit(Wrapped("<br>", 20)).Code;
+
+        code.ShouldContain("_createStaticVNode(");
+        code.ShouldNotContain("</br>");
+    }
+
+    [Fact]
+    public void SerializedHtml_KeepsStaticAttributes()
+    {
+        var code = Emit(Wrapped("<div id=\"x\"></div>", 20)).Code;
+
+        code.ShouldContain("<div id=\\\"x\\\"></div>");
+    }
+
+    // ---- slot content bails stringification ----
+
+    [Fact]
+    public void SlotContent_IsNotStringified()
+    {
+        // Upstream bails stringification when scopes.vSlot > 0: a component's slot content is not folded
+        // into an innerHTML string.
+        Emit(WrappedComponent("<div></div>", 20)).Code.ShouldNotContain("_createStaticVNode");
+    }
+
+    // ---- emitter snapshots ----
+
+    [Fact]
+    public void CachedSubtree_EmitsRenderCacheAssignmentWithCachedFlag()
+    {
+        Emit("<div><span>static</span></div>").Code.ShouldBeCode(
+"""
+return _createElementBlock(_openBlock(), "div", null, new object?[] { (_cache[0] ??= _createElementVNode("span", null, "static", -1 /* CACHED */)) });
+
+""");
+    }
+
+    [Fact]
+    public void TwoStaticSiblings_BelowThreshold_EmitTwoCacheSlots()
+    {
+        Emit("<section><p>a</p><p>b</p></section>").Code.ShouldBeCode(
+"""
+return _createElementBlock(_openBlock(), "section", null, new object?[] { (_cache[0] ??= _createElementVNode("p", null, "a", -1 /* CACHED */)), (_cache[1] ??= _createElementVNode("p", null, "b", -1 /* CACHED */)) });
+
+""");
+    }
+
+    [Fact]
+    public void CachedStaticProps_EmitRenderCacheAssignment()
+    {
+        Emit("<div class=\"card\">{{ msg }}</div>", prefixIdentifiers: true).Code.ShouldBeCode(
+"""
+return _createElementBlock(_openBlock(), "div", (_cache[0] ??= _createProps(("class", "card"))), _toDisplayString(_ctx.msg), 1 /* TEXT */);
+
+""");
+    }
+
+    // ---- the optimized output is valid C# ----
+
+    [Theory]
+    [InlineData("<div><span>static</span></div>")]                         // cached subtree
+    [InlineData("<section><p>a</p><p>b</p></section>")]                    // two cached siblings
+    [InlineData("<div class=\"card\">{{ msg }}</div>")]                    // cached static props
+    [InlineData("<section><div id=\"x\"></div><div id=\"y\"></div><div id=\"z\"></div><div></div><div></div></section>")] // stringified run (binding threshold)
+    [InlineData("<Comp><span>a</span><span>b</span></Comp>")]             // cached content inside a component slot
+    public void OptimizedOutput_ParsesAsValidCSharp(string source)
+    {
+        // Every cached/stringified render body must be syntactically valid C# in the render-method shape the
+        // generator emits (the serialized HTML rides through SymbolDisplay.FormatLiteral, so any content is a
+        // well-formed literal).
+        var code = Emit(source, prefixIdentifiers: true).Code;
+        var unit =
+            "internal static class RenderProbe { internal static object? Render(object _ctx, object?[] _cache) {\n" +
+            code +
+            "} }";
+
+        var tree = CSharpSyntaxTree.ParseText(unit, new CSharpParseOptions(LanguageVersion.Preview));
+        tree.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == RoslynDiagnosticSeverity.Error)
+            .ShouldBeEmpty(customMessage: code);
+    }
+
+    [Fact]
+    public void StringifiedRun_ForcedByBindingThreshold_ParsesWithEscapedHtmlLiteral()
+    {
+        // A run whose serialized HTML carries quotes and ampersands still produces a valid C# string literal.
+        var code = Emit(Wrapped("<p class=\"lead\">Hi &amp; bye</p>", 20)).Code;
+        var unit =
+            "internal static class RenderProbe { internal static object? Render(object _ctx, object?[] _cache) {\n" +
+            code +
+            "} }";
+
+        code.ShouldContain("<p class=\\\"lead\\\">Hi &amp; bye</p>");
+        CSharpSyntaxTree.ParseText(unit, new CSharpParseOptions(LanguageVersion.Preview))
+            .GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == RoslynDiagnosticSeverity.Error)
+            .ShouldBeEmpty(customMessage: code);
+    }
+
+    // ---- determinism / value equality (incremental generator caching contract) ----
+
+    [Fact]
+    public void Caching_IsDeterministicAndValueEquatable()
+    {
+        const string source = "<section><span>a</span><span>b</span></section>";
+        var first = TransformSource(source);
+        var second = TransformSource(source);
+
+        first.CodegenNode.ShouldBe(second.CodegenNode);
+        RenderFunctionEmitter.Emit(first).Code.ShouldBe(RenderFunctionEmitter.Emit(second).Code);
+    }
+
+    // ---- harness ----
+
+    private static TransformResult TransformSource(string source, bool prefixIdentifiers = false)
+    {
+        var root = TemplateParser.Parse(source, ParserOptions.CreateHtml());
+        var options = TransformOptions.CreateDom();
+        options.HoistStatic = true;
+        if (prefixIdentifiers)
+        {
+            options.PrefixIdentifiers = true;
+            options.BindingMetadata = BindingMetadata.Empty;
+        }
+
+        return Transformer.Transform(root, options);
+    }
+
+    private static TransformResult Transform(string source, bool prefixIdentifiers = false)
+        => TransformSource(source, prefixIdentifiers);
+
+    private static RenderFunctionEmitterResult Emit(string source, bool hoistStatic = true, bool prefixIdentifiers = false)
+    {
+        var root = TemplateParser.Parse(source, ParserOptions.CreateHtml());
+        var options = TransformOptions.CreateDom();
+        options.HoistStatic = hoistStatic;
+        if (prefixIdentifiers)
+        {
+            options.PrefixIdentifiers = true;
+            options.BindingMetadata = BindingMetadata.Empty;
+        }
+
+        return RenderFunctionEmitter.Emit(Transformer.Transform(root, options));
+    }
+
+    // The codegen node of the index-th child of the single root element.
+    private static TemplateSyntaxNode? ChildCodegen(TransformResult result, int index)
+    {
+        var root = result.CodegenNode.ShouldBeOfType<VNodeCall>();
+        var children = (SyntaxList<TemplateChildNode>)root.Children!;
+        return result.GetCodegenNode(children[index]);
+    }
+
+    private static string Wrapped(string unit, int count)
+        => "<section>" + string.Concat(Enumerable.Repeat(unit, count)) + "</section>";
+
+    private static string WrappedComponent(string unit, int count)
+        => "<Comp>" + string.Concat(Enumerable.Repeat(unit, count)) + "</Comp>";
+
+    private static int StaticVNodeCount(string code)
+    {
+        var occurrences = 0;
+        var index = 0;
+        while ((index = code.IndexOf("_createStaticVNode(", index, System.StringComparison.Ordinal)) >= 0)
+        {
+            occurrences++;
+            index += "_createStaticVNode(".Length;
+        }
+
+        return occurrences;
+    }
+}


### PR DESCRIPTION
## Summary

The C# port of Vue 3.5's static optimization: `cacheStatic.ts` (fully-static subtrees and static props cached through the render cache, driven by the full `constantType` subtree analysis with memoization and the svg/foreignObject/math static-block demotion) and `@vue/compiler-dom`'s `stringifyStatic` (contiguous cached siblings above upstream's numeric thresholds — `NODE_COUNT = 20`, `ELEMENT_WITH_BINDING_COUNT = 5`, pinned — collapse into one `_createStaticVNode(html, count)` insert). On WASM this is the founding-decision-#4 payoff: every stringified node is interop round-trips avoided.

Implemented in a delegated Claude Opus 4.8 session, reviewed, and verified standalone and stacked.

## Type of change

- [x] `feat` — new feature

## Changes

- `StaticCache` (the `cacheStatic` walk), context-aware `ConstantAnalysis` with `TransformContext.ConstantCache` memoization, `StaticStringifier` with the `@vue/shared` `escapeHtml` port, void-tag end-tag omission, and `isStringifiableAttr` over the shared DOM knowledge (known HTML/SVG attributes + `data-`/`aria-`).
- Gated on `TransformOptions.HoistStatic`; the `.viu` generator turns it on.
- 31 new tests: cache-eligibility pins (dynamic key / ref / runtime directive / component boundaries never cache), threshold boundary cases (19↛/20✓ nodes, 4↛/5✓ bindings), serialize-exactly-once run counts, escaping/void-tag serialization, opt-out parity, emitter snapshots, parse validity, and generator caching strictly `Cached`.

## Deviations (documented in DESIGN.md, pinned by tests)

- **Unified `_cache` seam**: cached vnode subtrees and props both route through the per-instance render cache (upstream splits vnodes into `context.cache` and props into module-const hoists; C# has no module-const scope without a new emitter↔generator contract). Same created-once semantics; `Hoists` stays reserved.
- **No constant-expression evaluation**: upstream pre-evaluates constant expressions with `new Function` — forbidden here (AOT); opaque expressions are never constant, so only static text/comments/attributes stringify.
- Stringification runs on root and plain-element parents only; MathML attributes are not stringifiable (no shared known-attr table yet).

## Verification

- `dotnet build Assimalign.Vuecs.slnx -warnaserror` — 0 warnings, 0 errors.
- Standalone: Templates 387, Generators 28, all other suites green. At the stacked tip the combination with the diagnostics source maps and the RenderHelpers end-to-end execution tests is green across all 14 suites.

## Work items resolved

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
