### PR TITLE
fix(compiler): emit void single-statement inline handlers as statement lambdas

### DIFF
--- a/libraries/Assimalign.Vue.RuntimeCore/test/Assimalign.Vue.RuntimeCore.CompiledRenderTests/CompiledRenderEndToEndTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeCore/test/Assimalign.Vue.RuntimeCore.CompiledRenderTests/CompiledRenderEndToEndTests.cs
@@ -221,6 +221,51 @@ public sealed class CompiledRenderEndToEndTests : IClassFixture<CompiledRenderEn
         assembly.Length.ShouldBeGreaterThan(0);
     }
 
+    [Fact]
+    public void VoidInlineHandler_CompilesAndExecutes_ThroughWithHandlerFacade()
+    {
+        // [V01.01.05.05.01] A void single-statement inline handler with no modifiers emits as a
+        // statement-block lambda `__event => { _ctx.record(__event); }`, which binds the runtime-core
+        // RenderHelpers._withHandler(Action<object?>) overload. Before the fix the emitter wrote
+        // `__event => (_ctx.record(__event))`, and a parenthesized void call binds no _withHandler overload
+        // — the generated render failed to compile. Here the generated render compiles AND, when the stored
+        // onClick delegate is invoked, actually runs the void method (upstream transformOn wraps inline
+        // statements: vuejs/core v3.5 compiler-core transforms/vOn.ts).
+        const string template = "@template {\n<button @click=\"record($event)\">go</button>\n}\n";
+        const string handWritten =
+            "#nullable enable\n" +
+            "namespace Demo\n" +
+            "{\n" +
+            "    partial class VoidHandler\n" +
+            "    {\n" +
+            "        public int RecordCount;\n" +
+            "        public object? LastEvent;\n" +
+            "        public void record(object? browserEvent) { RecordCount++; LastEvent = browserEvent; }\n" +
+            "    }\n" +
+            "}\n";
+
+        var generated = CompiledRenderSupport.Generate("VoidHandler", template);
+        // The void call emits as the statement-block lambda (not the parenthesized expression lambda).
+        generated.ShouldContain("_withHandler(__event => { _ctx.record(__event); })");
+
+        var type = Assembly.Load(CompiledRenderSupport.CompileToAssembly(generated, handWritten))
+            .GetType("Demo.VoidHandler")
+            ?? throw new InvalidOperationException("The compiled assembly did not contain Demo.VoidHandler.");
+        var instance = Activator.CreateInstance(type, nonPublic: true)!;
+        var cacheSize = (int)type.GetField("RenderCacheSize", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+        var render = type.GetMethod("Render", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var vnode = (VirtualNode)render.Invoke(null, new object?[] { instance, new object?[cacheSize] })!;
+        var handler = vnode.Properties!["onClick"].ShouldBeOfType<Action<object?>>();
+
+        var sentinel = new object();
+        handler(sentinel);
+
+        type.GetField("RecordCount")!.GetValue(instance).ShouldBe(1); // the void handler ran exactly once
+        type.GetField("LastEvent")!.GetValue(instance).ShouldBeSameAs(sentinel); // with the event argument
+    }
+
     // Wires the compiled component's static Render into a root render effect: the closure runs the generated
     // Render (reactive reads inside it are tracked) and normalizes the object? result to a vnode.
     private RenderEffect<TestNode> MountCounter(IRenderHarness counter, out StrongBox<int> renders)

--- a/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 
 using Microsoft.CodeAnalysis;
@@ -134,6 +135,62 @@ public sealed class DomCompiledRenderTests
             .SelectMany(step => step.Outputs)
             .Select(output => output.Reason)
             .ShouldAllBe(reason => reason == IncrementalStepRunReason.Cached);
+    }
+
+    [Fact]
+    public void VoidInlineHandlerWithModifier_CompilesAndExecutes_ThroughWithModifiersFacade()
+    {
+        // [V01.01.05.05.01] A void single-statement inline handler WITH a modifier emits as a statement-block
+        // lambda wrapped by the DOM guard: `_withModifiers(__event => { _ctx.record(__event); }, ["prevent"])`,
+        // binding DomRenderHelpers._withModifiers(Action<BrowserEvent>, params string[]). Before the fix the
+        // emitter wrote the parenthesized void call `__event => (_ctx.record(__event))`, which binds neither the
+        // Func<BrowserEvent, object?> nor the Action<BrowserEvent> overload — the generated render failed to
+        // compile. Here the generated render compiles AND, when the stored guarded onClick delegate is invoked,
+        // runs the void method and applies .prevent to the event (upstream compiler-dom transformOn's
+        // withModifiers wrapping: vuejs/core v3.5).
+        const string template = "@template {\n<button @click.prevent=\"record($event)\">go</button>\n}\n";
+        const string handWritten =
+            "#nullable enable\n" +
+            "using Assimalign.Vue.RuntimeDom;\n" +
+            "namespace Demo\n" +
+            "{\n" +
+            "    partial class VoidModifierHandler\n" +
+            "    {\n" +
+            "        public int RecordCount;\n" +
+            "        public BrowserEvent? LastEvent;\n" +
+            "        public void record(BrowserEvent browserEvent) { RecordCount++; LastEvent = browserEvent; }\n" +
+            "    }\n" +
+            "}\n";
+
+        var generated = CompiledRenderSupport.Generate("VoidModifierHandler", template);
+        // The void call emits as a statement-block lambda wrapped by the withModifiers guard.
+        generated.ShouldContain("_withModifiers(__event => { _ctx.record(__event); }, [\"prevent\"])");
+
+        var type = Assembly.Load(CompiledRenderSupport.CompileToAssembly(generated, handWritten))
+            .GetType("Demo.VoidModifierHandler")
+            ?? throw new InvalidOperationException("The compiled assembly did not contain Demo.VoidModifierHandler.");
+        var instance = Activator.CreateInstance(type, nonPublic: true)!;
+        var cacheSize = (int)type.GetField("RenderCacheSize", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+        var render = type.GetMethod("Render", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var vnode = (VirtualNode)render.Invoke(null, new object?[] { instance, new object?[cacheSize] })!;
+        var handler = vnode.Properties!["onClick"].ShouldBeOfType<Action<BrowserEvent>>();
+
+        // BrowserEvent's constructor is internal and this compile-binding project has no InternalsVisibleTo
+        // grant, so the dispatch event is built through the internal constructor by reflection (the argument
+        // order matches Assimalign.Vue.RuntimeDom.Events.BrowserEvent).
+        var browserEvent = (BrowserEvent)Activator.CreateInstance(
+            typeof(BrowserEvent),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: new object?[] { "click", 0.0, "", "", BrowserEventModifiers.None, -1, 0, 0.0, 0.0, 0, true, null, false, null },
+            culture: null)!;
+        handler(browserEvent);
+
+        type.GetField("RecordCount")!.GetValue(instance).ShouldBe(1);            // the void handler ran once
+        type.GetField("LastEvent")!.GetValue(instance).ShouldBeSameAs(browserEvent);
+        browserEvent.DefaultPrevented.ShouldBeTrue();                            // .prevent applied via the guard
     }
 }
 

--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -97,9 +97,21 @@ the common .NET base-class surface a template legitimately reaches (`Math`, `Con
 - **Inline-handler event parameter.** `$event` is not a legal C# identifier, so under prefixing an inline
   statement is parsed and emitted against the Vuecs spelling `__event`: `VOnTransform` substitutes
   `$event` → `__event` in the handler content before processing and names the wrapping lambda's parameter
-  `__event`, so `@input="save($event)"` emits `__event => (_ctx.save(__event))`. Template authors keep
+  `__event`, so `@input="save($event)"` emits `__event => { _ctx.save(__event); }`. Template authors keep
   Vue's `$event`; without prefixing the emitted wrapper keeps `$event` for upstream output parity. Pinned
   by `ExpressionBindingTests`.
+- **Single-statement call handlers are statement-block lambdas.** Upstream `transformOn` wraps every
+  single-statement inline handler as an expression arrow `$event => (expr)`; JavaScript has no `void`, so
+  the discarded result is harmless. C# has `void`, and a parenthesized void call binds no delegate, so a
+  single-statement handler whose expression is a **call** — a plain invocation `save($event)` or a
+  null-conditional invocation `model?.save()`, the only single-statement shape that can be void-typed —
+  emits as a statement-block lambda `__event => { save(__event); }` instead. Its `Action<…>` overload
+  binds both void and value calls (discarding any result, exactly as upstream's arrow function does).
+  Every other single-statement shape (an increment `count++`, an assignment `open = true`, a plain value
+  expression) yields a C# value and keeps the expression-lambda form, so it stays as close to upstream as
+  C# allows. Only the prefixed (C#-codegen) path diverges; non-prefixed output stays byte-for-byte
+  upstream parity. Pinned by `ExpressionBindingTests` and `RenderFunctionEmitterTests`
+  ([V01.01.05.05.01], issue #143).
 - **`asParams` validation is lenient.** Alias/prop declaration positions are registered for scope but not
   hard-validated as expressions, because C# deconstruction forms (`(a, b)`, `var (a, b)`) and JavaScript-style
   `{ a }` destructures do not all parse as C# expressions; a lenient identifier scan still contributes their
@@ -141,6 +153,7 @@ snapshot test in `RenderFunctionEmitterTests`.
 | `(setBlockTracking(-1, true), (_cache[0] = v).cacheIndex = 0, setBlockTracking(1), _cache[0])` | `_setCache(0, _setBlockTracking(-1, true), v)` | The comma sequence collapses into a helper: argument order pauses tracking before `v` is created; `_setCache` stamps the cache index, resumes tracking, and returns the value. |
 | `[...(cacheExpr)]` | `_spreadCache(cacheExpr)` | No spread operator; the helper clones the cached array. |
 | inline handler values (`$event => ...`, method refs) | wrapped in `_withHandler(...)` | A C# lambda or method group has no natural type in an object-typed position; the helper's delegate parameter supplies the target type. `_withModifiers`/`_withKeys` calls are not wrapped — their own contract signatures type the inner lambda. |
+| single-statement **call** handler (`$event => (call)`) | `__event => { call; }` (statement-block lambda) | JavaScript has no `void`; C# does, and a parenthesized void call binds no delegate. A call is the only single-statement shape that can be void, so it emits as a statement-block lambda (binds the `Action<…>` overload, discarding any value). Increments/assignments/value expressions yield a value and keep `__event => (expr)`. See the inline-handler divergence note above ([V01.01.05.05.01], issue #143). |
 | `$slots` / `$event` | `_ctx.__slots` / `__event` | `$` is not legal in C# identifiers; `__event` is the [V01.01.05.04] event-variable contract and `__slots` follows the same spelling rule. |
 | `undefined` / `void 0` | `null` | No `undefined` in C#. |
 | `{}` (renderSlot's empty-props placeholder) | `_createProps()` | Same object-literal rule as props. |
@@ -225,8 +238,10 @@ What code generation requires of each DOM member, mapped to the runtime machiner
   invoker registry understands) and forwarding to `BrowserEvents.WithModifiers` / `BrowserEvents.WithKeys`. The
   handler parameter is **overloaded**, not a single `Action` — this reconciles the earlier
   `_withModifiers(handler, string[])` pin: the emitter (`VOnTransform`) can write the handler as a value-returning
-  inline expression lambda (`__event => (expr)`), a void statement-block lambda (`__event => { … }`), or a
-  member/method-group reference (`_ctx.save`), and a parenthesized value expression cannot bind to `Action`. The
+  inline expression lambda (`__event => (expr)`), a statement-block lambda for a single-statement call
+  (`__event => { call; }`, the void-capable shape — see the single-statement call-handler divergence above) or a
+  multi-statement body, or a member/method-group reference (`_ctx.save`), and a parenthesized void call cannot
+  bind to `Func<BrowserEvent, object?>`. The
   overload set — `Func<BrowserEvent, object?>`, `Action<BrowserEvent>`, `Func<object?>`, `Action` (each with
   `params string[]`) — target-types every one of those, mirroring `_withHandler`'s multi-overload rationale.
   Because both return `Action<BrowserEvent>`, a stacked `@keyup.enter.prevent` nests cleanly as

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/VOnTransform.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace Assimalign.Vue.Syntax.Templates;
 
 /// <summary>
@@ -145,10 +148,28 @@ internal static class VOnTransform
             handler = processedExpression;
             if (isInlineStatement || (shouldCache && isMemberExpression))
             {
-                handler = Ir.CompoundExpression(
-                    (isInlineStatement ? (context.PrefixIdentifiers ? "__event" : "$event") : "(...args)") + " => " + (hasMultipleStatements ? "{" : "("),
-                    processedExpression,
-                    hasMultipleStatements ? "}" : ")");
+                var parameter = isInlineStatement ? (context.PrefixIdentifiers ? "__event" : "$event") : "(...args)";
+
+                // A single-statement inline handler that is a call emits as a statement-block lambda
+                // (`__event => { call; }`) instead of the expression lambda (`__event => (call)`) that a
+                // value-returning handler uses: a void call — the most common handler shape — has no value
+                // to place in the parenthesized body, so only the block form binds (to the runtime's
+                // `Action<…>` handler overload; a value call binds there too, its result discarded exactly
+                // as upstream's arrow function discards it). Every other single-statement shape (increment,
+                // assignment, a plain value expression) yields a C# value and stays an expression lambda,
+                // matching upstream's uniform `$event => (expr)` as closely as C#'s void-expression rule
+                // allows. Only the prefixed (C#-codegen) path diverges; non-prefixed output stays byte-for-
+                // byte upstream parity. Multi-statement bodies were already brace blocks upstream.
+                // Upstream transformOn: vuejs/core v3.5 compiler-core transforms/vOn.ts.
+                var asStatementBlock = hasMultipleStatements ||
+                    (isInlineStatement && context.PrefixIdentifiers && IsCallExpression(expression.Content));
+
+                handler = asStatementBlock
+                    ? Ir.CompoundExpression(
+                        parameter + " => " + (hasMultipleStatements ? "{" : "{ "),
+                        processedExpression,
+                        hasMultipleStatements ? "}" : "; }")
+                    : Ir.CompoundExpression(parameter + " => (", processedExpression, ")");
             }
         }
 
@@ -173,6 +194,25 @@ internal static class VOnTransform
 
         return result with { Properties = marked };
     }
+
+    // Whether a single-statement inline-handler expression is a C# call — a plain invocation
+    // (`save($event)`) or a null-conditional invocation (`model?.save()`). A call is the only handler
+    // shape that can be void-typed, so it alone must emit as a statement-block lambda
+    // (`__event => { call; }`); the parenthesized expression lambda (`__event => (call)`) that
+    // value-returning handlers use cannot bind a void result. Parsed with the C# parser because this is a
+    // C# code-generation question with no upstream (JavaScript) counterpart — JavaScript has no `void`, so
+    // upstream `transformOn` emits `$event => (expr)` uniformly. Mirrors the ExpressionProcessor use of
+    // SyntaxFactory.ParseExpression; a parse that is not a call keeps the expression-lambda form.
+    private static bool IsCallExpression(string content) => IsCallShape(SyntaxFactory.ParseExpression(content));
+
+    private static bool IsCallShape(ExpressionSyntax expression) => expression switch
+    {
+        InvocationExpressionSyntax => true,
+        // A null-conditional chain (`a?.b()`) parses as a conditional access whose right-hand operand is
+        // the invocation; unwrap to the terminal access to classify the whole chain.
+        ConditionalAccessExpressionSyntax conditionalAccess => IsCallShape(conditionalAccess.WhenNotNull),
+        _ => false,
+    };
 
     private static ExpressionNode BuildEventName(ExpressionNode argument, ElementNode element, TransformContext context)
     {

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
@@ -163,6 +163,18 @@ public class ExpressionBindingTests
     }
 
     [Fact]
+    public void ProcessExpression_InlineCallHandler_EmitsStatementBlockLambda()
+    {
+        // A call may be void-typed; a void call has no value to place in an expression lambda's
+        // parenthesized body, so a single-statement inline call handler emits as a statement-block lambda
+        // (__event => { call; }) — the shape that binds the Action<...> handler overload — rather than the
+        // expression lambda the value-returning increment/assignment handlers above keep
+        // ([V01.01.05.05.01], issue #143).
+        HandlerBody("<button @click=\"save($event)\"></button>", Bindings(("save", BindingType.Options)))
+            .ShouldBe("__event => { _ctx.save(__event); }");
+    }
+
+    [Fact]
     public void ProcessExpression_MethodHandler_ResolvesWithoutInlineWrapper()
     {
         // A bare member handler is a method reference, not an inline statement: no $event wrapper.

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/RenderFunctionEmitterTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/RenderFunctionEmitterTests.cs
@@ -243,13 +243,31 @@ return _createElementBlock(_openBlock(), "button", _createProps(
     }
 
     [Fact]
+    public void VoidCallHandler_EmitsStatementBlockLambda()
+    {
+        // A single-statement inline call handler emits as a statement-block lambda (__event => { call; })
+        // rather than an expression lambda (__event => (call)): a void call has no value to parenthesize
+        // and would bind no _withHandler delegate overload, so the block form — which binds
+        // Action<object?> and discards any value like upstream's arrow function — is used
+        // ([V01.01.05.05.01], issue #143; upstream transformOn: vuejs/core v3.5 compiler-core vOn.ts).
+        EmitPrefixed("<button @click=\"save($event)\">x</button>").Code.ShouldBeCode(
+"""
+return _createElementBlock(_openBlock(), "button", _createProps(("onClick", _withHandler(__event => { _ctx.save(__event); }))), "x", 8 /* PROPS */, ["onClick"]);
+
+""");
+    }
+
+    [Fact]
     public void ModifierHandler_KeepsWithModifiersUnwrapped()
     {
         // withModifiers/withKeys already give the inner lambda its delegate target type through their
-        // own contract signature, so no extra _withHandler wrapper is added around them.
+        // own contract signature, so no extra _withHandler wrapper is added around them. The inline
+        // handler is a call, which may be void-typed, so it emits as a statement-block lambda
+        // (__event => { call; }) — the shape that binds withModifiers' Action<BrowserEvent> overload;
+        // a parenthesized void call binds no overload ([V01.01.05.05.01], issue #143).
         EmitPrefixed("<button @click.stop=\"save($event)\">x</button>").Code.ShouldBeCode(
 """
-return _createElementBlock(_openBlock(), "button", _createProps(("onClick", _withModifiers(__event => (_ctx.save(__event)), ["stop"]))), "x", 8 /* PROPS */, ["onClick"]);
+return _createElementBlock(_openBlock(), "button", _createProps(("onClick", _withModifiers(__event => { _ctx.save(__event); }, ["stop"]))), "x", 8 /* PROPS */, ["onClick"]);
 
 """);
     }
@@ -329,6 +347,7 @@ return _withDirectives(_createElementBlock(_openBlock(), "input", null, null, 51
     [InlineData("<slot name=\"header\"><p>fallback {{ hint }}</p></slot>")]
     [InlineData("<div v-once><span>{{ frozen }}</span></div>")]
     [InlineData("<button @click=\"count++\" @submit=\"save\">Go</button>")]
+    [InlineData("<button @click=\"save($event)\">x</button>")]
     [InlineData("<button @click.stop=\"save($event)\">x</button>")]
     [InlineData("<input v-model=\"name\" />")]
     [InlineData("<div v-show=\"visible\">shown</div>")]


### PR DESCRIPTION
## Summary

`@click="doVoidThing($event)"` — a void single-statement inline handler — emitted as `__event => (voidCall)`, which binds no delegate overload and failed to compile. The fix is surgical and analysis-driven: an invocation is the **only** single-statement shape that can be void-typed, so only calls switch to the statement-lambda form `__event => { call; }` (binding the existing `Action` overloads, discarding results exactly as upstream's arrow function does); increments, assignments, and value expressions keep the byte-for-byte upstream-faithful expression form, and the non-prefixed parity output is untouched. No helper-overload changes were needed — verified, not assumed.

Pinned end to end: void handlers with and without `.prevent` compile AND execute through both facades in the compiled-render projects. Implemented in a delegated Claude Opus 4.8 session and reviewed.

> **Merge procedure:** merge the stack top-down (#-order below) and **delete each branch immediately after merging** — deletion triggers GitHub's retarget of the next PR to `main`. An undeleted base branch silently catches the next merge instead (the #141/#147 episodes).

## Type of change

- [x] `fix` — bug fix

## Discovered work (filed)

#150 `[V01.01.05.05.02]` — multi-statement handlers rely on an author-supplied trailing semicolon (pre-existing; distinct from this fix).

## Verification

`-warnaserror` 0/0; all 15 suites green (Templates 479, Generators 58, compiled-render 7+4); caching strictly `Cached`.

## Work items resolved

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
