### PR TITLE
feat(css,generators,runtime-dom): CSS Modules and v-bind() in CSS

### DIFF
--- a/analyzers/Assimalign.Vue.Syntax.Generators/docs/DIAGNOSTICS.md
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/docs/DIAGNOSTICS.md
@@ -110,9 +110,11 @@ Single-file component script parse information — an informational (or `Hidden`
 
 Single-file component style parse error — a recoverable error from the dispatched `@style` CSS parse
 ([V01.01.06.04]), a Vuecs-defined `CssErrorCode` following CSS Syntax Module Level 3 error recovery
-(e.g. an unterminated block, a stray `}`, or a declaration missing its `:`). The CSS parser never throws;
-the scaffold is still emitted, and the `CssErrorCode` (2000-based) rides on the message (e.g. `... (CSS code
-2006)`).
+(e.g. an unterminated block, a stray `}`, or a declaration missing its `:`). The CSS-Modules and `v-bind()`
+rewrites ([V01.01.06.06]) surface here too through the same style-origin envelope — a malformed
+`v-bind()` (an unterminated `v-bind(` or an empty `v-bind()`) reports `CssErrorCode` 2008/2009 on the
+offending declaration. The CSS parser and rewrites never throw; the scaffold is still emitted, and the
+`CssErrorCode` (2000-based) rides on the message (e.g. `... (CSS code 2006)`).
 
 ### VUECS1302
 

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/CssModuleClassEntry.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/CssModuleClassEntry.cs
@@ -1,0 +1,16 @@
+namespace Assimalign.Vue.Syntax.Generators;
+
+/// <summary>
+/// One entry of a component's CSS Modules map ([V01.01.06.06]): the <see cref="Accessor"/> the class
+/// belongs to (the C# analogue of a <c>$style</c> object name), the <see cref="Original"/> class name as
+/// authored, and the <see cref="Hashed"/> name it compiled to. The emitter groups entries by
+/// <see cref="Accessor"/> into a nested static class whose <c>const</c> members mirror the declared class
+/// names, so a reference to a missing class is a compile error — the typed, source-generated equivalent of
+/// Vue's <c>$style</c> / <c>useCssModule()</c> (https://vuejs.org/api/sfc-css-features.html#css-modules).
+/// A <see langword="readonly"/> <see langword="record"/> <see langword="struct"/> so it is value-equatable
+/// and rides inside the cached model without defeating the incremental cache.
+/// </summary>
+/// <param name="Accessor">The generated accessor class name (default module → <c>Style</c>, <c>module="foo"</c> → <c>Foo</c>).</param>
+/// <param name="Original">The original class name exactly as authored (without the leading <c>.</c>).</param>
+/// <param name="Hashed">The locally-hashed class name the selector compiled to.</param>
+internal readonly record struct CssModuleClassEntry(string Accessor, string Original, string Hashed);

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/CssVariableBindingEntry.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/CssVariableBindingEntry.cs
@@ -1,0 +1,14 @@
+namespace Assimalign.Vue.Syntax.Generators;
+
+/// <summary>
+/// One <c>v-bind()</c> CSS binding recorded in the generated component metadata ([V01.01.06.06]): the
+/// hashed custom-property <see cref="Name"/> the CSS was rewritten to (<c>var(--&lt;Name&gt;)</c>) and the
+/// original C# <see cref="Expression"/> the component evaluates. The emitter turns these into the
+/// <c>ApplyCssVariables</c> seam that calls the <c>UseCssVars</c> runtime with a getter mapping each name to
+/// its evaluated value — the compile-time half of Vue's <c>v-bind()</c>-in-CSS reactivity
+/// (https://vuejs.org/api/sfc-css-features.html#v-bind-in-css). A <see langword="readonly"/>
+/// <see langword="record"/> <see langword="struct"/> so it is value-equatable inside the cached model.
+/// </summary>
+/// <param name="Name">The hashed custom-property name (without the leading <c>--</c>).</param>
+/// <param name="Expression">The original expression text the component evaluates for the property value.</param>
+internal readonly record struct CssVariableBindingEntry(string Name, string Expression);

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentModel.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentModel.cs
@@ -50,6 +50,16 @@ namespace Assimalign.Vue.Syntax.Generators;
 /// when the component declares no <c>@style</c> block. Emitted as a generated string constant; the
 /// physical static-web-asset bundling is the MSBuild-side follow-up.
 /// </param>
+/// <param name="ModuleClasses">
+/// The CSS Modules class map ([V01.01.06.06]) — one entry per <c>original → hashed</c> class, grouped by
+/// its accessor — emitted as the typed <c>$style</c>-equivalent nested class(es). Empty when no
+/// <c>@style module</c> block is declared.
+/// </param>
+/// <param name="CssVariableBindings">
+/// The <c>v-bind()</c> CSS bindings ([V01.01.06.06]) — one entry per distinct <c>(hash, expression)</c> —
+/// emitted as the <c>ApplyCssVariables</c> seam the <c>UseCssVars</c> runtime consumes. Empty when no
+/// <c>@style</c> block uses <c>v-bind()</c>.
+/// </param>
 internal readonly record struct SingleFileComponentModel(
     string? Namespace,
     string ClassName,
@@ -65,7 +75,9 @@ internal readonly record struct SingleFileComponentModel(
     string? RenderBody,
     int RenderCacheSize,
     string? ScopeId,
-    string? ExtractedStyles)
+    string? ExtractedStyles,
+    EquatableArray<CssModuleClassEntry> ModuleClasses,
+    EquatableArray<CssVariableBindingEntry> CssVariableBindings)
 {
     /// <summary>
     /// Materializes the template compiler's <see cref="BindingMetadata"/> from the classified

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -265,6 +267,146 @@ internal static class SingleFileComponentSourceEmitter
         builder.Append("/// </summary>\n");
         AppendIndent(builder, indent);
         builder.Append("internal const string ExtractedStyles = ").Append(Literal(styles)).Append(";\n");
+
+        AppendModuleAccessors(builder, indent, model);
+        AppendCssVariableSeam(builder, indent, model);
+    }
+
+    // [V01.01.06.06] The @style module accessor seam. Each `module` block's original -> hashed class map is
+    // emitted as a nested static class (the C# analogue of Vue's `$style` / useCssModule()) whose const
+    // members mirror the declared class names, so a reference to a class that does not exist is a compile
+    // error. Blocks that share an accessor (several `@style module` blocks, or `module="name"` repeated)
+    // merge into one class; a duplicate member is emitted once.
+    private static void AppendModuleAccessors(StringBuilder builder, int indent, in SingleFileComponentModel model)
+    {
+        if (model.ModuleClasses.Count == 0)
+        {
+            return;
+        }
+
+        var accessors = new List<string>();
+        var membersByAccessor = new Dictionary<string, List<(string Member, string Hashed)>>(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var entry in model.ModuleClasses)
+        {
+            var member = MemberName(entry.Original);
+            if (!seen.Add(entry.Accessor + "." + member))
+            {
+                continue;
+            }
+
+            if (!membersByAccessor.TryGetValue(entry.Accessor, out var members))
+            {
+                members = new List<(string, string)>();
+                membersByAccessor[entry.Accessor] = members;
+                accessors.Add(entry.Accessor);
+            }
+
+            members.Add((member, entry.Hashed));
+        }
+
+        foreach (var accessor in accessors)
+        {
+            builder.Append('\n');
+            AppendIndent(builder, indent);
+            builder.Append("/// <summary>\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// The typed CSS Modules accessor for this component's <c>@style module</c> block — the C#\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// analogue of Vue 3.5's <c>$style</c> / <c>useCssModule()</c>. Each member is the locally-hashed\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// name of the like-named source class, so a reference to an undeclared class fails to compile.\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// </summary>\n");
+            AppendIndent(builder, indent);
+            builder.Append("internal static class ").Append(accessor).Append('\n');
+            AppendIndent(builder, indent);
+            builder.Append("{\n");
+            foreach (var (member, hashed) in membersByAccessor[accessor])
+            {
+                AppendIndent(builder, indent + 1);
+                builder.Append("public const string ").Append(member).Append(" = ").Append(Literal(hashed)).Append(";\n");
+            }
+
+            AppendIndent(builder, indent);
+            builder.Append("}\n");
+        }
+    }
+
+    // [V01.01.06.06] The v-bind() CSS custom-property seam. Each recorded (hash, expression) binding becomes
+    // an entry of the getter the ApplyCssVariables method hands to the UseCssVars runtime — which applies the
+    // evaluated values as custom properties on the component root and re-applies them reactively (post-flush)
+    // without re-rendering. The expressions are emitted verbatim inside an instance lambda, so an unqualified
+    // member name resolves against the merged @script members through the implicit `this`; the render/script
+    // seams stay untouched. A binding whose member is a Reference<T> is NOT auto-unwrapped here (upstream
+    // compiles v-bind expressions with binding-aware rewriting, which is the template compiler's job, out of
+    // this style seam's scope) — author `v-bind(count.Value)` for a ref. The component-runtime instantiation
+    // calls ApplyCssVariables during setup (that wiring lands with the .viu component runtime); the method is
+    // emitted here so the metadata exists for it.
+    private static void AppendCssVariableSeam(StringBuilder builder, int indent, in SingleFileComponentModel model)
+    {
+        if (model.CssVariableBindings.Count == 0)
+        {
+            return;
+        }
+
+        builder.Append('\n');
+        AppendIndent(builder, indent);
+        builder.Append("/// <summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// Registers this component's <c>v-bind()</c> CSS custom properties with the <c>UseCssVars</c>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// runtime ([V01.01.06.06]) — the C# analogue of the compiled <c>useCssVars(...)</c> call in Vue\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// 3.5's setup. Call once during the component's setup; the runtime applies the evaluated values as\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// <c>--&lt;hash&gt;</c> custom properties on the root element(s) and re-applies them on the next flush\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// when a bound value changes, without re-rendering.\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// </summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("internal void ApplyCssVariables()\n");
+        AppendIndent(builder, indent + 1);
+        builder.Append("=> global::Assimalign.Vue.RuntimeDom.CssVariables.UseCssVars(() =>\n");
+        AppendIndent(builder, indent + 2);
+        builder.Append("new global::System.Collections.Generic.Dictionary<string, string>(")
+            .Append(Count(model.CssVariableBindings.Count)).Append(")\n");
+        AppendIndent(builder, indent + 2);
+        builder.Append("{\n");
+        foreach (var binding in model.CssVariableBindings)
+        {
+            AppendIndent(builder, indent + 3);
+            builder.Append('[').Append(Literal(binding.Name)).Append("] = global::System.Convert.ToString((object?)(")
+                .Append(binding.Expression)
+                .Append("), global::System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,\n");
+        }
+
+        AppendIndent(builder, indent + 2);
+        builder.Append("});\n");
+    }
+
+    // Turns an authored class name into a valid C# member identifier: non-identifier characters become '_'
+    // and a leading digit is prefixed with '_'. Deterministic so the accessor is stable across rebuilds.
+    private static string MemberName(string original)
+    {
+        var builder = new StringBuilder(original.Length);
+        foreach (var character in original)
+        {
+            builder.Append(char.IsLetterOrDigit(character) || character == '_' ? character : '_');
+        }
+
+        if (builder.Length == 0)
+        {
+            return "_";
+        }
+
+        if (char.IsDigit(builder[0]))
+        {
+            builder.Insert(0, '_');
+        }
+
+        return builder.ToString();
     }
 
     // A valid C# string literal for arbitrary CSS text (quotes, backslashes, and newlines escaped).

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
@@ -33,6 +33,10 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
     private const string RootNamespaceProperty = "build_property.RootNamespace";
     private const string ProjectDirectoryProperty = "build_property.ProjectDir";
 
+    // The scope-id prefix ([V01.01.06.04] StyleScopeId), stripped to recover the short salt the
+    // module/v-bind hashes use ([V01.01.06.06]).
+    private const string ScopeIdPrefix = "data-v-";
+
     /// <summary>Pipeline step tracking name for the file-read transform (used by incremental-cache tests).</summary>
     public const string FileTrackingName = "SingleFileComponentFile";
 
@@ -128,10 +132,13 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             }
         }
 
-        // [V01.01.06.04] @style compilation: scoped blocks are rewritten with the component's scope id and
-        // non-scoped blocks pass through unmodified; the scope id surfaces in component metadata for the
-        // renderer to stamp, and the extracted CSS is emitted as a generated constant.
-        var (scopeId, extractedStyles) = CompileStyles(file, parse, cancellationToken);
+        // [V01.01.06.04]/[V01.01.06.06] @style compilation: scoped blocks are rewritten with the component's
+        // scope id, `module` blocks have their class names locally hashed, `v-bind()` usages become
+        // component-scoped custom properties, and non-scoped/non-module/non-v-bind blocks pass through
+        // unmodified. The scope id, extracted CSS, module class map, and v-bind bindings surface in the model.
+        var moduleClasses = new List<CssModuleClassEntry>();
+        var cssVariableBindings = new List<CssVariableBindingEntry>();
+        var (scopeId, extractedStyles) = CompileStyles(file, parse, diagnostics, moduleClasses, cssVariableBindings, cancellationToken);
 
         // [V01.01.06.03]/[V01.01.06.03.01] @script integration: when the component declares a script,
         // split it into a hoisted using region and a class-body member region, validate both, and extract
@@ -161,7 +168,13 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             RenderBody: null,
             RenderCacheSize: 0,
             ScopeId: scopeId,
-            ExtractedStyles: extractedStyles);
+            ExtractedStyles: extractedStyles,
+            ModuleClasses: moduleClasses.Count == 0
+                ? EquatableArray<CssModuleClassEntry>.Empty
+                : new EquatableArray<CssModuleClassEntry>(moduleClasses.ToArray()),
+            CssVariableBindings: cssVariableBindings.Count == 0
+                ? EquatableArray<CssVariableBindingEntry>.Empty
+                : new EquatableArray<CssVariableBindingEntry>(cssVariableBindings.ToArray()));
 
         // The [V01.01.06.03] -> [V01.01.05.05] hand-off: the script's classified bindings drive the
         // template compiler's ref-unwrapping decisions, so a Reference<T> member reads as `.Value` in
@@ -237,19 +250,31 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Compiles the dispatched <c>@style</c> parses ([V01.01.06.04]): each <c>scoped</c> block's parsed
-    /// stylesheet is rewritten with the component's stable scope id via <see cref="CssScopedRewriter"/>,
-    /// each non-scoped block passes through unmodified, and the results concatenate in source order. The
-    /// scope id is returned only when the component actually declares a scoped block, so a component with
-    /// no scoped styles carries none.
+    /// Compiles the dispatched <c>@style</c> parses ([V01.01.06.04]/[V01.01.06.06]): each block is run
+    /// through the CSS-Modules class rename (<c>module</c> blocks, <see cref="CssModuleRewriter"/>), the
+    /// <c>v-bind()</c> custom-property rewrite (<see cref="CssBindingRewriter"/>), and then serialized —
+    /// scoped blocks via <see cref="CssScopedRewriter"/> with the component's stable scope id, rewritten
+    /// non-scoped blocks via <see cref="CssStylesheetWriter"/>, and untouched non-scoped blocks verbatim.
+    /// The module class map and <c>v-bind()</c> bindings accumulate into <paramref name="moduleClasses"/> /
+    /// <paramref name="cssVariableBindings"/> for the metadata seams, and malformed <c>v-bind()</c>
+    /// diagnostics compose onto the <c>.viu</c> style coordinates through the same style-origin envelope the
+    /// CSS parse diagnostics use. The scope id is returned only when a <c>scoped</c> block is declared.
     /// </summary>
     private static (string? ScopeId, string? ExtractedStyles) CompileStyles(
         SingleFileComponentFile file,
         SingleFileComponentSyntaxParserResult parse,
+        List<DiagnosticInfo> diagnostics,
+        List<CssModuleClassEntry> moduleClasses,
+        List<CssVariableBindingEntry> cssVariableBindings,
         System.Threading.CancellationToken cancellationToken)
     {
         string? scopeId = null;
         StringBuilder? styles = null;
+
+        // The module/v-bind hashes are salted by the component's short scope id (the path hash without the
+        // `data-v-` prefix), which the file always carries — so a `module`/`v-bind` block is component-scoped
+        // even when it is not `scoped` ([V01.01.06.06]).
+        var localHashSalt = ShortScopeId(file.ScopeId);
 
         foreach (var sourceResult in parse.SourceResults)
         {
@@ -262,17 +287,64 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             cancellationToken.ThrowIfCancellationRequested();
 
             string css;
-            if (styleBlock.Scoped &&
-                sourceResult.Result.Nodes.Count > 0 &&
-                sourceResult.Result.Nodes[0] is CssStylesheetNode stylesheet)
+            if (sourceResult.Result.Nodes.Count > 0 && sourceResult.Result.Nodes[0] is CssStylesheetNode parsed)
             {
-                // A scoped block is rewritten with the component's stable scope id.
-                scopeId ??= file.ScopeId;
-                css = CssScopedRewriter.Rewrite(stylesheet, scopeId);
+                var stylesheet = parsed;
+                var rewritten = false;
+
+                // `module`: rename local class selectors and record original -> hashed for the accessor.
+                if (styleBlock.IsModule)
+                {
+                    var moduleResult = CssModuleRewriter.Rewrite(stylesheet, localHashSalt);
+                    stylesheet = moduleResult.Stylesheet;
+                    rewritten = rewritten || moduleResult.Classes.Count > 0;
+                    var accessor = ModuleAccessorName(styleBlock.ModuleName);
+                    foreach (var pair in moduleResult.Classes)
+                    {
+                        moduleClasses.Add(new CssModuleClassEntry(accessor, pair.Key, pair.Value));
+                    }
+                }
+
+                // `v-bind()`: rewrite each usage to a custom property and record the (hash, expression)
+                // binding. The content guard skips the rewrite for the common no-binding block.
+                if (styleBlock.Content.IndexOf("v-bind", StringComparison.Ordinal) >= 0)
+                {
+                    var bindingResult = CssBindingRewriter.Rewrite(stylesheet, localHashSalt);
+                    stylesheet = bindingResult.Stylesheet;
+                    rewritten = rewritten || bindingResult.Bindings.Count > 0;
+                    foreach (var binding in bindingResult.Bindings)
+                    {
+                        cssVariableBindings.Add(new CssVariableBindingEntry(binding.Name, binding.Expression));
+                    }
+
+                    var blockContentStart = sourceResult.Node.ContentLocation.Start;
+                    foreach (var diagnostic in bindingResult.Diagnostics)
+                    {
+                        diagnostics.Add(SingleFileComponentDiagnostics.CreateStyle(file.FilePath, diagnostic, blockContentStart));
+                    }
+                }
+
+                if (styleBlock.Scoped)
+                {
+                    // A scoped block is serialized with the component's stable scope id (module/v-bind
+                    // rewrites already updated the tree the scoped serializer reads).
+                    scopeId ??= file.ScopeId;
+                    css = CssScopedRewriter.Rewrite(stylesheet, scopeId);
+                }
+                else if (rewritten)
+                {
+                    // A rewritten non-scoped block is serialized canonically (its class names / values
+                    // changed, so the raw content no longer matches).
+                    css = CssStylesheetWriter.Write(stylesheet);
+                }
+                else
+                {
+                    // An untouched non-scoped block passes through verbatim (issue acceptance criterion).
+                    css = styleBlock.Content;
+                }
             }
             else
             {
-                // A non-scoped block passes through unmodified (issue acceptance criterion).
                 css = styleBlock.Content;
             }
 
@@ -285,6 +357,51 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         }
 
         return (scopeId, styles?.ToString());
+    }
+
+    // The component's short scope id — the `data-v-` scope id with its prefix stripped — used to salt the
+    // module/v-bind hashes so they are component-scoped and deterministic ([V01.01.06.06]).
+    private static string ShortScopeId(string scopeId)
+        => scopeId.StartsWith(ScopeIdPrefix, StringComparison.Ordinal)
+            ? scopeId.Substring(ScopeIdPrefix.Length)
+            : scopeId;
+
+    // The generated accessor class name for a `module` option: default (valueless `module`) maps to
+    // `Style` — the C# analogue of Vue's `$style`, which has no legal C# spelling — and `module="name"`
+    // maps to the pascal-cased name.
+    private static string ModuleAccessorName(string? moduleName)
+        => string.IsNullOrEmpty(moduleName) ? "Style" : PascalCase(moduleName!);
+
+    // Pascal-cases an authored identifier for use as a C# type/member name: word boundaries at '-'/'_'/' '
+    // start a new capitalized word, a leading digit is prefixed with '_', and non-identifier characters are
+    // dropped. Deterministic so the emitted accessor is stable.
+    private static string PascalCase(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        var capitalizeNext = true;
+        foreach (var character in value)
+        {
+            if (character == '-' || character == '_' || character == ' ')
+            {
+                capitalizeNext = true;
+                continue;
+            }
+
+            if (!char.IsLetterOrDigit(character))
+            {
+                continue;
+            }
+
+            if (builder.Length == 0 && char.IsDigit(character))
+            {
+                builder.Append('_');
+            }
+
+            builder.Append(capitalizeNext ? char.ToUpperInvariant(character) : character);
+            capitalizeNext = false;
+        }
+
+        return builder.Length == 0 ? "Style" : builder.ToString();
     }
 
     private static void Execute(SourceProductionContext context, SingleFileComponentGeneratorResult result)

--- a/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+using Shouldly;
+using Xunit;
+
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+
+namespace Assimalign.Vue.Syntax.Generators.Tests;
+
+/// <summary>
+/// End-to-end tests for the CSS Modules and <c>v-bind()</c> generator emission ([V01.01.06.06], issue #62):
+/// a <c>@style module</c> block produces the hashed CSS plus the typed <c>$style</c>-equivalent accessor,
+/// a <c>v-bind()</c> block produces the custom-property CSS plus the <c>ApplyCssVariables</c> seam the
+/// <c>UseCssVars</c> runtime consumes, both compose with <c>scoped</c>, malformed <c>v-bind()</c> surfaces a
+/// style diagnostic on the <c>.viu</c> coordinates, and the additions stay strictly cached. The rewrite
+/// semantics themselves are pinned in the Css library's rewriter tests; these pin the generator wiring.
+/// </summary>
+public sealed class SingleFileComponentCssModuleTests
+{
+    private const string ProjectDirectory = "C:/proj";
+    private const string RootNamespace = "Demo";
+
+    [Fact]
+    public void ModuleStyle_HashesClassNames_AndEmitsTypedAccessor()
+    {
+        const string source = "@style module {\n    .box { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        // The default `module` maps to the `Style` accessor (the C# analogue of Vue's `$style`).
+        generated.ShouldContain("internal static class Style");
+        generated.ShouldContain("public const string box = \"box_");
+        // The extracted CSS carries the hashed selector, not the original.
+        generated.ShouldContain(".box_");
+        generated.ShouldNotContain(".box {");
+    }
+
+    [Fact]
+    public void ModuleStyle_HonorsCustomModuleName_AndSanitizesMembers()
+    {
+        const string source = "@style module=\"classes\" {\n    .my-box { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        // module="classes" -> the `Classes` accessor; the hyphenated class becomes a valid C# member.
+        generated.ShouldContain("internal static class Classes");
+        generated.ShouldContain("public const string my_box = \"my-box_");
+    }
+
+    [Fact]
+    public void VBindStyle_RewritesToCustomProperty_AndEmitsApplyCssVariablesSeam()
+    {
+        const string source =
+            "@script {\n    public string color = \"red\";\n}\n" +
+            "@style {\n    .a { color: v-bind(color); }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        // The CSS references a hashed custom property, and the seam wires the UseCssVars runtime with a
+        // getter that evaluates the original expression (resolved against the merged @script member `color`).
+        generated.ShouldContain("color: var(--");
+        generated.ShouldContain("internal void ApplyCssVariables()");
+        generated.ShouldContain("global::Assimalign.Vue.RuntimeDom.CssVariables.UseCssVars(");
+        generated.ShouldContain("(object?)(color)");
+    }
+
+    [Fact]
+    public void ModuleAndVBind_ComposeWithScoped()
+    {
+        const string source =
+            "@script {\n    public string c = \"red\";\n}\n" +
+            "@style module scoped {\n    .box { color: v-bind(c); }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        // All three compose: the class is hashed, the scope attribute lands on it, and the value is a
+        // custom property — plus the module accessor, the v-bind seam, and the scope id are all emitted.
+        generated.ShouldContain("internal const string ScopeId = \"data-v-");
+        generated.ShouldContain(".box_");
+        generated.ShouldContain("[data-v-");
+        generated.ShouldContain("color: var(--");
+        generated.ShouldContain("internal static class Style");
+        generated.ShouldContain("internal void ApplyCssVariables()");
+    }
+
+    [Fact]
+    public void ComponentWithoutModuleOrVBind_EmitsNeitherSeam()
+    {
+        const string source = "@style {\n    .box { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Plain.viu", source, RootNamespace, ProjectDirectory);
+
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Plain.SingleFileComponent.g.cs");
+        generated.ShouldNotContain("internal static class Style");
+        generated.ShouldNotContain("ApplyCssVariables");
+        // A plain non-scoped block still passes through verbatim (unchanged [V01.01.06.04] behavior).
+        generated.ShouldContain(".box { color: red; }");
+    }
+
+    [Fact]
+    public void MalformedVBind_SurfacesStyleDiagnostic_OnExactViuCoordinates()
+    {
+        const string source =
+            "@template {\n" +   // line 1
+            "    <div>ok</div>\n" +  // line 2
+            "}\n" +            // line 3
+            "\n" +             // line 4
+            "@style {\n" +     // line 5
+            "    .a { color: v-bind(); }\n" +  // line 6 — the empty v-bind
+            "}\n";             // line 7
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        var diagnostic = outcome.Diagnostics.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe("VUECS1301");
+        diagnostic.Severity.ShouldBe(RoslynDiagnosticSeverity.Error);
+        diagnostic.GetMessage().ShouldContain("(CSS code");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.ShouldBe(5); // .viu file line 6, zero-based
+        // Recoverable: the scaffold is still emitted.
+        outcome.Sources.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void ModuleAndVBind_IdenticalInput_StaysStrictlyCached()
+    {
+        // The module/v-bind compilation is deterministic and value-equatable, so an unchanged component
+        // leaves the model step strictly Cached — the incremental-generator contract.
+        const string source =
+            "@script {\n    public string c = \"red\";\n}\n" +
+            "@style module {\n    .box { color: v-bind(c); }\n}\n";
+
+        var file = new InMemoryAdditionalText($"{ProjectDirectory}/Card.viu", source);
+        var compilation = GeneratorTestHarness.CreateCompilation();
+        var driver = GeneratorTestHarness.CreateDriver(
+            ImmutableArray.Create<AdditionalText>(file), RootNamespace, ProjectDirectory);
+
+        driver = driver.RunGenerators(compilation);
+        driver = driver.RunGenerators(compilation);
+
+        driver.GetRunResult().Results[0]
+            .TrackedSteps[SingleFileComponentGenerator.ModelTrackingName]
+            .SelectMany(step => step.Outputs)
+            .Select(output => output.Reason)
+            .ShouldAllBe(reason => reason == IncrementalStepRunReason.Cached);
+    }
+}

--- a/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentScriptTests.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentScriptTests.cs
@@ -415,7 +415,9 @@ public sealed class SingleFileComponentScriptTests
             RenderBody: null,
             RenderCacheSize: 0,
             ScopeId: null,
-            ExtractedStyles: null);
+            ExtractedStyles: null,
+            ModuleClasses: EquatableArray<CssModuleClassEntry>.Empty,
+            CssVariableBindings: EquatableArray<CssVariableBindingEntry>.Empty);
 
         var metadata = model.ToBindingMetadata();
 
@@ -445,7 +447,9 @@ public sealed class SingleFileComponentScriptTests
             RenderBody: null,
             RenderCacheSize: 0,
             ScopeId: null,
-            ExtractedStyles: null);
+            ExtractedStyles: null,
+            ModuleClasses: EquatableArray<CssModuleClassEntry>.Empty,
+            CssVariableBindings: EquatableArray<CssVariableBindingEntry>.Empty);
 
         var metadata = model.ToBindingMetadata();
 

--- a/libraries/Assimalign.Vue.RuntimeDom/src/CssVariables.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/CssVariables.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom;
+
+/// <summary>
+/// The <c>UseCssVars</c> runtime — the C# port of Vue 3.5's <c>useCssVars</c>
+/// (<c>@vue/runtime-dom</c> <c>helpers/useCssVars.ts</c>,
+/// https://vuejs.org/api/sfc-css-features.html#v-bind-in-css), the runtime half of <c>v-bind()</c> in CSS.
+/// It applies a component's evaluated <c>v-bind()</c> expressions as CSS custom properties on the
+/// component's root element(s) and re-applies them reactively, on the post-flush phase, when a bound value
+/// changes — without re-rendering the component.
+/// <para>
+/// It consumes only <em>generated metadata</em>: the getter the source generator emits
+/// (<c>ApplyCssVariables</c>, [V01.01.06.06]) maps each hashed custom-property name to its evaluated value,
+/// and this runtime never references the compiler. The hashed names match the <c>var(--&lt;hash&gt;)</c>
+/// the CSS compilation produced, because both derive from the same component-scoped hash of the same
+/// expression.
+/// </para>
+/// Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+public static class CssVariables
+{
+    /// <summary>
+    /// Registers the component's <c>v-bind()</c> custom properties (upstream: <c>useCssVars(getter)</c>).
+    /// Call during the component's <c>Setup</c>: <paramref name="getter"/> is evaluated once after mount
+    /// (applying the initial values) and again in the post-flush phase whenever a value it reads changes,
+    /// each pass batching every <c>style.setProperty</c> on a root element into one interop crossing. The
+    /// watcher and its cleanup stop with the component. Called with no active component instance (outside
+    /// <c>Setup</c>) it is a no-op, mirroring upstream's dev-time guard.
+    /// </summary>
+    /// <param name="getter">
+    /// Produces the map from each hashed custom-property name (without the leading <c>--</c>) to its current
+    /// value. Reading reactive state inside it is what makes the properties update reactively.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="getter"/> is <see langword="null"/>.</exception>
+    public static void UseCssVars(Func<IReadOnlyDictionary<string, string>> getter)
+    {
+        if (getter is null)
+        {
+            throw new ArgumentNullException(nameof(getter));
+        }
+
+        var instance = ComponentInstance.Current;
+        if (instance is null)
+        {
+            // Upstream warns and returns; without an instance there is no subtree to apply to.
+            return;
+        }
+
+        void SetVars() => ApplyToVirtualNode(instance.Subtree, getter());
+
+        // Upstream onBeforeUpdate -> queuePostFlushCb(setVars): a structural re-render can change which
+        // element is the root, so re-apply after each update's patch. The reusable job deduplicates within a
+        // flush, matching upstream's stable-function queuePostFlushCb.
+        var updateJob = new SchedulerJob(SetVars);
+        Lifecycle.OnBeforeUpdate(() => Scheduler.QueuePostFlushCallback(updateJob));
+
+        Lifecycle.OnMounted(() =>
+        {
+            // Upstream: watch(setVars, NOOP, { flush: 'post' }). WatchEffect runs setVars immediately — here
+            // that first run is inside onMounted, where the subtree's element handles exist, so it is the
+            // initial application — and re-runs it in the post-flush phase whenever a value the getter reads
+            // changes, tracking those values without touching the render effect (so no re-render).
+            var handle = VueWatch.WatchEffect(SetVars, new WatchOptions { Flush = WatchFlushMode.Post });
+            Lifecycle.OnUnmounted(handle.Stop);
+        });
+    }
+
+    // The C# port of upstream setVarsOnVNode: find the component's actual root element(s), drilling through
+    // higher-order components and descending into fragments, and apply the vars to each. Suspense is not
+    // implemented ([V01.01.03.19]), so its branch is intentionally absent.
+    private static void ApplyToVirtualNode(VirtualNode? virtualNode, IReadOnlyDictionary<string, string> vars)
+    {
+        if (virtualNode is null)
+        {
+            return;
+        }
+
+        // Drill through higher-order components until a non-component vnode (upstream: while (vnode.component)
+        // vnode = vnode.component.subTree).
+        while (virtualNode.Component is ComponentInstance childInstance && childInstance.Subtree is { } childSubtree)
+        {
+            virtualNode = childSubtree;
+        }
+
+        switch (virtualNode.Type)
+        {
+            case VirtualNodeType.Element when virtualNode.El is { } element:
+                ApplyToElement(element, vars);
+                break;
+            case VirtualNodeType.Fragment when virtualNode.ArrayChildren is { } children:
+                foreach (var child in children)
+                {
+                    ApplyToVirtualNode(child, vars);
+                }
+
+                break;
+            case VirtualNodeType.Static when virtualNode.El is { } staticElement:
+                // A static chunk is inserted as one span; apply to its first element (upstream walks el..anchor).
+                ApplyToElement(staticElement, vars);
+                break;
+        }
+    }
+
+    // Batches every custom-property write on one element into a single interop crossing (the acceptance
+    // criterion: never one interop call per property). The element handle is the DOM renderer's boxed int.
+    private static void ApplyToElement(object element, IReadOnlyDictionary<string, string> vars)
+    {
+        if (vars.Count == 0 || element is not int handle)
+        {
+            return;
+        }
+
+        var operations = BrowserDirectiveOperations.Current;
+        if (operations is null)
+        {
+            return;
+        }
+
+        var names = new string[vars.Count];
+        var values = new string[vars.Count];
+        var index = 0;
+        foreach (var pair in vars)
+        {
+            // The generated names are the bare hashes; the custom-property spelling adds the leading '--'
+            // (upstream setVarsOnNode: style.setProperty(`--${key}`, ...)).
+            names[index] = "--" + pair.Key;
+            values[index] = pair.Value;
+            index++;
+        }
+
+        operations.SetCssVariables(handle, names, values);
+    }
+}

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDirectiveOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDirectiveOperations.cs
@@ -42,6 +42,13 @@ internal sealed class BrowserDirectiveOperations
     /// <summary>Removes one inline style property — <c>v-show</c> uses it to restore an empty original <c>display</c>.</summary>
     public required Action<int, string> RemoveStyleProperty { get; init; }
 
+    /// <summary>
+    /// Batches setting several CSS custom properties (index-aligned name/value arrays, the names including
+    /// the leading <c>--</c>) on an element into a single interop crossing — the <c>UseCssVars</c>
+    /// application path ([V01.01.06.06]), which must never issue one interop call per property.
+    /// </summary>
+    public required Action<int, string[], string[]> SetCssVariables { get; init; }
+
     /// <summary>The ambient instance, or a thrown <see cref="InvalidOperationException"/> when none is installed.</summary>
     public static BrowserDirectiveOperations Require()
         => Current ?? throw new InvalidOperationException(

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserDomBridge.cs
@@ -285,6 +285,18 @@ internal static partial class BrowserDomBridge
         }
     }
 
+    internal static void SetCssVariables(int nodeHandle, string[] names, string[] values)
+    {
+        try
+        {
+            Imports.SetCssVariables(nodeHandle, names, values);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("setCssVars", nodeHandle, exception);
+        }
+    }
+
     internal static void AddEventListener(int nodeHandle, string eventName, bool once, bool capture, bool passive)
     {
         try
@@ -424,6 +436,12 @@ internal static partial class BrowserDomBridge
 
         [JSImport("dom.removeStyleProperty", ModuleName)]
         internal static partial void RemoveStyleProperty(int nodeHandle, string name);
+
+        [JSImport("dom.setCssVars", ModuleName)]
+        internal static partial void SetCssVariables(
+            int nodeHandle,
+            [JSMarshalAs<JSType.Array<JSType.String>>] string[] names,
+            [JSMarshalAs<JSType.Array<JSType.String>>] string[] values);
 
         [JSImport("dom.addEventListener", ModuleName)]
         internal static partial void AddEventListener(int nodeHandle, string eventName, bool once, bool capture, bool passive);

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -55,6 +55,9 @@ internal static class BrowserNodeOperations
             SetBooleanProperty = LeafOperations.SetBooleanProperty,
             SetStyleProperty = LeafOperations.SetStyleProperty,
             RemoveStyleProperty = LeafOperations.RemoveStyleProperty,
+            // One interop crossing per post-flush UseCssVars pass ([V01.01.06.06]): the whole custom-property
+            // batch for a root element crosses the boundary once.
+            SetCssVariables = static (element, names, values) => BrowserDomBridge.SetCssVariables(element, names, values),
         };
     }
 

--- a/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
@@ -183,6 +183,15 @@ internal sealed class BufferedBrowserNodeOperations
             SetBooleanProperty = _leaf.SetBooleanProperty,
             SetStyleProperty = _leaf.SetStyleProperty,
             RemoveStyleProperty = _leaf.RemoveStyleProperty,
+            // UseCssVars in buffered mode ([V01.01.06.06]): the per-property writes join the pending frame,
+            // which still commits in one boundary crossing per flush, so the batching AC holds.
+            SetCssVariables = (element, names, values) =>
+            {
+                for (var index = 0; index < names.Length; index++)
+                {
+                    _leaf.SetStyleProperty(element, names[index], values[index], false);
+                }
+            },
         };
     }
 

--- a/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
+++ b/libraries/Assimalign.Vue.RuntimeDom/src/wwwroot/vuecs-dom.js
@@ -339,6 +339,16 @@ export const dom = {
         getNode('removeStyleProperty', nodeHandle).style.removeProperty(name)
     },
 
+    // Batches the v-bind() CSS custom properties for one root element into a single crossing
+    // ([V01.01.06.06]): the .NET UseCssVars runtime passes index-aligned name/value arrays (names include
+    // the leading '--') and this loops style.setProperty, matching upstream setVarsOnNode.
+    setCssVars: (nodeHandle, names, values) => {
+        const style = getNode('setCssVars', nodeHandle).style
+        for (let index = 0; index < names.length; index++) {
+            style.setProperty(names[index], values[index])
+        }
+    },
+
     // --- events (invoker pattern: one listener per (element, event, capture); handler
     // changes are .NET-side delegate swaps with no listener churn; the attach-timestamp guard
     // ignores events that fired before their listener was attached, matching Vue's

--- a/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
@@ -113,6 +113,45 @@ public sealed class DomCompiledRenderTests
         assembly.Length.ShouldBeGreaterThan(0);
     }
 
+    // A component that exercises both [V01.01.06.06] seams: a `module` block (the typed accessor) and a
+    // `v-bind()` block (the ApplyCssVariables call into UseCssVars). The hand-written half supplies the
+    // members the emitted v-bind getter evaluates.
+    private const string CssModuleAndVBindComponent =
+        "@template {\n" +
+        "<div class=\"box\">hi</div>\n" +
+        "}\n" +
+        "@style module {\n" +
+        ".box { color: v-bind(color); width: v-bind(size); }\n" +
+        "}\n";
+
+    private const string CssModuleHandWrittenHalf =
+        "#nullable enable\n" +
+        "namespace Demo\n" +
+        "{\n" +
+        "    partial class CssWidget\n" +
+        "    {\n" +
+        "        public string color => \"red\";\n" +
+        "        public int size => 10;\n" +
+        "    }\n" +
+        "}\n";
+
+    [Fact]
+    public void CssModuleAndVBind_SeamsCompile_AgainstRuntimeDom()
+    {
+        // The generated $style accessor and the ApplyCssVariables -> UseCssVars seam are real runtime C#:
+        // the accessor's const members compile, and the getter binds CssVariables.UseCssVars in RuntimeDom
+        // while its expressions resolve against the merged component members. This proves the [V01.01.06.06]
+        // metadata the runtime half consumes is well-formed, DOM-free.
+        var generated = CompiledRenderSupport.Generate("CssWidget", CssModuleAndVBindComponent);
+
+        generated.ShouldContain("internal static class Style");
+        generated.ShouldContain("internal void ApplyCssVariables()");
+        generated.ShouldContain("global::Assimalign.Vue.RuntimeDom.CssVariables.UseCssVars(");
+
+        var assembly = CompiledRenderSupport.CompileToAssembly(generated, CssModuleHandWrittenHalf);
+        assembly.Length.ShouldBeGreaterThan(0);
+    }
+
     [Fact]
     public void GeneratorCaching_ForTheDomDirectiveTemplate_StaysStrictlyCached()
     {

--- a/libraries/Assimalign.Vue.RuntimeDom/test/BrowserDirectiveTestHarness.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/BrowserDirectiveTestHarness.cs
@@ -21,6 +21,7 @@ internal sealed class BrowserDirectiveTestHarness : IDisposable
     private readonly TestSchedulerPump _pump;
     private readonly Renderer<int> _renderer;
     private int _nextHandle = 1;
+    private int _cssVariableCrossings;
 
     public BrowserDirectiveTestHarness()
     {
@@ -54,6 +55,17 @@ internal sealed class BrowserDirectiveTestHarness : IDisposable
             SetBooleanProperty = SetBooleanProperty,
             SetStyleProperty = (element, name, value, _) => Element(element).Style[name] = value,
             RemoveStyleProperty = (element, name) => Element(element).Style.Remove(name),
+            // One recorded crossing per UseCssVars pass: apply every custom property, and count the call so
+            // tests can pin the single-interop-crossing-per-pass batching AC ([V01.01.06.06]).
+            SetCssVariables = (element, names, values) =>
+            {
+                _cssVariableCrossings++;
+                var style = Element(element).Style;
+                for (var index = 0; index < names.Length; index++)
+                {
+                    style[names[index]] = values[index];
+                }
+            },
         };
 
         _renderer = RendererFactory.CreateRenderer(new RendererOptions<int>
@@ -131,6 +143,13 @@ internal sealed class BrowserDirectiveTestHarness : IDisposable
     /// <summary>The element's inline <c>display</c>, or null when there is no inline display.</summary>
     public string? Display(int handle)
         => Element(handle).Style.TryGetValue("display", out var display) ? display : null;
+
+    /// <summary>The element's applied CSS custom property (e.g. <c>--abc12345</c>), or null when unset.</summary>
+    public string? CssVariable(int handle, string name)
+        => Element(handle).Style.TryGetValue(name, out var value) ? value : null;
+
+    /// <summary>The number of batched <c>UseCssVars</c> interop crossings recorded (one per applied element per pass).</summary>
+    public int CssVariableCrossings => _cssVariableCrossings;
 
     // --- event firing (routes through the real registry: property + model channels) ------------
 

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DirectHandleDomWorld.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CommandBuffer/DirectHandleDomWorld.cs
@@ -58,6 +58,13 @@ internal sealed class DirectHandleDomWorld : IDisposable
             SetBooleanProperty = leaf.SetBooleanProperty,
             SetStyleProperty = leaf.SetStyleProperty,
             RemoveStyleProperty = leaf.RemoveStyleProperty,
+            SetCssVariables = (element, names, values) =>
+            {
+                for (var index = 0; index < names.Length; index++)
+                {
+                    leaf.SetStyleProperty(element, names[index], values[index], false);
+                }
+            },
         };
     }
 

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CssVariablesTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CssVariablesTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Vue.Reactivity;
+using Assimalign.Vue.RuntimeCore;
+
+namespace Assimalign.Vue.RuntimeDom.Tests;
+
+/// <summary>
+/// Pins the <c>UseCssVars</c> runtime (<see cref="CssVariables"/>, [V01.01.06.06]) — the C# port of Vue
+/// 3.5's <c>useCssVars</c> (<c>@vue/runtime-dom</c> <c>helpers/useCssVars.ts</c>,
+/// https://vuejs.org/api/sfc-css-features.html#v-bind-in-css). Exercised DOM-free through the in-memory
+/// adapter (<see cref="BrowserDirectiveTestHarness"/>): the evaluated <c>v-bind()</c> values are applied as
+/// custom properties on the component root after mount, re-applied reactively on the next post-flush pass
+/// without re-rendering, batched into one interop crossing per element per pass, and torn down on unmount.
+/// </summary>
+public sealed class CssVariablesTests : IDisposable
+{
+    private readonly BrowserDirectiveTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    [Fact]
+    public void UseCssVars_AppliesCustomProperty_OnRootElement_AfterMount()
+    {
+        var color = Reactive.Reference("red");
+        _harness.Render(Component(() => new Dictionary<string, string> { ["abc12345"] = color.Value }));
+        _harness.RunUntilIdle();
+
+        var div = _harness.FindElement("div");
+        // Applied with the leading '--' (upstream setVarsOnNode: style.setProperty('--' + key, value)).
+        _harness.CssVariable(div, "--abc12345").ShouldBe("red");
+        // One crossing on mount — the initial application (upstream's watch source runs once in onMounted).
+        _harness.CssVariableCrossings.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseCssVars_UpdatesReactively_OnNextFlush_WithoutReRendering()
+    {
+        var color = Reactive.Reference("red");
+        var renderCount = 0;
+        _harness.Render(Component(
+            () => new Dictionary<string, string> { ["abc12345"] = color.Value },
+            onRender: () => renderCount++));
+        _harness.RunUntilIdle();
+
+        renderCount.ShouldBe(1);
+        _harness.CssVariableCrossings.ShouldBe(1);
+
+        // A bound value changes: the property updates on the next flush and the crossing count ticks by one,
+        // but the render function does not re-run — the AC's "without re-rendering the component".
+        color.Value = "blue";
+        _harness.RunUntilIdle();
+
+        var div = _harness.FindElement("div");
+        _harness.CssVariable(div, "--abc12345").ShouldBe("blue");
+        _harness.CssVariableCrossings.ShouldBe(2);
+        renderCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseCssVars_DoesNotReapply_WhenNoBoundValueChanged()
+    {
+        var color = Reactive.Reference("red");
+        var unrelated = Reactive.Reference(0);
+        _harness.Render(Component(() => new Dictionary<string, string> { ["abc12345"] = color.Value }));
+        _harness.RunUntilIdle();
+        _harness.CssVariableCrossings.ShouldBe(1);
+
+        // Mutating state the getter never reads triggers no post-flush re-application (dependency tracking,
+        // not a blanket post-flush hook) — the run-count guard the testing rules require.
+        unrelated.Value = 5;
+        _harness.RunUntilIdle();
+
+        _harness.CssVariableCrossings.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseCssVars_BatchesEveryProperty_IntoOneCrossingPerPass()
+    {
+        var color = Reactive.Reference("red");
+        var size = Reactive.Reference("10px");
+        _harness.Render(Component(() => new Dictionary<string, string>
+        {
+            ["c"] = color.Value,
+            ["s"] = size.Value,
+        }));
+        _harness.RunUntilIdle();
+
+        var div = _harness.FindElement("div");
+        _harness.CssVariable(div, "--c").ShouldBe("red");
+        _harness.CssVariable(div, "--s").ShouldBe("10px");
+        // Both properties applied in a single crossing — never one interop call per property (the batching AC).
+        _harness.CssVariableCrossings.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseCssVars_AppliesToEveryRoot_OfAFragmentComponent()
+    {
+        var color = Reactive.Reference("red");
+        var component = new RenderComponent((_, _) =>
+        {
+            CssVariables.UseCssVars(() => new Dictionary<string, string> { ["v"] = color.Value });
+            return () => VirtualNodeFactory.Fragment(
+                VirtualNodeFactory.Element("div", "a"),
+                VirtualNodeFactory.Element("span", "b"));
+        });
+
+        _harness.Render(component);
+        _harness.RunUntilIdle();
+
+        // A multi-root component applies the vars to each root element (upstream setVarsOnVNode descends the
+        // Fragment) — one crossing per root element.
+        _harness.CssVariable(_harness.FindElement("div"), "--v").ShouldBe("red");
+        _harness.CssVariable(_harness.FindElement("span"), "--v").ShouldBe("red");
+        _harness.CssVariableCrossings.ShouldBe(2);
+    }
+
+    [Fact]
+    public void UseCssVars_StopsApplying_AfterUnmount()
+    {
+        var color = Reactive.Reference("red");
+        _harness.Render(Component(() => new Dictionary<string, string> { ["abc12345"] = color.Value }));
+        _harness.RunUntilIdle();
+        _harness.CssVariableCrossings.ShouldBe(1);
+
+        _harness.Unmount();
+        _harness.RunUntilIdle();
+        var afterUnmount = _harness.CssVariableCrossings;
+
+        // The watcher stops with the component (onUnmounted -> handle.Stop), so a later mutation applies nothing.
+        color.Value = "blue";
+        _harness.RunUntilIdle();
+
+        _harness.CssVariableCrossings.ShouldBe(afterUnmount);
+    }
+
+    [Fact]
+    public void UseCssVars_WithoutActiveInstance_IsNoOp()
+    {
+        // Called outside a component Setup there is no subtree to apply to; upstream warns and returns.
+        Should.NotThrow(() => CssVariables.UseCssVars(() => new Dictionary<string, string> { ["x"] = "1" }));
+    }
+
+    [Fact]
+    public void UseCssVars_NullGetter_Throws()
+        => Should.Throw<ArgumentNullException>(() => CssVariables.UseCssVars(null!));
+
+    // A component whose setup registers UseCssVars and whose root is a single <div>, mirroring the shape the
+    // generator's ApplyCssVariables seam produces.
+    private static RenderComponent Component(Func<IReadOnlyDictionary<string, string>> getter, Action? onRender = null)
+        => new((_, _) =>
+        {
+            CssVariables.UseCssVars(getter);
+            return () =>
+            {
+                onRender?.Invoke();
+                return VirtualNodeFactory.Element("div", "content");
+            };
+        });
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Css/docs/DESIGN.md
@@ -2,7 +2,9 @@
 
 Why the CSS area is shaped the way it is, and its deliberate divergences from a full CSS engine. The
 scaffold that preceded this (a raw whole-source root node pinning the pipeline seam) was replaced by real
-rule-level parsing and the scoped-selector rewrite with scoped CSS **[V01.01.06.04]** (issue #60).
+rule-level parsing and the scoped-selector rewrite with scoped CSS **[V01.01.06.04]** (issue #60); CSS
+Modules and `v-bind()` in CSS were added with **[V01.01.06.06]** (issue #62), reusing the same tree and
+serializer machinery.
 
 ## Two-phase parse, context-directed, recoverable
 
@@ -80,6 +82,34 @@ production build additionally folds the source in for cache-busting, which is de
 static-web-asset emission below. A linked file outside the project directory falls back to hashing its
 leaf name so the id stays machine-independent.
 
+## CSS Modules and `v-bind()` — the [V01.01.06.06] rewrites
+
+Two more transforms sit alongside `CssScopedRewriter`, each a pure-.NET port of a `@vue/compiler-sfc`
+stage and each reached the same way — the composition-root generator runs them over the parsed tree, not
+the `.viu` parser wiring them in.
+
+- **`CssModuleRewriter`** ports `compileStyle()`'s CSS-Modules mode (`postcss-modules`). It renames every
+  local class selector `.foo` to `.foo_<hash>` and returns the original → hashed map for the generated
+  `$style` accessor. `<hash>` is the eight-hex-digit FNV-1a of `<shortScopeId>-foo` (`CssHash`, the same
+  FNV-1a as `StyleScopeId`), so it is deterministic, stable across rebuilds, and unique per component. The
+  rename touches only class selectors in normal compound position; class names inside functional-pseudo
+  arguments (`:not()`, `:deep()`, `:slotted()`, `:global()`) are left alone — `:deep`/`:global`
+  deliberately target external/un-hashed names, and non-reserved pseudo arguments are verbatim text (the
+  parser non-goal below).
+- **`CssBindingRewriter`** ports `cssVars.ts`. It scans each declaration value for `v-bind(expr)` (a port
+  of upstream's `lexBinding`: it skips string literals and `/* */` comments and balances nested parens),
+  replaces each with `var(--<hash>)`, and collects the distinct `(hash, expression)` bindings for the
+  `UseCssVars` runtime. `<hash>` is the FNV-1a of `<shortScopeId>-<expr>`, so the emitted CSS
+  `var(--<hash>)` and the runtime's `style.setProperty("--<hash>", …)` agree by construction. An
+  unterminated `v-bind(` or an empty `v-bind()` reports a recoverable 2000-band `CssError` on the
+  declaration and is left in place.
+
+Both are tree-to-tree, so they compose with `scoped` in any order — the scoped serializer reads the
+parsed selector parts and declaration values the rewrites already updated. A block that is `module`/`v-bind`
+but **not** `scoped` is serialized by **`CssStylesheetWriter`**, the plain (unscoped) sibling of
+`CssScopedRewriter` sharing its canonical two-space form; a non-scoped block with neither feature is still
+emitted verbatim and never reaches the writer, so only rewritten blocks lose their original whitespace.
+
 ## Composition boundary
 
 The library never wires itself into the `.viu` parser. The [V01.01.06.02] generator composition root
@@ -91,8 +121,14 @@ only the scope-id string.
 
 ## Non-goals (deliberate scope boundaries)
 
-- **CSS Modules and `v-bind()` in CSS** — [V01.01.06.06], not this item. The parser tree and kind catalog
-  are built to host them; the seams are left, not implemented.
+- **Class renaming inside functional-pseudo arguments** for CSS Modules — `.foo` inside `:not()`,
+  `:deep()`, `:slotted()`, `:global()` is not renamed (see the [V01.01.06.06] section). This follows the
+  verbatim-pseudo-argument non-goal below and, for `:deep`/`:global`, is the correct behavior (those target
+  external names).
+- **The production `hash(id + raw)` prod-mode `v-bind` name** — upstream's dev build uses a readable
+  `id-<escaped-expr>` custom property and its prod build a bare hash; Vuecs always uses the deterministic
+  component-scoped hash (`--<hash>`), which is unambiguous and needs no escaping, and records the readable
+  expression in metadata instead.
 - **Physical static-web-asset bundling.** A Roslyn source generator emits C#, not content files (and
   `System.IO` is off-limits under RS1035), so the extracted CSS surfaces as the generated `ExtractedStyles`
   constant. Writing the CSS into `dotnet publish` output as a bundled stylesheet is an MSBuild-task

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriteResult.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriteResult.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// The result of the <c>v-bind()</c> rewrite (<see cref="CssBindingRewriter.Rewrite"/>): the stylesheet
+/// with every <c>v-bind(expr)</c> in a declaration value replaced by <c>var(--&lt;hash&gt;)</c>, the
+/// <see cref="Bindings"/> collected for the generated component metadata, and any
+/// <see cref="Diagnostics"/> for malformed usages. Mirrors the two outputs of Vue's <c>cssVars.ts</c> — the
+/// rewritten declaration values and the <c>cssVars</c> expression list <c>useCssVars</c> consumes
+/// (https://vuejs.org/api/sfc-css-features.html#v-bind-in-css).
+/// </summary>
+/// <param name="Stylesheet">
+/// The stylesheet with rewritten declaration values. Feed it to <see cref="CssScopedRewriter.Rewrite"/>
+/// (when the block is also <c>scoped</c>) or <see cref="CssStylesheetWriter.Write"/> to serialize.
+/// </param>
+/// <param name="Bindings">
+/// The distinct bindings, in first-seen source order — each a hashed custom-property name paired with the
+/// original expression the runtime evaluates.
+/// </param>
+/// <param name="Diagnostics">
+/// Recoverable diagnostics for malformed usages (an unterminated <c>v-bind(</c> or an empty
+/// <c>v-bind()</c>), located on the offending declaration; empty when every usage was well formed.
+/// </param>
+public sealed record CssBindingRewriteResult(
+    CssStylesheetNode Stylesheet,
+    IReadOnlyList<CssVariableBinding> Bindings,
+    IReadOnlyList<CssError> Diagnostics);

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriter.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriter.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// Rewrites <c>v-bind()</c> occurrences in a parsed <see cref="CssStylesheetNode"/>'s declaration values —
+/// the pure-.NET C# port of Vue 3.5's <c>v-bind()</c>-in-CSS compilation (<c>@vue/compiler-sfc</c>
+/// <c>cssVars.ts</c>, https://vuejs.org/api/sfc-css-features.html#v-bind-in-css). Each
+/// <c>v-bind(expression)</c> is replaced with a component-scoped custom-property reference
+/// <c>var(--&lt;hash&gt;)</c>, and the referenced expressions are collected so the composition-root
+/// generator can record them as component metadata for the <c>UseCssVars</c> runtime ([V01.01.06.06],
+/// issue #62).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The variable scheme.</b> A usage <c>v-bind(expr)</c> becomes <c>var(--&lt;hash&gt;)</c>, where
+/// <c>&lt;hash&gt;</c> is the eight-hex-digit FNV-1a of <c>&lt;localHashSalt&gt;-&lt;expr&gt;</c>
+/// (<see cref="CssHash"/>). The caller passes the component's short scope id as the salt — Vue's
+/// <c>genVarName</c> likewise folds the file id into the hash — so the property is deterministic and
+/// component-scoped, and the CSS <c>var(--&lt;hash&gt;)</c> matches the runtime's
+/// <c>style.setProperty("--&lt;hash&gt;", …)</c> by construction because both derive from the same hash of
+/// the same expression. Distinct expressions are de-duplicated by their trimmed, unquoted text (upstream's
+/// <c>if (!vars.includes(variable))</c>), so a repeated <c>v-bind(color)</c> yields one binding.
+/// </para>
+/// <para>
+/// <b>Extraction.</b> The scan mirrors upstream's <c>lexBinding</c>: it walks each declaration value,
+/// skipping string literals and <c>/* … */</c> comments so a <c>v-bind(</c> inside them never matches, and
+/// balances nested parentheses to find the closing <c>)</c>. A surrounding pair of matching quotes on the
+/// expression is stripped (<c>v-bind('theme.color')</c> → <c>theme.color</c>), matching
+/// <c>normalizeExpression</c>. An unterminated <c>v-bind(</c> or an empty <c>v-bind()</c> reports a
+/// recoverable <see cref="CssError"/> (the 2000-band catalog) located on the declaration and is left in
+/// place, never throwing.
+/// </para>
+/// </remarks>
+public static class CssBindingRewriter
+{
+    private const string BindingKeyword = "v-bind";
+
+    /// <summary>
+    /// Rewrites every well-formed <c>v-bind()</c> in <paramref name="stylesheet"/>'s declaration values to a
+    /// custom-property reference salted by <paramref name="localHashSalt"/>.
+    /// </summary>
+    /// <param name="stylesheet">The parsed stylesheet to rewrite.</param>
+    /// <param name="localHashSalt">The component-scoped salt (the short <c>data-v-</c> scope id).</param>
+    /// <returns>The rewritten stylesheet, the collected bindings, and any malformed-usage diagnostics.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stylesheet"/> or <paramref name="localHashSalt"/> is <see langword="null"/>.</exception>
+    public static CssBindingRewriteResult Rewrite(CssStylesheetNode stylesheet, string localHashSalt)
+    {
+        if (stylesheet is null)
+        {
+            throw new ArgumentNullException(nameof(stylesheet));
+        }
+
+        if (localHashSalt is null)
+        {
+            throw new ArgumentNullException(nameof(localHashSalt));
+        }
+
+        var state = new RewriteState(localHashSalt);
+        var rewritten = stylesheet with { Rules = state.RewriteRules(stylesheet.Rules) };
+        return new CssBindingRewriteResult(rewritten, state.Bindings, state.Diagnostics);
+    }
+
+    // Carries the per-rewrite accumulators (salt, ordered bindings, dedupe map, diagnostics) so the
+    // recursive tree walk stays a set of small pure-ish methods.
+    private sealed class RewriteState
+    {
+        private readonly string _salt;
+        private readonly Dictionary<string, string> _namesByExpression = new(StringComparer.Ordinal);
+
+        public RewriteState(string salt) => _salt = salt;
+
+        public List<CssVariableBinding> Bindings { get; } = [];
+
+        public List<CssError> Diagnostics { get; } = [];
+
+        public SyntaxList<CssSyntaxNode> RewriteRules(SyntaxList<CssSyntaxNode> rules)
+        {
+            var rewritten = new CssSyntaxNode[rules.Count];
+            for (var index = 0; index < rules.Count; index++)
+            {
+                rewritten[index] = rules[index] switch
+                {
+                    CssQualifiedRuleNode qualified => qualified with
+                    {
+                        Declarations = RewriteDeclarations(qualified.Declarations),
+                    },
+                    // A body is nested rules (@media), declarations (@font-face), or keyframe rules
+                    // (@keyframes); recursing dispatches each child by type below.
+                    CssAtRuleNode atRule => atRule with { Body = RewriteRules(atRule.Body) },
+                    CssKeyframeRuleNode keyframe => keyframe with
+                    {
+                        Declarations = RewriteDeclarations(keyframe.Declarations),
+                    },
+                    CssDeclarationNode declaration => RewriteDeclaration(declaration),
+                    var other => other,
+                };
+            }
+
+            return new SyntaxList<CssSyntaxNode>(rewritten);
+        }
+
+        private SyntaxList<CssDeclarationNode> RewriteDeclarations(SyntaxList<CssDeclarationNode> declarations)
+        {
+            var rewritten = new CssDeclarationNode[declarations.Count];
+            for (var index = 0; index < declarations.Count; index++)
+            {
+                rewritten[index] = RewriteDeclaration(declarations[index]);
+            }
+
+            return new SyntaxList<CssDeclarationNode>(rewritten);
+        }
+
+        private CssDeclarationNode RewriteDeclaration(CssDeclarationNode declaration)
+        {
+            var value = declaration.Value;
+            if (value.IndexOf(BindingKeyword, StringComparison.Ordinal) < 0)
+            {
+                // Fast path: no 'v-bind' substring, so nothing to rewrite (the common declaration).
+                return declaration;
+            }
+
+            var rewrittenValue = RewriteValue(value, declaration.Location);
+            return ReferenceEquals(rewrittenValue, value) ? declaration : declaration with { Value = rewrittenValue };
+        }
+
+        // Scans one declaration value, replacing each well-formed v-bind(expr) with var(--<hash>) and
+        // collecting the binding. String literals and /* */ comments are copied verbatim so a keyword
+        // inside them never matches. Returns the same instance when nothing changed.
+        private string RewriteValue(string value, SourceLocation location)
+        {
+            StringBuilder? builder = null;
+            var index = 0;
+            var copiedThrough = 0;
+            while (index < value.Length)
+            {
+                var character = value[index];
+                if (character == '"' || character == '\'')
+                {
+                    index = SkipString(value, index);
+                    continue;
+                }
+
+                if (character == '/' && index + 1 < value.Length && value[index + 1] == '*')
+                {
+                    index = SkipComment(value, index);
+                    continue;
+                }
+
+                if (!MatchesBindingKeyword(value, index, out var afterKeyword))
+                {
+                    index++;
+                    continue;
+                }
+
+                var open = SkipWhitespace(value, afterKeyword);
+                if (open >= value.Length || value[open] != '(')
+                {
+                    // 'v-bind' not followed by '(' is ordinary text (e.g. a custom property named v-bind).
+                    index++;
+                    continue;
+                }
+
+                var argumentStart = open + 1;
+                var close = LexBinding(value, argumentStart);
+                if (close < 0)
+                {
+                    Diagnostics.Add(new CssError(CssErrorCode.UnterminatedCssBinding, location));
+                    // Unrecoverable within this value: leave the remainder verbatim and stop scanning.
+                    break;
+                }
+
+                var expression = NormalizeExpression(value.Substring(argumentStart, close - argumentStart));
+                if (expression.Length == 0)
+                {
+                    Diagnostics.Add(new CssError(CssErrorCode.EmptyCssBinding, location));
+                    // Leave the empty usage in place and continue past it.
+                    index = close + 1;
+                    continue;
+                }
+
+                builder ??= new StringBuilder(value.Length);
+                builder.Append(value, copiedThrough, index - copiedThrough);
+                builder.Append("var(--").Append(ResolveName(expression)).Append(')');
+                index = close + 1;
+                copiedThrough = index;
+            }
+
+            if (builder is null)
+            {
+                return value;
+            }
+
+            builder.Append(value, copiedThrough, value.Length - copiedThrough);
+            return builder.ToString();
+        }
+
+        // Deduplicates by the normalized expression so a repeated v-bind(color) shares one hashed name and
+        // one recorded binding (upstream vars.includes check).
+        private string ResolveName(string expression)
+        {
+            if (_namesByExpression.TryGetValue(expression, out var name))
+            {
+                return name;
+            }
+
+            name = CssHash.Compute(_salt + "-" + expression);
+            _namesByExpression[expression] = name;
+            Bindings.Add(new CssVariableBinding(name, expression));
+            return name;
+        }
+    }
+
+    // Whether the literal keyword 'v-bind' sits at index; sets afterKeyword to the index just past it.
+    private static bool MatchesBindingKeyword(string value, int index, out int afterKeyword)
+    {
+        afterKeyword = index + BindingKeyword.Length;
+        return afterKeyword <= value.Length
+            && string.CompareOrdinal(value, index, BindingKeyword, 0, BindingKeyword.Length) == 0;
+    }
+
+    // Finds the index of the ')' that closes the '(' whose content starts at argumentStart, balancing
+    // nested parens and skipping string literals (upstream lexBinding). Returns -1 when unterminated.
+    private static int LexBinding(string value, int argumentStart)
+    {
+        var depth = 1;
+        var index = argumentStart;
+        while (index < value.Length)
+        {
+            var character = value[index];
+            if (character == '"' || character == '\'')
+            {
+                index = SkipString(value, index);
+                continue;
+            }
+
+            if (character == '(')
+            {
+                depth++;
+            }
+            else if (character == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return index;
+                }
+            }
+
+            index++;
+        }
+
+        return -1;
+    }
+
+    // Strips one pair of matching surrounding quotes (upstream normalizeExpression) after trimming.
+    private static string NormalizeExpression(string raw)
+    {
+        var expression = raw.Trim();
+        if (expression.Length >= 2)
+        {
+            var first = expression[0];
+            if ((first == '\'' || first == '"') && expression[expression.Length - 1] == first)
+            {
+                return expression.Substring(1, expression.Length - 2).Trim();
+            }
+        }
+
+        return expression;
+    }
+
+    // Returns the index just past a string literal that begins at index (handling backslash escapes); an
+    // unterminated string consumes to end of value.
+    private static int SkipString(string value, int index)
+    {
+        var quote = value[index];
+        index++;
+        while (index < value.Length)
+        {
+            var character = value[index];
+            if (character == '\\')
+            {
+                index += 2;
+                continue;
+            }
+
+            index++;
+            if (character == quote)
+            {
+                break;
+            }
+        }
+
+        return index;
+    }
+
+    // Returns the index just past a /* … */ comment that begins at index; an unterminated comment consumes
+    // to end of value.
+    private static int SkipComment(string value, int index)
+    {
+        index += 2;
+        while (index + 1 < value.Length)
+        {
+            if (value[index] == '*' && value[index + 1] == '/')
+            {
+                return index + 2;
+            }
+
+            index++;
+        }
+
+        return value.Length;
+    }
+
+    private static int SkipWhitespace(string value, int index)
+    {
+        while (index < value.Length && char.IsWhiteSpace(value[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssVariableBinding.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssVariableBinding.cs
@@ -1,0 +1,17 @@
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// One <c>v-bind()</c> CSS binding extracted by <see cref="CssBindingRewriter"/>: the hashed custom-property
+/// <see cref="Name"/> the usage was rewritten to (<c>var(--&lt;Name&gt;)</c>) paired with the original
+/// <see cref="Expression"/> text. Mirrors an entry of the <c>cssVars</c> list Vue's
+/// <c>@vue/compiler-sfc</c> records for <c>useCssVars</c> (<c>packages/compiler-sfc/src/style/cssVars.ts</c>,
+/// https://vuejs.org/api/sfc-css-features.html#v-bind-in-css) — the compile-time half of the binding that
+/// the <c>UseCssVars</c> runtime evaluates and applies as a custom property.
+/// </summary>
+/// <param name="Name">
+/// The hashed custom-property name (without the leading <c>--</c>) the usage was rewritten to. Deterministic
+/// and component-scoped, so the CSS <c>var(--&lt;Name&gt;)</c> and the runtime's
+/// <c>style.setProperty("--&lt;Name&gt;", …)</c> agree by construction.
+/// </param>
+/// <param name="Expression">The original expression text inside <c>v-bind(…)</c>, trimmed and unquoted.</param>
+public sealed record CssVariableBinding(string Name, string Expression);

--- a/libraries/Assimalign.Vue.Syntax.Css/src/CssStylesheetWriter.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/CssStylesheetWriter.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Text;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// Serializes a parsed (or rewritten) <see cref="CssStylesheetNode"/> back to CSS text with no scoping —
+/// the plain counterpart of <see cref="CssScopedRewriter"/>. It is the serializer the composition-root
+/// generator uses for a non-<c>scoped</c> <c>@style module</c> or <c>v-bind()</c> block, whose tree
+/// <see cref="CssModuleRewriter"/> / <see cref="CssBindingRewriter"/> rewrote (renamed class selectors,
+/// rewritten declaration values) but which carries no <c>data-v-</c> attribute. Selectors are rendered from
+/// the parsed parts (so a renamed class's <c>Text</c> is what appears), not from the now-stale raw prelude.
+/// </summary>
+/// <remarks>
+/// Output uses the same deterministic canonical form as <see cref="CssScopedRewriter"/> — two-space
+/// indentation, <c>prop: value;</c>, <c>selector {</c> — so identical input yields identical output (the
+/// incremental-caching contract) and a scoped and non-scoped block of the same component format alike.
+/// Because the form is canonical, a non-scoped block that <em>is</em> rewritten no longer round-trips its
+/// original whitespace or comments, exactly as a scoped block does not (see the Css <c>DESIGN.md</c>); a
+/// non-scoped block with neither modules nor <c>v-bind()</c> is still emitted verbatim by the generator and
+/// never reaches this writer.
+/// </remarks>
+public static class CssStylesheetWriter
+{
+    /// <summary>Serializes <paramref name="stylesheet"/> to canonical, unscoped CSS text.</summary>
+    /// <param name="stylesheet">The stylesheet to serialize.</param>
+    /// <returns>The deterministic CSS text.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stylesheet"/> is <see langword="null"/>.</exception>
+    public static string Write(CssStylesheetNode stylesheet)
+    {
+        if (stylesheet is null)
+        {
+            throw new ArgumentNullException(nameof(stylesheet));
+        }
+
+        var builder = new StringBuilder();
+        WriteRules(stylesheet.Rules, indent: 0, builder);
+        return builder.ToString();
+    }
+
+    private static void WriteRules(SyntaxList<CssSyntaxNode> rules, int indent, StringBuilder builder)
+    {
+        foreach (var rule in rules)
+        {
+            switch (rule)
+            {
+                case CssQualifiedRuleNode qualified:
+                    WriteQualifiedRule(qualified, indent, builder);
+                    break;
+                case CssAtRuleNode atRule:
+                    WriteAtRule(atRule, indent, builder);
+                    break;
+                case CssKeyframeRuleNode keyframe:
+                    WriteKeyframeRule(keyframe, indent, builder);
+                    break;
+                case CssDeclarationNode declaration:
+                    WriteDeclaration(declaration, indent, builder);
+                    break;
+            }
+        }
+    }
+
+    private static void WriteQualifiedRule(CssQualifiedRuleNode rule, int indent, StringBuilder builder)
+    {
+        AppendIndent(builder, indent);
+        builder.Append(RenderSelectorList(rule.Selectors)).Append(" {\n");
+        foreach (var declaration in rule.Declarations)
+        {
+            WriteDeclaration(declaration, indent + 1, builder);
+        }
+
+        AppendIndent(builder, indent);
+        builder.Append("}\n");
+    }
+
+    private static void WriteAtRule(CssAtRuleNode atRule, int indent, StringBuilder builder)
+    {
+        AppendIndent(builder, indent);
+        builder.Append('@').Append(atRule.Name);
+        if (atRule.Prelude.Length > 0)
+        {
+            builder.Append(' ').Append(atRule.Prelude);
+        }
+
+        if (!atRule.HasBlock)
+        {
+            builder.Append(";\n");
+            return;
+        }
+
+        builder.Append(" {\n");
+        WriteRules(atRule.Body, indent + 1, builder);
+        AppendIndent(builder, indent);
+        builder.Append("}\n");
+    }
+
+    private static void WriteKeyframeRule(CssKeyframeRuleNode rule, int indent, StringBuilder builder)
+    {
+        AppendIndent(builder, indent);
+        builder.Append(rule.Selector).Append(" {\n");
+        foreach (var declaration in rule.Declarations)
+        {
+            WriteDeclaration(declaration, indent + 1, builder);
+        }
+
+        AppendIndent(builder, indent);
+        builder.Append("}\n");
+    }
+
+    private static void WriteDeclaration(CssDeclarationNode declaration, int indent, StringBuilder builder)
+    {
+        AppendIndent(builder, indent);
+        builder.Append(declaration.Property).Append(": ").Append(declaration.Value);
+        if (declaration.Important)
+        {
+            builder.Append(" !important");
+        }
+
+        builder.Append(";\n");
+    }
+
+    private static string RenderSelectorList(CssSelectorListNode list)
+    {
+        var builder = new StringBuilder();
+        for (var index = 0; index < list.Selectors.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(", ");
+            }
+
+            RenderComplexSelector(list.Selectors[index], builder);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void RenderComplexSelector(CssComplexSelectorNode complex, StringBuilder builder)
+    {
+        foreach (var part in complex.Parts)
+        {
+            switch (part)
+            {
+                case CssCombinatorNode combinator:
+                    builder.Append(RenderCombinator(combinator.Combinator));
+                    break;
+                case CssSimpleSelectorNode simple:
+                    builder.Append(simple.Text);
+                    break;
+                case CssPseudoSelectorNode pseudo:
+                    // Pseudos are never rewritten by the module/binding passes, so the exact authored slice
+                    // is still faithful.
+                    builder.Append(pseudo.Location.Source);
+                    break;
+            }
+        }
+    }
+
+    private static string RenderCombinator(CssCombinatorKind kind)
+        => kind switch
+        {
+            CssCombinatorKind.Child => " > ",
+            CssCombinatorKind.NextSibling => " + ",
+            CssCombinatorKind.SubsequentSibling => " ~ ",
+            _ => " ",
+        };
+
+    private static void AppendIndent(StringBuilder builder, int levels)
+    {
+        for (var level = 0; level < levels; level++)
+        {
+            builder.Append("  ");
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Diagnostics/CssErrorCode.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Diagnostics/CssErrorCode.cs
@@ -30,4 +30,10 @@ public enum CssErrorCode
 
     /// <summary>A qualified rule or at-rule reached end of file before its block opened.</summary>
     UnexpectedEndOfFile = 2007,
+
+    /// <summary>A <c>v-bind(</c> in a declaration value had no matching <c>)</c>; the usage was discarded.</summary>
+    UnterminatedCssBinding = 2008,
+
+    /// <summary>A <c>v-bind()</c> in a declaration value had an empty expression; the usage was discarded.</summary>
+    EmptyCssBinding = 2009,
 }

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Internal/CssErrorMessages.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Internal/CssErrorMessages.cs
@@ -25,6 +25,10 @@ internal static class CssErrorMessages
             "Malformed declaration. Expected ':' between the property and its value; the declaration was discarded.",
         [CssErrorCode.UnexpectedEndOfFile] =
             "Unexpected end of file. Expected a '{' block or ';' to close the rule.",
+        [CssErrorCode.UnterminatedCssBinding] =
+            "Unterminated 'v-bind('. Expected a closing ')' for the CSS binding; the usage was discarded.",
+        [CssErrorCode.EmptyCssBinding] =
+            "Empty 'v-bind()'. A CSS binding must reference an expression; the usage was discarded.",
     };
 
     /// <summary>Gets the message for <paramref name="code"/>, or an empty string when none is defined.</summary>

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Internal/CssHash.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Internal/CssHash.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// The deterministic FNV-1a hash the CSS Modules class-name rewrite (<see cref="CssModuleRewriter"/>) and
+/// the <c>v-bind()</c> custom-property rewrite (<see cref="CssBindingRewriter"/>) derive their local,
+/// component-scoped names from. It is the same FNV-1a scheme the generator's scope id uses
+/// (<c>Assimalign.Vue.Syntax.Generators.StyleScopeId</c>, [V01.01.06.04]) so all three families of hash
+/// are consistent: culture-free, stable across machines and rebuilds (the asset-caching contract), and
+/// eight lowercase hex digits. String-only (no <c>System.IO</c>), so it stays inside the analyzer API
+/// surface (RS1035).
+/// </summary>
+/// <remarks>
+/// The caller salts the input with the component's short scope id (the <c>data-v-</c> hash), so the same
+/// class name or expression in two different components hashes differently — the per-component uniqueness
+/// the CSS Modules and <c>v-bind()</c> acceptance criteria require, mirroring Vue's <c>compileStyle</c>
+/// modules hashing and <c>cssVars.ts</c> <c>genVarName</c> both folding the file id into the hash.
+/// </remarks>
+internal static class CssHash
+{
+    /// <summary>Computes the eight-hex-digit FNV-1a hash of <paramref name="value"/>.</summary>
+    /// <param name="value">The already-salted string to hash.</param>
+    /// <returns>The eight lowercase hex digits.</returns>
+    public static string Compute(string value)
+    {
+        unchecked
+        {
+            var hash = 2166136261u;
+            foreach (var character in value)
+            {
+                hash = (hash ^ character) * 16777619u;
+            }
+
+            return hash.ToString("x8", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Modules/CssModuleRewriteResult.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Modules/CssModuleRewriteResult.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// The result of the CSS Modules rewrite (<see cref="CssModuleRewriter.Rewrite"/>): the stylesheet with
+/// every local class selector renamed to its hashed form, and the <see cref="Classes"/> map from each
+/// original class name to that hashed name. Mirrors the two outputs of <c>@vue/compiler-sfc</c>'s
+/// <c>compileStyle</c> CSS-Modules mode — the rewritten CSS and the <c>modules</c> object the generated
+/// <c>$style</c> accessor exposes (https://vuejs.org/api/sfc-css-features.html#css-modules).
+/// </summary>
+/// <param name="Stylesheet">
+/// The stylesheet with local class selectors renamed. Feed it to <see cref="CssScopedRewriter.Rewrite"/>
+/// (when the block is also <c>scoped</c>) or <see cref="CssStylesheetWriter.Write"/> to serialize —
+/// both render selectors from the parsed parts, so the renamed <c>Text</c> is what they emit.
+/// </param>
+/// <param name="Classes">
+/// The map from each original class name (without the leading <c>.</c>) to its locally-hashed name, in
+/// first-seen source order. The composition-root generator emits this as the typed <c>$style</c>-equivalent
+/// accessor ([V01.01.06.02]).
+/// </param>
+public sealed record CssModuleRewriteResult(
+    CssStylesheetNode Stylesheet,
+    IReadOnlyDictionary<string, string> Classes);

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Modules/CssModuleRewriter.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Modules/CssModuleRewriter.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// Rewrites a parsed <see cref="CssStylesheetNode"/> for CSS Modules — the pure-.NET C# port of Vue 3.5's
+/// <c>@style module</c> compilation (<c>@vue/compiler-sfc</c> <c>compileStyle()</c> with
+/// <c>postcss-modules</c>, https://vuejs.org/api/sfc-css-features.html#css-modules). Every local class
+/// selector <c>.foo</c> is renamed to a deterministic, component-scoped hashed name and the original →
+/// hashed map is returned so the composition-root generator can emit the typed <c>$style</c>-equivalent
+/// accessor ([V01.01.06.06], issue #62).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The hashing scheme.</b> A class <c>foo</c> becomes <c>foo_&lt;hash&gt;</c>, where <c>&lt;hash&gt;</c>
+/// is the eight-hex-digit FNV-1a of <c>&lt;localHashSalt&gt;-foo</c> (<see cref="CssHash"/>). The caller
+/// passes the component's short scope id (the <c>data-v-</c> hash) as the salt, so the same class in two
+/// components hashes differently (per-component uniqueness) while the same class in the same component is
+/// stable across rebuilds (the asset-caching contract) — consistent with the [V01.01.06.04] scope-id
+/// scheme. Keeping the original name as a readable prefix mirrors <c>postcss-modules</c>' default
+/// <c>[local]_[hash]</c> shape and aids debugging the emitted CSS.
+/// </para>
+/// <para>
+/// <b>Scope of the rename.</b> Only class selectors in normal compound position are renamed. Class names
+/// nested inside functional pseudo arguments — <c>:not(.foo)</c>, <c>:deep(.foo)</c>, <c>:slotted(.foo)</c>,
+/// <c>:global(.foo)</c> — are <em>not</em> renamed: <c>:deep</c>/<c>:global</c> deliberately target
+/// external / un-hashed names, and the parser keeps non-reserved functional-pseudo arguments as verbatim
+/// text (see the Css <c>DESIGN.md</c> non-goals). Composing with <c>scoped</c> is order-independent because
+/// the rename only rewrites the parsed <c>Text</c> the scoped serializer reads.
+/// </para>
+/// </remarks>
+public static class CssModuleRewriter
+{
+    /// <summary>
+    /// Rewrites <paramref name="stylesheet"/>'s local class selectors to hashed names salted by
+    /// <paramref name="localHashSalt"/>.
+    /// </summary>
+    /// <param name="stylesheet">The parsed stylesheet to rewrite.</param>
+    /// <param name="localHashSalt">The component-scoped salt (the short <c>data-v-</c> scope id).</param>
+    /// <returns>The rewritten stylesheet and the original → hashed class map.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stylesheet"/> or <paramref name="localHashSalt"/> is <see langword="null"/>.</exception>
+    public static CssModuleRewriteResult Rewrite(CssStylesheetNode stylesheet, string localHashSalt)
+    {
+        if (stylesheet is null)
+        {
+            throw new ArgumentNullException(nameof(stylesheet));
+        }
+
+        if (localHashSalt is null)
+        {
+            throw new ArgumentNullException(nameof(localHashSalt));
+        }
+
+        var classes = new Dictionary<string, string>(StringComparer.Ordinal);
+        var rewritten = stylesheet with { Rules = RewriteRules(stylesheet.Rules, localHashSalt, classes) };
+        return new CssModuleRewriteResult(rewritten, classes);
+    }
+
+    private static SyntaxList<CssSyntaxNode> RewriteRules(
+        SyntaxList<CssSyntaxNode> rules,
+        string salt,
+        Dictionary<string, string> classes)
+    {
+        var rewritten = new CssSyntaxNode[rules.Count];
+        for (var index = 0; index < rules.Count; index++)
+        {
+            rewritten[index] = rules[index] switch
+            {
+                CssQualifiedRuleNode qualified => qualified with
+                {
+                    Selectors = RewriteSelectorList(qualified.Selectors, salt, classes),
+                },
+                // Conditional-group at-rules (@media/@supports/...) nest qualified rules; recurse so class
+                // selectors inside them are renamed too. @keyframes/@font-face bodies carry no class
+                // selectors, so recursion is a structural copy there.
+                CssAtRuleNode atRule => atRule with { Body = RewriteRules(atRule.Body, salt, classes) },
+                var other => other,
+            };
+        }
+
+        return new SyntaxList<CssSyntaxNode>(rewritten);
+    }
+
+    private static CssSelectorListNode RewriteSelectorList(
+        CssSelectorListNode list,
+        string salt,
+        Dictionary<string, string> classes)
+    {
+        var complexSelectors = new CssComplexSelectorNode[list.Selectors.Count];
+        for (var index = 0; index < list.Selectors.Count; index++)
+        {
+            complexSelectors[index] = RewriteComplexSelector(list.Selectors[index], salt, classes);
+        }
+
+        return list with { Selectors = new SyntaxList<CssComplexSelectorNode>(complexSelectors) };
+    }
+
+    private static CssComplexSelectorNode RewriteComplexSelector(
+        CssComplexSelectorNode complex,
+        string salt,
+        Dictionary<string, string> classes)
+    {
+        var parts = new CssSelectorPartNode[complex.Parts.Count];
+        for (var index = 0; index < complex.Parts.Count; index++)
+        {
+            var part = complex.Parts[index];
+            parts[index] = part is CssSimpleSelectorNode { Selector: CssSimpleSelectorKind.Class } classSelector
+                ? classSelector with { Text = RenameClass(classSelector.Text, salt, classes) }
+                : part;
+        }
+
+        return complex with { Parts = new SyntaxList<CssSelectorPartNode>(parts) };
+    }
+
+    // ".foo" -> ".foo_<hash>", recording foo -> foo_<hash> on first sight (a class used twice keeps its
+    // first hash, matching the one-name-one-hash module contract).
+    private static string RenameClass(string classText, string salt, Dictionary<string, string> classes)
+    {
+        // A class simple selector's Text is always ".<ident>" (the parser only classifies a '.' + ident run
+        // as Class), but guard defensively so a malformed slice is passed through untouched.
+        if (classText.Length < 2 || classText[0] != '.')
+        {
+            return classText;
+        }
+
+        var original = classText.Substring(1);
+        if (!classes.TryGetValue(original, out var hashed))
+        {
+            hashed = original + "_" + CssHash.Compute(salt + "-" + original);
+            classes[original] = hashed;
+        }
+
+        return "." + hashed;
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/test/CssBindingRewriterTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/test/CssBindingRewriterTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// Pins the <c>v-bind()</c>-in-CSS rewrite (<see cref="CssBindingRewriter"/>, [V01.01.06.06]) against the
+/// behavior of Vue 3.5's <c>cssVars.ts</c> (<c>@vue/compiler-sfc</c>,
+/// https://vuejs.org/api/sfc-css-features.html#v-bind-in-css): each <c>v-bind(expr)</c> becomes a
+/// component-scoped <c>var(--&lt;hash&gt;)</c>, expressions are collected (and de-duplicated) for the
+/// runtime, malformed usages surface recoverable diagnostics, and the rewrite composes with <c>scoped</c>.
+/// </summary>
+public sealed class CssBindingRewriterTests
+{
+    private const string Salt = "abc12345";
+
+    private static readonly Regex Hash = new(@"^[0-9a-f]{8}$", RegexOptions.Compiled);
+
+    [Fact]
+    public void Rewrite_ReplacesBinding_AndRecordsTheExpression()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color); }"), Salt);
+
+        result.Diagnostics.ShouldBeEmpty();
+        var binding = result.Bindings.ShouldHaveSingleItem();
+        binding.Expression.ShouldBe("color");
+        Hash.IsMatch(binding.Name).ShouldBeTrue();
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldContain("color: var(--" + binding.Name + ");");
+    }
+
+    [Fact]
+    public void Rewrite_TrimsWhitespaceAndStripsQuotes()
+    {
+        var spaced = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind( color ); }"), Salt);
+        var quoted = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind('theme.primary'); }"), Salt);
+
+        spaced.Bindings.ShouldHaveSingleItem().Expression.ShouldBe("color");
+        quoted.Bindings.ShouldHaveSingleItem().Expression.ShouldBe("theme.primary");
+    }
+
+    [Fact]
+    public void Rewrite_HandlesBindingNestedInAFunction()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { width: calc(v-bind(size) + 2px); }"), Salt);
+
+        var binding = result.Bindings.ShouldHaveSingleItem();
+        binding.Expression.ShouldBe("size");
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldContain("width: calc(var(--" + binding.Name + ") + 2px);");
+    }
+
+    [Fact]
+    public void Rewrite_DeduplicatesRepeatedExpression()
+    {
+        var result = CssBindingRewriter.Rewrite(
+            CssTestHelpers.ParseStylesheet(".a { color: v-bind(c); } .b { background: v-bind(c); }"),
+            Salt);
+
+        // A repeated expression yields one binding and one custom property (upstream vars.includes dedupe).
+        var binding = result.Bindings.ShouldHaveSingleItem();
+        Regex.Matches(CssStylesheetWriter.Write(result.Stylesheet), Regex.Escape("var(--" + binding.Name + ")")).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Rewrite_CollectsDistinctExpressions_InSourceOrder()
+    {
+        var result = CssBindingRewriter.Rewrite(
+            CssTestHelpers.ParseStylesheet(".a { color: v-bind(first); background: v-bind(second); }"),
+            Salt);
+
+        result.Bindings.Select(binding => binding.Expression).ShouldBe(new[] { "first", "second" });
+        result.Bindings[0].Name.ShouldNotBe(result.Bindings[1].Name);
+    }
+
+    [Fact]
+    public void Rewrite_IsDeterministic_AndComponentScoped()
+    {
+        var first = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color); }"), Salt);
+        var second = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color); }"), Salt);
+        var other = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color); }"), "zzzz9999");
+
+        second.Bindings[0].Name.ShouldBe(first.Bindings[0].Name);
+        second.Stylesheet.ShouldBe(first.Stylesheet);
+        other.Bindings[0].Name.ShouldNotBe(first.Bindings[0].Name);
+    }
+
+    [Fact]
+    public void Rewrite_IgnoresKeywordInsideStringLiteral()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { content: \"v-bind(x)\"; }"), Salt);
+
+        // A v-bind inside a string literal is not a binding (upstream strips comments/strings before matching).
+        result.Bindings.ShouldBeEmpty();
+        result.Diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Rewrite_ReportsUnterminatedBinding()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color; }"), Salt);
+
+        // The unbalanced '(' consumes to end of value; recoverable, no binding recorded.
+        var diagnostic = result.Diagnostics.ShouldHaveSingleItem();
+        diagnostic.Code.ShouldBe(CssErrorCode.UnterminatedCssBinding);
+        result.Bindings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Rewrite_ReportsEmptyBinding()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(); }"), Salt);
+
+        var diagnostic = result.Diagnostics.ShouldHaveSingleItem();
+        diagnostic.Code.ShouldBe(CssErrorCode.EmptyCssBinding);
+        result.Bindings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Rewrite_RewritesBindingsInKeyframesAndMedia()
+    {
+        var result = CssBindingRewriter.Rewrite(
+            CssTestHelpers.ParseStylesheet(
+                "@keyframes x { from { opacity: v-bind(a); } } @media screen { .b { color: v-bind(c); } }"),
+            Salt);
+
+        result.Bindings.Select(binding => binding.Expression).ShouldBe(new[] { "a", "c" });
+    }
+
+    [Fact]
+    public void Rewrite_ComposesWithScoped()
+    {
+        // v-bind rewrite over the tree, then the scoped serializer: the value carries var(--hash) and the
+        // selector carries the [data-v] attribute.
+        var bound = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: v-bind(color); }"), Salt);
+
+        var scoped = CssScopedRewriter.Rewrite(bound.Stylesheet, "data-v-test");
+
+        scoped.ShouldBe(".a[data-v-test] {\n  color: var(--" + bound.Bindings[0].Name + ");\n}\n");
+    }
+
+    [Fact]
+    public void Rewrite_LeavesBindingFreeStylesheetUnchanged()
+    {
+        var result = CssBindingRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".a { color: red; }"), Salt);
+
+        result.Bindings.ShouldBeEmpty();
+        result.Diagnostics.ShouldBeEmpty();
+        result.Stylesheet.ShouldBe(CssTestHelpers.ParseStylesheet(".a { color: red; }"));
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Css/test/CssModuleRewriterTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/test/CssModuleRewriterTests.cs
@@ -1,0 +1,126 @@
+using System.Text.RegularExpressions;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Css;
+
+/// <summary>
+/// Pins the CSS Modules class-name rewrite (<see cref="CssModuleRewriter"/>, [V01.01.06.06]) against the
+/// behavior of Vue 3.5's <c>@style module</c> compilation (<c>@vue/compiler-sfc</c> <c>compileStyle()</c>
+/// modules mode, https://vuejs.org/api/sfc-css-features.html#css-modules): local class selectors are
+/// renamed to deterministic, component-scoped hashed names, the original → hashed map is returned for the
+/// generated <c>$style</c> accessor, and the rewrite composes with <c>scoped</c>.
+/// </summary>
+public sealed class CssModuleRewriterTests
+{
+    private const string Salt = "abc12345";
+
+    // The documented scheme: "<original>_<8 lowercase hex>".
+    private static readonly Regex HashedName = new(@"^[A-Za-z0-9_-]+_[0-9a-f]{8}$", RegexOptions.Compiled);
+
+    [Fact]
+    public void Rewrite_RenamesClassSelector_AndRecordsTheMap()
+    {
+        var result = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), Salt);
+
+        result.Classes.ShouldContainKey("box");
+        var hashed = result.Classes["box"];
+        HashedName.IsMatch(hashed).ShouldBeTrue();
+        hashed.ShouldStartWith("box_");
+        // The rewritten tree carries the hashed selector text.
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldContain("." + hashed + " {");
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldNotContain(".box {");
+    }
+
+    [Fact]
+    public void Rewrite_IsDeterministic_ForTheSameInputAndSalt()
+    {
+        var first = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), Salt);
+        var second = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), Salt);
+
+        // Deterministic hashing is the asset-caching contract; the rewritten trees are value-equal.
+        second.Classes["box"].ShouldBe(first.Classes["box"]);
+        second.Stylesheet.ShouldBe(first.Stylesheet);
+    }
+
+    [Fact]
+    public void Rewrite_HashesDifferByComponentSalt()
+    {
+        var a = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), "aaaa0000");
+        var b = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), "bbbb1111");
+
+        // Unique per component: the same class in two components hashes differently.
+        a.Classes["box"].ShouldNotBe(b.Classes["box"]);
+    }
+
+    [Fact]
+    public void Rewrite_RenamesEveryClassInACompound_KeepingTypeAndId()
+    {
+        var result = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet("div.a.b#c { color: red; }"), Salt);
+
+        result.Classes.ShouldContainKey("a");
+        result.Classes.ShouldContainKey("b");
+        var css = CssStylesheetWriter.Write(result.Stylesheet);
+        css.ShouldContain("div." + result.Classes["a"] + "." + result.Classes["b"] + "#c {");
+        // Type and id selectors are untouched — only classes are module-local.
+        result.Classes.ShouldNotContainKey("c");
+    }
+
+    [Fact]
+    public void Rewrite_ReusesOneHash_ForARepeatedClass()
+    {
+        var result = CssModuleRewriter.Rewrite(
+            CssTestHelpers.ParseStylesheet(".box { color: red; } .box:hover { color: blue; }"),
+            Salt);
+
+        // A class used more than once maps to a single hashed name (the one-name-one-hash module contract).
+        result.Classes.Count.ShouldBe(1);
+        var css = CssStylesheetWriter.Write(result.Stylesheet);
+        Regex.Matches(css, Regex.Escape("." + result.Classes["box"])).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Rewrite_RenamesClassesNestedInConditionalGroups()
+    {
+        var result = CssModuleRewriter.Rewrite(
+            CssTestHelpers.ParseStylesheet("@media (min-width: 100px) { .box { color: red; } }"),
+            Salt);
+
+        result.Classes.ShouldContainKey("box");
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldContain("." + result.Classes["box"] + " {");
+    }
+
+    [Fact]
+    public void Rewrite_LeavesClassesInsideFunctionalPseudosVerbatim()
+    {
+        // :not(.inner) keeps its argument verbatim (parser non-goal), so .inner is not module-renamed —
+        // only .outer is. Documented in CssModuleRewriter's remarks.
+        var result = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".outer:not(.inner) { color: red; }"), Salt);
+
+        result.Classes.ShouldContainKey("outer");
+        result.Classes.ShouldNotContainKey("inner");
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldContain(":not(.inner)");
+    }
+
+    [Fact]
+    public void Rewrite_ComposesWithScoped()
+    {
+        // The compiler runs the module rename over the tree, then the scoped serializer — both read the
+        // parsed selector parts, so the class is renamed AND the [data-v] attribute lands on it.
+        var module = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet(".box { color: red; }"), Salt);
+
+        var scoped = CssScopedRewriter.Rewrite(module.Stylesheet, "data-v-test");
+
+        scoped.ShouldBe("." + module.Classes["box"] + "[data-v-test] {\n  color: red;\n}\n");
+    }
+
+    [Fact]
+    public void Rewrite_LeavesNonClassOnlyStylesheetUnchanged()
+    {
+        var result = CssModuleRewriter.Rewrite(CssTestHelpers.ParseStylesheet("div { color: red; }"), Salt);
+
+        result.Classes.ShouldBeEmpty();
+        CssStylesheetWriter.Write(result.Stylesheet).ShouldBe("div {\n  color: red;\n}\n");
+    }
+}


### PR DESCRIPTION
## Summary

The second styling feature over the [V01.01.06.04] CSS parser, all three layers: **CSS Modules** — `@style module` class names rewritten to deterministic component-scoped hashes (`foo_<hash8>`, FNV-1a over scope-id + name) with a typed, compile-checked accessor class emitted per module; **`v-bind()` in CSS** — expressions extracted and rewritten to `var(--<hash8>)` where the CSS variable name and the runtime's `setProperty` agree by construction; and the **`UseCssVars` runtime port** in RuntimeDom (upstream `runtime-dom` semantics: mount-time application, post-flush reactive re-application, HOC/fragment root-drilling, unmount cleanup) batching to **one interop crossing per element** per the founding interop budget — run counts pinned (mount = 1 crossing, +1 per bound change, nothing on unrelated state).

**Stacked on the void-handlers PR** — merge that first, delete its branch, and this retargets.

Implemented in a delegated Claude Opus 4.8 session, reviewed, and verified standalone and stacked.

> **Merge procedure:** merge the stack top-down (#-order below) and **delete each branch immediately after merging** — deletion triggers GitHub's retarget of the next PR to `main`. An undeleted base branch silently catches the next merge instead (the #141/#147 episodes).

## Type of change

- [x] `feat` — new feature

## Deviations / deferred (documented in the Css DESIGN.md and filed)

- Single component-scoped `var(--<hash>)` naming per the acceptance criteria (upstream's dev-readable `<id>-<expr>` form documented as the divergence).
- #148 `[V01.01.05.04.01]` — `$style` resolution in template expressions (the accessor is emitted and compile-checked; template binding is expression-compiler territory).
- #149 `[V01.01.06.06.01]` — binding-metadata rewriting for `v-bind()` expressions (today `v-bind(count.Value)` is authored explicitly).
- `ApplyCssVariables` is emitted as a seam; its invocation lands with the future `.viu` component-runtime instantiation work.

## Verification

`-warnaserror` 0/0; Css 58, Generators 65, RuntimeDom 149 (+4 compiled) standalone; all 15 suites green stacked; caching strictly `Cached`.

## Work items resolved

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
