### PR TITLE
feat(compiler): CSS module template accessors, v-bind() metadata rewriting, and inline-handler terminators

### DIFF
--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentModel.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentModel.cs
@@ -87,20 +87,30 @@ internal readonly record struct SingleFileComponentModel(
     /// script, mirroring Vue's <c>__isScriptSetup</c> for a <c>&lt;script setup&gt;</c> block.
     /// </summary>
     /// <returns>The binding metadata, or <see cref="BindingMetadata.Empty"/> for a scriptless component.</returns>
-    public BindingMetadata ToBindingMetadata()
+    public BindingMetadata ToBindingMetadata() => BuildBindingMetadata(HasScript, Bindings);
+
+    /// <summary>
+    /// Builds the template compiler's <see cref="BindingMetadata"/> from the classified script bindings — the
+    /// standalone form the generator needs before the model exists (the <c>v-bind()</c> CSS compile
+    /// [V01.01.06.06.01] rewrites its expressions with the same metadata the render path uses).
+    /// </summary>
+    /// <param name="hasScript">Whether the component declares a script block.</param>
+    /// <param name="bindings">The classified script bindings.</param>
+    /// <returns>The binding metadata, or <see cref="BindingMetadata.Empty"/> for a scriptless component.</returns>
+    public static BindingMetadata BuildBindingMetadata(bool hasScript, EquatableArray<ScriptBinding> bindings)
     {
-        if (!HasScript)
+        if (!hasScript)
         {
             return BindingMetadata.Empty;
         }
 
-        if (Bindings.Count == 0)
+        if (bindings.Count == 0)
         {
             return new BindingMetadata(isScriptSetup: true);
         }
 
-        var map = new Dictionary<string, BindingType>(Bindings.Count, StringComparer.Ordinal);
-        foreach (var binding in Bindings)
+        var map = new Dictionary<string, BindingType>(bindings.Count, StringComparer.Ordinal);
+        foreach (var binding in bindings)
         {
             // A later declaration of the same name wins (e.g. method overloads share a name); an
             // illegal duplicate-member script is already surfaced as a script diagnostic.

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
@@ -336,13 +336,13 @@ internal static class SingleFileComponentSourceEmitter
     // [V01.01.06.06] The v-bind() CSS custom-property seam. Each recorded (hash, expression) binding becomes
     // an entry of the getter the ApplyCssVariables method hands to the UseCssVars runtime — which applies the
     // evaluated values as custom properties on the component root and re-applies them reactively (post-flush)
-    // without re-rendering. The expressions are emitted verbatim inside an instance lambda, so an unqualified
-    // member name resolves against the merged @script members through the implicit `this`; the render/script
-    // seams stay untouched. A binding whose member is a Reference<T> is NOT auto-unwrapped here (upstream
-    // compiles v-bind expressions with binding-aware rewriting, which is the template compiler's job, out of
-    // this style seam's scope) — author `v-bind(count.Value)` for a ref. The component-runtime instantiation
-    // calls ApplyCssVariables during setup (that wiring lands with the .viu component runtime); the method is
-    // emitted here so the metadata exists for it.
+    // without re-rendering. The expressions arrive already rewritten by the template compiler's binding-metadata
+    // pass ([V01.01.06.06.01]) in instance-member mode: an unqualified member resolves against the merged @script
+    // members through the implicit `this`, and a Reference<T> member is auto-unwrapped to `.Value`, so
+    // `v-bind(count)` (not `v-bind(count.Value)`) updates reactively. This emitter writes them verbatim inside the
+    // instance lambda; the render/script seams stay untouched. The component-runtime instantiation calls
+    // ApplyCssVariables during setup (that wiring lands with the .viu component runtime); the method is emitted
+    // here so the metadata exists for it.
     private static void AppendCssVariableSeam(StringBuilder builder, int indent, in SingleFileComponentModel model)
     {
         if (model.CssVariableBindings.Count == 0)

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
@@ -388,7 +388,9 @@ internal static class SingleFileComponentSourceEmitter
 
     // Turns an authored class name into a valid C# member identifier: non-identifier characters become '_'
     // and a leading digit is prefixed with '_'. Deterministic so the accessor is stable across rebuilds.
-    private static string MemberName(string original)
+    // Internal so the template-compile path ([V01.01.05.04.01]) resolves `$style.<member>` references against
+    // the exact same member names this emitter writes as the accessor class's consts.
+    internal static string MemberName(string original)
     {
         var builder = new StringBuilder(original.Length);
         foreach (var character in original)

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
@@ -132,19 +132,11 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             }
         }
 
-        // [V01.01.06.04]/[V01.01.06.06] @style compilation: scoped blocks are rewritten with the component's
-        // scope id, `module` blocks have their class names locally hashed, `v-bind()` usages become
-        // component-scoped custom properties, and non-scoped/non-module/non-v-bind blocks pass through
-        // unmodified. The scope id, extracted CSS, module class map, and v-bind bindings surface in the model.
-        var moduleClasses = new List<CssModuleClassEntry>();
-        var cssVariableBindings = new List<CssVariableBindingEntry>();
-        var moduleTemplateNames = new Dictionary<string, string>(StringComparer.Ordinal);
-        var (scopeId, extractedStyles) = CompileStyles(file, parse, diagnostics, moduleClasses, cssVariableBindings, moduleTemplateNames, cancellationToken);
-
         // [V01.01.06.03]/[V01.01.06.03.01] @script integration: when the component declares a script,
         // split it into a hoisted using region and a class-body member region, validate both, and extract
         // binding metadata (routing any Roslyn parse diagnostics onto the .viu file). The regions carry
-        // their own #line anchors so the emitter maps each back to the .viu source.
+        // their own #line anchors so the emitter maps each back to the .viu source. This runs before @style
+        // compilation because the v-bind() CSS rewriting ([V01.01.06.06.01]) needs the same binding metadata.
         var scriptRegions = ScriptRegions.None;
         var bindings = EquatableArray<ScriptBinding>.Empty;
         if (descriptor.Script is { } script)
@@ -153,6 +145,19 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             scriptRegions = analysis.Regions;
             bindings = analysis.Bindings;
         }
+
+        var bindingMetadata = SingleFileComponentModel.BuildBindingMetadata(descriptor.Script is not null, bindings);
+
+        // [V01.01.06.04]/[V01.01.06.06] @style compilation: scoped blocks are rewritten with the component's
+        // scope id, `module` blocks have their class names locally hashed, `v-bind()` usages become
+        // component-scoped custom properties (with their expressions routed through the same binding-metadata
+        // rewriting the render path uses, [V01.01.06.06.01]), and non-scoped/non-module/non-v-bind blocks pass
+        // through unmodified. The scope id, extracted CSS, module class map, and v-bind bindings surface in the model.
+        var moduleClasses = new List<CssModuleClassEntry>();
+        var cssVariableBindings = new List<CssVariableBindingEntry>();
+        var moduleTemplateNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        var (scopeId, extractedStyles) = CompileStyles(
+            file, parse, diagnostics, moduleClasses, cssVariableBindings, moduleTemplateNames, bindingMetadata, cancellationToken);
 
         var model = new SingleFileComponentModel(
             file.Namespace,
@@ -183,7 +188,7 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         // ([V01.01.05.04.01] -> [V01.01.06.06]) let a `$style.<class>` template reference resolve to the
         // emitted accessor class instead of a phantom `_ctx` member.
         var cssModules = BuildCssModuleAccessors(moduleClasses, moduleTemplateNames);
-        var render = CompileRenderFunction(file, parse, model.ToBindingMetadata(), cssModules, diagnostics, cancellationToken);
+        var render = CompileRenderFunction(file, parse, bindingMetadata, cssModules, diagnostics, cancellationToken);
         model = model with { RenderBody = render.Body, RenderCacheSize = render.CacheSize };
 
         var array = diagnostics.Count == 0
@@ -276,6 +281,7 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         List<CssModuleClassEntry> moduleClasses,
         List<CssVariableBindingEntry> cssVariableBindings,
         Dictionary<string, string> moduleTemplateNames,
+        BindingMetadata bindingMetadata,
         System.Threading.CancellationToken cancellationToken)
     {
         string? scopeId = null;
@@ -326,12 +332,26 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
                     var bindingResult = CssBindingRewriter.Rewrite(stylesheet, localHashSalt);
                     stylesheet = bindingResult.Stylesheet;
                     rewritten = rewritten || bindingResult.Bindings.Count > 0;
+                    var blockContentStart = sourceResult.Node.ContentLocation.Start;
                     foreach (var binding in bindingResult.Bindings)
                     {
-                        cssVariableBindings.Add(new CssVariableBindingEntry(binding.Name, binding.Expression));
+                        // [V01.01.06.06.01] Route the extracted expression through the template compiler's
+                        // binding-metadata rewriting (instance-member mode), so `v-bind(count)` unwraps a script
+                        // Reference<T> member to `count.Value` automatically — matching upstream cssVars
+                        // ergonomics — instead of forcing `v-bind(count.Value)`. A malformed expression surfaces a
+                        // diagnostic on the exact .viu style coordinate through the same style-origin envelope the
+                        // CSS parse uses; the (recoverable) original text still emits, so the reported error fails
+                        // the build.
+                        var compiled = TemplateExpressionCompiler.CompileInstanceExpression(
+                            binding.Expression, bindingMetadata, binding.Location);
+                        foreach (var error in compiled.Diagnostics)
+                        {
+                            diagnostics.Add(SingleFileComponentDiagnostics.CreateStyle(file.FilePath, error, blockContentStart));
+                        }
+
+                        cssVariableBindings.Add(new CssVariableBindingEntry(binding.Name, compiled.Code));
                     }
 
-                    var blockContentStart = sourceResult.Node.ContentLocation.Start;
                     foreach (var diagnostic in bindingResult.Diagnostics)
                     {
                         diagnostics.Add(SingleFileComponentDiagnostics.CreateStyle(file.FilePath, diagnostic, blockContentStart));

--- a/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/src/SingleFileComponentGenerator.cs
@@ -138,7 +138,8 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         // unmodified. The scope id, extracted CSS, module class map, and v-bind bindings surface in the model.
         var moduleClasses = new List<CssModuleClassEntry>();
         var cssVariableBindings = new List<CssVariableBindingEntry>();
-        var (scopeId, extractedStyles) = CompileStyles(file, parse, diagnostics, moduleClasses, cssVariableBindings, cancellationToken);
+        var moduleTemplateNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        var (scopeId, extractedStyles) = CompileStyles(file, parse, diagnostics, moduleClasses, cssVariableBindings, moduleTemplateNames, cancellationToken);
 
         // [V01.01.06.03]/[V01.01.06.03.01] @script integration: when the component declares a script,
         // split it into a hoisted using region and a class-body member region, validate both, and extract
@@ -178,8 +179,11 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
 
         // The [V01.01.06.03] -> [V01.01.05.05] hand-off: the script's classified bindings drive the
         // template compiler's ref-unwrapping decisions, so a Reference<T> member reads as `.Value` in
-        // the emitted render body instead of falling back to `_ctx.`.
-        var render = CompileRenderFunction(file, parse, model.ToBindingMetadata(), diagnostics, cancellationToken);
+        // the emitted render body instead of falling back to `_ctx.`. The CSS module accessors
+        // ([V01.01.05.04.01] -> [V01.01.06.06]) let a `$style.<class>` template reference resolve to the
+        // emitted accessor class instead of a phantom `_ctx` member.
+        var cssModules = BuildCssModuleAccessors(moduleClasses, moduleTemplateNames);
+        var render = CompileRenderFunction(file, parse, model.ToBindingMetadata(), cssModules, diagnostics, cancellationToken);
         model = model with { RenderBody = render.Body, RenderCacheSize = render.CacheSize };
 
         var array = diagnostics.Count == 0
@@ -200,6 +204,7 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         SingleFileComponentFile file,
         SingleFileComponentSyntaxParserResult parse,
         BindingMetadata bindingMetadata,
+        CssModuleAccessors cssModules,
         List<DiagnosticInfo> diagnostics,
         System.Threading.CancellationToken cancellationToken)
     {
@@ -217,6 +222,10 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
             var transformOptions = TransformOptions.CreateDom();
             transformOptions.PrefixIdentifiers = true;
             transformOptions.BindingMetadata = bindingMetadata;
+            // CSS Modules accessors ([V01.01.05.04.01]): resolve `$style.<class>` (and named-module) references
+            // against the emitted accessor class. The map is complete (every declared class), so an access to an
+            // undeclared member is reported on the .viu coordinate.
+            transformOptions.CssModules = cssModules;
             // Static caching and stringification ([V01.01.05.07]): fully static subtrees are cached and long
             // static runs collapse to innerHTML string inserts, cutting per-node JS-interop round-trips on
             // WASM. Deterministic and value-equatable, so the incremental-generator cache is preserved.
@@ -266,6 +275,7 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         List<DiagnosticInfo> diagnostics,
         List<CssModuleClassEntry> moduleClasses,
         List<CssVariableBindingEntry> cssVariableBindings,
+        Dictionary<string, string> moduleTemplateNames,
         System.Threading.CancellationToken cancellationToken)
     {
         string? scopeId = null;
@@ -299,6 +309,10 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
                     stylesheet = moduleResult.Stylesheet;
                     rewritten = rewritten || moduleResult.Classes.Count > 0;
                     var accessor = ModuleAccessorName(styleBlock.ModuleName);
+                    // The template spelling ([V01.01.05.04.01]): the default (valueless `module`) is Vue's
+                    // `$style`, a named module is referenced by its authored name — recorded so the template
+                    // compiler maps the reference to this accessor class.
+                    moduleTemplateNames[accessor] = ModuleTemplateName(styleBlock.ModuleName);
                     foreach (var pair in moduleResult.Classes)
                     {
                         moduleClasses.Add(new CssModuleClassEntry(accessor, pair.Key, pair.Value));
@@ -371,6 +385,66 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
     // maps to the pascal-cased name.
     private static string ModuleAccessorName(string? moduleName)
         => string.IsNullOrEmpty(moduleName) ? "Style" : PascalCase(moduleName!);
+
+    // The template spelling of a `module` option ([V01.01.05.04.01]): the default (valueless `module`) is
+    // Vue's `$style`; a named module is referenced by its authored name (`<style module="theme">` -> `theme`),
+    // exactly as Vue's render context exposes it.
+    private static string ModuleTemplateName(string? moduleName)
+        => string.IsNullOrEmpty(moduleName) ? "$style" : moduleName!;
+
+    // Projects the collected CSS module class map into the CssModuleAccessors the template compiler consumes
+    // ([V01.01.05.04.01]): entries grouped by accessor class, each carrying its template spelling, its parse
+    // identifier (the `$`->`_` form of `$style`, length-preserving so expression offsets are unchanged), and
+    // the sanitized member names the emitter writes as consts. ReportsUnknownMembers is enabled because this
+    // map is complete — every declared class — so an access to an undeclared member is decidably wrong.
+    private static CssModuleAccessors BuildCssModuleAccessors(
+        List<CssModuleClassEntry> moduleClasses,
+        Dictionary<string, string> moduleTemplateNames)
+    {
+        if (moduleClasses.Count == 0)
+        {
+            return CssModuleAccessors.Empty;
+        }
+
+        var membersByAccessor = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var entry in moduleClasses)
+        {
+            if (!membersByAccessor.TryGetValue(entry.Accessor, out var members))
+            {
+                members = new List<string>();
+                membersByAccessor[entry.Accessor] = members;
+                order.Add(entry.Accessor);
+            }
+
+            var member = SingleFileComponentSourceEmitter.MemberName(entry.Original);
+            if (!members.Contains(member))
+            {
+                members.Add(member);
+            }
+        }
+
+        var accessors = new List<CssModuleAccessor>(order.Count);
+        foreach (var accessorClass in order)
+        {
+            var templateName = moduleTemplateNames.TryGetValue(accessorClass, out var name) ? name : accessorClass;
+            accessors.Add(new CssModuleAccessor(
+                templateName,
+                ModuleParseIdentifier(templateName),
+                accessorClass,
+                membersByAccessor[accessorClass]));
+        }
+
+        return new CssModuleAccessors(accessors, reportsUnknownMembers: true);
+    }
+
+    // The C#-parseable spelling of a template accessor name: `$style` -> `_style` (`$` is illegal in a C#
+    // identifier), every other name unchanged. Length-preserving so expression offsets — and remapped
+    // diagnostics — are not shifted.
+    private static string ModuleParseIdentifier(string templateName)
+        => templateName.Length > 0 && templateName[0] == '$'
+            ? "_" + templateName.Substring(1)
+            : templateName;
 
     // Pascal-cases an authored identifier for use as a C# type/member name: word boundaries at '-'/'_'/' '
     // start a new capitalized word, a leading digit is prefixed with '_', and non-identifier characters are

--- a/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
@@ -73,6 +73,59 @@ public sealed class SingleFileComponentCssModuleTests
     }
 
     [Fact]
+    public void ModuleStyle_TemplateStyleReference_ResolvesToAccessorClass()
+    {
+        // [V01.01.05.04.01] `:class="$style.box"` in the template resolves to the generated `Style` accessor
+        // class, so the render body binds `Style.box` (a const) — not a phantom `_ctx.box` member.
+        const string source =
+            "@template {\n    <div :class=\"$style.box\">hi</div>\n}\n" +
+            "@style module {\n    .box { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        generated.ShouldContain("Style.box");
+        generated.ShouldContain("internal static class Style");
+        generated.ShouldNotContain("_ctx.box");
+    }
+
+    [Fact]
+    public void ModuleStyle_NamedTemplateReference_ResolvesToPascalCasedAccessorClass()
+    {
+        // [V01.01.05.04.01] A named module `<style module="theme">` is referenced by its authored name
+        // `theme` in the template and resolves to the pascal-cased `Theme` accessor class.
+        const string source =
+            "@template {\n    <div :class=\"theme.active\">hi</div>\n}\n" +
+            "@style module=\"theme\" {\n    .active { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        generated.ShouldContain("Theme.active");
+        generated.ShouldContain("internal static class Theme");
+    }
+
+    [Fact]
+    public void ModuleStyle_UnknownTemplateMember_SurfacesMappedDiagnostic()
+    {
+        // [V01.01.05.04.01] The generator supplies the complete class map, so a `$style.<missing>` reference is
+        // reported on the .viu template coordinate (line 2), recoverable.
+        const string source =
+            "@template {\n    <div :class=\"$style.missing\">hi</div>\n}\n" +  // line 2 — the bad member
+            "@style module {\n    .box { color: red; }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        var diagnostic = outcome.Diagnostics.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe("VUECS1101"); // a dispatched @template-compile diagnostic
+        diagnostic.GetMessage().ShouldContain("'$style' has no member 'missing'.");
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.ShouldBe(1); // .viu file line 2, zero-based
+        outcome.Sources.ShouldNotBeEmpty();
+    }
+
+    [Fact]
     public void ModuleAndVBind_ComposeWithScoped()
     {
         const string source =
@@ -128,6 +181,31 @@ public sealed class SingleFileComponentCssModuleTests
         diagnostic.Location.GetLineSpan().StartLinePosition.Line.ShouldBe(5); // .viu file line 6, zero-based
         // Recoverable: the scaffold is still emitted.
         outcome.Sources.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void ModuleTemplateReference_IdenticalInput_StaysStrictlyCached()
+    {
+        // [V01.01.05.04.01] The CSS module accessor threaded into the template compile is rebuilt from the
+        // value-equatable module-class map, so an unchanged component still re-runs to an equal model — the
+        // model step stays strictly Cached (not Unchanged, which would mean it re-executed and merely matched).
+        const string source =
+            "@template {\n    <div :class=\"$style.box\">hi</div>\n}\n" +
+            "@style module {\n    .box { color: red; }\n}\n";
+
+        var file = new InMemoryAdditionalText($"{ProjectDirectory}/Card.viu", source);
+        var compilation = GeneratorTestHarness.CreateCompilation();
+        var driver = GeneratorTestHarness.CreateDriver(
+            ImmutableArray.Create<AdditionalText>(file), RootNamespace, ProjectDirectory);
+
+        driver = driver.RunGenerators(compilation);
+        driver = driver.RunGenerators(compilation);
+
+        driver.GetRunResult().Results[0]
+            .TrackedSteps[SingleFileComponentGenerator.ModelTrackingName]
+            .SelectMany(step => step.Outputs)
+            .Select(output => output.Reason)
+            .ShouldAllBe(reason => reason == IncrementalStepRunReason.Cached);
     }
 
     [Fact]

--- a/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
+++ b/analyzers/Assimalign.Vue.Syntax.Generators/test/SingleFileComponentCssModuleTests.cs
@@ -126,6 +126,56 @@ public sealed class SingleFileComponentCssModuleTests
     }
 
     [Fact]
+    public void VBind_ReferenceMember_UnwrapsToValue_InGetter()
+    {
+        // [V01.01.06.06.01] `v-bind(count)` with a script Reference<T> member unwraps to `count.Value` in the
+        // ApplyCssVariables getter — instance-member mode, so no `_ctx.` receiver — matching upstream cssVars
+        // ergonomics instead of forcing `v-bind(count.Value)`.
+        const string source =
+            "@script {\n    public Reference<int> count;\n}\n" +
+            "@style {\n    .a { width: v-bind(count); }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        generated.ShouldContain("(object?)(count.Value)");
+        generated.ShouldNotContain("count.Value.Value"); // not double-unwrapped
+    }
+
+    [Fact]
+    public void VBind_NonReferenceMember_StaysBare_InGetter()
+    {
+        // A non-reference @script member is provably non-reactive, so it is read bare (no `.Value`, no unref).
+        const string source =
+            "@script {\n    public string color = \"red\";\n}\n" +
+            "@style {\n    .a { color: v-bind(color); }\n}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "Card.SingleFileComponent.g.cs");
+        generated.ShouldContain("(object?)(color)");
+    }
+
+    [Fact]
+    public void VBind_MalformedExpression_SurfacesMappedStyleDiagnostic()
+    {
+        // [V01.01.06.06.01] A malformed C# v-bind expression is caught by the expression compile and surfaces a
+        // diagnostic on the .viu style coordinate (line 2), recoverable.
+        const string source =
+            "@style {\n    .a { width: v-bind(1 +); }\n}\n"; // line 2 — the malformed expression
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/Card.viu", source, RootNamespace, ProjectDirectory);
+
+        var diagnostic = outcome.Diagnostics.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe("VUECS1301"); // the style-origin envelope
+        diagnostic.GetMessage().ShouldContain("Error parsing"); // the X_INVALID_EXPRESSION message prefix
+        diagnostic.Location.GetLineSpan().StartLinePosition.Line.ShouldBe(1); // .viu file line 2, zero-based
+        outcome.Sources.ShouldNotBeEmpty();
+    }
+
+    [Fact]
     public void ModuleAndVBind_ComposeWithScoped()
     {
         const string source =

--- a/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
@@ -136,6 +136,36 @@ public sealed class DomCompiledRenderTests
         "    }\n" +
         "}\n";
 
+    // [V01.01.05.04.01] A component whose template references the CSS module accessor `$style.box`: the
+    // render body must resolve it to the generated `Style` accessor class and compile against it end to end.
+    private const string CssModuleTemplateReferenceComponent =
+        "@template {\n" +
+        "<div :class=\"$style.box\">hi</div>\n" +
+        "}\n" +
+        "@style module {\n" +
+        ".box { color: red; }\n" +
+        "}\n";
+
+    [Fact]
+    public void CssModuleTemplateReference_ResolvesAccessor_AndCompiles()
+    {
+        // [V01.01.05.04.01] `:class="$style.box"` resolves to the generated `Style` accessor class (not a
+        // phantom `_ctx.box`), so the render body binds `Style.box` — a compile-time const of the emitted
+        // accessor — and compiles end to end against it. This is the loop [V01.01.06.06] left open: it emitted
+        // and compile-checked the accessor, but the template expression compiler had no $style binding source.
+        var generated = CompiledRenderSupport.Generate("StyleRefWidget", CssModuleTemplateReferenceComponent);
+
+        generated.ShouldContain("Style.box");
+        generated.ShouldContain("internal static class Style");
+        generated.ShouldNotContain("_ctx.box");
+
+        // The accessor is self-contained (a const class), so only an empty partial half is needed.
+        var assembly = CompiledRenderSupport.CompileToAssembly(
+            generated,
+            "#nullable enable\nnamespace Demo\n{\n    partial class StyleRefWidget\n    {\n    }\n}\n");
+        assembly.Length.ShouldBeGreaterThan(0);
+    }
+
     [Fact]
     public void CssModuleAndVBind_SeamsCompile_AgainstRuntimeDom()
     {

--- a/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/Assimalign.Vue.RuntimeDom.CompiledRenderTests/DomCompiledRenderTests.cs
@@ -183,6 +183,38 @@ public sealed class DomCompiledRenderTests
         assembly.Length.ShouldBeGreaterThan(0);
     }
 
+    // [V01.01.06.06.01] A v-bind() CSS expression referencing a script Reference<T> member: the generated
+    // ApplyCssVariables getter must unwrap it to `count.Value` and compile against the real Reference<int>.
+    private const string ReactiveVBindComponent =
+        "@script {\n" +
+        "using Assimalign.Vue.Reactivity;\n" +
+        "public Reference<int> count = Reactive.Reference(1);\n" +
+        "}\n" +
+        "@template {\n" +
+        "<div>hi</div>\n" +
+        "}\n" +
+        "@style {\n" +
+        ".box { width: v-bind(count); }\n" +
+        "}\n";
+
+    [Fact]
+    public void VBindReferenceMember_UnwrapsToValue_AndCompilesAgainstReactivity()
+    {
+        // The v-bind(count) expression, routed through the instance-mode binding rewriting, unwraps the script
+        // Reference<int> to `count.Value` in the getter and compiles end to end: `count.Value` is an int, so
+        // Convert.ToString((object?)(count.Value), ...) binds. Before the fix the getter emitted `count`, which
+        // stringified the Reference object (wrong) and never tracked reactively.
+        var generated = CompiledRenderSupport.Generate("ReactiveVBindWidget", ReactiveVBindComponent);
+
+        generated.ShouldContain("(object?)(count.Value)");
+        generated.ShouldContain("internal void ApplyCssVariables()");
+
+        var assembly = CompiledRenderSupport.CompileToAssembly(
+            generated,
+            "#nullable enable\nnamespace Demo\n{\n    partial class ReactiveVBindWidget\n    {\n    }\n}\n");
+        assembly.Length.ShouldBeGreaterThan(0);
+    }
+
     [Fact]
     public void GeneratorCaching_ForTheDomDirectiveTemplate_StaysStrictlyCached()
     {
@@ -374,6 +406,9 @@ internal static class CompiledRenderSupport
         Add(typeof(object).Assembly.Location);
         Add(typeof(RenderHelpers).Assembly.Location);
         Add(typeof(DomRenderHelpers).Assembly.Location);
+        // Reactivity: a @script Reference<T> member that a v-bind() getter unwraps ([V01.01.06.06.01]) binds
+        // Assimalign.Vue.Reactivity's Reference<T>/Reactive.
+        Add(typeof(Assimalign.Vue.Reactivity.Reactive).Assembly.Location);
         var shared = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(assembly => string.Equals(assembly.GetName().Name, "Assimalign.Vue.Shared", StringComparison.Ordinal));
         Add(shared?.Location);

--- a/libraries/Assimalign.Vue.RuntimeDom/test/CssVariablesTests.cs
+++ b/libraries/Assimalign.Vue.RuntimeDom/test/CssVariablesTests.cs
@@ -62,6 +62,41 @@ public sealed class CssVariablesTests : IDisposable
     }
 
     [Fact]
+    public void UseCssVars_WithGeneratorEmittedReferenceGetter_UpdatesReactively_RunCountsPinned()
+    {
+        // [V01.01.06.06.01] The exact getter shape the generator emits for `v-bind(count)` where `count` is a
+        // script Reference<int>: `Convert.ToString((object?)(count.Value), InvariantCulture)`. Because the
+        // auto-unwrap reads the ref's .Value inside the getter, the getter tracks the ref and re-applies on the
+        // next flush when it changes — the run-count proof that v-bind(count) (not v-bind(count.Value)) is
+        // reactive end to end. The getter never ran before the unwrap read a plain object with no tracking.
+        var count = Reactive.Reference(1);
+        var getterRuns = 0;
+        _harness.Render(Component(() =>
+        {
+            getterRuns++;
+            return new Dictionary<string, string>
+            {
+                ["w"] = Convert.ToString((object?)count.Value, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+            };
+        }));
+        _harness.RunUntilIdle();
+
+        var div = _harness.FindElement("div");
+        _harness.CssVariable(div, "--w").ShouldBe("1");
+        _harness.CssVariableCrossings.ShouldBe(1);
+        getterRuns.ShouldBe(1);
+
+        // The ref changes: the getter re-runs (it tracked count.Value) and the property re-applies — one more
+        // crossing, one more getter run, and no re-render.
+        count.Value = 42;
+        _harness.RunUntilIdle();
+
+        _harness.CssVariable(div, "--w").ShouldBe("42");
+        _harness.CssVariableCrossings.ShouldBe(2);
+        getterRuns.ShouldBe(2);
+    }
+
+    [Fact]
     public void UseCssVars_DoesNotReapply_WhenNoBoundValueChanged()
     {
         var color = Reactive.Reference("red");

--- a/libraries/Assimalign.Vue.Syntax.Css/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Css/docs/DESIGN.md
@@ -98,13 +98,31 @@ the `.viu` parser wiring them in.
   parser non-goal below).
 - **`CssBindingRewriter`** ports `cssVars.ts`. It scans each declaration value for `v-bind(expr)` (a port
   of upstream's `lexBinding`: it skips string literals and `/* */` comments and balances nested parens),
-  replaces each with `var(--<hash>)`, and collects the distinct `(hash, expression)` bindings for the
-  `UseCssVars` runtime. `<hash>` is the FNV-1a of `<shortScopeId>-<expr>`, so the emitted CSS
-  `var(--<hash>)` and the runtime's `style.setProperty("--<hash>", …)` agree by construction. An
-  unterminated `v-bind(` or an empty `v-bind()` reports a recoverable 2000-band `CssError` on the
-  declaration and is left in place.
+  replaces each with `var(--<hash>)`, and collects the distinct `(hash, expression, location)` bindings for
+  the `UseCssVars` runtime. `<hash>` is the FNV-1a of `<shortScopeId>-<expr>`, so the emitted CSS
+  `var(--<hash>)` and the runtime's `style.setProperty("--<hash>", …)` agree by construction. Each binding
+  carries the block-relative source location of its expression so the composition root can map a
+  compile diagnostic back onto the exact `.viu` coordinate. An unterminated `v-bind(` or an empty
+  `v-bind()` reports a recoverable 2000-band `CssError` on the declaration and is left in place.
 
-Both are tree-to-tree, so they compose with `scoped` in any order — the scoped serializer reads the
+### The `v-bind()` expression rewriting path ([V01.01.06.06.01])
+
+`CssBindingRewriter` extracts the expression **text**; the C# rewriting is the template compiler's job, so the
+composition-root generator routes each extracted expression through
+`Assimalign.Vue.Syntax.Templates`' `TemplateExpressionCompiler.CompileInstanceExpression` with the component's
+binding metadata — the same binding-aware rewriting a render expression gets. This makes `v-bind(count)` unwrap
+a script `Reference<T>` member to `count.Value` automatically (matching upstream cssVars ergonomics), instead of
+forcing the author to write `v-bind(count.Value)`. The getter runs as an **instance member** of the component
+partial class (`ApplyCssVariables`), so the rewriting is instance-member mode: bindings read through the implicit
+`this` (no `_ctx.`), a definite `Reference<T>` unwraps to `.Value`, and every other binding reads bare — the
+generator only marks a binding a definite reference when its declared type is reactive, so no `unref` (and thus no
+runtime-helper import) is needed in the getter. A **malformed** expression surfaces its `X_INVALID_EXPRESSION`
+diagnostic on the exact `.viu` style coordinate through the same style-origin envelope (`VUECS1301`) the CSS parse
+diagnostics use; the recoverable original text still emits, so the reported error fails the build. Member
+existence is left to the C# compiler (the same permissive choice the render path makes, so a member declared in a
+hand-written sibling partial is not false-flagged). The runtime half is `UseCssVars` in `Assimalign.Vue.RuntimeDom`.
+
+Both rewrites are tree-to-tree, so they compose with `scoped` in any order — the scoped serializer reads the
 parsed selector parts and declaration values the rewrites already updated. A block that is `module`/`v-bind`
 but **not** `scoped` is serialized by **`CssStylesheetWriter`**, the plain (unscoped) sibling of
 `CssScopedRewriter` sharing its canonical two-space form; a non-scoped block with neither feature is still

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriter.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssBindingRewriter.cs
@@ -183,7 +183,8 @@ public static class CssBindingRewriter
 
                 builder ??= new StringBuilder(value.Length);
                 builder.Append(value, copiedThrough, index - copiedThrough);
-                builder.Append("var(--").Append(ResolveName(expression)).Append(')');
+                var expressionLocation = LocateExpression(location, value, argumentStart, close - argumentStart);
+                builder.Append("var(--").Append(ResolveName(expression, expressionLocation)).Append(')');
                 index = close + 1;
                 copiedThrough = index;
             }
@@ -198,8 +199,8 @@ public static class CssBindingRewriter
         }
 
         // Deduplicates by the normalized expression so a repeated v-bind(color) shares one hashed name and
-        // one recorded binding (upstream vars.includes check).
-        private string ResolveName(string expression)
+        // one recorded binding (upstream vars.includes check). The first occurrence's location is retained.
+        private string ResolveName(string expression, SourceLocation location)
         {
             if (_namesByExpression.TryGetValue(expression, out var name))
             {
@@ -208,9 +209,52 @@ public static class CssBindingRewriter
 
             name = CssHash.Compute(_salt + "-" + expression);
             _namesByExpression[expression] = name;
-            Bindings.Add(new CssVariableBinding(name, expression));
+            Bindings.Add(new CssVariableBinding(name, expression, location));
             return name;
         }
+    }
+
+    // Computes the block-relative location of the raw expression region [startInValue, startInValue+length)
+    // within a declaration value, so a consumer that compiles the expression ([V01.01.06.06.01]) can map a
+    // diagnostic onto the exact source coordinate. The value is a substring of the declaration slice, so the
+    // declaration's start position is advanced through the intervening text.
+    private static SourceLocation LocateExpression(SourceLocation declarationLocation, string value, int startInValue, int length)
+    {
+        var source = declarationLocation.Source;
+        var valueOffset = source.IndexOf(value, StringComparison.Ordinal);
+        if (valueOffset < 0)
+        {
+            // Defensive: the trimmed value should always be a slice of the declaration source; fall back to
+            // the whole declaration if it is not, so a diagnostic still lands on the declaration.
+            return declarationLocation;
+        }
+
+        var start = valueOffset + startInValue;
+        var end = start + length;
+        var startPosition = Advance(declarationLocation.Start, source, start);
+        var endPosition = Advance(declarationLocation.Start, source, end);
+        var slice = end <= source.Length ? source.Substring(start, length) : string.Empty;
+        return new SourceLocation(startPosition, endPosition, slice);
+    }
+
+    // Advances a start position forward through source[0..count) (mirrors the template compiler's position
+    // advance): columns add on the same line, and a newline resets the column to the distance past it.
+    private static Position Advance(Position from, string source, int count)
+    {
+        var line = from.Line;
+        var lastNewLine = -1;
+        var end = Math.Min(source.Length, count);
+        for (var index = 0; index < end; index++)
+        {
+            if (source[index] == '\n')
+            {
+                line++;
+                lastNewLine = index;
+            }
+        }
+
+        var column = lastNewLine == -1 ? from.Column + count : count - lastNewLine;
+        return new Position(from.Offset + count, line, column);
     }
 
     // Whether the literal keyword 'v-bind' sits at index; sets afterKeyword to the index just past it.

--- a/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssVariableBinding.cs
+++ b/libraries/Assimalign.Vue.Syntax.Css/src/Bindings/CssVariableBinding.cs
@@ -3,10 +3,11 @@ namespace Assimalign.Vue.Syntax.Css;
 /// <summary>
 /// One <c>v-bind()</c> CSS binding extracted by <see cref="CssBindingRewriter"/>: the hashed custom-property
 /// <see cref="Name"/> the usage was rewritten to (<c>var(--&lt;Name&gt;)</c>) paired with the original
-/// <see cref="Expression"/> text. Mirrors an entry of the <c>cssVars</c> list Vue's
-/// <c>@vue/compiler-sfc</c> records for <c>useCssVars</c> (<c>packages/compiler-sfc/src/style/cssVars.ts</c>,
-/// https://vuejs.org/api/sfc-css-features.html#v-bind-in-css) — the compile-time half of the binding that
-/// the <c>UseCssVars</c> runtime evaluates and applies as a custom property.
+/// <see cref="Expression"/> text and the <see cref="Location"/> of that expression. Mirrors an entry of the
+/// <c>cssVars</c> list Vue's <c>@vue/compiler-sfc</c> records for <c>useCssVars</c>
+/// (<c>packages/compiler-sfc/src/style/cssVars.ts</c>, https://vuejs.org/api/sfc-css-features.html#v-bind-in-css)
+/// — the compile-time half of the binding that the <c>UseCssVars</c> runtime evaluates and applies as a custom
+/// property.
 /// </summary>
 /// <param name="Name">
 /// The hashed custom-property name (without the leading <c>--</c>) the usage was rewritten to. Deterministic
@@ -14,4 +15,9 @@ namespace Assimalign.Vue.Syntax.Css;
 /// <c>style.setProperty("--&lt;Name&gt;", …)</c> agree by construction.
 /// </param>
 /// <param name="Expression">The original expression text inside <c>v-bind(…)</c>, trimmed and unquoted.</param>
-public sealed record CssVariableBinding(string Name, string Expression);
+/// <param name="Location">
+/// The block-relative source location of the expression, so a consumer compiling the expression
+/// ([V01.01.06.06.01]) can map a diagnostic back onto the exact source coordinate. For a de-duplicated
+/// expression it is the first occurrence's location.
+/// </param>
+public sealed record CssVariableBinding(string Name, string Expression, SourceLocation Location);

--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -112,6 +112,17 @@ the common .NET base-class surface a template legitimately reaches (`Math`, `Con
   C# allows. Only the prefixed (C#-codegen) path diverges; non-prefixed output stays byte-for-byte
   upstream parity. Pinned by `ExpressionBindingTests` and `RenderFunctionEmitterTests`
   ([V01.01.05.05.01], issue #143).
+- **Multi-statement handlers get a synthesized statement terminator.** A multi-statement inline handler
+  (`@click="foo(); bar()"`) is emitted into `__event => { <body> }`. Upstream wraps it the same way and
+  relies on JavaScript's automatic semicolon insertion for the final statement; C# has no ASI, so a body
+  whose last statement omits its terminator would emit invalid C#. Under prefixing, `ExpressionProcessor`
+  decides with the same statement-list parse that validates the body (`asRawStatements`): if `{ body }`
+  does not parse clean but `{ body; }` does, the only fault was the missing terminator, so a `;` is
+  synthesized onto the rewritten content (a genuine syntax error is left untouched and still surfaces as
+  `X_INVALID_EXPRESSION`). The terminator rides out even when no identifier needs rewriting. An
+  author-supplied trailing `;` is never doubled. Only the prefixed path is affected; non-prefixed output
+  stays byte-for-byte upstream parity. Pinned by `ExpressionBindingTests` and `RenderFunctionEmitterTests`
+  ([V01.01.05.05.02], issue #150).
 - **`asParams` validation is lenient.** Alias/prop declaration positions are registered for scope but not
   hard-validated as expressions, because C# deconstruction forms (`(a, b)`, `var (a, b)`) and JavaScript-style
   `{ a }` destructures do not all parse as C# expressions; a lenient identifier scan still contributes their

--- a/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Vue.Syntax.Templates/docs/DESIGN.md
@@ -50,6 +50,7 @@ single closure over the component), and the table below is the compiler-owned co
 | `SetupLet` | `unref(_ctx.name)` | `_ctx.name` — upstream emits an `isRef`-guarded write, which a C# expression cannot; the helper-backed guarded write is deferred to [V01.01.05.05] |
 | `SetupConstant` / `SetupReactiveConstant` / `LiteralConstant` | `_ctx.name` | `_ctx.name` |
 | `Property` / `PropertyAliased` / `Data` / `Options` | `_ctx.name` (alias resolved for `PropertyAliased`) | same |
+| CSS module accessor (`$style`, named module) | `Style.member` / `<Accessor>.member` (bare accessor class) | n/a (read-only) |
 | unresolved | `_ctx.name` | `_ctx.name` |
 
 Key divergences from Vue's JS contract, all forced by C# semantics:
@@ -68,6 +69,40 @@ Key divergences from Vue's JS contract, all forced by C# semantics:
   (`BindingMetadata.ReportsUnresolvedIdentifiers`), such an identifier surfaces `XVuecsUnresolvedIdentifier`
   (code 66 — a Vuecs-specific extension past the upstream and DOM `__EXTEND_POINT__` sentinels) while still
   emitting the recoverable `_ctx.` fallback. With the default permissive metadata the behavior matches Vue.
+
+### CSS Modules accessors (`$style` and named modules, [V01.01.05.04.01])
+
+Vue exposes a `<style module>` block's class map to templates as the `$style` render-context object (a named
+module `<style module="theme">` as `theme`), indexed at runtime: `:class="$style.box"`. Vuecs generates static
+C# with no render-context object to index, so [V01.01.06.06] emits the map as a compile-time nested `const` class
+(`internal static class Style { public const string box = "box_<hash>"; }`). This feature wires that class into
+expression classification as a **new binding source**, so `$style.box` resolves to `Style.box` (the emitted
+const) instead of a phantom component member — the loop [V01.01.06.06] left open. The seam is
+`CssModuleAccessors`, a transform-input object (like `BindingMetadata`) the composition-root generator supplies
+on `TransformOptions.CssModules`; it is rebuilt from the model's already-value-equatable module-class map, so it
+never rides in the cached model and the incremental cache stays `Cached`.
+
+- **`$` spelling.** `$` is not a legal C# identifier character, so before the Roslyn parse the accessor spelling
+  is rewritten to a parse identifier — `$style`→`_style` — the same spelling-substitution precedent as
+  `$event`→`__event` and `$slots`→`__slots`. The substitution is **length-preserving**, so every offset in the
+  expression (and therefore every remapped diagnostic span) is unchanged; classification then maps the parse
+  identifier to the accessor class name (`Style`). A named module is referenced by its authored name (`theme`),
+  already C#-parseable, and maps to its pascal-cased accessor class (`Theme`) — a divergence from Vue's runtime
+  string-indexed access, forced because the accessor is a C# type. A member with a non-identifier name (`.a-b`)
+  is reached through its sanitized C# member (`$style.a_b`), the same name the emitter writes as the const.
+- **Precedence (shadowing).** A module accessor is resolved before component bindings, so a same-named component
+  member is shadowed — matching Vue's render context, which exposes `$style`/named modules over component state.
+- **Unknown members are a compile-time error.** The generator supplies the *complete* class map, so an access to
+  an undeclared class (`$style.missing`) is decidably wrong and surfaces `XVuecsUnknownCssModuleMember` (code
+  1001, the Vuecs-specific band) on the exact template coordinate under strict metadata
+  (`CssModuleAccessors.ReportsUnknownMembers`, which the generator sets). The access still emits the accessor
+  member (recoverable), so the C# compiler is the backstop; with a partial map the check is silent and only the
+  C# compiler catches it. Pinned by `ExpressionBindingTests`, `SingleFileComponentCssModuleTests`, and the
+  compiled-render projects.
+- **Known simplification (collision).** The `$`→`_` substitution means a component member literally named
+  `_style` referenced in a template while a `$style` module is in scope would be misclassified as the accessor
+  (both spell `_style` post-substitution). This mirrors the documented lambda-shadowing approximation and is
+  vanishingly rare given the repo's whole-word naming; a real `$style` reference is always unambiguous.
 
 ### Diagnostics and source mapping
 

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingRewriteMode.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/BindingRewriteMode.cs
@@ -1,0 +1,26 @@
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// How expression classification spells the receiver of a rewritten component binding. Vue's single render
+/// context has no such choice — every binding resolves through the runtime proxy — but Vuecs generates code into
+/// two distinct member contexts, so the compiler must decide the receiver form for each.
+/// </summary>
+public enum BindingRewriteMode
+{
+    /// <summary>
+    /// The render function ([V01.01.05.05]): a static method receiving the component as <c>_ctx</c>, so every
+    /// binding reads through <c>_ctx.</c> and a maybe/let binding guards its read through <c>unref</c>. The
+    /// default and the mode the whole template pipeline uses.
+    /// </summary>
+    RenderContext,
+
+    /// <summary>
+    /// An instance member of the generated component partial class ([V01.01.06.06.01]) — the <c>v-bind()</c> CSS
+    /// getter — where bindings read through the implicit <c>this</c> (no <c>_ctx</c>). Only a definite
+    /// <see cref="BindingType.SetupReference"/> unwraps (<c>name.Value</c>); every other classification reads bare,
+    /// because the generator marks a binding <c>SetupReference</c> exactly when its declared type is a reactive
+    /// reference — every other binding it produces is provably non-reactive, so <c>unref</c> would be a no-op and
+    /// the getter needs no runtime-helper import.
+    /// </summary>
+    InstanceMember,
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/CssModuleAccessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/CssModuleAccessor.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// One CSS Modules accessor a template expression may reference — the Vuecs equivalent of Vue 3.5's
+/// <c>$style</c> (and named-module) render-context object (https://vuejs.org/api/sfc-css-features.html#css-modules).
+/// Vue exposes the class map as a runtime object indexed dynamically; Vuecs has no such render-context object, so
+/// the composition-root generator ([V01.01.06.06]) emits the map as a compile-time nested <c>const</c> class and
+/// supplies this descriptor to expression classification ([V01.01.05.04.01]) so <c>$style.box</c> resolves to that
+/// class's <c>box</c> member instead of a phantom component binding.
+/// </summary>
+/// <remarks>
+/// This is transform <i>input</i>, like <see cref="BindingMetadata"/>: a plain immutable class (not a value-
+/// equatable record) rebuilt from the generator's already-value-equatable module-class map, so it never rides in
+/// the cached model and cannot perturb the incremental cache.
+/// </remarks>
+public sealed class CssModuleAccessor
+{
+    private readonly HashSet<string> members;
+
+    /// <summary>Creates a CSS module accessor descriptor.</summary>
+    /// <param name="templateName">The accessor as authored in the template (<c>$style</c>, or a named module's name).</param>
+    /// <param name="parseIdentifier">
+    /// The C#-parseable spelling of <paramref name="templateName"/> — identical for a named module, and the
+    /// <c>$</c>→<c>_</c> substitution for the default <c>$style</c> (<c>$</c> is not a legal C# identifier
+    /// character, so the expression is parsed against <c>_style</c>). Length-preserving, so expression offsets
+    /// map back to the template unchanged.
+    /// </param>
+    /// <param name="accessorClass">The generated accessor class name the member access compiles against (<c>Style</c>, <c>Theme</c>).</param>
+    /// <param name="members">The declared member names (the sanitized class names the accessor class exposes as <c>const</c>s).</param>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public CssModuleAccessor(string templateName, string parseIdentifier, string accessorClass, IEnumerable<string> members)
+    {
+        TemplateName = templateName ?? throw new ArgumentNullException(nameof(templateName));
+        ParseIdentifier = parseIdentifier ?? throw new ArgumentNullException(nameof(parseIdentifier));
+        AccessorClass = accessorClass ?? throw new ArgumentNullException(nameof(accessorClass));
+        this.members = new HashSet<string>(members ?? throw new ArgumentNullException(nameof(members)), StringComparer.Ordinal);
+    }
+
+    /// <summary>The accessor as authored in the template (<c>$style</c>, or a named module's name).</summary>
+    public string TemplateName { get; }
+
+    /// <summary>The C#-parseable spelling of <see cref="TemplateName"/> (the <c>$</c>→<c>_</c> form for <c>$style</c>).</summary>
+    public string ParseIdentifier { get; }
+
+    /// <summary>The generated accessor class name a member access compiles against.</summary>
+    public string AccessorClass { get; }
+
+    /// <summary>The declared member names.</summary>
+    public IReadOnlyCollection<string> Members => members;
+
+    /// <summary>Whether <paramref name="name"/> is a declared member of this accessor.</summary>
+    /// <param name="name">The member name.</param>
+    public bool HasMember(string name) => members.Contains(name);
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/CssModuleAccessors.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Binding/CssModuleAccessors.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The set of CSS Modules accessors ([V01.01.05.04.01]) a template's expressions may reference, keyed by their
+/// C#-parseable spelling. Supplied by the composition-root generator ([V01.01.06.06]) alongside
+/// <see cref="BindingMetadata"/>, it lets expression classification resolve <c>$style.box</c> (and named-module
+/// forms) to the generated accessor class rather than a phantom component binding — the Vuecs stand-in for Vue
+/// 3.5's runtime <c>$style</c> render-context object, which Vuecs cannot have because it generates static,
+/// trimming-safe C# (no runtime proxy, no dynamic member access).
+/// </summary>
+/// <remarks>
+/// Transform <i>input</i> like <see cref="BindingMetadata"/>: a plain immutable class rebuilt from the generator's
+/// value-equatable module-class map, so it never rides in the cached model and the incremental cache stays intact.
+/// The <c>$</c> in <c>$style</c> is not a legal C# identifier character, so an expression is parsed against the
+/// length-preserving <c>$</c>→<c>_</c> substitution (<see cref="Substitute"/>) — the same spelling-substitution
+/// precedent as <c>$event</c>→<c>__event</c> and <c>$slots</c>→<c>__slots</c>.
+/// </remarks>
+public sealed class CssModuleAccessors
+{
+    /// <summary>The empty set — no CSS module accessors are in scope (the common, no-<c>module</c> component).</summary>
+    public static readonly CssModuleAccessors Empty = new(Array.Empty<CssModuleAccessor>(), reportsUnknownMembers: false);
+
+    private readonly Dictionary<string, CssModuleAccessor> byParseIdentifier;
+    private readonly List<KeyValuePair<string, string>> substitutions;
+
+    /// <summary>Creates a CSS module accessor set.</summary>
+    /// <param name="accessors">The accessors in scope.</param>
+    /// <param name="reportsUnknownMembers">
+    /// Whether a member access on an accessor whose name is not a declared class surfaces a
+    /// <see cref="CompilerErrorCode.XVuecsUnknownCssModuleMember"/> diagnostic. The generator sets this because it
+    /// supplies the <i>complete</i> class map (every declared class), so an unknown member is decidably wrong;
+    /// defaults to <see langword="false"/> so a partial map never spuriously errors.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="accessors"/> is <see langword="null"/>.</exception>
+    public CssModuleAccessors(IEnumerable<CssModuleAccessor> accessors, bool reportsUnknownMembers)
+    {
+        if (accessors is null)
+        {
+            throw new ArgumentNullException(nameof(accessors));
+        }
+
+        byParseIdentifier = new Dictionary<string, CssModuleAccessor>(StringComparer.Ordinal);
+        substitutions = new List<KeyValuePair<string, string>>();
+        foreach (var accessor in accessors)
+        {
+            byParseIdentifier[accessor.ParseIdentifier] = accessor;
+            if (!string.Equals(accessor.TemplateName, accessor.ParseIdentifier, StringComparison.Ordinal))
+            {
+                // A spelling that is not already C#-parseable (the `$style` default): record its
+                // length-preserving substitution so Substitute() can rewrite it before the Roslyn parse.
+                substitutions.Add(new KeyValuePair<string, string>(accessor.TemplateName, accessor.ParseIdentifier));
+            }
+        }
+
+        ReportsUnknownMembers = reportsUnknownMembers;
+    }
+
+    /// <summary>The number of accessors in scope.</summary>
+    public int Count => byParseIdentifier.Count;
+
+    /// <summary>Whether an access to an undeclared member surfaces a diagnostic (the generator supplies a complete map).</summary>
+    public bool ReportsUnknownMembers { get; }
+
+    /// <summary>Resolves the accessor for a C#-parseable identifier (the <see cref="Substitute"/>d spelling).</summary>
+    /// <param name="parseIdentifier">The identifier as it appears in the parsed expression.</param>
+    /// <param name="accessor">The resolved accessor when found.</param>
+    /// <returns><see langword="true"/> when <paramref name="parseIdentifier"/> names an accessor.</returns>
+    public bool TryResolve(string parseIdentifier, out CssModuleAccessor accessor)
+        => byParseIdentifier.TryGetValue(parseIdentifier, out accessor!);
+
+    /// <summary>
+    /// Rewrites the not-yet-C#-parseable accessor spellings in <paramref name="raw"/> to their parse identifiers
+    /// (<c>$style</c>→<c>_style</c>), at identifier boundaries and length-preserving so every other offset in the
+    /// expression is unchanged. A no-op when no <c>$</c>-spelling is in scope or <paramref name="raw"/> has no
+    /// <c>$</c>.
+    /// </summary>
+    /// <param name="raw">The raw expression text.</param>
+    /// <returns>The substituted text, or the same instance when nothing changed.</returns>
+    public string Substitute(string raw)
+    {
+        if (substitutions.Count == 0 || raw.IndexOf('$') < 0)
+        {
+            return raw;
+        }
+
+        var result = raw;
+        foreach (var pair in substitutions)
+        {
+            result = ReplaceToken(result, pair.Key, pair.Value);
+        }
+
+        return result;
+    }
+
+    // Replaces whole-token occurrences of `from` with `to`. A match counts only when the character just past it
+    // is not an identifier-continuation char, so a longer name is never partially rewritten; the leading char is
+    // never an identifier-continuation char for a `$`-prefixed token, so only the trailing boundary is checked.
+    private static string ReplaceToken(string text, string from, string to)
+    {
+        var index = text.IndexOf(from, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var cursor = 0;
+        while (index >= 0)
+        {
+            var after = index + from.Length;
+            builder.Append(text, cursor, index - cursor);
+            if (after >= text.Length || !IsIdentifierContinuation(text[after]))
+            {
+                builder.Append(to);
+            }
+            else
+            {
+                builder.Append(from);
+            }
+
+            cursor = after;
+            index = text.IndexOf(from, cursor, StringComparison.Ordinal);
+        }
+
+        builder.Append(text, cursor, text.Length - cursor);
+        return builder.ToString();
+    }
+
+    private static bool IsIdentifierContinuation(char character)
+        => (character >= 'a' && character <= 'z') ||
+           (character >= 'A' && character <= 'Z') ||
+           (character >= '0' && character <= '9') ||
+           character == '_';
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Diagnostics/CompilerErrorCode.cs
@@ -250,4 +250,15 @@ public enum CompilerErrorCode
     /// +1 mapping scheme; the server-renderer area [V01.01.07] will claim them).
     /// </summary>
     XVuecsUnresolvedIdentifier = 1000,
+
+    /// <summary>
+    /// A template expression accessed a member that does not exist on a CSS Modules accessor (the
+    /// <c>$style</c>/named-module equivalent, [V01.01.05.04.01]) whose full class map the generator supplied
+    /// (<see cref="CssModuleAccessors.ReportsUnknownMembers"/>). Vuecs-specific; no upstream counterpart —
+    /// Vue's runtime <c>$style</c> is a plain object indexed at runtime, whereas the Vuecs accessor is a
+    /// compile-time class whose members are exactly the declared classes, so an unknown member is a
+    /// compile-time error the compiler surfaces on the template coordinate rather than a runtime
+    /// <see langword="undefined"/>.
+    /// </summary>
+    XVuecsUnknownCssModuleMember = 1001,
 }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerErrorMessages.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/CompilerErrorMessages.cs
@@ -112,6 +112,9 @@ internal static class CompilerErrorMessages
         [CompilerErrorCode.XVuecsUnresolvedIdentifier] =
             "Cannot resolve template identifier against any component binding, template scope variable, or " +
             "allowed global: ",
+
+        // The offending "'<module>' has no member '<member>'." detail is appended by the reporter ([V01.01.05.04.01]).
+        [CompilerErrorCode.XVuecsUnknownCssModuleMember] = "Unknown CSS module member: ",
     };
 
     /// <summary>Gets the message for <paramref name="code"/>, or an empty string when none is defined.</summary>

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
@@ -187,11 +187,30 @@ internal static class ExpressionProcessor
             context.ReportError(new CompilerError(CompilerErrorCode.XVuecsUnresolvedIdentifier, message, location));
         }
 
-        return "_ctx." + raw;
+        // Instance-member mode ([V01.01.06.06.01]): the expression runs as a member of the component partial
+        // class, so an unresolved identifier reads through the implicit `this` (bare) rather than `_ctx.`.
+        return context.BindingRewriteMode == BindingRewriteMode.InstanceMember ? raw : "_ctx." + raw;
     }
 
     private static string RewriteBoundIdentifier(string raw, BindingType type, bool isWriteTarget, TransformContext context)
-        => type switch
+    {
+        if (context.BindingRewriteMode == BindingRewriteMode.InstanceMember)
+        {
+            // The v-bind() CSS getter ([V01.01.06.06.01]) is an instance member: bindings read through the
+            // implicit `this` (no `_ctx.`), and only a definite reference unwraps (`.Value`). Every other
+            // classification the generator produces is provably non-reactive (SetupLet is a non-reference
+            // field/property; SetupConstant/LiteralConstant are constants), so it reads bare with no `unref`
+            // — the getter therefore needs no runtime-helper import. Mirrors the read column of the render
+            // contract table with the `_ctx.` receiver and the `unref` guard removed.
+            return type switch
+            {
+                BindingType.SetupReference => raw + ".Value",
+                BindingType.PropertyAliased => context.BindingMetadata.GetPropertyAlias(raw) ?? raw,
+                _ => raw,
+            };
+        }
+
+        return type switch
         {
             // Every setup binding routes through _ctx: the generated render function is a static
             // method receiving the component instance (the C# analogue of upstream's non-inline
@@ -228,6 +247,7 @@ internal static class ExpressionProcessor
             // Props, options-API members, and plain data are component-instance members reached through _ctx.
             _ => "_ctx." + raw,
         };
+    }
 
     // ---- CSS Modules member validation ([V01.01.05.04.01]) ----
 

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
@@ -95,9 +95,31 @@ internal static class ExpressionProcessor
 
         // Full parse: validates the whole text (consumeFullText) and yields a tree to walk.
         var prefixLength = asRawStatements ? 1 : 0;
-        Microsoft.CodeAnalysis.SyntaxNode parsed = asRawStatements
-            ? SyntaxFactory.ParseStatement("{" + raw + "}", 0, ParseOptions)
-            : SyntaxFactory.ParseExpression(raw, 0, ParseOptions);
+        Microsoft.CodeAnalysis.SyntaxNode parsed;
+        if (asRawStatements)
+        {
+            // A multi-statement inline handler is emitted into `__event => { <raw> }`. C# has no automatic
+            // semicolon insertion — JavaScript's ASI, which upstream's `$event => { ... }` handler wrapping
+            // relies on — so a body whose final statement omits its terminator (`foo(); bar()`) would emit
+            // invalid C#. Synthesize the terminator from the same statement-list parse that validates the
+            // body: if `{ raw }` does not parse clean but `{ raw; }` does, the only fault was the missing
+            // terminator, so append one and reuse the clean tree; a genuine syntax error leaves `raw`
+            // untouched and still surfaces as X_INVALID_EXPRESSION below. [V01.01.05.05.02], issue #150.
+            parsed = SyntaxFactory.ParseStatement("{" + raw + "}", 0, ParseOptions);
+            if (TryGetFirstError(parsed, out _, out _))
+            {
+                var terminated = SyntaxFactory.ParseStatement("{" + raw + ";}", 0, ParseOptions);
+                if (!TryGetFirstError(terminated, out _, out _))
+                {
+                    raw += ";";
+                    parsed = terminated;
+                }
+            }
+        }
+        else
+        {
+            parsed = SyntaxFactory.ParseExpression(raw, 0, ParseOptions);
+        }
 
         if (TryGetFirstError(parsed, out var errorSpan, out var errorMessage))
         {
@@ -114,7 +136,9 @@ internal static class ExpressionProcessor
         var references = CollectReferences(parsed, context, prefixLength);
         if (references.Count == 0)
         {
-            return node;
+            // No identifier needs rewriting, but a synthesized statement terminator (above) still must ride
+            // out on the content, or the emitted `__event => { ... }` stays unterminated.
+            return raw == node.Content ? node : node with { Content = raw };
         }
 
         return BuildCompound(node, raw, references, context);

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Internal/ExpressionProcessor.cs
@@ -81,6 +81,17 @@ internal static class ExpressionProcessor
             return node;
         }
 
+        // CSS Modules accessor spelling ([V01.01.05.04.01]): `$style` is not C#-parseable (`$` is an illegal
+        // identifier character), so rewrite it to its parse identifier (`$style`->`_style`) before the
+        // identifier fast-path and the Roslyn parse. The substitution is length-preserving, so every offset in
+        // the expression — and therefore every remapped diagnostic and member span — is unchanged. Named
+        // modules (`theme.box`) are already C#-parseable and pass through untouched. The classification and
+        // member validation below recognize the parse identifier through `context.CssModules`.
+        if (context.CssModules.Count > 0)
+        {
+            raw = context.CssModules.Substitute(raw);
+        }
+
         // Fast path: a lone identifier (upstream's isSimpleIdentifier branch).
         if (!asParams && CompilerText.IsSimpleIdentifier(raw))
         {
@@ -133,6 +144,15 @@ internal static class ExpressionProcessor
             return node;
         }
 
+        // CSS Modules member validation ([V01.01.05.04.01]): the generator supplies the complete class map, so a
+        // `$style.<member>` (or named-module) access to an undeclared class is decidably wrong and surfaces a
+        // mapped diagnostic on the exact template coordinate (the C# compiler would also reject the emitted
+        // accessor member, but this points at the .viu instead of the generated accessor class).
+        if (context.CssModules.ReportsUnknownMembers && context.CssModules.Count > 0)
+        {
+            ValidateModuleMembers(parsed, context, node, raw, prefixLength);
+        }
+
         var references = CollectReferences(parsed, context, prefixLength);
         if (references.Count == 0)
         {
@@ -148,6 +168,14 @@ internal static class ExpressionProcessor
 
     private static string RewriteIdentifier(string raw, TransformContext context, bool isWriteTarget, SourceLocation location)
     {
+        // A CSS Modules accessor ([V01.01.05.04.01]) resolves to its generated accessor class, taking
+        // precedence over component bindings and the unresolved-identifier fallback — the compile-time analogue
+        // of Vue's render context exposing `$style`/named modules over same-named component state.
+        if (context.CssModules.Count > 0 && context.CssModules.TryResolve(raw, out var accessor))
+        {
+            return accessor.AccessorClass;
+        }
+
         if (context.BindingMetadata.TryGetBindingType(raw, out var type))
         {
             return RewriteBoundIdentifier(raw, type, isWriteTarget, context);
@@ -200,6 +228,45 @@ internal static class ExpressionProcessor
             // Props, options-API members, and plain data are component-instance members reached through _ctx.
             _ => "_ctx." + raw,
         };
+
+    // ---- CSS Modules member validation ([V01.01.05.04.01]) ----
+
+    // Reports an XVuecsUnknownCssModuleMember diagnostic for each `<accessor>.<member>` whose member is not a
+    // declared class of the resolved CSS module accessor. The offending member span is remapped from the
+    // expression-relative offset back into template coordinates so the diagnostic lands on the exact .viu
+    // position (the same remapping X_INVALID_EXPRESSION uses). The substitution above is length-preserving, so
+    // the parsed span aligns with the original template text.
+    private static void ValidateModuleMembers(
+        Microsoft.CodeAnalysis.SyntaxNode root,
+        TransformContext context,
+        SimpleExpressionNode node,
+        string raw,
+        int prefixLength)
+    {
+        foreach (var descendant in root.DescendantNodesAndSelf())
+        {
+            if (descendant is not MemberAccessExpressionSyntax access ||
+                access.Expression is not IdentifierNameSyntax identifier ||
+                !context.CssModules.TryResolve(identifier.Identifier.ValueText, out var accessor))
+            {
+                continue;
+            }
+
+            var member = access.Name.Identifier.ValueText;
+            if (member.Length == 0 || accessor.HasMember(member))
+            {
+                continue;
+            }
+
+            var span = access.Name.Span;
+            var start = Clamp(span.Start - prefixLength, 0, raw.Length);
+            var length = start + span.Length > raw.Length ? raw.Length - start : span.Length;
+            var location = SubLocation(node.Location, raw, start, length < 0 ? 0 : length);
+            var message = CompilerErrorMessages.GetMessage(CompilerErrorCode.XVuecsUnknownCssModuleMember) +
+                "'" + accessor.TemplateName + "' has no member '" + member + "'.";
+            context.ReportError(new CompilerError(CompilerErrorCode.XVuecsUnknownCssModuleMember, message, location));
+        }
+    }
 
     // ---- reference collection ----
 

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/ExpressionCompileResult.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/ExpressionCompileResult.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// The result of compiling a standalone expression through <see cref="TemplateExpressionCompiler"/>: the rewritten
+/// C# <see cref="Code"/> and any <see cref="Diagnostics"/> the compile produced (a malformed expression is
+/// reported here rather than thrown, matching the recoverable transform model).
+/// </summary>
+public sealed class ExpressionCompileResult
+{
+    /// <summary>Creates an expression compile result.</summary>
+    /// <param name="code">The rewritten C# expression text (the original when a diagnostic prevented rewriting).</param>
+    /// <param name="diagnostics">The diagnostics the compile produced.</param>
+    public ExpressionCompileResult(string code, IReadOnlyList<CompilerError> diagnostics)
+    {
+        Code = code;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>The rewritten C# expression text.</summary>
+    public string Code { get; }
+
+    /// <summary>The diagnostics the compile produced (empty when the expression compiled cleanly).</summary>
+    public IReadOnlyList<CompilerError> Diagnostics { get; }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TemplateExpressionCompiler.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TemplateExpressionCompiler.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+/// <summary>
+/// Compiles a single, standalone C# expression through the template compiler's binding-metadata rewriting —
+/// the same identifier classification and <c>Ref&lt;T&gt;</c> unwrapping ([V01.01.05.04]) a template expression
+/// receives, but for an expression that lives outside a template. The composition-root generator uses it for
+/// <c>v-bind()</c> CSS expressions ([V01.01.06.06.01]): routing them through this compiler makes
+/// <c>v-bind(count)</c> unwrap a script <c>Reference&lt;T&gt;</c> to <c>count.Value</c> automatically, matching
+/// upstream's cssVars ergonomics, instead of forcing the author to write <c>v-bind(count.Value)</c>.
+/// </summary>
+/// <remarks>
+/// The <c>v-bind()</c> getter runs as an <em>instance member</em> of the component partial class, so this compiles
+/// in <see cref="BindingRewriteMode.InstanceMember"/>: bindings read through the implicit <c>this</c> (no
+/// <c>_ctx.</c>), a definite reference unwraps to <c>name.Value</c>, and every other classification reads bare —
+/// the getter needs no runtime-helper import. A malformed expression is reported through
+/// <see cref="ExpressionCompileResult.Diagnostics"/> (never thrown) with its span remapped back onto the supplied
+/// <see cref="SourceLocation"/>, so the composition root lands it on the exact <c>.viu</c> coordinate.
+/// </remarks>
+public static class TemplateExpressionCompiler
+{
+    /// <summary>
+    /// Compiles <paramref name="expression"/> for an instance-member context, classifying its identifiers against
+    /// <paramref name="bindingMetadata"/> and unwrapping definite references.
+    /// </summary>
+    /// <param name="expression">The raw C# expression text.</param>
+    /// <param name="bindingMetadata">The component binding classifications to resolve identifiers against.</param>
+    /// <param name="location">
+    /// The expression's source location — diagnostics are remapped onto it (its <see cref="SourceLocation.Start"/>
+    /// anchors the reported span), so pass the expression's position in the originating file/block.
+    /// </param>
+    /// <returns>The rewritten code and any diagnostics.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+    public static ExpressionCompileResult CompileInstanceExpression(
+        string expression,
+        BindingMetadata bindingMetadata,
+        SourceLocation location)
+    {
+        if (expression is null)
+        {
+            throw new ArgumentNullException(nameof(expression));
+        }
+
+        if (bindingMetadata is null)
+        {
+            throw new ArgumentNullException(nameof(bindingMetadata));
+        }
+
+        if (location is null)
+        {
+            throw new ArgumentNullException(nameof(location));
+        }
+
+        var diagnostics = new List<CompilerError>();
+        var options = new TransformOptions
+        {
+            PrefixIdentifiers = true,
+            BindingMetadata = bindingMetadata,
+            BindingRewriteMode = BindingRewriteMode.InstanceMember,
+            OnError = diagnostics.Add,
+        };
+
+        // A minimal transform context: the expression compiler needs no template tree, only the binding
+        // classification, the rewrite mode, and the error sink. Empty transforms keep it inert.
+        var root = new RootNode
+        {
+            Children = new SyntaxList<TemplateChildNode>(Array.Empty<TemplateChildNode>()),
+            Source = string.Empty,
+            Location = Ir.LocationStub,
+        };
+        var context = new TransformContext(
+            root,
+            Array.Empty<NodeTransform>(),
+            new Dictionary<string, DirectiveTransform>(),
+            options);
+
+        var node = new SimpleExpressionNode { Content = expression, IsStatic = false, Location = location };
+        var processed = ExpressionProcessor.ProcessExpression(node, context);
+        return new ExpressionCompileResult(Flatten(processed), diagnostics);
+    }
+
+    // Serializes a rewritten expression node back to C# text: a simple expression is its content, a compound is
+    // the concatenation of its parts (raw strings and nested simple/compound expressions).
+    private static string Flatten(object? part)
+    {
+        switch (part)
+        {
+            case null:
+                return string.Empty;
+            case string text:
+                return text;
+            case SimpleExpressionNode simple:
+                return simple.Content;
+            case CompoundExpressionNode compound:
+            {
+                var builder = new StringBuilder();
+                foreach (var child in compound.Parts)
+                {
+                    builder.Append(Flatten(child));
+                }
+
+                return builder.ToString();
+            }
+
+            default:
+                return part.ToString() ?? string.Empty;
+        }
+    }
+}

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
@@ -44,6 +44,7 @@ public sealed class TransformContext
         CacheHandlers = options.CacheHandlers;
         PrefixIdentifiers = options.PrefixIdentifiers;
         BindingMetadata = options.BindingMetadata ?? BindingMetadata.Empty;
+        CssModules = options.CssModules ?? CssModuleAccessors.Empty;
         InSSR = options.InSSR;
         Ssr = options.Ssr;
         Slotted = options.Slotted;
@@ -85,6 +86,12 @@ public sealed class TransformContext
     /// <c>bindingMetadata</c>). Defaults to <see cref="BindingMetadata.Empty"/>.
     /// </summary>
     public BindingMetadata BindingMetadata { get; }
+
+    /// <summary>
+    /// The CSS Modules accessors ([V01.01.05.04.01]) expression classification resolves <c>$style</c> (and
+    /// named-module) references against. Defaults to <see cref="CssModuleAccessors.Empty"/>.
+    /// </summary>
+    public CssModuleAccessors CssModules { get; }
 
     /// <summary>Whether this is a nested SSR slot compilation.</summary>
     public bool InSSR { get; }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformContext.cs
@@ -45,6 +45,7 @@ public sealed class TransformContext
         PrefixIdentifiers = options.PrefixIdentifiers;
         BindingMetadata = options.BindingMetadata ?? BindingMetadata.Empty;
         CssModules = options.CssModules ?? CssModuleAccessors.Empty;
+        BindingRewriteMode = options.BindingRewriteMode;
         InSSR = options.InSSR;
         Ssr = options.Ssr;
         Slotted = options.Slotted;
@@ -92,6 +93,9 @@ public sealed class TransformContext
     /// named-module) references against. Defaults to <see cref="CssModuleAccessors.Empty"/>.
     /// </summary>
     public CssModuleAccessors CssModules { get; }
+
+    /// <summary>How a rewritten binding spells its receiver. Defaults to <see cref="BindingRewriteMode.RenderContext"/>.</summary>
+    public BindingRewriteMode BindingRewriteMode { get; }
 
     /// <summary>Whether this is a nested SSR slot compilation.</summary>
     public bool InSSR { get; }

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
@@ -60,6 +60,14 @@ public sealed class TransformOptions
     public CssModuleAccessors? CssModules { get; set; }
 
     /// <summary>
+    /// How a rewritten binding spells its receiver (upstream has no counterpart — one render context). Defaults to
+    /// <see cref="BindingRewriteMode.RenderContext"/> (the <c>_ctx.</c> render form); the composition-root
+    /// generator sets <see cref="BindingRewriteMode.InstanceMember"/> only for the standalone <c>v-bind()</c> CSS
+    /// getter compile ([V01.01.06.06.01]).
+    /// </summary>
+    public BindingRewriteMode BindingRewriteMode { get; set; } = BindingRewriteMode.RenderContext;
+
+    /// <summary>
     /// Whether static event handlers are cached so blocks are not invalidated (upstream <c>cacheHandlers</c>).
     /// Defaults to <see langword="false"/>.
     /// </summary>

--- a/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/src/Transforms/TransformOptions.cs
@@ -52,6 +52,14 @@ public sealed class TransformOptions
     public BindingMetadata? BindingMetadata { get; set; }
 
     /// <summary>
+    /// The CSS Modules accessors ([V01.01.05.04.01]) expression classification resolves <c>$style</c> (and
+    /// named-module) references against — the Vuecs stand-in for Vue's runtime <c>$style</c> object, supplied by
+    /// the composition-root generator ([V01.01.06.06]). Defaults to <see cref="CssModuleAccessors.Empty"/> and is
+    /// only consulted when <see cref="PrefixIdentifiers"/> is set.
+    /// </summary>
+    public CssModuleAccessors? CssModules { get; set; }
+
+    /// <summary>
     /// Whether static event handlers are cached so blocks are not invalidated (upstream <c>cacheHandlers</c>).
     /// Defaults to <see langword="false"/>.
     /// </summary>

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
@@ -245,6 +245,89 @@ public class ExpressionBindingTests
         props.ShouldContain("_ctx.value");
     }
 
+    // ---- CSS Modules accessors ([V01.01.05.04.01]) ----
+
+    [Fact]
+    public void ProcessExpression_DefaultCssModuleAccessor_ResolvesToAccessorClass()
+    {
+        // `$style.box` resolves to the generated `Style` accessor class (the C# analogue of Vue's runtime
+        // `$style` object); `$` is not a legal C# identifier char, so it is parsed against the `_style`
+        // substitution and rewritten to the accessor class name.
+        var modules = Modules(strict: true, ("$style", "_style", "Style", "box"));
+        var result = TransformWithModules("<div :class=\"$style.box\"></div>", BindingMetadata.Empty, modules, out var errors);
+
+        errors.ShouldBeEmpty();
+        FlattenProps(result).ShouldContain("Style.box");
+    }
+
+    [Fact]
+    public void ProcessExpression_NamedCssModuleAccessor_ResolvesToPascalCasedClass()
+    {
+        // A named module `<style module="theme">` is referenced by its authored name `theme` (already
+        // C#-parseable, no substitution) and resolves to the pascal-cased `Theme` accessor class.
+        var modules = Modules(strict: true, ("theme", "theme", "Theme", "active"));
+        var result = TransformWithModules("<div :class=\"theme.active\"></div>", BindingMetadata.Empty, modules, out var errors);
+
+        errors.ShouldBeEmpty();
+        FlattenProps(result).ShouldContain("Theme.active");
+    }
+
+    [Fact]
+    public void ProcessExpression_CssModuleAccessor_ShadowsSameNamedComponentBinding()
+    {
+        // A module accessor takes precedence over a same-named component binding, matching Vue's render
+        // context exposing `$style`/named modules over component state.
+        var modules = Modules(strict: true, ("theme", "theme", "Theme", "active"));
+        var result = TransformWithModules(
+            "<div :class=\"theme.active\"></div>",
+            Bindings(("theme", BindingType.Data)),
+            modules,
+            out var errors);
+
+        errors.ShouldBeEmpty();
+        var props = FlattenProps(result);
+        props.ShouldContain("Theme.active");
+        props.ShouldNotContain("_ctx.theme");
+    }
+
+    [Fact]
+    public void ProcessExpression_UnknownCssModuleMember_ReportsMappedDiagnostic()
+    {
+        // The generator supplies the complete class map, so an access to an undeclared class is a compile-time
+        // error surfaced on the template coordinate (ReportsUnknownMembers). The offset is exact because the
+        // `$`->`_` substitution is length-preserving.
+        var modules = Modules(strict: true, ("$style", "_style", "Style", "box"));
+        var result = TransformWithModules("<div :class=\"$style.missing\"></div>", BindingMetadata.Empty, modules, out var errors);
+
+        var error = errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe(CompilerErrorCode.XVuecsUnknownCssModuleMember);
+        error.Message.ShouldContain("'$style' has no member 'missing'.");
+        // The reported slice is the offending member, `missing`, at its exact template offset.
+        error.Location.Source.ShouldBe("missing");
+        // Recoverable: the accessor member access still emits (the C# compiler would also reject it).
+        FlattenProps(result).ShouldContain("Style.missing");
+    }
+
+    [Fact]
+    public void ProcessExpression_KnownCssModuleMember_ReportsNoDiagnostic_UnderStrictMap()
+    {
+        var modules = Modules(strict: true, ("$style", "_style", "Style", "box"));
+        TransformWithModules("<div :class=\"$style.box\"></div>", BindingMetadata.Empty, modules, out var errors);
+        errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ProcessExpression_UnknownCssModuleMember_IsSilent_WhenMapDoesNotReportUnknownMembers()
+    {
+        // Without ReportsUnknownMembers (a partial/non-generator map), an unknown member is not flagged; the
+        // access still rewrites to the accessor class and the C# compiler is the backstop.
+        var modules = Modules(strict: false, ("$style", "_style", "Style", "box"));
+        var result = TransformWithModules("<div :class=\"$style.missing\"></div>", BindingMetadata.Empty, modules, out var errors);
+
+        errors.ShouldBeEmpty();
+        FlattenProps(result).ShouldContain("Style.missing");
+    }
+
     // ---- v-for / v-slot scope and shadowing ----
 
     [Fact]
@@ -562,6 +645,33 @@ public class ExpressionBindingTests
         var result = TransformTestHelpers.Transform(source, options);
         errors = collected;
         return result;
+    }
+
+    private static TransformResult TransformWithModules(
+        string source,
+        BindingMetadata metadata,
+        CssModuleAccessors modules,
+        out List<CompilerError> errors)
+    {
+        var collected = new List<CompilerError>();
+        var options = TransformOptions.CreateDom();
+        options.PrefixIdentifiers = true;
+        options.BindingMetadata = metadata;
+        options.CssModules = modules;
+        options.OnError = collected.Add;
+        var result = TransformTestHelpers.Transform(source, options);
+        errors = collected;
+        return result;
+    }
+
+    private static CssModuleAccessors Modules(
+        bool strict,
+        params (string TemplateName, string ParseIdentifier, string Accessor, string Member)[] entries)
+    {
+        var accessors = entries
+            .Select(e => new CssModuleAccessor(e.TemplateName, e.ParseIdentifier, e.Accessor, new[] { e.Member }))
+            .ToArray();
+        return new CssModuleAccessors(accessors, strict);
     }
 
     private static List<string> Interpolations(string source, BindingMetadata metadata)

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/ExpressionBindingTests.cs
@@ -175,6 +175,42 @@ public class ExpressionBindingTests
     }
 
     [Fact]
+    public void ProcessExpression_MultiStatementHandlerWithoutTrailingSemicolon_SynthesizesTerminator()
+    {
+        // A multi-statement inline handler is emitted into `__event => { <body> }`. C# has no automatic
+        // semicolon insertion — JavaScript's ASI, which upstream's `$event => { ... }` handler wrapping
+        // relies on — so a body whose final statement omits its terminator (`first(); second()`) must gain a
+        // synthesized `;` or the generated lambda is invalid C#; both statements are still rewritten.
+        // [V01.01.05.05.02], issue #150.
+        HandlerBody(
+                "<button @click=\"first(); second()\"></button>",
+                Bindings(("first", BindingType.Options), ("second", BindingType.Options)))
+            .ShouldBe("__event => {_ctx.first(); _ctx.second();}");
+    }
+
+    [Fact]
+    public void ProcessExpression_MultiStatementHandlerWithTrailingSemicolon_IsNotDoubleTerminated()
+    {
+        // An author-supplied trailing terminator is not duplicated: the synthesis is gated on the body not
+        // already parsing as a clean statement list, so a terminated body is emitted unchanged.
+        HandlerBody(
+                "<button @click=\"first(); second();\"></button>",
+                Bindings(("first", BindingType.Options), ("second", BindingType.Options)))
+            .ShouldBe("__event => {_ctx.first(); _ctx.second();}");
+    }
+
+    [Fact]
+    public void ProcessExpression_MultiStatementHandlerWithGlobalsOnly_StillSynthesizesTerminator()
+    {
+        // The terminator must ride out even when no identifier needs rewriting (both calls are allowed
+        // globals), so the no-reference fast path still carries the synthesized `;`.
+        HandlerBody(
+                "<button @click=\"Math.Abs(-1); Math.Abs(1)\"></button>",
+                Bindings())
+            .ShouldBe("__event => {Math.Abs(-1); Math.Abs(1);}");
+    }
+
+    [Fact]
     public void ProcessExpression_MethodHandler_ResolvesWithoutInlineWrapper()
     {
         // A bare member handler is a method reference, not an inline statement: no $event wrapper.

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/RenderFunctionEmitterTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/RenderFunctionEmitterTests.cs
@@ -258,6 +258,20 @@ return _createElementBlock(_openBlock(), "button", _createProps(("onClick", _wit
     }
 
     [Fact]
+    public void MultiStatementHandlerWithoutTrailingSemicolon_EmitsTerminatedStatementBlockLambda()
+    {
+        // A multi-statement inline handler emits into `__event => { <body> }`. C# has no automatic
+        // semicolon insertion (JavaScript's, which upstream's handler wrapping relies on), so a body whose
+        // final statement omits its terminator gains a synthesized `;`, keeping the generated lambda valid
+        // C# ([V01.01.05.05.02], issue #150).
+        EmitPrefixed("<button @click=\"first(); second()\">x</button>").Code.ShouldBeCode(
+"""
+return _createElementBlock(_openBlock(), "button", _createProps(("onClick", _withHandler(__event => {_ctx.first(); _ctx.second();}))), "x", 8 /* PROPS */, ["onClick"]);
+
+""");
+    }
+
+    [Fact]
     public void ModifierHandler_KeepsWithModifiersUnwrapped()
     {
         // withModifiers/withKeys already give the inner lambda its delegate target type through their

--- a/libraries/Assimalign.Vue.Syntax.Templates/test/TemplateExpressionCompilerTests.cs
+++ b/libraries/Assimalign.Vue.Syntax.Templates/test/TemplateExpressionCompilerTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Vue.Syntax.Templates;
+
+// The standalone instance-member expression compile ([V01.01.06.06.01], issue #149): the v-bind() CSS getter
+// routes its expressions through the template compiler's binding-metadata rewriting, but as an instance member
+// (no _ctx receiver, definite references unwrap to .Value, everything else bare). Malformed expressions surface
+// diagnostics rather than throwing.
+public class TemplateExpressionCompilerTests
+{
+    [Fact]
+    public void CompileInstanceExpression_Reference_UnwrapsToValue_WithoutContextReceiver()
+    {
+        // The pinned acceptance shape: `v-bind(count)` with a script Reference<T> member unwraps to `count.Value`,
+        // read through the implicit `this` (no `_ctx.`) because the getter is an instance member.
+        var result = Compile("count", ("count", BindingType.SetupReference));
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.Code.ShouldBe("count.Value");
+    }
+
+    [Fact]
+    public void CompileInstanceExpression_NonReference_StaysBare()
+    {
+        // A non-reference binding (a plain field) is provably not reactive, so it is never unwrapped and stays bare.
+        var result = Compile("color", ("color", BindingType.SetupLet));
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.Code.ShouldBe("color");
+    }
+
+    [Fact]
+    public void CompileInstanceExpression_ReferenceMemberAccess_UnwrapsTheReferenceOnly()
+    {
+        // Only the reference identifier unwraps; the member access rides on the unwrapped value.
+        var result = Compile("theme.color", ("theme", BindingType.SetupReference));
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.Code.ShouldBe("theme.Value.color");
+    }
+
+    [Fact]
+    public void CompileInstanceExpression_Malformed_SurfacesDiagnostic_NeverThrows()
+    {
+        var result = Compile("1 +", ("count", BindingType.SetupReference));
+
+        var error = result.Diagnostics.ShouldHaveSingleItem();
+        error.Code.ShouldBe(CompilerErrorCode.XInvalidExpression);
+    }
+
+    [Fact]
+    public void CompileInstanceExpression_UnresolvedUnderPermissiveMetadata_StaysBare_NoDiagnostic()
+    {
+        // Permissive metadata (the generator's choice, matching the render path so hand-written members are not
+        // false-flagged) leaves an unknown identifier bare; the C# compiler is the backstop.
+        var result = Compile("mystery");
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.Code.ShouldBe("mystery");
+    }
+
+    private static ExpressionCompileResult Compile(string expression, params (string Name, BindingType Type)[] bindings)
+    {
+        var map = new Dictionary<string, BindingType>();
+        foreach (var (name, type) in bindings)
+        {
+            map[name] = type;
+        }
+
+        var metadata = new BindingMetadata(map, isScriptSetup: true);
+        var location = new SourceLocation(
+            new Position(0, 1, 1),
+            new Position(expression.Length, 1, expression.Length + 1),
+            expression);
+        return TemplateExpressionCompiler.CompileInstanceExpression(expression, metadata, location);
+    }
+}


### PR DESCRIPTION
Three compiler tasks that finish the template-facing seams of the scoped-CSS/module work.

## What's here

- **[V01.01.05.04.01] CSS module accessors in template expressions** — `$style.foo` (and named
  modules) resolve inside template expressions through the generated per-component accessor
  classes, using the same binding-metadata pass the rest of the expression compiler uses. `$style`
  spells `_style` in emitted C# (length-preserving, so `#line` columns stay exact).
- **[V01.01.06.06.01] Binding-metadata rewriting for `v-bind()` CSS expressions** — the cssVars
  getter now compiles each `v-bind()` expression with instance-member rewriting, so
  `v-bind(count)` unwraps a script `Reference<T>` to `count.Value` automatically (upstream cssVars
  ergonomics). Malformed expressions surface diagnostics on the exact `.viu` style coordinates.
- **[V01.01.05.05.02] Statement terminators in multi-statement inline handlers** — inline
  handlers written Vue-style without trailing semicolons (`a++, b = 1`) synthesize the
  terminators the C# statement parser needs, pinned against upstream's multi-statement handler
  semantics.

## Verification

- `dotnet build Assimalign.Vuecs.slnx -warnaserror` — 0 warnings / 0 errors.
- Full solution test sweep green (all suites, including the 72 generator tests and 495
  template-compiler tests).

## Stack

Bottom of a three-PR stack:
1. **this PR** → `main`
2. #171 — `feature/V01.01.04.07-transitions` (DOM Transition/TransitionGroup)
3. #172 — `feature/V01.01.12.12-css-bundling` (VuecsBundleCss + shared CSS core)

**Merge procedure:** merge this PR first, then **delete its branch** — GitHub retargets the next
PR to `main` automatically. Repeat down the stack (merge → delete branch → next). Closing
keywords only fire on merges into `main`, so each PR carries its own `Closes` lines.

## Work items resolved by this PR

Closes #148
Closes #149
Closes #150

Discovered follow-ups filed during review (not resolved here): #165 (`#line` map for the cssVars
getter), #166 (style-origin envelope catalog naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
