### PR TITLE
feat(tooling): adopt Cohesion SDK/shared-framework packaging - Assimalign.Viu.Sdk + Assimalign.Viu.App [V01.01.12.19]

### DIFF
--- a/.claude/rules/build-system.md
+++ b/.claude/rules/build-system.md
@@ -93,3 +93,31 @@ set `IsAotCompatible` (they are not shipping libraries).
 2. Add both csprojs to `Assimalign.Viu.slnx`.
 3. Wire a CI workflow entry for the area ([V01.01.12.02]).
 4. No dangling references — when a project is renamed or moved, update every referrer.
+5. If the library is a runtime framework member (ships in every Viu app), add it to
+   `@(ViuFrameworkAssembly)` in `frameworks/Assimalign.Viu.App.props` so the framework packs
+   deliver it.
+
+## SDK and shared-framework packaging ([V01.01.12.19], #174)
+
+External consumers use `<Project Sdk="Assimalign.Viu.Sdk">` — never `ViuProjectReference`, which is
+the **in-repo dogfooding** mechanism. The packaging layer mirrors `assimalign/cohesion`:
+
+- **`frameworks/Assimalign.Viu.App.props`** — the authoritative `@(ViuFrameworkAssembly)` /
+  `@(ViuFrameworkAnalyzer)` manifest, gated on `$(ViuFrameworkName)`.
+- **`frameworks/Assimalign.Viu.App.targets`** — the `ViuWriteFrameworkList` manifest writer and
+  pack layout, branching on `$(ViuFrameworkKind)` = `Ref` (targeting pack: `ref/<tfm>/` +
+  `data/FrameworkList.xml` + the generators and their parser closure at `analyzers/dotnet/cs/`,
+  every DLL listed as an `Analyzer` entry) | `Runtime` (per-RID runtime pack: `runtimes/<rid>/lib/`
+  + `data/RuntimeList.xml`).
+- **`sdks/Assimalign.Viu.Sdk/`** — the SDK package (packable unit: `Tasks/…Tasks.csproj` with
+  `PackageId=Assimalign.Viu.Sdk`). `Sdk.props` chains `Microsoft.NET.Sdk.WebAssembly`, imports a
+  pack-time-frozen `Build.Version.props` snapshot, and registers the `KnownFrameworkReference` for
+  `Assimalign.Viu.App` (`browser-wasm`). The `.viu` AdditionalFiles wiring and
+  `Build.Css.Bundling.targets` are packed **from their in-repo source files**; the `ViuBundleCss`
+  task ships under `Tasks/`; `viu-dom.js` ships under `assets/` and flows into consumer
+  `wwwroot/_content/`.
+- **Local loop**: `scripts/Install-Local.ps1` packs SDK → runtime pack(s) → ref pack into
+  `_out/packages` (gitignored). Consumption docs: `sdks/README.md`.
+- The `frameworks/` csprojs carry documented deviations from the no-raw-`ProjectReference` rule
+  (build-order edges needing `ReferenceOutputAssembly=false` + `UndefineProperties` metadata the
+  `ViuProjectReference` transform does not carry).

--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -15,8 +15,11 @@ win** — link the reference in the code, test, or issue that pins the behavior.
 
 - Inverted library layout: `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name **is** the
   assembly / package id. `src/` holds the shipping project, `test/` its test project. No area wrapper
-  folders. Package root is `Assimalign.Viu.*` (the product/repo name stays "Viu").
-- Examples live in `examples/`; repo planning docs in `docs/`.
+  folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug remains
+  `assimalign/vuecs`).
+- Examples live in `examples/`; repo planning docs in `docs/`; the consumer-facing MSBuild SDK in
+  `sdks/` and the `Assimalign.Viu.App` shared-framework pack producers in `frameworks/` (see
+  [build-system.md](build-system.md)).
 
 ## Namespaces
 

--- a/.github/workflows/area-packaging.yml
+++ b/.github/workflows/area-packaging.yml
@@ -1,0 +1,61 @@
+# Area build+pack for the Viu SDK and shared-framework packs ([V01.01.12.19]): proves the
+# Assimalign.Viu.Sdk nupkg and the Assimalign.Viu.App Ref/Runtime pack shapes stay healthy.
+# Path-filtered like the other area workflows; shared build files trigger every area.
+name: area-packaging
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sdks/**'
+      - 'frameworks/**'
+      - 'scripts/Install-Local.ps1'
+      - 'libraries/**'
+      - 'analyzers/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-packaging.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdks/**'
+      - 'frameworks/**'
+      - 'scripts/Install-Local.ps1'
+      - 'libraries/**'
+      - 'analyzers/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-packaging.yml'
+
+jobs:
+  pack:
+    name: pack SDK + framework
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Pack SDK, runtime pack, and ref pack
+        shell: pwsh
+        run: ./scripts/Install-Local.ps1
+
+      - name: Assert package shapes
+        shell: pwsh
+        run: |
+          $feed = "_out/packages"
+          $expected = @('Assimalign.Viu.Sdk.*.nupkg', 'Assimalign.Viu.App.Ref.*.nupkg', 'Assimalign.Viu.App.Runtime.browser-wasm.*.nupkg')
+          foreach ($pattern in $expected) {
+            if (-not (Get-ChildItem $feed -Filter $pattern)) { throw "Missing package: $pattern" }
+          }
+          Get-ChildItem $feed -Filter 'Assimalign.Viu.*.nupkg' | ForEach-Object { Write-Host $_.Name }

--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,6 @@ FodyWeavers.xsd
 
 # Library static web assets copied into example apps by build/Targets/Build.StaticWebAssets.targets
 examples/**/wwwroot/_content/
+
+# Local pack/SDK output feed
+_out/

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -53,6 +53,7 @@
 	</Folder>
 	<Folder Name="/viu/.github/workflows/">
 		<File Path=".github/workflows/area-generators.yml" />
+		<File Path=".github/workflows/area-packaging.yml" />
 		<File Path=".github/workflows/area-reactivity.yml" />
 		<File Path=".github/workflows/area-runtimecore.yml" />
 		<File Path=".github/workflows/area-runtimedom.yml" />
@@ -103,6 +104,7 @@
 	</Folder>
 	<Folder Name="/viu/docs/">
 		<File Path="docs/PLAN.md" />
+		<File Path="docs/UTILITY-CSS-DESIGN.md" />
 	</Folder>
 	<Folder Name="/viu/frameworks/">
 		<File Path="frameworks/Assimalign.Viu.App.props" />

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -104,6 +104,38 @@
 	<Folder Name="/viu/docs/">
 		<File Path="docs/PLAN.md" />
 	</Folder>
+	<Folder Name="/viu/frameworks/">
+		<File Path="frameworks/Assimalign.Viu.App.props" />
+		<File Path="frameworks/Assimalign.Viu.App.targets" />
+		<File Path="frameworks/Directory.Build.props" />
+		<File Path="frameworks/Directory.Build.targets" />
+	</Folder>
+	<Folder Name="/viu/frameworks/Assimalign.Viu.App.Refs/" />
+	<Folder Name="/viu/frameworks/Assimalign.Viu.App.Refs/src/">
+		<Project Path="frameworks/Assimalign.Viu.App.Refs/src/Assimalign.Viu.App.Refs.csproj" />
+	</Folder>
+	<Folder Name="/viu/frameworks/Assimalign.Viu.App.Runtime/" />
+	<Folder Name="/viu/frameworks/Assimalign.Viu.App.Runtime/src/">
+		<Project Path="frameworks/Assimalign.Viu.App.Runtime/src/Assimalign.Viu.App.Runtime.csproj" />
+	</Folder>
+	<Folder Name="/viu/sdks/">
+		<File Path="sdks/Directory.Build.props" />
+		<File Path="sdks/Directory.Build.targets" />
+		<File Path="sdks/README.md" />
+	</Folder>
+	<Folder Name="/viu/sdks/Assimalign.Viu.Sdk/">
+		<File Path="sdks/Assimalign.Viu.Sdk/Sdk/Sdk.props" />
+		<File Path="sdks/Assimalign.Viu.Sdk/Sdk/Sdk.targets" />
+		<File Path="sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.Common.props" />
+		<File Path="sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.FrameworkReference.props" />
+		<File Path="sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.StaticWebAssets.targets" />
+	</Folder>
+	<Folder Name="/viu/sdks/Assimalign.Viu.Sdk/Tasks/">
+		<Project Path="sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj" />
+	</Folder>
+	<Folder Name="/viu/scripts/">
+		<File Path="scripts/Install-Local.ps1" />
+	</Folder>
 	<Folder Name="/viu/examples/" />
 	<Folder Name="/viu/examples/Assimalign.Viu.WebApp/">
 		<Project Path="examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj" />

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ C# through a handle-based JS-interop bridge. See the stopwatch demo in
 Libraries use the `Assimalign.Viu.*` package root with the inverted layout
 `libraries/Assimalign.Viu.<Name>/{src|test}`.
 
+Viu apps consume the framework through an MSBuild project SDK — a complete app csproj is
+`<Project Sdk="Assimalign.Viu.Sdk">` — which chains `Microsoft.NET.Sdk.WebAssembly` and delivers
+the framework libraries plus the `[Reactive]`/`.viu` source generators via the
+`Assimalign.Viu.App` shared framework (`.Ref` targeting pack + `.Runtime.browser-wasm` runtime
+pack). See [`sdks/README.md`](sdks/README.md).
+
 ## Plan and tracking
 
 - [Delivery plan](docs/PLAN.md) — architecture mapping (Vue 3 package → Viu library), founding

--- a/build/Targets/Build.TargetFramework.props
+++ b/build/Targets/Build.TargetFramework.props
@@ -5,10 +5,11 @@
         <TargetFrameworkForLibraries>$(TargetFrameworkLatest)</TargetFrameworkForLibraries>
         <TargetFrameworkForSdks>$(TargetFrameworkLatest)</TargetFrameworkForSdks>
         <!--
-            Alias consumed by framework Ref/Runtime targets (frameworks\Assimalign.Cohesion.App.targets)
+            Alias consumed by the framework Ref/Runtime targets (frameworks\Assimalign.Viu.App.targets)
             in path construction. Kept derived from TargetFramework so bumping the TFM here continues to
             drive everything from one place.
         -->
+        <TargetFrameworkForFrameworks>$(TargetFrameworkLatest)</TargetFrameworkForFrameworks>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
 		<RollForward>LatestPatch</RollForward>
     </PropertyGroup>

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -24,14 +24,18 @@ What it validates: the adapter-injected renderer design (identical in spirit to 
 lacks: reactivity (the demo polls every 100 ms), a component model, a scheduler, keyed diffing with
 minimal moves, compiler-informed patching, and every ecosystem piece. The child reconciliation is
 index-based (no LIS), the diff/patch path is duplicated in two implementations, and naming was split
-between `Assimalign.Viu.*` and `Assimalign.Viu.*` (now standardized on `Assimalign.Viu.*`).
+between `Assimalign.Vue.*` and `Assimalign.Vuecs.*` (standardized on `Assimalign.Vue.*` 2026-07-16,
+then renamed to `Assimalign.Viu.*` with the product rename — see the architecture note below).
 
 ## Architecture: Vue 3 package → Viu library
 
 Package boundaries map 1:1 to .NET class libraries using the inverted layout
 `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name is the assembly/package id, with no
-area wrapper folders (project decision, 2026-07-16). The product/repo name stays **Viu**; the
-package root is **`Assimalign.Viu.*`**:
+area wrapper folders (project decision, 2026-07-16). The product name is **Viu** and the package
+root is **`Assimalign.Viu.*`** (renamed from Vue/Vuecs 2026-07-19, `V01.01.12.18`/#173, aligning
+the brand with the `.viu` SFC extension; the GitHub repo slug remains `assimalign/vuecs`, and
+upstream Vue.js references — `@vue/*` names, vuejs.org links, the `vue:` template prefix — are
+deliberately untouched):
 
 | Area (WBS) | Viu library | Vue 3 counterpart |
 | --- | --- | --- |
@@ -88,12 +92,32 @@ These are deliberate, recorded divergences from upstream — everything else tra
    linker-unfriendly activation. Every area publishes a representative WASM consumer with trimming
    validation; size and startup budgets gate CI from W03.
 7. **Cohesion integration at MVP.** Viu will integrate with the Cohesion platform
-   (`assimalign/cohesion`) as MVP approaches — apps served by Cohesion Web, SSR hosted in-process,
-   packaging aligned with Cohesion's SDK/shared-framework model (tracked as `V01.01.12.08`, #104).
-   Consequence now: hosting and server-rendering seams stay host-agnostic — [V01.01.07.04] ships
-   a server adaptor contract that any web framework implements as a thin downstream adapter
-   (Cohesion Web first; ASP.NET Core only if ever wanted), and no Assimalign.Viu.* library may
-   reference a web framework (decision reaffirmed and made binding 2026-07-17).
+   (`assimalign/cohesion`) as MVP approaches — apps served by Cohesion Web, SSR hosted in-process
+   (tracked as `V01.01.12.08`, #104, now narrowed to the hosting integration — the packaging half
+   landed as decision 8). Consequence now: hosting and server-rendering seams stay host-agnostic —
+   [V01.01.07.04] ships a server adaptor contract that any web framework implements as a thin
+   downstream adapter (Cohesion Web first; ASP.NET Core only if ever wanted), and no
+   Assimalign.Viu.* library may reference a web framework (decision reaffirmed and made binding
+   2026-07-17).
+8. **SDK-first packaging on Cohesion's shared-framework model (landed 2026-07-19,
+   `V01.01.12.19`/#174).** Viu ships as an MSBuild project SDK — a consumer csproj is just
+   `<Project Sdk="Assimalign.Viu.Sdk">` — chaining `Microsoft.NET.Sdk.WebAssembly`, with the
+   framework delivered as the `Assimalign.Viu.App` shared framework: a `KnownFrameworkReference`
+   registration resolving to the `Assimalign.Viu.App.Ref` targeting pack (compile references +
+   `data/FrameworkList.xml`) and per-RID `Assimalign.Viu.App.Runtime.<rid>` runtime packs
+   (`browser-wasm` today) — the `Microsoft.AspNetCore.App.Ref`/`.Runtime.<rid>` shape, mirrored
+   from `assimalign/cohesion`'s `sdks/` + `frameworks/`. **Codegen placement decision:** the source
+   generators stay Roslyn incremental generators (moving them into MSBuild tasks would forfeit IDE
+   integration and incrementality) but are *delivered* through the Ref pack's `analyzers/dotnet/cs`
+   with `<File Type="Analyzer">` manifest entries, so SDK consumers get `[Reactive]` and `.viu`
+   compilation with zero wiring; the `ViuBundleCss` MSBuild task and the `.viu`
+   AdditionalFiles/CSS-bundling MSBuild logic ship inside the SDK package (`Tasks/` + `Targets/`,
+   packed from their in-repo sources so they cannot drift). The local loop is
+   `scripts/Install-Local.ps1` → `_out/packages` (see `sdks/README.md`). In-repo projects keep
+   dogfooding via `ViuProjectReference` — the SDK is the *external consumer* surface. This
+   re-scopes `V01.01.12.03` (#92: library packages + feed publishing on top of the pack loop) and
+   delivers `V01.01.12.12.02` (#168: the task now ships in the SDK rather than a standalone
+   package).
 
 ## Delivery model
 
@@ -266,6 +290,18 @@ Work is tracked exactly like the sibling Cohesion repo:
 | `V01.01.12.05` | Build the dev-loop experience | W05 | P005 |
 | `V01.01.12.06` | Establish WASM size and AOT budget gates | W03 | P003 |
 | `V01.01.12.07` | Build .viu editor support | W06 | P007 |
+| `V01.01.12.08` | Integrate Viu with the Cohesion platform (hosting; packaging landed via `.19`) | W05 | P004 |
+| `V01.01.12.09` | Modularize the library folder structure, whole-word naming | W03 | P002 |
+| `V01.01.12.10` | Scope the build-time utility-first CSS engine | W04 | P005 |
+| `V01.01.12.11` | CSS construction/emission surface in Assimalign.Viu.Syntax.Css | W04 | P004 |
+| `V01.01.12.12` | ViuBundleCss MSBuild task for CSS bundling | W04 | P004 |
+| `V01.01.12.13` | Utility-class candidate grammar and variant model | W05 | P005 |
+| `V01.01.12.14` | AOT-safe utility theme configuration model | W05 | P005 |
+| `V01.01.12.15` | Build-time utility candidate extraction pass | W05 | P005 |
+| `V01.01.12.16` | Utility-to-CSS resolver and incremental pipeline | W05 | P005 |
+| `V01.01.12.17` | @apply and utility composition inside @style | W06 | P006 |
+| `V01.01.12.18` | Rename product naming from Vue/Vuecs to Viu repo-wide | W04 | P002 |
+| `V01.01.12.19` | Adopt Cohesion SDK/shared-framework packaging (Assimalign.Viu.Sdk + Assimalign.Viu.App) | W05 | P003 |
 
 ### [V01.01.13] Framework - Documentation (W02, P003)
 

--- a/frameworks/Assimalign.Viu.App.Refs/src/Assimalign.Viu.App.Refs.csproj
+++ b/frameworks/Assimalign.Viu.App.Refs/src/Assimalign.Viu.App.Refs.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+
+		<RootNamespace>Assimalign.Viu</RootNamespace>
+
+		<!--
+			This project produces the Assimalign.Viu.App targeting pack
+			(Assimalign.Viu.App.Ref.nupkg). It compiles nothing of its own:
+			frameworks/Assimalign.Viu.App.targets generates
+			data/FrameworkList.xml from the authoritative
+			@(ViuFrameworkAssembly) list (imported below) and packs the
+			matching assemblies from App.Runtime's bin folder, plus the
+			source-generator closure at analyzers/dotnet/cs/.
+		-->
+		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<GenerateDependencyFile>false</GenerateDependencyFile>
+
+		<PackageId>Assimalign.Viu.App.Ref</PackageId>
+		<IsPackable>true</IsPackable>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<!-- CS2008: this project deliberately compiles no sources - it only
+		     assembles the targeting pack from Runtime's bin. -->
+		<NoWarn>$(NoWarn);NU5128;NU5100;NU5131;CS2008</NoWarn>
+
+		<ViuFrameworkName>Assimalign.Viu.App</ViuFrameworkName>
+		<ViuFrameworkKind>Ref</ViuFrameworkKind>
+	</PropertyGroup>
+
+	<!--
+		Pure build dependency on App.Runtime. ReferenceOutputAssembly=false
+		because the targeting pack consumes Runtime's bin folder (where every
+		framework assembly CopyLocal'd in) via the collection target, not
+		Runtime's compiled assembly directly. UndefineProperties drops our
+		TargetFramework/RuntimeIdentifier so Runtime builds in its default
+		(RID-less) configuration - that's the bin/ path the collection target
+		reads from.
+		Deviates from the repo central-build-system rule (raw <ProjectReference>)
+		per design decision: build-order edge with UndefineProperties metadata
+		the ViuProjectReference transform does not carry.
+	-->
+	<ItemGroup>
+		<ProjectReference Include="..\..\Assimalign.Viu.App.Runtime\src\Assimalign.Viu.App.Runtime.csproj"
+			ReferenceOutputAssembly="false"
+			SkipGetTargetFrameworkProperties="true"
+			UndefineProperties="TargetFramework;RuntimeIdentifier" />
+	</ItemGroup>
+
+	<!-- Import the authoritative framework manifest so the manifest writer
+	     in Assimalign.Viu.App.targets can iterate it. -->
+	<Import Project="..\..\Assimalign.Viu.App.props" />
+
+	<Import Project="..\..\Assimalign.Viu.App.targets" />
+</Project>

--- a/frameworks/Assimalign.Viu.App.Runtime/src/Assimalign.Viu.App.Runtime.csproj
+++ b/frameworks/Assimalign.Viu.App.Runtime/src/Assimalign.Viu.App.Runtime.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+
+		<RootNamespace>Assimalign.Viu</RootNamespace>
+		<AssemblyName>Assimalign.Viu.App</AssemblyName>
+
+		<!--
+			Emit a ref assembly alongside the implementation so the App.Refs
+			project can collect it if it ever needs to.
+		-->
+		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+		<IsAotCompatible>true</IsAotCompatible>
+
+		<!--
+			Framework runtime packs are per-RID by convention. Each RID
+			produces a separate .nupkg whose ID embeds the RID (browser-wasm
+			is the shipping RID for Viu apps). Without an explicit RID
+			(design-time builds in the IDE) the ViuCollectFrameworkPack
+			target is gated on RuntimeIdentifier != '' so it simply doesn't
+			run, which is correct for IDE compile.
+		-->
+		<PackageId Condition="'$(RuntimeIdentifier)' != ''">Assimalign.Viu.App.Runtime.$(RuntimeIdentifier)</PackageId>
+		<PackageId Condition="'$(RuntimeIdentifier)' == ''">Assimalign.Viu.App.Runtime</PackageId>
+
+		<IsPackable>true</IsPackable>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<NoWarn>$(NoWarn);NU5128;NU5100;NU5131</NoWarn>
+
+		<ViuFrameworkName>Assimalign.Viu.App</ViuFrameworkName>
+		<ViuFrameworkKind>Runtime</ViuFrameworkKind>
+	</PropertyGroup>
+
+	<!--
+		Import the authoritative framework manifest, then generate
+		<ViuProjectReference> items for every assembly except this project's
+		own output (the umbrella Assimalign.Viu.App.dll). The by-name
+		references resolve via build/Targets/Build.References.Projects.targets,
+		so building this project builds every framework library and CopyLocals
+		every DLL into bin/ for the pack target to collect.
+	-->
+	<Import Project="..\..\Assimalign.Viu.App.props" />
+	<ItemGroup>
+		<ViuProjectReference Include="@(ViuFrameworkAssembly)"
+		                     Exclude="$(AssemblyName)" />
+	</ItemGroup>
+
+	<Import Project="..\..\Assimalign.Viu.App.targets" />
+</Project>

--- a/frameworks/Assimalign.Viu.App.props
+++ b/frameworks/Assimalign.Viu.App.props
@@ -1,0 +1,66 @@
+<Project>
+    <!--
+        Authoritative list of assemblies that ship in the Viu shared framework
+        (Assimalign.Viu.App), mirroring the sibling Cohesion repo's
+        frameworks/Assimalign.Cohesion.App.props model ([V01.01.12.19], #174).
+
+        Multiple consumers read this file:
+
+          1. frameworks/Assimalign.Viu.App.Runtime/src/...csproj
+             Generates <ViuProjectReference> items so each library is built
+             and CopyLocal'd into the Runtime project's bin folder.
+
+          2. frameworks/Assimalign.Viu.App.Refs/src/...csproj
+             (together with Assimalign.Viu.App.targets) drives
+             FrameworkList.xml and RuntimeList.xml generation - no DLL
+             inspection needed.
+
+        The ItemGroups below are conditioned on $(ViuFrameworkName), which
+        every Refs/Runtime csproj sets in its PropertyGroup BEFORE importing
+        this file, so additional framework families (e.g. a future
+        Assimalign.Viu.App.Server for SSR) can share this manifest file.
+
+        Two parallel item types are recognized per framework:
+
+          @(ViuFrameworkAssembly)        - PUBLIC. Listed in the Ref pack's
+                                           FrameworkList.xml AND shipped in
+                                           the Runtime pack. Visible to
+                                           consumers at compile time.
+
+          @(ViuFrameworkPrivateAssembly) - PRIVATE. NOT listed on the Ref
+                                           pack. Shipped in the Runtime pack
+                                           only and enumerated in
+                                           RuntimeList.xml so the host
+                                           resolves them. (Empty today.)
+
+        @(ViuFrameworkAnalyzer) entries name Roslyn source generators (by
+        analyzers/**/*.csproj filename) shipped INSIDE the Ref pack at
+        analyzers/dotnet/cs/. SDK-path consumers pick these up via the .NET
+        SDK's ResolveTargetingPackAssets, so `[Reactive]` classes and .viu
+        single-file components compile with zero per-project wiring. The
+        Syntax generator's parser closure travels with it (its GetTargetPath
+        is extended by build/Targets/Build.References.Analyzers.targets when
+        ViuAnalyzerBundlesProjectReferenceOutputs=true), and every collected
+        DLL is listed as an Analyzer entry so Roslyn can resolve the
+        generator's dependencies among the registered analyzer paths.
+    -->
+
+    <!-- ================================================================
+         Assimalign.Viu.App: the browser framework. Bundled with every Viu
+         app via Assimalign.Viu.Sdk. Compile-time-only libraries (the
+         Syntax.* parsers, Tooling.Css) are deliberately NOT framework
+         assemblies - they reach consumers only inside analyzers/dotnet/cs
+         of the Ref pack. Assimalign.Viu.Testing is a dev-time harness, not
+         a runtime framework member.
+         ================================================================ -->
+    <ItemGroup Condition="'$(ViuFrameworkName)' == 'Assimalign.Viu.App'">
+        <ViuFrameworkAssembly Include="Assimalign.Viu.App" />
+        <ViuFrameworkAssembly Include="Assimalign.Viu.Shared" />
+        <ViuFrameworkAssembly Include="Assimalign.Viu.Reactivity" />
+        <ViuFrameworkAssembly Include="Assimalign.Viu.RuntimeCore" />
+        <ViuFrameworkAssembly Include="Assimalign.Viu.RuntimeDom" />
+
+        <ViuFrameworkAnalyzer Include="Assimalign.Viu.Reactivity.Generators" />
+        <ViuFrameworkAnalyzer Include="Assimalign.Viu.Syntax.Generators" />
+    </ItemGroup>
+</Project>

--- a/frameworks/Assimalign.Viu.App.targets
+++ b/frameworks/Assimalign.Viu.App.targets
@@ -1,0 +1,288 @@
+<Project>
+    <!--
+        Assimalign.Viu.App framework build targets ([V01.01.12.19], #174 -
+        the Viu port of cohesion's frameworks/Assimalign.Cohesion.App.targets).
+
+        Imported by:
+          Assimalign.Viu.App.Runtime/src/...csproj  (per-RID runtime pack)
+          Assimalign.Viu.App.Refs/src/...csproj     (targeting pack)
+
+        Branches on the $(ViuFrameworkKind) property the consumer csproj sets:
+
+            Ref     -> produce ref/<tfm>/<dll> + data/FrameworkList.xml
+                       + analyzers/dotnet/cs/<generator closure>
+            Runtime -> produce runtimes/<rid>/lib/<tfm>/<dll> + data/RuntimeList.xml
+
+        Driven by the item lists declared in Assimalign.Viu.App.props
+        (sibling file). Distribution is via NuGet - these targets just
+        produce the .nupkg layouts the SDK's KnownFrameworkReference
+        machinery (ResolveTargetingPackAssets / ResolveRuntimePackAssets)
+        expects to find.
+    -->
+
+    <PropertyGroup>
+        <!--
+            Each framework family has its own Runtime project at
+            frameworks/<FrameworkName>.Runtime/src/. The Refs project for
+            the same framework reads bin/ from there to collect assemblies.
+            Computed from $(ViuFrameworkName) so the same targets file can
+            serve additional framework families without per-family branches.
+        -->
+        <_ViuRuntimeProjectDir>$(ViuRepositoryDirectory)frameworks\$(ViuFrameworkName).Runtime\src\</_ViuRuntimeProjectDir>
+
+        <!--
+            _ViuFrameworkSourceDir and the two manifest paths are computed
+            inside ViuCollectFrameworkPack below, NOT at file scope:
+            $(OutputPath) / $(IntermediateOutputPath) are defined by
+            Microsoft.NET.Sdk.targets, which imports AFTER this file.
+        -->
+
+        <!-- Hardcoded empty until the framework is strong-named; the
+             manifest writer uses it verbatim. -->
+        <ViuPublicKeyToken Condition="'$(ViuPublicKeyToken)' == ''"></ViuPublicKeyToken>
+
+        <!-- "net10.0" -> "10.0" for the manifest TargetFrameworkVersion. -->
+        <_ViuTargetFrameworkVersion>$(TargetFrameworkLatest.TrimStart('net'))</_ViuTargetFrameworkVersion>
+    </PropertyGroup>
+
+    <!-- Hook into NuGet's standard extension point for dynamic pack content. -->
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);ViuCollectFrameworkPack</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+
+    <!--
+        Resolve <ViuFrameworkAnalyzer> items declared in App.props and add a
+        build-only ProjectReference for each. The Ref pack bundles each
+        resolved analyzer DLL (plus, for generators that opt into
+        ViuAnalyzerBundlesProjectReferenceOutputs, their parser dependency
+        closure) at analyzers/dotnet/cs/ inside the .nupkg, so SDK-path
+        consumers pick the generators up automatically via the .NET SDK's
+        ResolveTargetingPackAssets. By-name lookup against
+        analyzers/**/*.csproj, exactly like build/Targets/Build.References.Analyzers.targets.
+
+        Deviates from the repo central-build-system rule (raw <ProjectReference>)
+        per design decision: the reference needs ReferenceOutputAssembly=false +
+        UndefineProperties metadata that the ViuProjectReference transform does
+        not carry; it is a pure build-order edge, not a compile reference.
+    -->
+    <ItemGroup>
+        <_ViuFrameworkAnalyzerProject Include="$(ViuRepositoryDirectory)analyzers\**\*.csproj" />
+        <_ViuFrameworkAnalyzerProject Update="@(_ViuFrameworkAnalyzerProject)"
+                                      ProjectId="%(_ViuFrameworkAnalyzerProject.Filename)"
+                                      ProjectPath="%(_ViuFrameworkAnalyzerProject.Identity)" />
+
+        <ViuFrameworkAnalyzer Update="@(_ViuFrameworkAnalyzerProject->'%(ProjectId)')"
+                              ProjectPath="%(_ViuFrameworkAnalyzerProject.ProjectPath)" />
+
+        <_ViuFrameworkAnalyzerResolved Include="@(ViuFrameworkAnalyzer->'%(ProjectPath)')" />
+
+        <ProjectReference Include="@(_ViuFrameworkAnalyzerResolved)"
+                          Condition="'$(ViuFrameworkKind)' == 'Ref'"
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="all"
+                          SkipGetTargetFrameworkProperties="true"
+                          UndefineProperties="TargetFramework;RuntimeIdentifier" />
+
+        <_ViuFrameworkAnalyzerProject Remove="@(_ViuFrameworkAnalyzerProject)" />
+    </ItemGroup>
+
+    <!--
+        Auto-extend each Runtime csproj's ViuProjectReference list with the
+        private-assembly bucket so individual Runtime csprojs never need to
+        know the private bucket exists.
+    -->
+    <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Runtime'">
+        <ViuProjectReference Include="@(ViuFrameworkPrivateAssembly)"
+                             Exclude="$(AssemblyName)" />
+    </ItemGroup>
+
+    <!--
+        Manifest writer. Takes the declarative assembly-name list and emits
+        FrameworkList.xml or RuntimeList.xml depending on RootElementName.
+        Version + PKT are uniform across the framework. No DLL inspection.
+    -->
+    <UsingTask TaskName="ViuWriteFrameworkList"
+               TaskFactory="RoslynCodeTaskFactory"
+               AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <AssemblyNames ParameterType="System.String[]" Required="true" />
+            <!--
+                Optional Roslyn analyzer DLL identities. Emitted as
+                <File Type="Analyzer" Path="analyzers/dotnet/cs/<name>.dll" ...>
+                entries so ResolveTargetingPackAssets surfaces them as
+                @(Analyzer) items in the consumer's compile. Only meaningful
+                for the Ref pack; pass empty for the Runtime pack.
+            -->
+            <AnalyzerNames ParameterType="System.String[]" Required="false" />
+            <FrameworkName Required="true" />
+            <FrameworkVersion Required="true" />
+            <TargetFrameworkVersion Required="true" />
+            <PublicKeyToken Required="false" />
+            <!--
+                Prefix prepended to each <File Path="..."> entry.
+                FrameworkList.xml (Ref pack): empty - ResolveTargetingPackAssets
+                knows the ref/<tfm>/ layout. RuntimeList.xml (Runtime pack):
+                "runtimes/<rid>/lib/<tfm>/" - ResolveRuntimePackAssets treats
+                Path as fully package-relative (MSB3030 without it).
+            -->
+            <PathPrefix Required="false" />
+            <RootElementName Required="true" />
+            <OutputPath Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Using Namespace="System" />
+            <Using Namespace="System.IO" />
+            <Using Namespace="System.Linq" />
+            <Using Namespace="System.Text" />
+            <Code Type="Fragment" Language="cs"><![CDATA[
+                Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+                // PE metadata AssemblyVersion is always 4 parts ("10.0.1" -> "10.0.1.0").
+                string asmVersion = FrameworkVersion;
+                if (asmVersion.Split('.').Length < 4) { asmVersion += ".0"; }
+                string fileVersion = asmVersion;
+                string pkt = PublicKeyToken ?? "";
+                string pathPrefix = PathPrefix ?? "";
+
+                var sb = new StringBuilder();
+                sb.Append("<").Append(RootElementName)
+                  .Append(" Name=\"").Append(FrameworkName).Append("\"")
+                  .Append(" TargetFrameworkIdentifier=\".NETCoreApp\"")
+                  .Append(" TargetFrameworkVersion=\"").Append(TargetFrameworkVersion).Append("\"")
+                  .Append(" FrameworkName=\"").Append(FrameworkName).Append("\">\r\n");
+
+                foreach (var name in AssemblyNames.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                {
+                    sb.Append("  <File Type=\"Managed\"")
+                      .Append(" Path=\"").Append(pathPrefix).Append(name).Append(".dll\"")
+                      .Append(" PublicKeyToken=\"").Append(pkt).Append("\"")
+                      .Append(" AssemblyName=\"").Append(name).Append("\"")
+                      .Append(" AssemblyVersion=\"").Append(asmVersion).Append("\"")
+                      .Append(" FileVersion=\"").Append(fileVersion).Append("\"")
+                      .Append(" />\r\n");
+                }
+
+                // Analyzer entries. Path matches where TfmSpecificPackageFile
+                // placed the DLLs: analyzers/dotnet/cs/.
+                var analyzerNames = AnalyzerNames ?? new string[0];
+                foreach (var name in analyzerNames.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                {
+                    sb.Append("  <File Type=\"Analyzer\"")
+                      .Append(" Path=\"analyzers/dotnet/cs/").Append(name).Append(".dll\"")
+                      .Append(" PublicKeyToken=\"").Append(pkt).Append("\"")
+                      .Append(" AssemblyName=\"").Append(name).Append("\"")
+                      .Append(" AssemblyVersion=\"").Append(asmVersion).Append("\"")
+                      .Append(" FileVersion=\"").Append(fileVersion).Append("\"")
+                      .Append(" />\r\n");
+                }
+
+                sb.Append("</").Append(RootElementName).Append(">\r\n");
+                File.WriteAllText(OutputPath, sb.ToString());
+            ]]></Code>
+        </Task>
+    </UsingTask>
+
+    <Target Name="ViuCollectFrameworkPack" DependsOnTargets="ResolveProjectReferences">
+
+        <!--
+            Resolve the source directory at execution time:
+              Ref kind     -> Runtime project's RID-less bin/ (built via the
+                              build-order ProjectReference from App.Refs).
+              Runtime kind -> this project's $(OutputPath), which is
+                              bin/<cfg>/<tfm>/<rid>/ when -p:RuntimeIdentifier
+                              is set on `dotnet pack`.
+        -->
+        <PropertyGroup>
+            <_ViuFrameworkSourceDir Condition="'$(ViuFrameworkKind)' == 'Ref'">$(_ViuRuntimeProjectDir)bin\$(Configuration)\$(TargetFrameworkLatest)\</_ViuFrameworkSourceDir>
+            <_ViuFrameworkSourceDir Condition="'$(ViuFrameworkKind)' == 'Runtime'">$(OutputPath)</_ViuFrameworkSourceDir>
+
+            <!-- Forward slashes for cross-platform safety (Linux CI). -->
+            <_ViuFrameworkListPath>$(IntermediateOutputPath)data/FrameworkList.xml</_ViuFrameworkListPath>
+            <_ViuRuntimeListPath>$(IntermediateOutputPath)data/RuntimeList.xml</_ViuRuntimeListPath>
+        </PropertyGroup>
+
+        <!-- ============ REF PACK ============ -->
+        <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Ref'">
+            <_ViuExpectedAssembly Include="@(ViuFrameworkAssembly->'$(_ViuFrameworkSourceDir)%(Identity).dll')" />
+        </ItemGroup>
+
+        <Error Condition="'$(ViuFrameworkKind)' == 'Ref' and !Exists('%(_ViuExpectedAssembly.Identity)')"
+               Text="Framework assembly declared in @(ViuFrameworkAssembly) but missing on disk: %(_ViuExpectedAssembly.Identity). Confirm the library has a project under libraries/ that ViuProjectReference can resolve, and that the Runtime project builds successfully." />
+
+        <!--
+            Analyzer DLLs are collected BEFORE the manifest writer runs so the
+            FrameworkList.xml can list every DLL that actually lands in
+            analyzers/dotnet/cs/ - the Syntax generator's GetTargetPath returns
+            its parser closure too (Roslyn resolves generator dependencies
+            exclusively among registered analyzer paths, so every closure DLL
+            must be a listed Analyzer entry, not just the generators).
+        -->
+        <MSBuild Condition="'$(ViuFrameworkKind)' == 'Ref' and '@(_ViuFrameworkAnalyzerResolved)' != ''"
+                 Projects="@(_ViuFrameworkAnalyzerResolved)"
+                 Targets="GetTargetPath"
+                 Properties="Configuration=$(Configuration)"
+                 RemoveProperties="OutDir;OutputPath;IntermediateOutputPath;TargetFramework;TargetFrameworks;RuntimeIdentifier">
+            <Output TaskParameter="TargetOutputs" ItemName="_ViuFrameworkAnalyzerDll" />
+        </MSBuild>
+        <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Ref' and '@(_ViuFrameworkAnalyzerDll)' != ''">
+            <!-- KeepDuplicates=false: multiple generators may share closure DLLs. -->
+            <_ViuFrameworkAnalyzerPackFile Include="@(_ViuFrameworkAnalyzerDll)" KeepDuplicates="false" />
+            <TfmSpecificPackageFile Include="@(_ViuFrameworkAnalyzerPackFile)">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+
+        <!--
+            FrameworkVersion = $(ViuVersionPrefix), NOT $(ViuVersion):
+            ResolveTargetingPackAssets parses AssemblyVersion as System.Version,
+            which rejects semver suffixes.
+        -->
+        <ViuWriteFrameworkList Condition="'$(ViuFrameworkKind)' == 'Ref'"
+            AssemblyNames="@(ViuFrameworkAssembly)"
+            AnalyzerNames="@(_ViuFrameworkAnalyzerPackFile->'%(Filename)')"
+            FrameworkName="$(ViuFrameworkName)"
+            FrameworkVersion="$(ViuVersionPrefix)"
+            TargetFrameworkVersion="$(_ViuTargetFrameworkVersion)"
+            PublicKeyToken="$(ViuPublicKeyToken)"
+            PathPrefix=""
+            RootElementName="FileList"
+            OutputPath="$(_ViuFrameworkListPath)" />
+
+        <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Ref'">
+            <TfmSpecificPackageFile Include="@(_ViuExpectedAssembly)">
+                <PackagePath>ref/$(TargetFrameworkLatest)/%(Filename)%(Extension)</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="$(_ViuFrameworkListPath)">
+                <PackagePath>data/FrameworkList.xml</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+
+        <!-- ============ RUNTIME PACK ============ -->
+        <!-- Only when an RID is explicitly set; RID-less design-time builds
+             skip pack. Iterates the UNION of public + private assemblies. -->
+        <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Runtime' and '$(RuntimeIdentifier)' != ''">
+            <_ViuExpectedAssembly Include="@(ViuFrameworkAssembly->'$(_ViuFrameworkSourceDir)%(Identity).dll');@(ViuFrameworkPrivateAssembly->'$(_ViuFrameworkSourceDir)%(Identity).dll')" />
+        </ItemGroup>
+
+        <Error Condition="'$(ViuFrameworkKind)' == 'Runtime' and '$(RuntimeIdentifier)' != '' and !Exists('%(_ViuExpectedAssembly.Identity)')"
+               Text="Framework assembly declared in @(ViuFrameworkAssembly) or @(ViuFrameworkPrivateAssembly) but missing on disk: %(_ViuExpectedAssembly.Identity). Build must run before pack and every entry needs a ViuProjectReference that CopyLocals into bin." />
+
+        <ViuWriteFrameworkList Condition="'$(ViuFrameworkKind)' == 'Runtime' and '$(RuntimeIdentifier)' != ''"
+            AssemblyNames="@(ViuFrameworkAssembly);@(ViuFrameworkPrivateAssembly)"
+            FrameworkName="$(ViuFrameworkName)"
+            FrameworkVersion="$(ViuVersionPrefix)"
+            TargetFrameworkVersion="$(_ViuTargetFrameworkVersion)"
+            PublicKeyToken="$(ViuPublicKeyToken)"
+            PathPrefix="runtimes/$(RuntimeIdentifier)/lib/$(TargetFrameworkLatest)/"
+            RootElementName="RuntimeList"
+            OutputPath="$(_ViuRuntimeListPath)" />
+
+        <ItemGroup Condition="'$(ViuFrameworkKind)' == 'Runtime' and '$(RuntimeIdentifier)' != ''">
+            <TfmSpecificPackageFile Include="@(_ViuExpectedAssembly)">
+                <PackagePath>runtimes/$(RuntimeIdentifier)/lib/$(TargetFrameworkLatest)/%(Filename)%(Extension)</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="$(_ViuRuntimeListPath)">
+                <PackagePath>data/RuntimeList.xml</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
+</Project>

--- a/frameworks/Directory.Build.props
+++ b/frameworks/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+    <Import Project="..\Directory.Build.props" />
+
+    <!--
+        Framework Ref/Runtime pack producers ([V01.01.12.19], #174).
+
+        TargetFramework comes from the central alias. VersionPrefix/VersionSuffix
+        are forced here because Microsoft.NET.Sdk pre-seeds VersionPrefix=1.0.0
+        early in evaluation; build/Targets/Build.Version.props handles that
+        default for ordinary projects, but framework pack versions must never
+        drift from $(ViuVersion), so the split is pinned explicitly (prefix
+        feeds AssemblyVersion/FileVersion - numeric only per CS7034; suffix
+        feeds PackageVersion/InformationalVersion).
+    -->
+    <PropertyGroup>
+        <TargetFramework>$(TargetFrameworkForFrameworks)</TargetFramework>
+        <VersionPrefix>$(ViuVersionPrefix)</VersionPrefix>
+        <VersionSuffix Condition="'$(ViuVersionSuffix)' != ''">$(ViuVersionSuffix)</VersionSuffix>
+    </PropertyGroup>
+</Project>

--- a/frameworks/Directory.Build.targets
+++ b/frameworks/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+    <Import Project="..\Directory.Build.targets" />
+</Project>

--- a/scripts/Install-Local.ps1
+++ b/scripts/Install-Local.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+    Packs the Viu SDK + shared-framework chain into the repo-local NuGet feed
+    (_out/packages), exercising SDK resolution -> framework reference ->
+    targeting pack -> runtime pack end-to-end for local consumers.
+    ([V01.01.12.19], #174 - the Viu port of cohesion's installer/scripts/Install-Local.ps1.)
+
+.PARAMETER Rids
+    Runtime identifiers to produce runtime packs for. browser-wasm is the
+    shipping RID for Viu apps.
+
+.PARAMETER SkipSdk
+    Re-pack the framework only.
+
+.PARAMETER SkipFramework
+    Re-pack the SDK only.
+
+.PARAMETER Configuration
+    Build configuration (default Release).
+#>
+[CmdletBinding()]
+param(
+    [string[]] $Rids = @('browser-wasm'),
+    [switch] $SkipSdk,
+    [switch] $SkipFramework,
+    [string] $Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$feed = Join-Path $repoRoot '_out\packages'
+
+# Resolve the version the build will stamp, straight from the MSBuild props
+# so PowerShell can never drift from MSBuild.
+$tfLatest = ([xml](Get-Content (Join-Path $repoRoot 'build\Targets\Build.TargetFramework.props'))).Project.PropertyGroup.TargetFrameworkLatest |
+    Where-Object { $_ } | Select-Object -First 1
+$versionProps = ([xml](Get-Content (Join-Path $repoRoot 'build\Targets\Build.Version.props'))).Project.PropertyGroup
+$major = ([version]($tfLatest.Trim() -replace '^net', '')).Major
+$minor = ($versionProps.ViuMinorVersion | Where-Object { $_ } | Select-Object -First 1).Trim()
+$patch = ($versionProps.ViuPatchVersion | Where-Object { $_ } | Select-Object -First 1).Trim()
+$viuVersion = "$major.$minor.$patch"
+Write-Host "Viu version: $viuVersion -> feed $feed" -ForegroundColor Cyan
+
+# Same-version repack workaround: prune cached package extracts so NuGet
+# re-extracts fresh content instead of serving a stale same-version copy.
+$packageIds = @('assimalign.viu.sdk', 'assimalign.viu.app.ref') + ($Rids | ForEach-Object { "assimalign.viu.app.runtime.$_" })
+$nugetCache = Join-Path $HOME '.nuget\packages'
+foreach ($id in $packageIds) {
+    $extract = Join-Path $nugetCache $id
+    if (Test-Path $extract) {
+        Write-Host "Pruning cached extract: $extract"
+        Remove-Item -Recurse -Force $extract
+    }
+}
+
+New-Item -ItemType Directory -Force $feed | Out-Null
+
+if (-not $SkipSdk) {
+    Write-Host "[1/3] Packing Assimalign.Viu.Sdk" -ForegroundColor Green
+    dotnet pack (Join-Path $repoRoot 'sdks\Assimalign.Viu.Sdk\Tasks\Assimalign.Viu.Sdk.Tasks.csproj') `
+        --configuration $Configuration -p:PackageOutputPath=$feed
+    if ($LASTEXITCODE -ne 0) { throw 'SDK pack failed.' }
+}
+
+if (-not $SkipFramework) {
+    foreach ($rid in $Rids) {
+        Write-Host "[2/3] Packing Assimalign.Viu.App.Runtime.$rid" -ForegroundColor Green
+        dotnet pack (Join-Path $repoRoot 'frameworks\Assimalign.Viu.App.Runtime\src\Assimalign.Viu.App.Runtime.csproj') `
+            --configuration $Configuration -p:RuntimeIdentifier=$rid -p:PackageOutputPath=$feed
+        if ($LASTEXITCODE -ne 0) { throw "Runtime pack failed for $rid." }
+    }
+
+    Write-Host "[3/3] Packing Assimalign.Viu.App.Ref" -ForegroundColor Green
+    dotnet pack (Join-Path $repoRoot 'frameworks\Assimalign.Viu.App.Refs\src\Assimalign.Viu.App.Refs.csproj') `
+        --configuration $Configuration -p:PackageOutputPath=$feed
+    if ($LASTEXITCODE -ne 0) { throw 'Ref pack failed.' }
+}
+
+Write-Host "Done. Packages in $feed :" -ForegroundColor Cyan
+Get-ChildItem $feed -Filter "Assimalign.Viu.*$viuVersion.nupkg" | ForEach-Object { Write-Host "  $($_.Name)" }

--- a/sdks/Assimalign.Viu.Sdk/Sdk/Sdk.props
+++ b/sdks/Assimalign.Viu.Sdk/Sdk/Sdk.props
@@ -1,0 +1,23 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!--
+		Assimalign.Viu.Sdk ([V01.01.12.19], #174): the entry point for
+		<Project Sdk="Assimalign.Viu.Sdk"> consumers. A Viu app is a WASM
+		browser app, so the chain starts at Microsoft.NET.Sdk.WebAssembly
+		(in-box; resolved by the default MSBuild SDK resolver).
+	-->
+	<Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.props" />
+	<!-- Define $(ViuVersion) FIRST so every subsequent import can use it.
+	     Without this, FrameworkReference.props evaluates KnownFrameworkReference
+	     with TargetingPackVersion="" and NuGet's restore fails with
+	     "'[]' is not a valid version string" before any pack is extracted.
+	     (This file is a pack-time-frozen snapshot; see sdks/Directory.Build.targets.) -->
+	<Import Project="..\Targets\Build.Version.props" />
+	<Import Project="..\Targets\Assimalign.Viu.Sdk.Common.props" />
+	<Import Project="..\Targets\Assimalign.Viu.Sdk.FrameworkReference.props" />
+	<!-- .viu single-file component compiler wiring (CompilerVisibleProperty
+	     declarations; the AdditionalFiles glob lives in the paired .targets).
+	     The file's own EnableSingleFileComponentGeneration gate honors
+	     consumer-body overrides because item evaluation sees final property
+	     values. -->
+	<Import Project="..\Targets\Assimalign.Viu.Syntax.Generators.props" Condition="Exists('..\Targets\Assimalign.Viu.Syntax.Generators.props')" />
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Sdk/Sdk.targets
+++ b/sdks/Assimalign.Viu.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,16 @@
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.targets" />
+	<!-- WASM runtime-pack selection shim + implicit browser platform identity. -->
+	<Import Project="..\Targets\Assimalign.Viu.Sdk.WebAssembly.targets" Condition="Exists('..\Targets\Assimalign.Viu.Sdk.WebAssembly.targets')" />
+	<!-- .viu -> AdditionalFiles glob (evaluated after the consumer's items and
+	     default excludes are known). -->
+	<Import Project="..\Targets\Assimalign.Viu.Syntax.Generators.targets" Condition="Exists('..\Targets\Assimalign.Viu.Syntax.Generators.targets')" />
+	<!-- CSS bundling for .viu @style blocks: the in-repo
+	     build/Targets/Build.Css.Bundling.targets packed verbatim;
+	     Assimalign.Viu.Sdk.Common.props preset $(ViuBundleCssTaskAssembly) to
+	     the packaged Tasks/ copy of the ViuBundleCss task. -->
+	<Import Project="..\Targets\Assimalign.Viu.Sdk.Css.Bundling.targets" Condition="Exists('..\Targets\Assimalign.Viu.Sdk.Css.Bundling.targets')" />
+	<!-- Flow the framework's static web assets (viu-dom.js) into the
+	     consumer's wwwroot/_content/. -->
+	<Import Project="..\Targets\Assimalign.Viu.Sdk.StaticWebAssets.targets" Condition="Exists('..\Targets\Assimalign.Viu.Sdk.StaticWebAssets.targets')" />
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.Common.props
+++ b/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.Common.props
@@ -1,0 +1,34 @@
+<Project>
+    <PropertyGroup>
+        <_ViuSdk>true</_ViuSdk>
+
+        <!--
+            Single-file components on by default: <Project Sdk="Assimalign.Viu.Sdk">
+            plus App.viu files is a working app with zero wiring. Consumers can
+            set either property to false in their csproj body - property
+            evaluation is document-ordered, so the body assignment wins over
+            these defaults.
+        -->
+        <ViuUseSingleFileComponents Condition="'$(ViuUseSingleFileComponents)' == ''">true</ViuUseSingleFileComponents>
+
+        <!--
+            The ViuBundleCss MSBuild task ships inside this SDK package at
+            Tasks/ (with its parser dependency closure alongside). Presetting
+            the assembly path here keeps the packed Css.Bundling.targets'
+            in-repo default path (which needs $(ViuRepositoryDirectory))
+            dormant.
+        -->
+        <ViuBundleCssTaskAssembly Condition="'$(ViuBundleCssTaskAssembly)' == ''">$(MSBuildThisFileDirectory)..\Tasks\Assimalign.Viu.Tooling.Tasks.dll</ViuBundleCssTaskAssembly>
+
+        <!--
+            The Assimalign.Viu.App framework libraries opt into runtime preview
+            APIs ([assembly: RequiresPreviewFeatures] - see the repo's
+            build/Targets/Build.TargetFramework.props). The attribute is viral,
+            so consumers referencing the framework must opt in too; default it
+            here (overridable in the consumer csproj body).
+        -->
+        <EnablePreviewFeatures Condition="'$(EnablePreviewFeatures)' == ''">true</EnablePreviewFeatures>
+        <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
+        <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+    </PropertyGroup>
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.FrameworkReference.props
+++ b/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.FrameworkReference.props
@@ -1,0 +1,50 @@
+<Project>
+    <!--
+        Registers the Viu shared framework with the .NET SDK ([V01.01.12.19],
+        #174 - the Viu port of cohesion's
+        Assimalign.Cohesion.Sdk.FrameworkReference.props).
+
+        One framework is registered: Assimalign.Viu.App. The SDK auto-includes
+        <FrameworkReference Include="Assimalign.Viu.App" /> so a consumer
+        compiles against the whole framework (Shared, Reactivity, RuntimeCore,
+        RuntimeDom + the umbrella) and picks up the Reactivity/.viu source
+        generators from the Ref pack's analyzers/dotnet/cs - with a single
+        one-line SDK reference and no PackageReferences.
+
+        Pack resolution: the .NET SDK looks for the packs locally under
+        $(NetCoreTargetingPackRoot) / packs; not found there (the normal case
+        for third-party frameworks), it restores them from the configured
+        NuGet feeds:
+
+            Assimalign.Viu.App.Ref                   (targeting pack - compile)
+            Assimalign.Viu.App.Runtime.browser-wasm  (runtime pack - app bundle)
+
+        ViuAutoIncludeAppFramework=false disables the implicit
+        <FrameworkReference>. The KnownFrameworkReference registration stays,
+        so explicit <FrameworkReference> entries keep working.
+
+        ViuAppFrameworkVersion lets consumers pin or roll forward the
+        framework independently of the SDK version.
+    -->
+
+    <PropertyGroup>
+        <ViuAppFrameworkVersion Condition="'$(ViuAppFrameworkVersion)' == ''">$(ViuVersion)</ViuAppFrameworkVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <KnownFrameworkReference Include="Assimalign.Viu.App"
+            TargetFramework="net10.0"
+            RuntimeFrameworkName="Assimalign.Viu.App"
+            DefaultRuntimeFrameworkVersion="$(ViuAppFrameworkVersion)"
+            LatestRuntimeFrameworkVersion="$(ViuAppFrameworkVersion)"
+            TargetingPackName="Assimalign.Viu.App.Ref"
+            TargetingPackVersion="$(ViuAppFrameworkVersion)"
+            RuntimePackNamePatterns="Assimalign.Viu.App.Runtime.**RID**"
+            RuntimePackRuntimeIdentifiers="browser-wasm"
+            IsTrimmable="true" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(ViuAutoIncludeAppFramework)' != 'false'">
+        <FrameworkReference Include="Assimalign.Viu.App" />
+    </ItemGroup>
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.StaticWebAssets.targets
+++ b/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.StaticWebAssets.targets
@@ -1,0 +1,29 @@
+<Project>
+    <!--
+        Flow the framework's static web assets into the consuming WebAssembly
+        app's SOURCE wwwroot under _content/<library>/ (a gitignored build
+        artifact) - the SDK-consumer counterpart of the in-repo
+        build/Targets/Build.StaticWebAssets.targets, and the same
+        [V01.01.04.01] dev-host constraint: the WasmAppHost only serves the
+        app's source wwwroot, so /_content/... URLs (JSHost.ImportAsync of
+        viu-dom.js) must exist there.
+
+        Sources come from the SDK package's assets/ folder
+        (assets/Assimalign.Viu.RuntimeDom/viu-dom.js today; the RecursiveDir
+        carries the library folder into the _content path).
+    -->
+    <Target Name="ViuFlowFrameworkWebAssets"
+            BeforeTargets="ResolveProjectStaticWebAssets;AssignTargetPaths"
+            Condition="'$(UsingMicrosoftNETSdkWebAssembly)' == 'true'">
+        <ItemGroup>
+            <_ViuSdkFrameworkWebAsset Include="$(MSBuildThisFileDirectory)..\assets\**\*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(_ViuSdkFrameworkWebAsset)"
+              DestinationFiles="@(_ViuSdkFrameworkWebAsset->'$(MSBuildProjectDirectory)\wwwroot\_content\%(RecursiveDir)%(Filename)%(Extension)')"
+              SkipUnchangedFiles="true"
+              Condition="'@(_ViuSdkFrameworkWebAsset)' != ''" />
+        <ItemGroup>
+            <_ViuSdkFrameworkWebAsset Remove="@(_ViuSdkFrameworkWebAsset)" />
+        </ItemGroup>
+    </Target>
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.WebAssembly.targets
+++ b/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.WebAssembly.targets
@@ -1,0 +1,41 @@
+<Project>
+    <!--
+        WebAssembly integration shims for Assimalign.Viu.Sdk consumers.
+
+        1. Runtime-pack selection: Microsoft.NET.Runtime.WebAssembly.Sdk's
+           _InitializeCommonProperties derives MicrosoftNetCoreAppRuntimePackDir
+           by batching over ALL @(ResolvedRuntimePack) items - with the
+           Assimalign.Viu.App runtime pack resolved alongside the Mono one, the
+           wrong pack can win and the WASM build fails with "Could not find
+           System.Runtime.dll in ...assimalign.viu.app.runtime.browser-wasm...".
+           Pin the property to the Microsoft.NETCore.App pack before that
+           target runs.
+
+        2. Browser platform identity: a Viu app is browser-only, so emit
+           [assembly: SupportedOSPlatform("browser")] (exactly what the repo's
+           example app declares by hand) so browser-only framework APIs
+           (BrowserRuntime, BrowserApplication) don't raise CA1416 in every
+           consumer. Opt out with ViuImplicitBrowserPlatform=false.
+    -->
+
+    <Target Name="_ViuPinMicrosoftNetCoreAppRuntimePack"
+            BeforeTargets="_InitializeCommonProperties"
+            Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == ''">
+        <ItemGroup>
+            <_ViuMicrosoftNetCoreAppRuntimePack Include="@(ResolvedRuntimePack)"
+                Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' or $([System.String]::new('%(ResolvedRuntimePack.NuGetPackageId)').StartsWith('Microsoft.NETCore.App.Runtime'))" />
+        </ItemGroup>
+        <PropertyGroup>
+            <MicrosoftNetCoreAppRuntimePackDir Condition="'@(_ViuMicrosoftNetCoreAppRuntimePack)' != ''">%(_ViuMicrosoftNetCoreAppRuntimePack.PackageDirectory)</MicrosoftNetCoreAppRuntimePackDir>
+        </PropertyGroup>
+        <ItemGroup>
+            <_ViuMicrosoftNetCoreAppRuntimePack Remove="@(_ViuMicrosoftNetCoreAppRuntimePack)" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup Condition="'$(ViuImplicitBrowserPlatform)' != 'false' and '$(GenerateAssemblyInfo)' != 'false'">
+        <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
+            <_Parameter1>browser</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+</Project>

--- a/sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj
+++ b/sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<!-- The Tasks csproj is the packable unit: its PackageId is the SDK id
+		     (not ...Tasks), IncludeBuildOutput=false (sdks/Directory.Build.props)
+		     keeps the DLLs out of lib/, and sdks/Directory.Build.targets places
+		     Sdk/, Targets/, Tasks/, and assets/ at the nupkg root - the shape
+		     NuGet's MSBuild SDK resolver expects. -->
+		<PackageId>Assimalign.Viu.Sdk</PackageId>
+		<OutDir>$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Tasks</OutDir>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!-- The ViuBundleCss MSBuild task ([V01.01.12.12]) and its parser
+		     closure (Tooling.Css -> Syntax/SingleFileComponent/Templates/Css)
+		     CopyLocal into $(OutDir) and are swept into the package's Tasks/
+		     folder by CollectSdkTaskFiles. Private: the Tooling.Tasks project
+		     is IsPackable=false, so it must never surface as a .nuspec
+		     dependency of this package. -->
+		<ViuPrivateProjectReference Include="Assimalign.Viu.Tooling.Tasks" />
+	</ItemGroup>
+</Project>

--- a/sdks/Directory.Build.props
+++ b/sdks/Directory.Build.props
@@ -1,0 +1,33 @@
+<Project>
+	<Import Project="..\Directory.Build.props" />
+	<!-- Shared package properties for every SDK Tasks project ([V01.01.12.19], #174 -
+	     the Viu port of cohesion's sdks/Directory.Build.props). -->
+	<PropertyGroup>
+		<TargetFramework>$(TargetFrameworkForSdks)</TargetFramework>
+		<OutputType>Library</OutputType>
+		<GenerateDependencyFile>false</GenerateDependencyFile>
+		<!-- The Tasks DLL ships under Tasks/ in the nupkg, never under lib/. -->
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<NoPackageAnalysis>true</NoPackageAnalysis>
+		<!-- Pull the ViuBundleCss task and its parser closure into $(OutDir) so
+		     CollectSdkTaskFiles can sweep the whole dependency set into Tasks/. -->
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<IsPackable>true</IsPackable>
+		<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+		<!-- Build-task code targets the stable surface (see Build.TargetFramework.props). -->
+		<EnablePreviewFeatures>false</EnablePreviewFeatures>
+	</PropertyGroup>
+	<!-- Package metadata -->
+	<PropertyGroup>
+		<!-- VersionPrefix/VersionSuffix split (not <Version> directly): a prerelease
+		     semver handed straight to <Version> propagates to AssemblyVersion and
+		     trips CS7034. The SDK composes Version at the end, which becomes
+		     PackageVersion via the default. -->
+		<VersionPrefix>$(ViuVersionPrefix)</VersionPrefix>
+		<VersionSuffix Condition="'$(ViuVersionSuffix)' != ''">$(ViuVersionSuffix)</VersionSuffix>
+		<Authors>Assimalign</Authors>
+		<Description>Viu MSBuild SDK: chains Microsoft.NET.Sdk.WebAssembly, references the Assimalign.Viu.App shared framework, and compiles .viu single-file components.</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageTags>Sdk;MSBuild;Viu;WebAssembly</PackageTags>
+	</PropertyGroup>
+</Project>

--- a/sdks/Directory.Build.targets
+++ b/sdks/Directory.Build.targets
@@ -1,0 +1,146 @@
+<Project>
+    <Import Project="..\Directory.Build.targets" />
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CollectSdkTaskFiles;CollectShippedVersionProps</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- The SDK-shaped nupkg layout: Sdk/ and Targets/ at package root -
+             exactly what NuGet's MSBuild SDK resolver expects. -->
+        <None Include="$(MSBuildProjectDirectory)\..\Sdk\**\*" Pack="true" PackagePath="Sdk\%(RecursiveDir)%(Filename)%(Extension)">
+            <Visible>false</Visible>
+        </None>
+        <None Include="$(MSBuildProjectDirectory)\..\Targets\**\*" Pack="true" PackagePath="Targets\%(RecursiveDir)%(Filename)%(Extension)">
+            <Visible>false</Visible>
+        </None>
+
+        <!--
+            Consumer-facing build logic packed FROM ITS IN-REPO SOURCE so the
+            SDK can never drift from the dogfooded implementation:
+              * the .viu AdditionalFiles wiring that
+                build/Targets/Build.References.Analyzers.targets imports for
+                in-repo projects, and
+              * the CSS bundling targets (Sdk.props presets
+                $(ViuBundleCssTaskAssembly) to the packaged Tasks/ copy, so the
+                file's in-repo default path stays dormant).
+        -->
+        <None Include="$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Syntax.Generators\build\Assimalign.Viu.Syntax.Generators.props"
+              Pack="true" PackagePath="Targets\Assimalign.Viu.Syntax.Generators.props" Visible="false" />
+        <None Include="$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Syntax.Generators\build\Assimalign.Viu.Syntax.Generators.targets"
+              Pack="true" PackagePath="Targets\Assimalign.Viu.Syntax.Generators.targets" Visible="false" />
+        <None Include="$(ViuRepositoryDirectory)build\Targets\Build.Css.Bundling.targets"
+              Pack="true" PackagePath="Targets\Assimalign.Viu.Sdk.Css.Bundling.targets" Visible="false" />
+
+        <!--
+            Framework static web assets. A FrameworkReference delivers DLLs
+            only, so the JS half of the RuntimeDom interop bridge rides in the
+            SDK package and Assimalign.Viu.Sdk.StaticWebAssets.targets copies
+            it into the consumer's wwwroot/_content/<library>/ (the same
+            /_content/<id>/ URL shape the in-repo
+            build/Targets/Build.StaticWebAssets.targets produces).
+        -->
+        <None Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.RuntimeDom\src\wwwroot\**\*"
+              Pack="true" PackagePath="assets\Assimalign.Viu.RuntimeDom\%(RecursiveDir)%(Filename)%(Extension)" Visible="false" />
+
+        <None Include="$(ViuRepositoryDirectory)sdks\README.md" Pack="true" PackagePath="README.md" Visible="false" />
+    </ItemGroup>
+
+    <!-- #region Loose local-SDK layout copies under $(ViuOutputPathForSdk) -->
+    <Target Name="CopyRootSdkFiles" AfterTargets="Build">
+        <ItemGroup>
+            <_ViuSdkRootFile Include="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))\Sdk\*.*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(_ViuSdkRootFile)" DestinationFolder="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Sdk\" />
+    </Target>
+    <Target Name="CopyTargetSdkFiles" AfterTargets="Build">
+        <ItemGroup>
+            <_ViuSdkTargetsFile Include="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))\Targets\*.*" />
+            <_ViuSdkTargetsFile Include="$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Syntax.Generators\build\Assimalign.Viu.Syntax.Generators.props" />
+            <_ViuSdkTargetsFile Include="$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Syntax.Generators\build\Assimalign.Viu.Syntax.Generators.targets" />
+        </ItemGroup>
+        <Copy SourceFiles="@(_ViuSdkTargetsFile)" DestinationFolder="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Targets\" />
+        <Copy SourceFiles="$(ViuRepositoryDirectory)build\Targets\Build.Css.Bundling.targets"
+              DestinationFiles="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Targets\Assimalign.Viu.Sdk.Css.Bundling.targets" />
+        <ItemGroup>
+            <_ViuSdkAssetFile Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.RuntimeDom\src\wwwroot\**\*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(_ViuSdkAssetFile)"
+              DestinationFiles="@(_ViuSdkAssetFile->'$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\assets\Assimalign.Viu.RuntimeDom\%(RecursiveDir)%(Filename)%(Extension)')" />
+    </Target>
+
+    <!--
+        Emit a static, version-resolved snapshot of Build.Version.props.
+        The repo's build/Targets/Build.Version.props derives ViuMajorVersion
+        from $(TargetFrameworkLatest), which is empty at a consumer's
+        Sdk.props evaluation phase (MSB4184). A shipped artifact's version is
+        frozen at pack time, so this writes a literal snapshot into obj/ and
+        CollectShippedVersionProps packs it as Targets/Build.Version.props -
+        resolving the base Sdk.props import.
+    -->
+    <Target Name="GenerateShippedVersionProps" AfterTargets="Build">
+        <PropertyGroup>
+            <_ShippedVersionPropsPath>$(IntermediateOutputPath)Build.Version.props</_ShippedVersionPropsPath>
+        </PropertyGroup>
+        <ItemGroup>
+            <_ShippedVersionPropsLines Include="&lt;!-- Auto-generated by sdks/Directory.Build.targets at SDK pack time." />
+            <_ShippedVersionPropsLines Include="     Snapshot of build/Targets/Build.Version.props with values frozen at $(ViuVersion). --&gt;" />
+            <_ShippedVersionPropsLines Include="&lt;Project&gt;" />
+            <_ShippedVersionPropsLines Include="    &lt;PropertyGroup&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuMajorVersion&gt;$(ViuMajorVersion)&lt;/ViuMajorVersion&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuMinorVersion&gt;$(ViuMinorVersion)&lt;/ViuMinorVersion&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuPatchVersion&gt;$(ViuPatchVersion)&lt;/ViuPatchVersion&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuVersionPrefix&gt;$(ViuVersionPrefix)&lt;/ViuVersionPrefix&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuVersionSuffix&gt;$(ViuVersionSuffix)&lt;/ViuVersionSuffix&gt;" />
+            <_ShippedVersionPropsLines Include="        &lt;ViuVersion&gt;$(ViuVersion)&lt;/ViuVersion&gt;" />
+            <_ShippedVersionPropsLines Include="    &lt;/PropertyGroup&gt;" />
+            <_ShippedVersionPropsLines Include="&lt;/Project&gt;" />
+        </ItemGroup>
+        <MakeDir Directories="$(IntermediateOutputPath)" />
+        <WriteLinesToFile File="$(_ShippedVersionPropsPath)"
+                          Lines="@(_ShippedVersionPropsLines)"
+                          Overwrite="true"
+                          Encoding="UTF-8" />
+        <Copy SourceFiles="$(_ShippedVersionPropsPath)"
+              DestinationFolder="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Targets\" />
+    </Target>
+
+    <Target Name="CollectShippedVersionProps" DependsOnTargets="GenerateShippedVersionProps">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(IntermediateOutputPath)Build.Version.props">
+                <PackagePath>Targets\Build.Version.props</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
+    <!-- #endregion -->
+
+    <Target Name="CollectSdkTaskFiles">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(OutDir)**\*" Exclude="$(OutDir)**\*.nupkg;$(OutDir)**\*.snupkg;$(OutDir)**\*.nuspec">
+                <PackagePath>Tasks\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
+
+    <!-- Optional: pack every shipping library into the local feed alongside the
+         SDK (dotnet pack -p:PackViuProjects=true on the Tasks csproj). -->
+    <Target Name="PackViuProjects" BeforeTargets="GenerateNuspec" Condition="'$(PackViuProjects)' == 'true'">
+        <ItemGroup>
+            <ViuSdkPackProject Include="$(ViuRepositoryDirectory)libraries\**\src\*.csproj"
+                Exclude="**\bin\**;**\obj\**;**\test\**;**\*.Tests.csproj;**\*Tests.csproj" />
+        </ItemGroup>
+        <Message Text="Packing Viu libraries into $(ViuOutputPathForLibraries)" Importance="High" />
+        <MSBuild
+            Projects="@(ViuSdkPackProject)"
+            Targets="Restore;Pack"
+            BuildInParallel="true"
+            Properties="Configuration=$(Configuration);PackageOutputPath=$(ViuOutputPathForLibraries)"
+            RemoveProperties="OutDir;PackageId;TargetFramework;TargetFrameworks;IncludeBuildOutput;GenerateDependencyFile;CopyLocalLockFileAssemblies"
+            ContinueOnError="WarnAndContinue" />
+    </Target>
+
+    <Target Name="CleanOutDir" AfterTargets="Clean">
+        <ItemGroup>
+            <_ViuSdkOutputToClean Include="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\**\*" />
+        </ItemGroup>
+        <Delete Files="@(_ViuSdkOutputToClean)" />
+    </Target>
+</Project>

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,0 +1,91 @@
+# Viu SDK
+
+Viu ships an MSBuild project SDK, **`Assimalign.Viu.Sdk`**, that chains through
+`Microsoft.NET.Sdk.WebAssembly` and delivers the whole framework through a single
+shared-framework reference — the same packaging model as the sibling Cohesion repo
+(`Assimalign.Cohesion.Sdk` / `Assimalign.Cohesion.App`), re-targeted at WASM browser apps.
+
+A complete Viu app project is:
+
+```xml
+<Project Sdk="Assimalign.Viu.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+</Project>
+```
+
+Pin the SDK version inline (`Sdk="Assimalign.Viu.Sdk/10.0.1-preview.2"`) or in
+`global.json`:
+
+```json
+{
+    "msbuild-sdks": {
+        "Assimalign.Viu.Sdk": "10.0.1-preview.2"
+    }
+}
+```
+
+The SDK is resolved by NuGet's built-in MSBuild SDK resolver — the same machinery
+that handles `Microsoft.NET.Sdk.Web` — so it works in Visual Studio, Rider, and the
+dotnet CLI with no installer and no admin rights.
+
+## What the SDK gives a consumer
+
+| Piece | Mechanism |
+| --- | --- |
+| WASM browser app model | `Sdk.props`/`Sdk.targets` chain `Microsoft.NET.Sdk.WebAssembly` |
+| The framework libraries (`Assimalign.Viu.Shared`, `.Reactivity`, `.RuntimeCore`, `.RuntimeDom`) | Implicit `<FrameworkReference Include="Assimalign.Viu.App" />` via the `KnownFrameworkReference` registration in [Targets/Assimalign.Viu.Sdk.FrameworkReference.props](Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.FrameworkReference.props) |
+| The `[Reactive]` and `.viu` source generators | Shipped inside the `Assimalign.Viu.App.Ref` targeting pack at `analyzers/dotnet/cs/` and listed as `<File Type="Analyzer">` in its `data/FrameworkList.xml` |
+| `.viu` single-file component compilation | The generator's AdditionalFiles/CompilerVisibleProperty wiring, packed into the SDK's `Targets/` from its in-repo source |
+| `.viu` `@style` CSS bundling | The `ViuBundleCss` MSBuild task (+ parser closure) in the SDK package's `Tasks/`, driven by the packed `Assimalign.Viu.Sdk.Css.Bundling.targets` |
+| `viu-dom.js` interop bridge | Packed under `assets/` and copied to the consumer's `wwwroot/_content/Assimalign.Viu.RuntimeDom/` at build |
+
+The framework reference resolves to two NuGet packages (the
+`Microsoft.AspNetCore.App.Ref` / `.Runtime.<rid>` shape):
+
+| Package | Contents | When restored |
+| --- | --- | --- |
+| `Assimalign.Viu.App.Ref` | `ref/net10.0/` reference assemblies, `data/FrameworkList.xml`, `analyzers/dotnet/cs/` generators | Compile time |
+| `Assimalign.Viu.App.Runtime.browser-wasm` | `runtimes/browser-wasm/lib/net10.0/` implementation assemblies, `data/RuntimeList.xml` | App build/publish |
+
+Opt out / pin independently:
+
+```xml
+<PropertyGroup>
+    <!-- Skip the implicit FrameworkReference (explicit ones keep working). -->
+    <ViuAutoIncludeAppFramework>false</ViuAutoIncludeAppFramework>
+    <!-- Pin the App framework independently of the SDK version. -->
+    <ViuAppFrameworkVersion>10.0.2</ViuAppFrameworkVersion>
+    <!-- Keep .viu compilation but skip CSS bundling / disable .viu entirely. -->
+    <ViuBundleSingleFileComponentCss>false</ViuBundleSingleFileComponentCss>
+    <EnableSingleFileComponentGeneration>false</EnableSingleFileComponentGeneration>
+</PropertyGroup>
+```
+
+## Local development loop
+
+`scripts/Install-Local.ps1` packs the full chain into the repo-local feed
+`_out/packages/`:
+
+1. `dotnet pack sdks/Assimalign.Viu.Sdk/Tasks` → `Assimalign.Viu.Sdk.<ver>.nupkg`
+2. `dotnet pack frameworks/Assimalign.Viu.App.Runtime/src -p:RuntimeIdentifier=browser-wasm` → `Assimalign.Viu.App.Runtime.browser-wasm.<ver>.nupkg`
+3. `dotnet pack frameworks/Assimalign.Viu.App.Refs/src` → `Assimalign.Viu.App.Ref.<ver>.nupkg`
+
+It prunes `~/.nuget/packages/` extracts for the same versions first, so
+same-version repacks always pick up fresh content.
+
+A consumer outside this repo points a `nuget.config` at the feed:
+
+```xml
+<configuration>
+    <packageSources>
+        <add key="viu-local" value="C:\Source\repos\assimalign\vuecs\_out\packages" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>
+```
+
+The in-repo build does **not** consume the SDK — repo projects stay on
+`ViuProjectReference` dogfooding (see `.claude/rules/build-system.md`) so the
+framework can be developed without a pack/restore cycle in the loop.


### PR DESCRIPTION
## Summary

Adopts Cohesion's `sdks/` + `frameworks/` packaging model ([V01.01.12.19]): a NuGet-distributed MSBuild project SDK **`Assimalign.Viu.Sdk`** — a complete Viu app csproj is `<Project Sdk="Assimalign.Viu.Sdk">` — and the **`Assimalign.Viu.App`** shared framework delivered as a targeting pack (`Assimalign.Viu.App.Ref`) plus a per-RID runtime pack (`Assimalign.Viu.App.Runtime.browser-wasm`), the `Microsoft.AspNetCore.App.Ref`/`.Runtime.<rid>` shape. The SDK chains `Microsoft.NET.Sdk.WebAssembly` and auto-includes the framework via a `KnownFrameworkReference` registration.

**Codegen placement** (per the re-evaluation asked by this work item, recorded as PLAN.md founding decision 8): the source generators stay Roslyn incremental generators — moving them into MSBuild tasks would forfeit IDE integration and incrementality — but are *delivered* through the Ref pack's `analyzers/dotnet/cs` with `<File Type="Analyzer">` manifest entries, so SDK consumers get `[Reactive]` and `.viu` compilation with zero wiring. The `ViuBundleCss` MSBuild task and the `.viu` AdditionalFiles/CSS-bundling MSBuild logic ship inside the SDK package (`Tasks/` + `Targets/`, packed from their in-repo source files so they cannot drift). In-repo projects keep `ViuProjectReference` dogfooding — the SDK is the external-consumer surface.

**Stacked on** #175 (`feature/V01.01.12.18-viu-rename`) — merge that first.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — behavior-preserving change
- [ ] `test` — tests only
- [x] `docs` — documentation only
- [x] `chore` — build / tooling / CI

## Changes

- `frameworks/Assimalign.Viu.App.{props,targets}` — the authoritative `@(ViuFrameworkAssembly)`/`@(ViuFrameworkAnalyzer)` manifest and the `ViuWriteFrameworkList` pack machinery (`data/FrameworkList.xml` / `data/RuntimeList.xml`), with `Refs`/`Runtime` producer projects.
- `sdks/Assimalign.Viu.Sdk/{Sdk,Targets,Tasks}` — the SDK package (packable unit `Tasks/Assimalign.Viu.Sdk.Tasks.csproj`, `PackageId=Assimalign.Viu.Sdk`): frozen `Build.Version.props` snapshot, framework registration, `.viu` wiring, CSS bundling driven by the in-package `ViuBundleCss` task, `viu-dom.js` shipped under `assets/` and flowed into consumer `wwwroot/_content/`, a WASM runtime-pack selection shim (the WASM SDK's `_InitializeCommonProperties` batches over **all** resolved runtime packs and can pick the wrong one), and implicit `[assembly: SupportedOSPlatform("browser")]`.
- `scripts/Install-Local.ps1` — packs SDK → runtime pack(s) → ref pack into the local feed `_out/packages` (now gitignored); `sdks/README.md` documents consumption.
- `build/Targets/Build.TargetFramework.props` — adds `TargetFrameworkForFrameworks` (and makes the previously-stale framework-targets comment true).
- CI: `area-packaging` workflow packs the chain and asserts all three package shapes.
- Docs realignment: PLAN.md (rename architecture note, founding decision 8, decision 7/#104 narrowed to hosting, Tooling backlog table brought current through `.19`), build-system/general rules, README.

**Recorded deviations** (per the deviations rule): the `frameworks/` csprojs and `Assimalign.Viu.App.targets` use raw `<ProjectReference>` for pure build-order edges needing `ReferenceOutputAssembly=false` + `UndefineProperties` metadata that the `ViuProjectReference` transform does not carry — documented at each site.

## Work items resolved

Closes #174
Closes #168

Related (re-scoped, not closed): #92 (remaining NuGet scope: library packages, SourceLink, feed publishing), #104 (narrowed to Cohesion hosting integration).

## Testing & verification

- [x] `dotnet build` and the affected `dotnet test` projects pass locally.
- [x] The sample WASM app(s) still build and run where the change touches runtime/interop code.
- Root solution (now including `frameworks/` + `sdks/` projects) builds with `-warnaserror`: 0 warnings / 0 errors; the in-repo build and tests are unaffected.
- `Install-Local.ps1` produces `Assimalign.Viu.Sdk`, `Assimalign.Viu.App.Ref`, and `Assimalign.Viu.App.Runtime.browser-wasm` nupkgs; package layouts inspected (ref/, runtimes/, data/ manifests, analyzers/dotnet/cs with the generator parser closure, every DLL listed as an `Analyzer` entry).
- End-to-end consumer proof: a standalone project containing only `<Project Sdk="Assimalign.Viu.Sdk">` + a component + `Counter.viu` restored from the local feed, compiled 0 warnings/0 errors against the Ref pack, ran **both** source generators from it (verified via `EmitCompilerGeneratedFiles`: `CounterState.Reactive.g.cs`, `Counter.SingleFileComponent.g.cs`), produced the `.viu.css` bundle via the SDK-shipped task, bundled the runtime-pack assemblies into the WASM app, and served a working reactive app in the browser (click → re-render verified).

## Checklist

- [x] Each resolved work item (the parent feature **and** its sub-issues) has its own `Closes #` line; deferred/backlog items are linked without a closing keyword.
- [x] Public APIs have XML docs; behavior that mirrors Vue 3 links the upstream doc in code or tests.
- [x] Remains trimming-safe and WASM/NativeAOT-compatible (no runtime reflection serialization, no dynamic code generation; source generators are the sanctioned path); the framework registration sets `IsTrimmable=true`.
- [x] JS-interop surface changes keep the interop boundary minimal (batch where possible) and clean up handles/listeners (no interop changes; `viu-dom.js` is delivered, not modified).
- [x] Tests added/updated and passing; any new project is wired into the solution and CI.
- [x] No dangling solution/project references left behind (renamed or moved projects updated everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
