### PR TITLE
docs: establish the repository documentation skeleton [V01.01.13.01]

### DIFF
--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -15,7 +15,7 @@ win** — link the reference in the code, test, or issue that pins the behavior.
 
 - Inverted library layout: `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name **is** the
   assembly / package id. `src/` holds the shipping project, `test/` its test project. No area wrapper
-  folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug remains
+  folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug is
   `assimalign/viu`).
 - Examples live in `examples/`; repo planning docs in `docs/`; the consumer-facing MSBuild SDK in
   `sdks/` and the `Assimalign.Viu.App` shared-framework pack producers in `frameworks/` (see

--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -16,7 +16,7 @@ win** — link the reference in the code, test, or issue that pins the behavior.
 - Inverted library layout: `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name **is** the
   assembly / package id. `src/` holds the shipping project, `test/` its test project. No area wrapper
   folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug remains
-  `assimalign/vuecs`).
+  `assimalign/viu`).
 - Examples live in `examples/`; repo planning docs in `docs/`; the consumer-facing MSBuild SDK in
   `sdks/` and the `Assimalign.Viu.App` shared-framework pack producers in `frameworks/` (see
   [build-system.md](build-system.md)).

--- a/.claude/skills/viu-work-items/SKILL.md
+++ b/.claude/skills/viu-work-items/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: viu-work-items
-description: Create and link GitHub work items (area epics / features / tasks) in the assimalign/vuecs Project #15 using the gh CLI — following the V01.01.NN WBS scheme, native parent/sub-issue links, and the Summary / Acceptance Criteria body template. Use whenever new development is requested, and ESPECIALLY when scope creep is discovered mid-branch: file the out-of-scope work as its own tracked work item so one PR can attach and close several items. Triggers include "create a work item", "file an issue for this", "capture this scope creep", "track this extra change", "open a Viu issue", "this is out of scope — log it", or "assemble the Closes list for my PR". Use only in the assimalign/vuecs repo.
+description: Create and link GitHub work items (area epics / features / tasks) in the assimalign/viu Project #15 using the gh CLI — following the V01.01.NN WBS scheme, native parent/sub-issue links, and the Summary / Acceptance Criteria body template. Use whenever new development is requested, and ESPECIALLY when scope creep is discovered mid-branch: file the out-of-scope work as its own tracked work item so one PR can attach and close several items. Triggers include "create a work item", "file an issue for this", "capture this scope creep", "track this extra change", "open a Viu issue", "this is out of scope — log it", or "assemble the Closes list for my PR". Use only in the assimalign/viu repo.
 ---
 
 # Viu Work Items
@@ -141,7 +141,7 @@ Closing a parent feature does not close its sub-issues and vice-versa, so list e
 
 ## Guardrails
 
-- **Only operate on `assimalign/vuecs`** and Project #15. Confirm `gh auth status` has the `project` scope.
+- **Only operate on `assimalign/viu`** and Project #15. Confirm `gh auth status` has the `project` scope.
   Project #15 also lists `assimalign/cohesion` items — never modify those from this repo.
 - **Never invent a WBS code** — always derive the next child from existing siblings (the script does this; if
   doing it by hand, list the parent's children and take max+1, zero-padded to two digits).

--- a/.claude/skills/viu-work-items/reference/project-schema.md
+++ b/.claude/skills/viu-work-items/reference/project-schema.md
@@ -8,7 +8,7 @@ understanding the model. If an ID stops working, re-run the discovery commands a
 
 | Thing | Value |
 | --- | --- |
-| Repo | `assimalign/vuecs` |
+| Repo | `assimalign/viu` |
 | Org / owner | `assimalign` |
 | Project | **#15 "Viu"** |
 | Project node id | `PVT_kwDOA9eCcc4BdkOB` |
@@ -55,7 +55,7 @@ in the branch names the **feature** currently in flight.
 
 (Program root: `#1 [V01.01.00] Viu - Framework Libraries`.)
 
-(Re-list with: `gh issue list --repo assimalign/vuecs --state open --search '"Framework -" in:title' --json number,title`)
+(Re-list with: `gh issue list --repo assimalign/viu --state open --search '"Framework -" in:title' --json number,title`)
 
 ## Custom fields (single-select)
 
@@ -89,7 +89,7 @@ W06 enterprise polish.
 
 ```bash
 # By label (issues CLI):
-gh issue list --repo assimalign/vuecs --label scope-creep --state all --json number,title,state
+gh issue list --repo assimalign/viu --label scope-creep --state all --json number,title,state
 # By field on the board: filter or group Project #15 by Origin (DiscoveredTask / DiscoveredFeature).
 ```
 
@@ -111,7 +111,7 @@ gh issue list --repo assimalign/vuecs --label scope-creep --state all --json num
 ## Manual recipe (when not using the helper script)
 
 ```bash
-REPO=assimalign/vuecs ; OWNER=assimalign ; PROJ=15
+REPO=assimalign/viu ; OWNER=assimalign ; PROJ=15
 PROJECT_ID=PVT_kwDOA9eCcc4BdkOB
 
 # 1. Find the parent + its node id (feature for a task, area epic for a sibling feature)

--- a/.claude/skills/viu-work-items/scripts/New-ViuWorkItem.ps1
+++ b/.claude/skills/viu-work-items/scripts/New-ViuWorkItem.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Create a GitHub work item (feature / task) in the assimalign/vuecs Project #15,
+    Create a GitHub work item (feature / task) in the assimalign/viu Project #15,
     following the V01.01.NN WBS scheme, native parent/sub-issue links, and the
     Summary / Acceptance Criteria body template — classifying scope creep and reusing
     existing items instead of creating duplicates.
@@ -120,7 +120,7 @@ Set-StrictMode -Version Latest
 
 # --- Constants -------------------------------------------------------------------------------
 $Owner       = 'assimalign'
-$Repo        = 'assimalign/vuecs'
+$Repo        = 'assimalign/viu'
 $ProjectNum  = 15
 $WbsPattern  = 'V\d{2}(?:\.\d{2})+'      # viu WBS codes are V-prefixed
 $AreaPattern = 'Framework - (.+)$'       # area-epic title convention

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Viu work-item helper (preferred)
-    url: https://github.com/assimalign/vuecs/blob/main/.claude/skills/viu-work-items/SKILL.md
+    url: https://github.com/assimalign/viu/blob/main/.claude/skills/viu-work-items/SKILL.md
     about: >-
       Prefer New-ViuWorkItem.ps1 — it computes the next WBS code, links the native
       sub-issue, adds the item to Project #15, and tags its Origin. Use the forms below only

--- a/README.md
+++ b/README.md
@@ -2,39 +2,134 @@
 
 A faithful re-implementation of [Vue.js 3](https://vuejs.org) in C#/.NET, running in the browser
 through the .NET WebAssembly build tools (`Microsoft.NET.Sdk.WebAssembly`, `JSImport`/`JSExport`
-interop) — compiler-informed virtual DOM, Ref-first reactivity, and Roslyn source generators where
-Vue uses JS `Proxy` and runtime template compilation.
+interop). Viu mirrors Vue 3's package boundaries as `Assimalign.Viu.*` class libraries and tracks
+[vuejs/core](https://github.com/vuejs/core) (v3.5.x) semantics, with three deliberate C#/WASM
+divergences at its core:
+
+- **Roslyn source generators** stand in for everything Vue does with the JavaScript `Proxy` and
+  runtime `new Function` — WASM is AOT/trimming territory, so reflection-based serialization and
+  dynamic code generation are forbidden.
+- **Ref-first reactivity** replaces Proxy-based reactive objects; `[Reactive]` partial classes are
+  source-generated.
+- **Batched JS-interop** is the performance budget: the interop boundary is the dominant cost, so
+  DOM mutations batch and static content is stringified aggressively.
+
+These are recorded as architecture decisions in [`docs/adr/`](docs/adr/); the full architecture map,
+founding decisions, and wave strategy live in [`docs/PLAN.md`](docs/PLAN.md).
 
 ## Status
 
-Early development. The current code proves the rendering seam: a platform-agnostic virtual DOM
-renderer (`VirtualDomRenderer<TNode>` over an injected adapter) patching the real browser DOM from
-C# through a handle-based JS-interop bridge. See the stopwatch demo in
+Early, active development, delivered in waves (see [`docs/PLAN.md`](docs/PLAN.md) and the
+[project board](https://github.com/orgs/assimalign/projects/15) for the authoritative status). The
+reactive core, the platform-agnostic renderer with scheduler and component model, the browser DOM
+bridge, the template compiler front end, and the `.viu` single-file-component pipeline are all in
+the tree at varying maturity; each library's `docs/OVERVIEW.md` states what it currently provides.
+The demo is a reactively re-rendering stopwatch in
 [`examples/Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp).
 
-Libraries use the `Assimalign.Viu.*` package root with the inverted layout
-`libraries/Assimalign.Viu.<Name>/{src|test}`.
+## Repository map
 
-Viu apps consume the framework through an MSBuild project SDK — a complete app csproj is
-`<Project Sdk="Assimalign.Viu.Sdk">` — which chains `Microsoft.NET.Sdk.WebAssembly` and delivers
-the framework libraries plus the `[Reactive]`/`.viu` source generators via the
-`Assimalign.Viu.App` shared framework (`.Ref` targeting pack + `.Runtime.browser-wasm` runtime
-pack). See [`sdks/README.md`](sdks/README.md).
+Framework libraries use the inverted layout `libraries/Assimalign.Viu.<Name>/{src,test,docs}` — the
+folder name **is** the assembly and package id (no area wrapper folders). Each shipping library
+carries a `docs/OVERVIEW.md` (what it is, its public surface, its Vue 3 counterpart) and a
+`docs/DESIGN.md` (why it is shaped that way, the vuejs/core module it ports, and known deltas).
+
+### Framework libraries (`libraries/`)
+
+| Library | Vue 3 counterpart | Docs |
+| --- | --- | --- |
+| [`Assimalign.Viu.Shared`](libraries/Assimalign.Viu.Shared) | [`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared) — PatchFlags/ShapeFlags/SlotFlags, class/style normalization, DOM knowledge tables | [OVERVIEW](libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Shared/docs/DESIGN.md) |
+| [`Assimalign.Viu.Reactivity`](libraries/Assimalign.Viu.Reactivity) | [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity) — dependencies, Ref/Computed, effects, scopes, watch, reactive collections | [OVERVIEW](libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md) |
+| [`Assimalign.Viu.RuntimeCore`](libraries/Assimalign.Viu.RuntimeCore) | [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core) — vnodes, renderer, scheduler, component model, built-ins | [OVERVIEW](libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md) |
+| [`Assimalign.Viu.RuntimeDom`](libraries/Assimalign.Viu.RuntimeDom) | [`@vue/runtime-dom`](https://github.com/vuejs/core/tree/main/packages/runtime-dom) — JS-interop DOM bridge, patchProp, events, v-model/v-show | [OVERVIEW](libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax`](libraries/Assimalign.Viu.Syntax) | (shared base) — the located node/diagnostic primitives and registration-based parser pipeline every language library roots on | [OVERVIEW](libraries/Assimalign.Viu.Syntax/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.Templates`](libraries/Assimalign.Viu.Syntax.Templates) | [`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) + [`compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom) — the Vue template language front end and C# render-function codegen | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.SingleFileComponent`](libraries/Assimalign.Viu.Syntax.SingleFileComponent) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) — the `.viu` `@`-block container parser | [OVERVIEW](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md) · [FORMAT](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md) |
+| [`Assimalign.Viu.Syntax.Css`](libraries/Assimalign.Viu.Syntax.Css) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) `compileStyle()` — CSS tokenizer, rule parser, and scoped-CSS rewrite | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Css/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.Html`](libraries/Assimalign.Viu.Syntax.Html) | (Vite HTML entry processing) — the `.html` host-page language (scaffold) | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.JavaScript`](libraries/Assimalign.Viu.Syntax.JavaScript) | (interop-glue JavaScript) — the `.js` language around the interop boundary (scaffold) | [OVERVIEW](libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md) |
+| [`Assimalign.Viu.Testing`](libraries/Assimalign.Viu.Testing) | [`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test) + [`@vue/test-utils`](https://test-utils.vuejs.org) — the in-memory renderer and component test harness | [OVERVIEW](libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Testing/docs/DESIGN.md) |
+| [`Assimalign.Viu.Tooling.Css`](libraries/Assimalign.Viu.Tooling.Css) | (build-time composition core, no direct Vue peer) — shared `.viu` `@style` compilation and bundling used by both build-time hosts | [OVERVIEW](libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Tooling.Css/docs/DESIGN.md) |
+
+### Source generators and build tasks (`analyzers/`)
+
+These are build-time (netstandard2.0) components — the sanctioned replacement for Vue's `Proxy` and
+runtime template compilation. They never ship in the runtime assemblies.
+
+| Project | Role |
+| --- | --- |
+| `Assimalign.Viu.Reactivity.Generators` | Emits the property wrappers for `[Reactive]`/`[ShallowReactive]` partial classes (Vue's `reactive()`, source-generated). |
+| `Assimalign.Viu.Syntax.Generators` | The incremental generator that compiles `.viu` single-file components and templates to C# render methods (the composition root that registers the template and style parsers). |
+| `Assimalign.Viu.Tooling.Tasks` | The `ViuBundleCss` MSBuild task that writes the compiled `.viu` `@style` output to a physical stylesheet (outside the analyzer sandbox). |
+
+### Examples (`examples/`)
+
+| Sample | What it shows |
+| --- | --- |
+| [`Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp) | A browser WASM app: a stopwatch rendered from C# through the handle-based DOM bridge. Its `?diagnostics=1` mode runs the interop marshaling benchmark behind [RuntimeDom ADR-0001](libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md). |
+
+### Packaging (`sdks/`, `frameworks/`)
+
+External apps consume Viu through an MSBuild project SDK, not project references — a complete app
+csproj is `<Project Sdk="Assimalign.Viu.Sdk">`. The SDK chains `Microsoft.NET.Sdk.WebAssembly` and
+delivers the framework as the `Assimalign.Viu.App` shared framework (the
+`Microsoft.AspNetCore.App.Ref`/`.Runtime.<rid>` model, mirrored from `assimalign/cohesion`). See
+[`sdks/README.md`](sdks/README.md) for the full consumer surface and the local development loop.
+
+| Path | Produces | Role |
+| --- | --- | --- |
+| `sdks/Assimalign.Viu.Sdk` | `Assimalign.Viu.Sdk` | The project SDK: chains the WebAssembly SDK, registers the `Assimalign.Viu.App` framework reference, and ships the `.viu`/CSS build wiring and the `viu-dom.js` bridge. |
+| `frameworks/Assimalign.Viu.App.Refs` | `Assimalign.Viu.App.Ref` | The targeting pack: reference assemblies, `FrameworkList.xml`, and the generators (delivered as analyzers). |
+| `frameworks/Assimalign.Viu.App.Runtime` | `Assimalign.Viu.App.Runtime.browser-wasm` | The per-RID runtime pack: implementation assemblies for `browser-wasm`. |
+
+In-repo projects dogfood the framework through `ViuProjectReference` (see
+[`.claude/rules/build-system.md`](.claude/rules/build-system.md)); the SDK is the external-consumer
+surface.
+
+## Getting started
+
+### Prerequisites
+
+- The [.NET SDK](https://dotnet.microsoft.com/download) pinned in [`global.json`](global.json)
+  (currently `10.0.301`).
+- The WebAssembly tools workload, needed to build and run the browser sample:
+  ```sh
+  dotnet workload install wasm-tools
+  ```
+
+### Clone and build
+
+```sh
+git clone https://github.com/assimalign/viu.git
+cd viu
+dotnet build Assimalign.Viu.slnx
+```
+
+### Test
+
+Each library's tests live beside it under `test/`:
+
+```sh
+dotnet test libraries/Assimalign.Viu.Reactivity/test/
+dotnet test libraries/Assimalign.Viu.RuntimeCore/test/
+```
+
+### Run the demo
+
+```sh
+dotnet run --project examples/Assimalign.Viu.WebApp
+```
 
 ## Plan and tracking
 
 - [Delivery plan](docs/PLAN.md) — architecture mapping (Vue 3 package → Viu library), founding
-  design decisions, and the wave strategy
+  design decisions, and the wave strategy.
+- [Architecture decisions](docs/adr/) — the append-only decision log (founding C#/WASM divergences).
+- [Documentation conventions](docs/CONTRIBUTING.md) — where `OVERVIEW.md`, `DESIGN.md`, and ADRs
+  live, what belongs in each, and when they must be updated.
 - [Project board](https://github.com/orgs/assimalign/projects/15) — the authoritative backlog
-  (`[V01.01.*]` WBS items: program → area epics → features → tasks)
-- Work-item intake: [`.claude/skills/viu-work-items`](.claude/skills/viu-work-items/SKILL.md)
-
-## Build
-
-```sh
-dotnet build Assimalign.Viu.slnx
-dotnet run --project examples/Assimalign.Viu.WebApp
-```
+  (`[V01.01.*]` WBS items: program → area epics → features → tasks).
+- Work-item intake: [`.claude/skills/viu-work-items`](.claude/skills/viu-work-items/SKILL.md).
 
 ## License
 

--- a/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentDiagnostics.cs
+++ b/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentDiagnostics.cs
@@ -30,7 +30,7 @@ internal static class SingleFileComponentDiagnostics
     // The stable per-id help-link target: the VIU diagnostic catalog documents every descriptor's ID,
     // origin, severity, and configuration ([V01.01.05.08]). Each descriptor links its own heading anchor.
     private const string HelpLinkBase =
-        "https://github.com/assimalign/vuecs/blob/main/analyzers/Assimalign.Viu.Syntax.Generators/docs/DIAGNOSTICS.md";
+        "https://github.com/assimalign/viu/blob/main/analyzers/Assimalign.Viu.Syntax.Generators/docs/DIAGNOSTICS.md";
 
     private static string HelpLink(string id) => HelpLinkBase + "#" + id.ToLowerInvariant();
 

--- a/build/Targets/Build.Branding.props
+++ b/build/Targets/Build.Branding.props
@@ -3,6 +3,6 @@
         <Company>Assimalign</Company>
         <Copyright>© Assimalign $([System.DateTime]::Now.ToString(`yyyy`))</Copyright>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/assimalign/vuecs</RepositoryUrl>
+        <RepositoryUrl>https://github.com/assimalign/viu</RepositoryUrl>
     </PropertyGroup>
 </Project>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Documentation conventions
+
+This page defines Viu's documentation system: where each kind of document lives, what belongs in it,
+and when it must be updated. It exists so every WBS area documents itself the same way without having
+to re-decide. The canonical *working* conventions (C# style, build system, testing) live under
+[`.claude/rules/`](../.claude/rules/); this page covers the prose-documentation layout and lifecycle
+and complements [`.claude/rules/documentation.md`](../.claude/rules/documentation.md).
+
+## The map
+
+| Document | Location | What it holds |
+| --- | --- | --- |
+| Root `README.md` | repository root | The project mission, the repository map (every project under `libraries/`, `analyzers/`, `examples/`, `sdks/`, `frameworks/`), and clone/build/run instructions. |
+| `PLAN.md` | [`docs/PLAN.md`](PLAN.md) | The authoritative narrative: the Vue 3 → Viu architecture map, the founding design decisions, and the wave strategy. The GitHub [Project #15](https://github.com/orgs/assimalign/projects/15) board is the authoritative *backlog*. |
+| Architecture decision records | [`docs/adr/`](adr/) | The append-only log of repo-wide, cross-cutting decisions (see [`adr/README.md`](adr/README.md)). |
+| Per-library `OVERVIEW.md` | `libraries/Assimalign.Viu.<Name>/docs/OVERVIEW.md` | What the library **is**. |
+| Per-library `DESIGN.md` | `libraries/Assimalign.Viu.<Name>/docs/DESIGN.md` | **Why** the library is shaped the way it is. |
+| Per-library topic docs | `libraries/Assimalign.Viu.<Name>/docs/*.md` | Focused specs or local ADRs (e.g. `FORMAT.md`, a library-local `ADR-000N-*.md`). |
+| XML doc comments | in source, on every public member | The API-level reference and the pinned Vue 3 counterpart links. |
+
+## What belongs in `OVERVIEW.md`
+
+The reader-facing description of the library. Keep it concise and accurate — describe what exists,
+not what is planned.
+
+- **Purpose** — one or two sentences: the role it plays, phrased against its Vue 3 counterpart.
+- **Public surface** — the entry points and currency types a consumer touches (the facade, the key
+  public types), with a one-line note on each. Not an exhaustive member list — that is the XML docs.
+- **Vue 3 package counterpart** — name it and link it (`@vue/<pkg>` on `vuejs.org` or the
+  `github.com/vuejs/core/tree/main/packages/<pkg>` path). A scaffold says so plainly.
+- **Boundaries** — allowed dependency direction; any interop/AOT/generator constraint; a pointer to
+  `DESIGN.md`.
+
+## What belongs in `DESIGN.md`
+
+The rationale and the divergences — why the shape, not the shape itself.
+
+- **Upstream counterpart** — the specific `vuejs/core` package/module this ports, named and linked so
+  parity review is mechanical (e.g. `@vue/reactivity`'s `ref.ts`).
+- **Design rationale** — the internal structure and the forces behind it (the interop budget, the
+  AOT/trimming constraint, the single-threaded model, the incremental-generator caching contract).
+- **Known deltas / divergences from Vue 3** — every deliberate departure from upstream, why it was
+  forced, and the test that pins the *chosen* behavior. A repo-wide divergence links its ADR under
+  [`docs/adr/`](adr/); a library-local one is documented here.
+- **Non-goals** — what is intentionally out of scope, sequenced to the work item that will add it.
+
+## When documents must be updated
+
+- **Same change as the code.** An `OVERVIEW.md`/`DESIGN.md` that lags the code actively misleads;
+  update it in the commit that changes the public surface or the design it describes.
+- **New public type or behavior mirroring Vue 3** — add the XML doc comment with the counterpart
+  link, and reflect any new entry point in `OVERVIEW.md`.
+- **A deliberate divergence from vuejs/core v3.5** — record it (XML docs + a `DESIGN.md` non-goal or
+  delta) and pin it with a test that asserts the chosen behavior (see
+  [`.claude/rules/deviations.md`](../.claude/rules/deviations.md)).
+- **A cross-cutting or repo-wide decision** — add an ADR (never edit a past one; supersede it — see
+  [`adr/README.md`](adr/README.md)).
+
+## Where new things go
+
+- **A new library** — `libraries/Assimalign.Viu.<Name>/{src,test,docs}` (folder name = assembly id,
+  no area wrapper folders). Seed `docs/OVERVIEW.md` and `docs/DESIGN.md` with the code. Wire the
+  csprojs per [`.claude/rules/build-system.md`](../.claude/rules/build-system.md) ("Adding a new
+  library") and add a row to the root `README.md` repository map.
+- **A new sample** — `examples/Assimalign.Viu.<Name>/`, referenced from the root `README.md`
+  Examples table; keep the demo's own `README` or in-code notes describing what it shows.
+- **A new ADR** — copy [`adr/template.md`](adr/template.md) to `adr/NNNN-kebab-title.md` (next number),
+  and add it to the [`adr/README.md`](adr/README.md) index.
+- **Work items** — every change traces to a `[V01.01.NN…]` WBS item on Project #15; capture
+  mid-branch scope creep with the `viu-work-items` skill (see
+  [`.claude/rules/workflow.md`](../.claude/rules/workflow.md)).
+
+## Links must resolve
+
+Every relative link in a Markdown doc must point at a real file, and every Vue 3 reference should
+point at a stable `vuejs.org` or `vuejs/core` URL. Verify links before committing. (Automated
+link-checking in CI is planned under the Documentation area, [V01.01.13]; until it lands, this is a
+manual check.)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -33,9 +33,9 @@ Package boundaries map 1:1 to .NET class libraries using the inverted layout
 `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name is the assembly/package id, with no
 area wrapper folders (project decision, 2026-07-16). The product name is **Viu** and the package
 root is **`Assimalign.Viu.*`** (renamed from Vue/Vuecs 2026-07-19, `V01.01.12.18`/#173, aligning
-the brand with the `.viu` SFC extension; the GitHub repo slug remains `assimalign/vuecs`, and
-upstream Vue.js references — `@vue/*` names, vuejs.org links, the `vue:` template prefix — are
-deliberately untouched):
+the brand with the `.viu` SFC extension; the GitHub repo slug is now `assimalign/viu` (renamed
+from `assimalign/vuecs`), and upstream Vue.js references — `@vue/*` names, vuejs.org links, the
+`vue:` template prefix — are deliberately untouched):
 
 | Area (WBS) | Viu library | Vue 3 counterpart |
 | --- | --- | --- |
@@ -133,7 +133,7 @@ Work is tracked exactly like the sibling Cohesion repo:
   (`.claude/skills/viu-work-items/`) files discovered work as its own item with
   `Origin=DiscoveredTask|DiscoveredFeature` and the `scope-creep` label, so one PR closes everything
   it actually resolved and creep stays measurable.
-- Project #15 carries viu work only (`V`-prefixed WBS codes, repo `assimalign/vuecs`).
+- Project #15 carries viu work only (`V`-prefixed WBS codes, repo `assimalign/viu`).
 
 ### Wave narrative
 

--- a/docs/UTILITY-CSS-DESIGN.md
+++ b/docs/UTILITY-CSS-DESIGN.md
@@ -1,7 +1,7 @@
 # Build-time utility-first CSS engine — design
 
 Scoping deliverable for **[V01.01.12.10] Scope the build-time utility-first CSS engine**
-([#129](https://github.com/assimalign/vuecs/issues/129)). This is a design document plus a proposed
+([#129](https://github.com/assimalign/viu/issues/129)). This is a design document plus a proposed
 work-item breakdown, **not** an implementation — no engine code ships on this branch.
 
 The engine is an in-house, Tailwind-style utility-first CSS system built entirely at **build time**:
@@ -43,10 +43,10 @@ MSBuild pipeline — and no single library's `docs/DESIGN.md` owns the whole pic
   [documentation](../.claude/rules/documentation.md), [deviations](../.claude/rules/deviations.md)
 - Landed architecture this builds on:
   [`Assimalign.Viu.Syntax` DESIGN](../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) (the
-  registration seam, [#127](https://github.com/assimalign/vuecs/issues/127)) and
+  registration seam, [#127](https://github.com/assimalign/viu/issues/127)) and
   [`Assimalign.Viu.Syntax.Css` DESIGN](../libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md) (the
   tokenizer/tree/selector parser/scoped rewriter,
-  [#60](https://github.com/assimalign/vuecs/issues/60))
+  [#60](https://github.com/assimalign/viu/issues/60))
 
 ---
 
@@ -54,12 +54,12 @@ MSBuild pipeline — and no single library's `docs/DESIGN.md` owns the whole pic
 
 Viu already compiles `.viu` single-file components at build time through the
 `Assimalign.Viu.Syntax.*` cluster and the `SingleFileComponentGenerator`
-([#58](https://github.com/assimalign/vuecs/issues/58)). The utility-first CSS engine is the **flagship
+([#58](https://github.com/assimalign/viu/issues/58)). The utility-first CSS engine is the **flagship
 second consumer** of the same machinery — the role a Tailwind Vite plugin plays alongside
 `@vitejs/plugin-vue` in a Vue build. It reuses three landed foundations:
 
 1. **The registration seam** ([`Assimalign.Viu.Syntax`](../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md),
-   [#127](https://github.com/assimalign/vuecs/issues/127)). `AggregateSyntaxParserOptions<T>.RegisterParser(SyntaxSourcePredicate, SyntaxParser)`
+   [#127](https://github.com/assimalign/viu/issues/127)). `AggregateSyntaxParserOptions<T>.RegisterParser(SyntaxSourcePredicate, SyntaxParser)`
    is the seam a composition root uses to attach a parser to a block name, `lang`, or file type
    without the container library referencing it. The utility engine registers its own extraction
    pass here — "language libraries never reference each other; the composition root constructs the
@@ -68,7 +68,7 @@ second consumer** of the same machinery — the role a Tailwind Vite plugin play
    use.
 
 2. **The CSS AST and emitters** ([`Assimalign.Viu.Syntax.Css`](../libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md),
-   [#60](https://github.com/assimalign/vuecs/issues/60)). The two-phase tokenizer (`CssTokenizer`) →
+   [#60](https://github.com/assimalign/viu/issues/60)). The two-phase tokenizer (`CssTokenizer`) →
    context-directed rule parser (`CssParseEngine`), the record-graph tree (`CssStylesheetNode`,
    `CssQualifiedRuleNode`, `CssDeclarationNode`, …), the flat selector model, and the deterministic
    canonical serializer behind `CssScopedRewriter` are all reusable. The Css DESIGN already names
@@ -79,7 +79,7 @@ second consumer** of the same machinery — the role a Tailwind Vite plugin play
 
 3. **The incremental generator pipeline and its MSBuild integration**
    (`SingleFileComponentGenerator`, `.props`/`.targets`,
-   [#58](https://github.com/assimalign/vuecs/issues/58)). `.viu` files already flow in as
+   [#58](https://github.com/assimalign/viu/issues/58)). `.viu` files already flow in as
    `AdditionalFiles`; every pipeline stage is a value-equatable record; the RS1035 content-file
    limitation (a source generator emits C#, not files, and `System.IO` is banned in the analyzer
    sandbox) is already documented, with the extracted CSS surfacing as the generated `ExtractedStyles`
@@ -390,12 +390,12 @@ Css library owns rule-level CSS parsing and serialization; each higher feature o
 | **Programmatic rule construction** (new, [§7](#7-work-item-breakdown) V01.01.12.11) | `Assimalign.Viu.Syntax.Css` | **utility engine** (scoped CSS never needed it because it rewrites an existing tree) |
 | Scoped `[data-v-…]` selector rewrite (`CssScopedRewriter`) | `Assimalign.Viu.Syntax.Css` | scoped CSS; utility engine **only in optional scoped-utility mode** |
 | Candidate grammar + resolver | utility engine core | — (owned) |
-| Local module-class hashing + `v-bind()`→`var()` rewrite | CSS Modules ([#62](https://github.com/assimalign/vuecs/issues/62)) | — (owned) |
+| Local module-class hashing + `v-bind()`→`var()` rewrite | CSS Modules ([#62](https://github.com/assimalign/viu/issues/62)) | — (owned) |
 
 The utility engine **reuses** the tokenizer/tree/serializer and **adds** a construction surface; it
 does not modify or fork the parser.
 
-### 5.2 Composition with scoped CSS ([#60](https://github.com/assimalign/vuecs/issues/60), landed)
+### 5.2 Composition with scoped CSS ([#60](https://github.com/assimalign/viu/issues/60), landed)
 
 Tailwind utilities are **global by design** — `bg-blue-500` means the same thing everywhere. So the
 utility stylesheet is emitted **once, globally, un-scoped** — it is *not* rewritten with any
@@ -407,7 +407,7 @@ scoped-utility mode** (per-component utilities that *are* rewritten with the com
 reuse `CssScopedRewriter` unchanged — this is the "for its own scoping, `CssScopedRewriter`" reuse the
 Css DESIGN anticipates — but it is off by default and deferred (OQ-6).
 
-### 5.3 Composition with CSS Modules and `v-bind()` ([#62](https://github.com/assimalign/vuecs/issues/62), in flight)
+### 5.3 Composition with CSS Modules and `v-bind()` ([#62](https://github.com/assimalign/viu/issues/62), in flight)
 
 Designed against #62's **issue contract**, not its in-progress code:
 
@@ -423,7 +423,7 @@ Designed against #62's **issue contract**, not its in-progress code:
   (`bg-[var(--brand)]`) — which just works, because the arbitrary value is emitted verbatim.
 - Hash determinism: where the utility engine ever needs a component-scoped hash (scoped-utility mode,
   OQ-6), it uses the **same FNV-1a-over-project-relative-path scheme** as `StyleScopeId`
-  ([#60](https://github.com/assimalign/vuecs/issues/60)), so all three features agree on hashing.
+  ([#60](https://github.com/assimalign/viu/issues/60)), so all three features agree on hashing.
 
 ### 5.4 `@apply`
 
@@ -473,7 +473,7 @@ sets, keyed so it is skipped when no per-file set changed.
   hit). Edits that add a genuinely new utility re-run only stages 4–6 over the whole (small) set.
 - The **`ViuBundleCss`** task is gated by MSBuild `Inputs`/`Outputs`, so a no-op build does no CSS
   file work.
-- A **budget** to hold the line (validated by the [#95](https://github.com/assimalign/vuecs/issues/95)
+- A **budget** to hold the line (validated by the [#95](https://github.com/assimalign/viu/issues/95)
   size/AOT gates, extended per V01.01.12.16): full generation for the reference sample stays within a
   low-tens-of-milliseconds share of the build, and the runtime WASM payload gains **zero** bytes of
   CSS-generation code (only the static `.css` asset, which is not in the WASM module).
@@ -483,11 +483,11 @@ sets, keyed so it is skipped when no per-file set changed.
 ## 7. Work-item breakdown
 
 Proposed as **sibling features under area [V01.01.12] Framework - Tooling**
-([#89](https://github.com/assimalign/vuecs/issues/89)) — the parent area of this scoping feature
+([#89](https://github.com/assimalign/viu/issues/89)) — the parent area of this scoping feature
 [V01.01.12.10]. The existing Tooling features run `.01`–`.10`
-(`.08` = [#104](https://github.com/assimalign/vuecs/issues/104),
-`.09` = [#125](https://github.com/assimalign/vuecs/issues/125),
-`.10` = [#129](https://github.com/assimalign/vuecs/issues/129), this item), so the next free feature
+(`.08` = [#104](https://github.com/assimalign/viu/issues/104),
+`.09` = [#125](https://github.com/assimalign/viu/issues/125),
+`.10` = [#129](https://github.com/assimalign/viu/issues/129), this item), so the next free feature
 codes are **`.11`+**. Tasks under a feature take `<feature>.NN`. Codes and metadata are **proposals**
 for the orchestrator to validate against the live board before filing via the
 [`viu-work-items` skill](../.claude/skills/viu-work-items/SKILL.md); the skill computes the next
@@ -515,7 +515,7 @@ scoped CSS (W04) also wants bundling and they unblock everything else. The engin
 
 Each feature body below is **file-ready** (repo issue-body standard: `## Summary` →
 `## Acceptance Criteria` → `### Standards and Compliance` → `### Architectural boundaries`, per
-[#62](https://github.com/assimalign/vuecs/issues/62)/[#129](https://github.com/assimalign/vuecs/issues/129)).
+[#62](https://github.com/assimalign/viu/issues/62)/[#129](https://github.com/assimalign/viu/issues/129)).
 Representative child tasks are listed for the two largest features (`.15`, `.16`).
 
 ---
@@ -902,7 +902,7 @@ implementation is not blocked.
 
 ## 9. Acceptance-criteria traceability
 
-Mapping each [#129](https://github.com/assimalign/vuecs/issues/129) acceptance criterion to where this
+Mapping each [#129](https://github.com/assimalign/viu/issues/129) acceptance criterion to where this
 document satisfies it.
 
 | #129 criterion | Satisfied in |

--- a/docs/adr/0001-source-generators-over-reflection.md
+++ b/docs/adr/0001-source-generators-over-reflection.md
@@ -1,0 +1,67 @@
+# ADR-0001: Roslyn source generators over reflection and dynamic code generation
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** Repo-wide — every `Assimalign.Viu.*` runtime library and every build-time generator.
+
+## Context
+
+Viu targets the browser through the .NET WebAssembly build tools, which is AOT and trimming
+territory (mono-wasm today, NativeAOT-shaped constraints throughout). Two pillars of Vue 3 are
+unavailable or unsafe there:
+
+- Vue models `reactive(obj)` with a JavaScript [`Proxy`](https://vuejs.org/guide/extras/reactivity-in-depth.html),
+  which has no AOT-safe .NET equivalent (a `DispatchProxy`/`Reflection.Emit` analogue is dynamic
+  codegen).
+- Vue's full build compiles templates at runtime with `new Function` (see
+  [ADR-0005](0005-no-runtime-template-compilation.md)) — impossible in WASM.
+
+Reflection-based serialization, `Reflection.Emit`, compiled expression trees, and linker-unfriendly
+activation (`Activator.CreateInstance` over discovered types) are all trimming-hostile: the linker
+cannot prove what stays reachable, so it either bloats output or breaks at runtime.
+
+## Decision
+
+**Roslyn source generators are the sanctioned mechanism for everything Vue achieves with `Proxy` or
+runtime `new Function`.** Concretely, repo-wide:
+
+- No reflection-based serialization, no dynamic code generation, no linker-unfriendly activation
+  paths. Shipping libraries set `<IsAotCompatible>true</IsAotCompatible>`.
+- Compile-time metaprogramming is a Roslyn incremental source generator. Component and reactive
+  metadata are emitted at build time, never discovered by reflection at runtime; component
+  factories are source-generated, never reflection-activated.
+
+Deviating from AOT/trimming safety requires explicit confirmation and a documented, test-pinned
+exception (see [`.claude/rules/deviations.md`](../../.claude/rules/deviations.md)).
+
+## Consequences
+
+- `reactive()` becomes `[Reactive]`/`[ShallowReactive]` partial classes whose property wrappers are
+  emitted by `Assimalign.Viu.Reactivity.Generators` (see [ADR-0002](0002-ref-first-reactivity.md)).
+- `.viu` single-file components and templates compile through `Assimalign.Viu.Syntax.Generators`
+  (see [ADR-0005](0005-no-runtime-template-compilation.md)).
+- Generator inputs and outputs must be **value-equatable** so the incremental-generator cache holds
+  — this shapes the whole `Assimalign.Viu.Syntax.*` cluster (immutable records, `SyntaxList<T>`; see
+  [`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md)).
+- Generators run in netstandard2.0 analyzer hosts with no file/network I/O and are delivered to SDK
+  consumers through the `Assimalign.Viu.App.Ref` targeting pack's `analyzers/dotnet/cs/` (see
+  [`docs/PLAN.md`](../PLAN.md) founding decision 8).
+- Each area publishes a representative WASM consumer with trimming validation; size and startup
+  budgets gate CI from W03.
+
+## Alternatives considered
+
+- **Reflection / dynamic codegen** (`Reflection.Emit`, compiled expression trees, `DispatchProxy`) —
+  the most direct port of Vue's `Proxy`, rejected outright: forbidden by the AOT/trimming constraint.
+- **MSBuild tasks for all codegen** — rejected for the reactive and template generators because it
+  forfeits IDE integration and incrementality. The generators stay Roslyn incremental generators;
+  MSBuild tasks are used only where a generator legally cannot act — emitting a *content* file
+  (RS1035), as the `ViuBundleCss` task does (`docs/PLAN.md` founding decision 8).
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decisions 2, 3, 6, and 8.
+- [`.claude/rules/general-rules.md`](../../.claude/rules/general-rules.md) — the AOT/trimming hard
+  constraints.
+- Vue 3: [reactivity in depth](https://vuejs.org/guide/extras/reactivity-in-depth.html),
+  [rendering mechanism](https://vuejs.org/guide/extras/rendering-mechanism.html).

--- a/docs/adr/0002-ref-first-reactivity.md
+++ b/docs/adr/0002-ref-first-reactivity.md
@@ -1,0 +1,58 @@
+# ADR-0002: Ref-first reactivity instead of JavaScript `Proxy`
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.Reactivity` and every consumer of it (`RuntimeCore`, the compiler's
+  expression-binding contract).
+
+## Context
+
+Vue 3's public reactivity story leads with `reactive(obj)` — a deep [`Proxy`](https://vuejs.org/api/reactivity-core.html#reactive)
+that intercepts every property read and write and auto-unwraps refs on access — and treats `ref()`
+as the primitive for standalone values. The `Proxy` is unavailable AOT/trimming-safe in WASM (see
+[ADR-0001](0001-source-generators-over-reflection.md)). However, Vue 3.5's *own* ref internals are a
+plain getter/setter over a dependency with explicit track-on-read / trigger-on-write, plus a
+version-counter and doubly-linked-list dependency graph — all of which port to C# directly.
+
+## Decision
+
+**`Ref<T>`-style references are the primary reactive primitive; there is no `Proxy`.**
+
+- `Reference<T>` (Vue's `ref()`), `ShallowReference<T>` (`shallowRef()`), `CustomReference<T>`
+  (`customRef()`), and `Computed<T>` (`computed()`) are plain C# types with a settable `Value`
+  property that tracks on read and triggers on write. The static `Reactive` facade mirrors the
+  `@vue/reactivity` API surface (refs, computeds, effects, scopes, tracking control, batching).
+- `reactive(obj)` becomes a `[Reactive]` partial class whose per-property reactive wrappers are
+  emitted by `Assimalign.Viu.Reactivity.Generators` — not a runtime-proxied object.
+- Reactive collections are dedicated types — `ReactiveList<T>`, `ReactiveDictionary<TKey,TValue>`,
+  `ReactiveSet<T>` — implementing the BCL collection interfaces, **not** proxied BCL types.
+- The dependency engine ports Vue 3.5's version-counter + doubly-linked-list subscriber design.
+- The model is single-threaded (the JS event loop); ambient tracking state is `static` and not
+  thread-safe by design.
+
+## Consequences
+
+- **The compiler, not a runtime proxy, decides every access form.** With no `Proxy` to auto-unwrap
+  refs, a template that reads a ref must emit `.Value`, and — because `Ref<T>.Value` is a settable
+  property — compound assignment and increment (`count++`, `count += 1`) rewrite cleanly to
+  `count.Value …`. This is the expression-binding contract pinned in
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md);
+  a change to `Ref<T>.Value` requires a matching change there.
+- No implicit deep reactivity: authors reach for `[Reactive]` classes or reactive collections
+  explicitly, which is more predictable but less magical than a deep `Proxy`.
+- Escape hatches and introspection (`unref`/`isRef`, raw markers) are provided explicitly rather
+  than falling out of proxy identity.
+
+## Alternatives considered
+
+- **A `Proxy` analogue** (`DispatchProxy`, `Reflection.Emit`) — rejected under
+  [ADR-0001](0001-source-generators-over-reflection.md): trimming-unsafe.
+- **Proxied BCL collections** — impossible without a `Proxy`; dedicated reactive collection types
+  give the same reactivity with AOT-safe, allocation-predictable code.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 2.
+- [`Assimalign.Viu.Reactivity/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md).
+- Vue 3: [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity),
+  [Reactivity API: Core](https://vuejs.org/api/reactivity-core.html).

--- a/docs/adr/0003-batched-interop-dom-operations.md
+++ b/docs/adr/0003-batched-interop-dom-operations.md
@@ -1,0 +1,62 @@
+# ADR-0003: Batched JS-interop DOM operations as the performance budget
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.RuntimeDom`, `Assimalign.Viu.RuntimeCore` (renderer, scheduler, block
+  tree), `Assimalign.Viu.Shared` (the flag vocabulary), and the compiler's static-optimization
+  passes.
+
+## Context
+
+In a browser WASM app every DOM mutation crosses the .NET ↔ JavaScript interop boundary, and that
+marshaling is the framework's dominant per-operation cost — far more so than the equivalent property
+access in Vue's JavaScript runtime. Vue's [compiler-informed rendering](https://vuejs.org/guide/extras/rendering-mechanism.html)
+(patch flags, shape flags, the block tree that flattens dynamic descendants) exists to skip work;
+on WASM each skipped patch visit is additionally a **marshaling round-trip avoided**, so the same
+idea pays off more.
+
+## Decision
+
+**The interop boundary is Viu's performance budget, and the runtime is organized to spend as few
+crossings as possible and keep each one cheap.**
+
+- Decision logic lives in .NET; the JS side is a dumb applier. Patch operations batch into a
+  command buffer applied by **one** JS call per scheduler flush.
+- Events use the invoker pattern: one delegated JS listener per (element, event); a re-rendered
+  handler is a .NET delegate swap on the invoker — zero `addEventListener`/`removeEventListener`
+  interop between renders.
+- Static content is stringified aggressively and inserted via `innerHTML` (`insertStaticContent`),
+  collapsing many node ops into one.
+- The compiler and runtime share the `PatchFlags`/`ShapeFlags`/`SlotFlags` bitmask vocabulary (in
+  `Assimalign.Viu.Shared`); the renderer patches only what the flags mark dynamic, and the block
+  tree flattens dynamic nodes so patching skips the static structure.
+- JS-side handles and event listeners are always cleaned up deterministically (two-sided release).
+
+## Consequences
+
+- Node identity crosses the boundary as **int handles**, not `JSObject` proxies — the measured,
+  RuntimeDom-local realization of this budget, recorded in
+  [`Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md).
+- The command buffer requires primitive-typed ops (opcode + int + string), which int handles
+  satisfy and proxies would not.
+- The compiler carries static hoisting and stringification passes (`cacheStatic` / `stringifyStatic`)
+  whose payoff is counted in avoided interop calls — see
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md).
+- WASM size and startup budgets gate CI from W03; a benchmark suite ([V01.01.11.04]) re-measures
+  interop cost under AOT.
+
+## Alternatives considered
+
+- **Per-operation interop** (a JS call per node op) — the naive port, rejected: it spends the exact
+  resource that is scarcest.
+- **`JSObject` proxy per node** — natural JS ergonomics, but measured ~2× slower for node
+  creation/teardown and incompatible with the batched command buffer; see the RuntimeDom ADR-0001
+  measurement.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decisions 1 and 4.
+- [`Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md),
+  [`DESIGN.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md), and its
+  [ADR-0001](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md).
+- Vue 3: [rendering mechanism](https://vuejs.org/guide/extras/rendering-mechanism.html).

--- a/docs/adr/0004-composition-only-component-model.md
+++ b/docs/adr/0004-composition-only-component-model.md
@@ -1,0 +1,59 @@
+# ADR-0004: Composition-only component model (no Options API, mixins, or global properties)
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.RuntimeCore` — the component instance, setup model, app API, and
+  provide/inject.
+
+## Context
+
+Vue 3 supports two authoring styles: the [Options API](https://vuejs.org/guide/typescript/options-api.html)
+(`data`/`methods`/`computed` merged onto a `this` context) and the
+[Composition API](https://vuejs.org/guide/extras/composition-api-faq.html) (`setup()` returning
+reactive state). It also offers [mixins](https://vuejs.org/api/options-composition.html#mixins) for
+sharing option fragments and
+[`app.config.globalProperties`](https://vuejs.org/api/application.html#app-config-globalproperties)
+for injecting ambient members onto every component's `this`.
+
+The Options API and mixins depend on runtime option resolution and `this`-based merging; global
+properties inject untyped ambient members. All three fight static typing and add reflection-shaped
+runtime machinery — a poor fit for an AOT/trimming target and for C#'s type system.
+
+## Decision
+
+**Viu ships a composition-only component model.**
+
+- No Options API and no mixins: component logic is expressed in a setup function returning reactive
+  state (refs, computeds) and handlers.
+- No `app.config.globalProperties`: cross-cutting values are supplied through **typed
+  provide/inject** (`InjectionKey<T>`, app-level `Provide<T>`) and plugins (`IPlugin<TNode>`).
+- `Application<TNode>` (the C# port of `createAppAPI(render)`) and `ApplicationConfiguration`
+  deliberately exclude a global-properties bag; `ApplicationConfiguration` carries the error
+  handler, warn handler, and performance flag only. This exclusion is called out in
+  `Application<TNode>`'s own XML docs, which reference this ADR.
+
+## Consequences
+
+- Composition functions and typed provide/inject replace every Options-API and mixin use case;
+  shared behavior is a plain function, and shared state is an injected, typed value.
+- Cross-cutting registration (components, directives, app-level provides) flows through the app API
+  and plugins, all typed.
+- Easier: static typing end to end, trimming safety, and no `this`-merge order ambiguity. Harder:
+  there is no drop-in Options API path for Vue authors migrating Options-style components — that is
+  the accepted cost of the divergence.
+
+## Alternatives considered
+
+- **Support the Options API and mixins** — rejected: runtime option merging is untyped, reflection-
+  shaped, and reintroduces the `this`-merge ambiguity even Vue's own guidance steers larger apps
+  away from.
+- **Provide `globalProperties`** — rejected: untyped ambient state that the trimmer cannot reason
+  about; typed provide/inject covers the same need with compile-time safety.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 5.
+- [`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md)
+  and `Application<TNode>` / `ApplicationConfiguration`.
+- Vue 3: [Composition API FAQ](https://vuejs.org/guide/extras/composition-api-faq.html),
+  [provide/inject](https://vuejs.org/guide/components/provide-inject.html).

--- a/docs/adr/0005-no-runtime-template-compilation.md
+++ b/docs/adr/0005-no-runtime-template-compilation.md
@@ -1,0 +1,56 @@
+# ADR-0005: No runtime template compilation (build-time source generators only)
+
+- **Status:** Accepted
+- **Date:** 2026-07-17 (the build-time `.viu` compilation container was decided this date, `docs/PLAN.md`
+  founding decision 3; formally recorded as an ADR under [V01.01.13.01], #98, on 2026-07-19)
+- **Scope:** `Assimalign.Viu.Syntax.Templates`, `Assimalign.Viu.Syntax.SingleFileComponent`, and the
+  `Assimalign.Viu.Syntax.Generators` composition root.
+
+## Context
+
+Vue's full build compiles templates to render functions at runtime with `new Function` (its
+in-browser compiler). That path is impossible in WASM — dynamic code generation is forbidden AOT
+(see [ADR-0001](0001-source-generators-over-reflection.md)). Vue's own guidance already prefers a
+build step so the runtime ships without the compiler; Viu makes the build step mandatory.
+
+## Decision
+
+**Templates and `.viu` single-file components compile at build time only, via Roslyn source
+generators; there is no runtime compilation path.**
+
+- The template front end (`Assimalign.Viu.Syntax.Templates`) tokenizes, parses, transforms, and
+  emits a C# render method; `Assimalign.Viu.Syntax.Generators` is the incremental generator that
+  drives it and stitches the output into the component's partial class.
+- There is no runtime `compile(templateString)` API — a template that is not present at build time
+  cannot be rendered.
+- The `.viu` container uses `@template`/`@script`/`@style` `@`-block syntax — a deliberate divergence
+  from Vue's tag-based SFC container (decided 2026-07-17). The **markup inside `@template` remains
+  standard Vue template syntax**; only the container framing differs. The container is specified in
+  [`Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md).
+
+## Consequences
+
+- Compilation is compiler-grade tooling: diagnostics carry template source locations mapped back to
+  the `.viu` file (Roslyn `#line`), so C# errors in a template expression point at the real line and
+  column — the tooling story reaches Razor-grade because it *is* a compiler.
+- The JavaScript-to-C# serialization divergences (no comma operator, no object literals with
+  arbitrary keys, `.Value` unwrapping, `undefined`→`null`, …) are documented and test-pinned in
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md).
+- Compiler-informed patch flags, block trees, and static hoisting all fall out of build-time
+  compilation and feed the interop budget ([ADR-0003](0003-batched-interop-dom-operations.md)).
+- Dynamic, string-sourced templates are unsupported by design.
+
+## Alternatives considered
+
+- **A runtime compiler** (`new Function` equivalent) — impossible/forbidden AOT.
+- **A runtime template interpreter** — technically AOT-safe but rejected: it forfeits compiler-
+  informed patch flags and static hoisting, adds per-render cost, and gives up the build-time
+  diagnostics that make the authoring experience strong.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 3.
+- [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md)
+  and [`Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md).
+- Vue 3: [render functions](https://vuejs.org/guide/extras/render-function.html),
+  [SFC spec](https://vuejs.org/api/sfc-spec.html).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture decision records
+
+This is Viu's append-only log of architecture decisions — the *why* behind the choices that shape
+the framework, especially the deliberate C#/WASM divergences from Vue 3. The narrative summary of
+these decisions lives in [`docs/PLAN.md`](../PLAN.md) ("Founding design decisions"); this directory
+records each one as a standalone, citable document a future session can act on without that
+conversation's context.
+
+## Conventions
+
+- **Numbering.** ADRs are numbered sequentially from `0001`, zero-padded to four digits. The
+  filename is `NNNN-kebab-case-title.md`; the document title is `# ADR-NNNN: <decision>`.
+- **Append-only.** An ADR is never rewritten to change a past decision. To change course, add a new
+  ADR that supersedes the old one: set the new ADR's status to `Accepted`, set the old ADR's status
+  to `Superseded by ADR-NNNN` with a link to the new record, and link both ways. History is
+  preserved, not edited.
+  (Correcting a typo or a broken link is fine; reversing the recorded decision is not.)
+- **Template.** Copy [`template.md`](template.md) for a new record.
+- **When to write one.** Any decision with lasting architectural consequence — a divergence from
+  vuejs/core semantics, a cross-cutting constraint, a technology or boundary choice. Small, local
+  choices belong in the relevant `DESIGN.md`, not here.
+
+## Repo-level versus library-level ADRs
+
+This directory holds **repo-wide and cross-cutting** decisions. A decision that is contained within
+a single library — measured, library-specific, and unlikely to be cited elsewhere — may instead live
+in that library's `docs/` folder as a local ADR. The existing example is
+[`Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md)
+(int-handle node identity over `JSObject` proxies), which is the RuntimeDom-local realization of the
+repo-wide budget recorded here in [ADR-0003](0003-batched-interop-dom-operations.md). Library-local
+ADRs keep their own numbering within their library folder.
+
+## Index
+
+| ADR | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-source-generators-over-reflection.md) | Roslyn source generators over reflection and dynamic code generation | Accepted |
+| [0002](0002-ref-first-reactivity.md) | Ref-first reactivity instead of JavaScript `Proxy` | Accepted |
+| [0003](0003-batched-interop-dom-operations.md) | Batched JS-interop DOM operations as the performance budget | Accepted |
+| [0004](0004-composition-only-component-model.md) | Composition-only component model (no Options API, mixins, or global properties) | Accepted |
+| [0005](0005-no-runtime-template-compilation.md) | No runtime template compilation (build-time source generators only) | Accepted |
+
+See also [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for how ADRs fit into the wider documentation
+convention.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,34 @@
+# ADR-NNNN: <short decision title, stated as the decision>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN (link the superseding record) | Deprecated
+- **Date:** YYYY-MM-DD (the date the decision was made; keep the original when superseding)
+- **Work item:** [V01.01.NN.MM] (#issue), when the decision was made under one
+- **Scope:** which area(s) the decision governs (repo-wide, or specific `Assimalign.Viu.*` libraries)
+
+## Context
+
+The forces at play: what problem this decides, the constraints that bound it (AOT/trimming, the
+WASM interop budget, upstream Vue 3 parity, the single-threaded model), and the relevant upstream
+Vue 3 behavior. Link the authoritative reference — vuejs.org or the specific `vuejs/core` source
+file/module — so the parity baseline the decision diverges from (or preserves) is explicit.
+
+## Decision
+
+The decision itself, in active voice ("We use X"), specific enough that a future session can apply
+it without this conversation's context. State the rule, not just the sentiment.
+
+## Consequences
+
+What becomes easier and what becomes harder. Include the follow-on obligations the decision creates
+(new seams to maintain, tests that pin the chosen behavior, budgets to gate) and the deltas from
+Vue 3 that the decision commits Viu to.
+
+## Alternatives considered
+
+Each seriously weighed option and why it was not chosen. For a measured decision, cite the
+measurement (link the harness/benchmark). This is where a superseding ADR will look first.
+
+## References
+
+- Vue 3 counterpart(s): vuejs.org guide / `vuejs/core` package or source file.
+- Related ADRs, `docs/PLAN.md` founding decisions, per-library `DESIGN.md` sections.

--- a/libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md
@@ -1,0 +1,54 @@
+# Assimalign.Viu.Reactivity — design
+
+Why the reactive core is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterpart: [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity) (v3.5).
+
+## Ref-first, no `Proxy`
+
+The founding divergence is [ADR-0002](../../../docs/adr/0002-ref-first-reactivity.md): Vue's public
+lead is the deep `Proxy` (`reactive(obj)`), which is not AOT/trimming-safe in WASM. Viu leads with
+references instead. `Reference<T>` and `Computed<T>` are plain getter/setter types that track on read
+and trigger on write — Vue 3.5's own ref internals port directly. `reactive(obj)` becomes a
+`[Reactive]` partial class whose property wrappers a source generator emits, and reactive collections
+are dedicated types rather than proxied BCL collections.
+
+## The dependency engine
+
+The engine ports Vue 3.5's **version-counter + doubly-linked-list** design: a `Dependency` holds
+subscribers, a `Subscriber` holds its dependencies, and the `Link` nodes between them (internal) are
+reused across runs so a stable dependency set allocates nothing on re-track. Batching
+(`StartBatch`/`EndBatch`) coalesces triggers so multiple writes produce at most one run per effect;
+`PauseTracking`/`ResetTracking` gate collection.
+
+`Subscriber` is a **`public abstract` class with `internal` members and a `private protected`
+constructor** — opaque and un-subclassable externally, but a real base so the engine's hot path
+(per-trigger notification) dispatches through a vtable virtual call rather than interface dispatch,
+which is measurably costlier on mono-wasm / NativeAOT (the repo's "dispatch on hot paths" rule).
+Concrete leaves (`ReactiveEffect`, `Computed<T>`) are `sealed` so the JIT can devirtualize.
+
+## The compiler contract
+
+Because there is no runtime `Proxy` to auto-unwrap refs, the *compiler* decides every access form,
+and `Ref<T>.Value` being a **settable property** is what makes it work: `count.Value` serves both
+reads and writes, so `count++` and `count += 1` rewrite cleanly. This library owns the `Value`
+semantics; the template compiler's expression-binding table
+([`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../Assimalign.Viu.Syntax.Templates/docs/DESIGN.md))
+is pinned to it — a change to `Value` requires a matching change there.
+
+## Deltas from Vue 3
+
+- **`.Value` in read and write positions** replaces Vue's read-time `unref` plus `isRef`-guarded
+  assignment (forced by, and enabled by, C# properties).
+- **`effect()` stops the effect if its first run throws** before rethrowing (upstream `effect()`
+  parity), so a failed effect leaves no live subscriptions.
+- **The abstract-base hot-path model** (over interfaces) is a deliberate C#/WASM performance shape
+  with no upstream analogue — JavaScript has no equivalent dispatch cost.
+- **Reactive collections are concrete types**, not proxied BCL types; behavior tracks the mutation
+  triggers Vue's collection handlers fire.
+
+## Non-goals
+
+- No deep implicit reactivity without `[Reactive]` or a reactive collection — reactivity is opted
+  into explicitly.
+- Reactivity escape hatches and introspection beyond the current surface are sequenced work
+  ([V01.01.02.09]).

--- a/libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md
@@ -1,0 +1,38 @@
+# Assimalign.Viu.Reactivity — overview
+
+The reactive core of Viu — the C# port of
+[`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity): dependencies,
+refs, computeds, effects, effect scopes, watch, reactive collections, and source-generated reactive
+objects. It is Ref-first — there is no JavaScript `Proxy` (see
+[ADR-0002](../../../docs/adr/0002-ref-first-reactivity.md)). Area: `V01.01.02`.
+
+## Public surface
+
+- **`Reactive`** (static facade) — the `@vue/reactivity` API surface: `Reference`/`ShallowReference`/
+  `CustomReference`/`Computed`, `Effect`, `EffectScope`, `OnScopeDispose`, `TriggerReference`,
+  `PauseTracking`/`ResetTracking`, and `StartBatch`/`EndBatch`.
+- **References** — `Reference<T>` (Vue's `ref()`), `ShallowReference<T>` (`shallowRef()`),
+  `CustomReference<T>` (`customRef()`), and `Computed<T>` (`computed()`, lazy versioned caching).
+  All expose a settable `Value` and implement `IReference` / `IReference<T>`.
+- **Effects and scopes** — `ReactiveEffect` (the effect runner with scheduler injection),
+  `EffectScope` (hierarchical disposal, `effectScope()`), `Dependency` (the tracked-dependency
+  primitive), and `Subscriber` (the opaque `public abstract` base for effect-like subscribers).
+- **Watch** — `WatchOptions`, `WatchHandle`, `WatchJob`, `WatchFlushMode`, the `WatchCallback<T>` and
+  `OnCleanup` delegates, and the `IWatchScheduler` seam a host (the runtime scheduler) plugs into.
+- **Source-generated reactive objects** — the `[Reactive]` / `[ShallowReactive]` attributes
+  (`ReactiveAttribute` / `ShallowReactiveAttribute`); a companion source generator emits the
+  reactive property wrappers for the annotated partial class (Vue's `reactive()`).
+- **Reactive collections** — `ReactiveList<T>`, `ReactiveDictionary<TKey,TValue>`, `ReactiveSet<T>`
+  (dedicated reactive types implementing the BCL collection interfaces).
+- **Traversal and introspection** — `ReactiveTraversal`, `IReactiveTraversable`, `IReactiveObject`,
+  `IReadonlyReactive`.
+
+## Boundaries
+
+- **No `Assimalign.Viu.*` project references** — a standalone base alongside `Assimalign.Viu.Shared`.
+  Ships as a net10.0 runtime library with `IsAotCompatible=true`, and **carries the `[Reactive]`
+  source generator as an analyzer** so any consumer that references this library gets `[Reactive]`
+  support with no extra wiring.
+- **Single-threaded** (the JS event-loop model): ambient tracking state is `static` and not
+  thread-safe by design.
+- Design rationale, the dependency-engine port, and the compiler contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -1,0 +1,63 @@
+# Assimalign.Viu.RuntimeCore — design
+
+Why the platform-agnostic runtime is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md).
+Upstream counterpart: [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core).
+
+## The renderer is platform-agnostic by construction
+
+`RendererFactory.CreateRenderer(options)` (Vue's `createRenderer(RendererOptions)`) builds the
+mount/patch/unmount pipeline over an injected `RendererOptions<TNode>` — the platform node-ops
+(create/insert/remove/text, `patchProp`, static-content insert). **The core never performs interop
+itself.** `TNode` is the platform node type: `int` handles for the browser
+(`Assimalign.Viu.RuntimeDom`), `TestNode` for the in-memory renderer (`Assimalign.Viu.Testing`).
+This single seam is what lets the browser and the DOM-free test host share one renderer, and it is
+the exact shape upstream's `createRenderer` takes.
+
+## Compiler-informed patching, decoupled from the compiler
+
+The renderer reads the `PatchFlags`/`ShapeFlags` a vnode carries (from `Assimalign.Viu.Shared`) and
+patches only what the flags mark dynamic; the block tree (`BlockToken`) flattens dynamic descendants
+so the static structure is skipped. On WASM this is the interop budget in action (see
+[ADR-0003](../../../docs/adr/0003-batched-interop-dom-operations.md)).
+
+Compiler-generated render methods bind to `RenderHelpers` **by name** (`_openBlock`,
+`_createElementBlock`, …) through a `using static`, so this library and the template compiler share a
+contract without a project reference in either direction. The helper members deliberately carry the
+upstream-aliased names (a generated-code-only exception to the whole-word naming rule — the names
+*are* the contract). The counterpart contract lives in
+[`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../Assimalign.Viu.Syntax.Templates/docs/DESIGN.md);
+build-time compilation is [ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md).
+
+## Scheduler and reactive re-render
+
+A component's render is a `RenderEffect<TNode>` — a `ReactiveEffect` (from
+`Assimalign.Viu.Reactivity`) whose scheduler enqueues the component's update job on the `Scheduler`.
+The `Scheduler` batches jobs into flush phases with `NextTick`; the internal `RuntimeWatchScheduler`
+bridges Reactivity's `IWatchScheduler` seam to the same queue so `ViuWatch` flushes with rendering.
+This is how the stopwatch re-renders reactively instead of polling.
+
+## Composition-only component model
+
+Per [ADR-0004](../../../docs/adr/0004-composition-only-component-model.md), the component model is
+composition-only: a `ComponentInstance` runs a setup function; props/emits/slots/lifecycle are
+typed; cross-cutting values flow through typed provide/inject (`InjectionKey<T>`) and plugins
+(`IPlugin<TNode>`). `Application<TNode>` and `ApplicationConfiguration` deliberately omit an
+`app.config.globalProperties` bag.
+
+## Deltas from Vue 3
+
+- **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*
+  members of `RenderHelpers`; they ship as `DomRenderHelpers` in `Assimalign.Viu.RuntimeDom`, so
+  runtime-core stays DOM-free and a real DOM directive can never mis-bind onto a runtime-core marker
+  (see [`Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md`](../../Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md)).
+- **`RenderHelpers` uses upstream-aliased member names** in generated code — a documented,
+  generated-code-only naming deviation.
+- **Hot-path dispatch** favors sealed types and abstract bases over interfaces where the JIT's
+  devirtualization matters on mono-wasm — a C#/WASM performance shape with no JS analogue.
+- Not thread-safe (single-threaded JS event-loop model).
+
+## Non-goals (sequenced work)
+
+- `Suspense` — [V01.01.03.20] (W06).
+- DOM `Transition`/`TransitionGroup` and custom elements — `Assimalign.Viu.RuntimeDom`.
+- Server-side rendering and hydration — `Assimalign.Viu.ServerRenderer` (a later area).

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Assimalign.Viu.RuntimeCore — overview
+
+The platform-agnostic runtime — the C# port of
+[`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core): the virtual
+DOM model, the renderer factory, the scheduler, the component model, provide/inject, the runtime
+directive system, and the built-in component scaffolding. It performs no DOM or JS interop itself —
+a platform package supplies the node-ops (the browser's `Assimalign.Viu.RuntimeDom`, tests'
+`Assimalign.Viu.Testing`). Area: `V01.01.03`.
+
+## Public surface
+
+- **Virtual DOM model** (`src/` root) — `VirtualNode` (the unified vnode: element / component /
+  text / comment / static / fragment via `VirtualNodeType` + a shape-flag bitmask),
+  `VirtualNodeFactory`, `VirtualNodeProperties`.
+- **Renderer** (`Rendering/`) — `RendererFactory.CreateRenderer(options)` (Vue's `createRenderer`),
+  `Renderer<TNode>` (the mount/patch/unmount pipeline), `RendererOptions<TNode>` (the injected
+  platform node-ops), `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
+- **Scheduler** (`Scheduling/`) — `Scheduler` (batched flush phases and `NextTick`) and
+  `SchedulerJob`.
+- **Component model** (`Components/`) — `ComponentInstance`, `ComponentSetupContext`,
+  `ComponentProperties` / `ComponentPropertyDefinition` (props declaration and validation),
+  `ComponentAttributes` (attrs fallthrough), `ComponentEmitDefinition` (emits), `ComponentSlots`,
+  `Lifecycle` (the hook registration facade), `DynamicComponents`, and the transition scaffolding
+  (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
+- **Application / plugins** — `Application<TNode>` (Vue's `createApp` shell: one root mounted into
+  one container), `ApplicationConfiguration` (error/warn handlers, performance flag),
+  `IComponentDefinition`, `IPlugin<TNode>`.
+- **Provide / inject** (`DependencyInjection/`) — `DependencyInjection` and the typed
+  `InjectionKey<T>`.
+- **Directives** (`Directives/`) — `IDirective`, `Directive`, `Directives`, `DirectiveBinding`,
+  `DirectiveArgument`, plus the `DirectiveHook` delegate.
+- **Watch** (`Watch/`) — `ViuWatch`, the runtime-scheduler-integrated `watch`/`watchEffect` over the
+  `Assimalign.Viu.Reactivity` primitives.
+- **`RenderHelpers`** — the static helper surface (`_openBlock`, `_createElementBlock`,
+  `_toDisplayString`, `_renderList`, …) that compiler-generated render methods bind to **by name**.
+
+## Boundaries
+
+- References **`Assimalign.Viu.Shared`** (the flag vocabulary) and **`Assimalign.Viu.Reactivity`**
+  only; it never references a platform/DOM package. Ships as a net10.0 runtime library with
+  `IsAotCompatible=true`.
+- **Composition-only** component model — no Options API, no mixins, no `app.config.globalProperties`
+  (see [ADR-0004](../../../docs/adr/0004-composition-only-component-model.md)).
+- Design rationale, the renderer seam, and the render-helper contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Shared/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Shared/docs/DESIGN.md
@@ -1,0 +1,42 @@
+# Assimalign.Viu.Shared — design
+
+Why the shared base is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterpart: [`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared).
+
+## The flags are a cross-boundary contract
+
+`PatchFlags`, `ShapeFlags`, and `SlotFlags` are not merely enums — they are the vocabulary the
+build-time compiler and the runtime share (PLAN founding decision 1). The compiler *stamps* a vnode
+with the flags describing what can change; the runtime *reads* them to patch only that and to skip
+static structure. On WASM this is doubly valuable: every patch visit skipped is a JS-interop
+round-trip avoided (see [ADR-0003](../../../docs/adr/0003-batched-interop-dom-operations.md)).
+
+Because two independently built artifacts must agree on every bit, the flag values are **pinned
+numerically to the upstream `@vue/shared` constants**, and the definition files are compiled into
+both sides from one source: `PatchFlags.cs` and `SlotFlags.cs` (and `Internal/DomKnowledgeData.cs`)
+are `<Compile Include>` links in the netstandard2.0 `Assimalign.Viu.Syntax.*` generator projects.
+There is no second copy to drift. Their paths are frozen; moving one means updating every linking
+csproj in the same change.
+
+## Pure data and pure functions only
+
+The library holds only bitmask enums, static lookup tables, and pure normalization functions. It has
+no vnodes, no reactivity, no renderer state — those belong to the layers above. This is what lets
+everything depend on it without a cycle, and what keeps it trivially AOT/trimming-safe.
+
+## Deltas from Vue 3
+
+- The flag enums are `[Flags]` C# enums with the upstream bit values; the extension methods
+  (`PatchFlagsExtensions`, `ShapeFlagsExtensions`) provide the `flag & X` tests upstream writes
+  inline in JavaScript.
+- Normalization ports `normalizeClass`/`normalizeStyle`/`toDisplayString`/`looseEqual`/`toNumber`
+  with C# type handling in place of JavaScript's coercions; the *observable* results track upstream.
+- Naming spells out whole words except the approved acronyms (DOM/HTML/CSS/SSR/AOT/JSON/WASM), so
+  identifiers read `DisplayStringFormatter`, not `ToDisplayString`-style abbreviations, while the XML
+  docs name the upstream function each ports.
+
+## Non-goals
+
+- No runtime types (vnodes, components, effects) — those are `RuntimeCore`/`Reactivity`.
+- No platform/DOM interop — `DomKnowledge` is static knowledge only; the live DOM bridge is
+  `Assimalign.Viu.RuntimeDom`.

--- a/libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md
@@ -1,0 +1,35 @@
+# Assimalign.Viu.Shared — overview
+
+The dependency-free base of the framework — the role
+[`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared) plays for Vue 3. It holds
+the bitmask vocabulary the compiler and runtime both speak, the class/style/display normalization
+helpers, and the DOM knowledge tables. It references no other `Assimalign.Viu.*` library; everything
+else in the framework sits above it. Area: `V01.01.01`.
+
+## What it contains
+
+- **The flag vocabulary** (currency types, `src/` root):
+  - **`PatchFlags`** (+ `PatchFlagsExtensions`, `PatchFlagNames`) — the compiler's patch hints
+    telling the runtime what on a vnode can change ([`@vue/shared` `patchFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/patchFlags.ts)).
+  - **`ShapeFlags`** (+ `ShapeFlagsExtensions`) — what a vnode *is* (element / component / text /
+    slot children shape), as a bitmask ([`shapeFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/shapeFlags.ts)).
+  - **`SlotFlags`** — slot stability classification ([`slotFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/slotFlags.ts)).
+- **Normalization** (`Normalization/`):
+  - **`StyleAndClassNormalization`** — `normalizeClass` / `normalizeStyle` (string/array/map forms).
+  - **`DisplayStringFormatter`** — `toDisplayString` (interpolation stringification).
+  - **`LooseEquality`** — `looseEqual` / `looseIndexOf`.
+  - **`NumberCoercion`** — `toNumber` / `looseToNumber`.
+- **DOM knowledge** (`Dom/DomKnowledge`, backed by `Internal/DomKnowledgeData`) — the HTML, SVG, and
+  MathML tag and attribute tables ([V01.01.01.03]) the compiler and DOM runtime consult instead of
+  probing a live element.
+
+## Boundaries
+
+- **No `Assimalign.Viu.*` dependencies** — this is the root of the dependency graph. Ships as a
+  net10.0 runtime library with `IsAotCompatible=true`.
+- The flag definitions are the **contract between the build-time compiler and the runtime**. A few
+  source files (`PatchFlags.cs`, `SlotFlags.cs`, `Internal/DomKnowledgeData.cs`) are shared-source
+  compiled into the netstandard2.0 `Assimalign.Viu.Syntax.*` generators so both sides use identical
+  bit values (their paths are frozen — see
+  [`.claude/rules/general-rules.md`](../../../.claude/rules/general-rules.md)).
+- Design rationale and the parity contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md
@@ -1,0 +1,30 @@
+# Assimalign.Viu.Syntax.Html — design
+
+Why the HTML scaffold exists and how it is shaped. What it is: see [OVERVIEW.md](OVERVIEW.md).
+Upstream analogue: Vite's HTML entry processing (there is no `@vue/compiler-*` HTML-document parser;
+Vue's template markup is a different language, handled by `Assimalign.Viu.Syntax.Templates`).
+
+## Why a scaffold now
+
+The library exists to **pin the seam** before the parser is built: the project shape, the
+`SyntaxParser<T>` registration dispatch, and the value-equatable result contract that the shared
+`Assimalign.Viu.Syntax` pipeline requires (see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). Registering a
+scaffold now means the host-page rewrite work item can grow the parser in place without moving the
+seam or churning the composition roots that depend on it.
+
+`ParseCore` returns a single `HtmlDocumentNode` spanning the whole source, upholding the
+`SourceLocation` exact-slice invariant; the whole-source span is replaced by real tokenizer positions
+when element-level parsing lands.
+
+## Constraints (inherited from the cluster)
+
+- **netstandard2.0** analyzer TFM, no file/network I/O, no reflection-based serialization, no dynamic
+  code generation. Parsing is recoverable — malformed input never throws.
+- Results are immutable and value-equatable so incremental generators cache on them.
+
+## Non-goals (until the work item lands)
+
+- Element-, attribute-, and text-level parsing per the WHATWG model.
+- Host-page entry rewriting (static-web-asset injection) — the consumer-facing feature this parser
+  will back.

--- a/libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md
@@ -1,0 +1,26 @@
+# Assimalign.Viu.Syntax.Html — overview
+
+The `.html` language of the `Assimalign.Viu.Syntax.*` cluster — the parser build tooling registers
+for HTML documents, above all the WASM host page (`wwwroot/index.html`), the role Vite's HTML entry
+processing plays in a Vue build. Vue *template* markup is the separate
+`Assimalign.Viu.Syntax.Templates` parser, not this one. Area: `V01.01.05` (Syntax cluster).
+
+> **Scaffold.** The parser currently produces a single located `HtmlDocumentNode` carrying the raw
+> source, with no diagnostics — enough to pin the pipeline seam and the caching contract. Element-
+> level parsing per the [WHATWG HTML parsing model](https://html.spec.whatwg.org/multipage/parsing.html)
+> lands with its own work item.
+
+## Public surface
+
+- **`HtmlSyntaxParser`** — the `SyntaxParser<HtmlSyntaxNode>` build tooling registers for `.html`
+  sources.
+- **`HtmlDocumentNode`** — the located document node (currently the whole-source root).
+- **`HtmlSyntaxNode`** / **`HtmlSyntaxNodeKind`** — the node base and its kind projection.
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; a build-time library on the netstandard2.0 analyzer TFM
+  that runs inside Roslyn generator hosts.
+- Parsing is recoverable and value-equatable (the incremental-generator caching contract), following
+  the shared pipeline in [`Assimalign.Viu.Syntax/docs/OVERVIEW.md`](../../Assimalign.Viu.Syntax/docs/OVERVIEW.md).
+- Design notes and the scaffold's rationale: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md
@@ -1,0 +1,31 @@
+# Assimalign.Viu.Syntax.JavaScript — design
+
+Why the JavaScript scaffold exists and how it is shaped. What it is: see [OVERVIEW.md](OVERVIEW.md).
+There is no `@vue/compiler-*` counterpart — Viu's component logic is C#, so this library covers only
+the plain `.js` around the interop boundary (the role a Vite build's JS handling plays for glue and
+host-page scripts).
+
+## Why a scaffold now
+
+The library exists to **pin the seam** before the parser is built: the project shape, the
+`SyntaxParser<T>` registration dispatch, and the value-equatable result contract the shared
+`Assimalign.Viu.Syntax` pipeline requires (see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). A registered
+scaffold lets the interop-tooling work item grow the parser in place without disturbing the seam or
+its composition roots.
+
+`ParseCore` returns a single `JavaScriptProgramNode` spanning the whole source, upholding the
+`SourceLocation` exact-slice invariant; the whole-source span is replaced by real tokenizer positions
+when statement-level parsing lands.
+
+## Constraints (inherited from the cluster)
+
+- **netstandard2.0** analyzer TFM, no file/network I/O, no reflection-based serialization, no dynamic
+  code generation. Parsing is recoverable — malformed input never throws.
+- Results are immutable and value-equatable so incremental generators cache on them.
+
+## Non-goals (until the work item lands)
+
+- Statement- and expression-level parsing per ECMA-262.
+- Any transformation of interop glue or host-page scripts — this parser only locates and slices
+  today.

--- a/libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md
@@ -1,0 +1,25 @@
+# Assimalign.Viu.Syntax.JavaScript — overview
+
+The `.js` language of the `Assimalign.Viu.Syntax.*` cluster — the parser build tooling registers for
+JavaScript around the JS-interop boundary (interop glue modules, host-page scripts). Component logic
+is C# (Roslyn's domain) and template expressions stay in `Assimalign.Viu.Syntax.Templates`, so this
+library is scoped to the plain `.js` files a Viu build touches. Area: `V01.01.05` (Syntax cluster).
+
+> **Scaffold.** The parser currently produces a single located `JavaScriptProgramNode` carrying the
+> raw source, with no diagnostics — enough to pin the pipeline seam and the caching contract.
+> Statement-level parsing per [ECMA-262](https://tc39.es/ecma262/) lands with its own work item.
+
+## Public surface
+
+- **`JavaScriptSyntaxParser`** — the `SyntaxParser<JavaScriptSyntaxNode>` build tooling registers for
+  `.js`/`.mjs` sources.
+- **`JavaScriptProgramNode`** — the located program node (currently the whole-source root).
+- **`JavaScriptSyntaxNode`** / **`JavaScriptSyntaxNodeKind`** — the node base and its kind projection.
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; a build-time library on the netstandard2.0 analyzer TFM
+  that runs inside Roslyn generator hosts.
+- Parsing is recoverable and value-equatable (the incremental-generator caching contract), following
+  the shared pipeline in [`Assimalign.Viu.Syntax/docs/OVERVIEW.md`](../../Assimalign.Viu.Syntax/docs/OVERVIEW.md).
+- Design notes and the scaffold's rationale: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
@@ -1,0 +1,54 @@
+# Assimalign.Viu.Syntax.SingleFileComponent — design
+
+Why the `.viu` parser is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md); the exact
+grammar is [FORMAT.md](FORMAT.md). Upstream counterpart:
+[`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) `parse()`
+(`packages/compiler-sfc/src/parse.ts`).
+
+## The `@`-block container is a deliberate divergence
+
+Vue wraps SFC blocks in HTML-like tags (`<template>`, `<script>`, `<style>`); a `.viu` file uses
+`@`-block container syntax instead (decided 2026-07-17). Only the **container** differs — block
+*semantics* follow the Vue SFC spec unchanged, and the markup inside `@template` remains standard Vue
+template syntax. This is one half of [ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md)
+(build-time-only compilation); the full rule set and its rationale are in [FORMAT.md](FORMAT.md).
+
+## Slice, don't parse
+
+The parser only slices the file into blocks and records spans — it never re-parses, trims, or
+normalizes block content. The termination rule is purely structural ("column 0 is structural": a
+line whose first column is `}` closes a block), so it needs no knowledge of C#, CSS, or HTML syntax.
+Downstream libraries parse the block contents: the template compiler
+(`Assimalign.Viu.Syntax.Templates`) for `@template`, the CSS library for `@style`, and script
+analysis for `@script` ([V01.01.06.03]).
+
+## The registration seam
+
+`SingleFileComponentSyntaxParser` is an `AggregateSyntaxParser` over the shared
+`Assimalign.Viu.Syntax` pipeline: it exposes each block as a `SyntaxSource` (content, block name,
+`lang`) so a composition root (the generator, a build task, a test) can register the parsers the
+build embeds — without this library referencing any of them. A registration-free parse is just the
+plain container parse, preserving `@vue/compiler-sfc` parity (`parse()` never looks inside block
+content).
+
+## Value equality and recoverable diagnostics
+
+The descriptor and every block are immutable records with structural equality, so identical file
+content yields equal (and equally hashed) descriptors — the prerequisite for incremental-generator
+caching ([V01.01.06.02], and see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). Parsing is
+recoverable: malformed input is reported through diagnostics and the parser never throws for bad
+content.
+
+## Deltas from Vue 3
+
+- **`@`-block container** instead of tag-based blocks (above; specified in [FORMAT.md](FORMAT.md)).
+- **Viu-defined error codes** (`SingleFileComponentErrorCode`, 1000-based). Unlike the template
+  compiler, which mirrors vuejs/core's numbering, the `@`-block container is a Viu divergence with no
+  upstream codes to align to.
+
+## Non-goals
+
+- **Script analysis.** Every `@script` block is treated uniformly (at most one per file); the Vue
+  `<script setup>` distinction and script analysis are [V01.01.06.03].
+- **Parsing block interiors.** By design — that belongs to the per-language parsers.

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
@@ -1,0 +1,35 @@
+# Assimalign.Viu.Syntax.SingleFileComponent — overview
+
+The build-time parser for the `.viu` single-file component (SFC) — the Viu counterpart of Vue's
+`.vue` files and the role [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc)
+`parse()` plays: it slices a `.viu` file into its blocks and records their source spans. It does
+**not** parse the contents of a block — the template markup, C#, and CSS inside are parsed by other
+libraries. Area: `V01.01.06`.
+
+The exact container syntax (the `@template`/`@script`/`@style` `@`-block grammar, the column-0
+termination rule, options, diagnostics) is specified in [FORMAT.md](FORMAT.md) — the authoritative
+spec that the test suite pins.
+
+## Public surface
+
+- **`SingleFileComponentParser`** (static) — `Parse(string)` returns a `SingleFileComponentParseResult`
+  (an `SingleFileComponentDescriptor` plus recoverable diagnostics). This is the authoritative,
+  `@vue/compiler-sfc`-parity entry point.
+- **`SingleFileComponentDescriptor`** — the parsed file, mirroring Vue's `SFCDescriptor`: `Template`
+  (0/1), `Script` (0/1), `Styles` (0..n, source order), `CustomBlocks`, and `Source`.
+- **The block model** (`Blocks/`) — `SingleFileComponentBlock` and its
+  `Template`/`Script`/`Style`/`CustomBlock` kinds, `SingleFileComponentBlockKind`, and
+  `SingleFileComponentBlockOption`. Each block carries its raw content and exact-slice source spans.
+- **`SingleFileComponentSyntaxParser`** — the `AggregateSyntaxParser<SingleFileComponentBlock>`
+  adapter (`ParseComponent`): same slicing, but each block is exposed to the registration seam as a
+  `SyntaxSource` so build tooling can attach the template/style/custom parsers.
+- **Diagnostics** (`Diagnostics/`) — `SingleFileComponentError` and the Viu-defined
+  `SingleFileComponentErrorCode` (1000-based).
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; it never references the template, CSS, or any other
+  language library — the composition root wires those in through the aggregate registration seam.
+- Build-time library: targets the netstandard2.0 analyzer TFM and runs inside Roslyn generator hosts;
+  `IsAotCompatible` does not apply (a documented deviation for this TFM).
+- Design rationale and the divergences: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Assimalign.Viu.Syntax.Templates — overview
+
+The Vue template language front end — the C# port of
+[`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) plus
+[`@vue/compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom): it tokenizes
+and parses Vue template markup into a located AST, runs the transform pipeline (structural and
+directive transforms, expression binding, static optimization), and generates a **C# render method**.
+It is a build-time library that runs inside the source generator ([V01.01.05.05]/[V01.01.06.02]);
+there is no runtime compilation (see
+[ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md)). Area: `V01.01.05`.
+
+The rationale, the JavaScript-to-C# codegen divergences, and the runtime-helper contract are
+detailed in [DESIGN.md](DESIGN.md); this page is the surface map.
+
+## Public surface
+
+- **Parsing** (`Parsing/`) — `TemplateParser.Parse` (the authoritative, `@vue/compiler-core`-parity
+  entry), `TemplateSyntaxParser` (the registration adapter over the shared pipeline),
+  `TemplateSyntaxParserResult`, `ParserOptions`, `TemplateParseMode`, `WhitespaceStrategy`.
+- **The AST** (`Ast/`, plus root-level `TemplateSyntaxNode` / `TemplateChildNode` / `ExpressionNode`
+  / `PropertyNode` / `NodeType`) — `RootNode`, `ElementNode`, `AttributeNode`, `DirectiveNode`,
+  `InterpolationNode`, `TextNode`, `CommentNode`, `SimpleExpressionNode`, `CompoundExpressionNode`,
+  and the `ElementType` / `ElementNamespace` / `ConstantType` classifiers. `NodeType` is pinned
+  numerically to `@vue/compiler-core`'s `NodeTypes`.
+- **Transforms** (`Transforms/`) — `Transformer`, `TransformContext`, `TransformOptions`,
+  `TransformResult`, `TemplateExpressionCompiler`, and the `NodeTransform` / `DirectiveTransform`
+  delegates.
+- **Binding** (`Binding/`) — `BindingMetadata`, `BindingType`, `BindingRewriteMode`, and the CSS
+  module accessors (`CssModuleAccessor`, `CssModuleAccessors`) that let the compiler resolve
+  `$style.x`.
+- **Code generation** (`CodeGeneration/`) — `RenderFunctionEmitter` (Vue's `generate`), its
+  options/result, `RenderSourceMapping` (the `#line` correspondence), and the code-generation IR.
+- **Diagnostics** (`Diagnostics/`) — `CompilerError` and `CompilerErrorCode` (numeric parity with
+  vuejs/core).
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only. It does **not** reference the runtime: the emitted
+  render method binds to `Assimalign.Viu.RuntimeCore`'s `RenderHelpers` (and the DOM directive
+  helpers in `Assimalign.Viu.RuntimeDom`) **by name**, so the contract flows one way (see
+  [`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../Assimalign.Viu.RuntimeCore/docs/DESIGN.md)).
+- Build-time library on the netstandard2.0 analyzer TFM; runs in Roslyn generator hosts.
+- Everything a parse or transform produces is value-equatable to preserve the incremental-generator
+  caching contract.

--- a/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
@@ -1,0 +1,43 @@
+# Assimalign.Viu.Testing — design
+
+Why the testing package is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterparts: [`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test)
+and [`@vue/test-utils`](https://test-utils.vuejs.org).
+
+## A second platform for the one renderer
+
+`Assimalign.Viu.RuntimeCore`'s renderer is platform-agnostic: it drives whatever
+`RendererOptions<TNode>` it is given (see
+[`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../Assimalign.Viu.RuntimeCore/docs/DESIGN.md)).
+`TestNodeOperations.Create(log)` supplies node-ops over a plain in-memory tree
+(`TestElement`/`TestText`/`TestComment`), so component behavior is exercised through the *same*
+mount/patch/unmount pipeline the browser uses — just with no DOM and no interop. This is exactly
+`@vue/runtime-test`'s role, and it is why a component tested here behaves as it will in the browser.
+
+## The op log is the assertion surface
+
+Every node operation the renderer issues lands in `TestNodeOperationLog` as a `TestNodeOperation`
+(`@vue/runtime-test`'s `nodeOps` op log). Tests assert *what the renderer did* — which inserts,
+removes, and text writes happened, in order — not only the final tree. `TestNodeSerializer` renders
+the tree to a string for snapshot-style assertions. Container creation is intentionally **not**
+logged, so the log isolates the renderer's own work.
+
+## Determinism is owned by the mount
+
+`ViuTest.Mount` takes ownership of the scheduler lifecycle for the mount: it resets the `Scheduler`
+and installs a `TestSchedulerPump` so flushes are captured and async update helpers are
+reproducible, with no reliance on an ambient `SynchronizationContext`. The returned `ComponentWrapper`
+is `IDisposable`; disposing it (a `using`) unmounts and returns the scheduler to baseline, so one
+test cannot leak reactive subscriptions or queued jobs into the next.
+
+## Deltas from Vue 3
+
+- **No jsdom.** `@vue/test-utils` normally mounts into a jsdom DOM; Viu's platform here is a pure
+  in-memory node tree, keeping the whole harness dependency-light and AOT-clean.
+- **Component instances are caller-supplied**, constructed by source-generated factories — never
+  reflection-activated — so the harness stays trimming/AOT-safe.
+
+## Non-goals (sequenced work)
+
+- The end-to-end browser test harness — [V01.01.11.03].
+- The performance benchmark suite — [V01.01.11.04].

--- a/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
@@ -1,0 +1,34 @@
+# Assimalign.Viu.Testing — overview
+
+The DOM-free testing package — the C# counterpart of
+[`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test) (the in-memory
+renderer and node-op log) plus [`@vue/test-utils`](https://test-utils.vuejs.org) (the `mount` entry
+and the component wrapper). Everything runs on a plain CoreCLR test host — no browser, no WASM
+toolchain, no JS interop. Area: `V01.01.11`.
+
+## Public surface
+
+- **`ViuTest`** (static) — `Mount<TComponent>(component, options?)` (Vue's `mount`): renders a
+  component against the in-memory renderer and returns a `ComponentWrapper`. The caller supplies the
+  component instance (source-generated factories, never reflection activation).
+- **`TestRenderer`** — the ready-to-use in-memory renderer (`@vue/runtime-test`'s `render` + `nodeOps`
+  pair): `Render`, `CreateContainer`, the underlying `Renderer<TestNode>`, and the `OperationLog`
+  every node operation is recorded into.
+- **The in-memory node tree** (`Nodes/`) — `TestNode` (abstract), `TestElement`, `TestText`,
+  `TestComment`; `TestNodeOperations` (the `RendererOptions<TestNode>` factory); the op log
+  (`TestNodeOperationLog`, `TestNodeOperation`, `TestNodeOperationType`); `TestNodeSerializer`
+  (tree-to-string for snapshot assertions); and `TestEventDispatcher`.
+- **Wrappers** (`Wrappers/`) — `ComponentWrapper` (`IDisposable`: query, interact, assert, and
+  unmount on dispose), `ElementWrapper`, and `ComponentMountOptions` (props, slots, provides,
+  registered components, stubs).
+- **`TestSchedulerPump`** — the deterministic scheduler pump the mount installs so async update
+  helpers are reproducible.
+
+## Boundaries
+
+- References **`Assimalign.Viu.RuntimeCore`** (and transitively Shared/Reactivity) only. Ships as a
+  net10.0 library with `IsAotCompatible=true`.
+- It is a **platform package** in the same sense as `Assimalign.Viu.RuntimeDom` — it supplies a
+  `RendererOptions<TNode>` (here `TNode = TestNode`) to the shared renderer — but its platform is an
+  in-memory tree instead of the browser DOM.
+- Design rationale and the determinism model: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md
@@ -1,0 +1,39 @@
+# Assimalign.Viu.Tooling.Css — overview
+
+The shared, build-time CSS composition core for `.viu` `@style` blocks. It compiles a component's
+styles (scoped CSS, CSS Modules, and `v-bind()` rewrites) and bundles a project's components into one
+deterministic stylesheet. It exists so the two build-time hosts that need this logic — the
+`Assimalign.Viu.Syntax.Generators` source generator (which emits the styles as a C# constant) and the
+`ViuBundleCss` MSBuild task (which writes the physical file) — run **one** implementation and cannot
+drift. Area: `V01.01.12.12`.
+
+This is tooling / composition-root code, not a peer `Assimalign.Viu.Syntax.*` language library — the
+reason it is *allowed* to reference several language libraries. The rationale, the RS1035 / no-I/O
+constraint, and the byte-stable bundle layout are in [DESIGN.md](DESIGN.md); the broader utility-CSS
+plan is [`docs/UTILITY-CSS-DESIGN.md`](../../../docs/UTILITY-CSS-DESIGN.md).
+
+## Public surface
+
+- **`SingleFileComponentStyleCompiler`** — the compilation itself: `Compile(parse, scopeId)` (for the
+  generator, which already holds the parse) and `CompileFile(parser, text, path, projectDirectory)`
+  (for the task). Returns a `SingleFileComponentStyleCompilation`.
+- **`SingleFileComponentStyleBundler`** — composes a project's components into one deterministic
+  bundle string (stable ordering, LF-only layout). Pure: the caller performs file I/O and hands in
+  the already-read text via `SingleFileComponentStyleInput`.
+- **`StyleScopeId`** — the `data-v-<hash>` scope-id derivation both hosts resolve identically.
+- **`SingleFileComponentParserFactory`** — the shared `.viu` parser composition (`Create()` /
+  `CreateForStyleExtraction()`), so the task can parse only `@style` without loading the template
+  compiler.
+- **Result and input types** — `SingleFileComponentStyleCompilation`,
+  `SingleFileComponentStyleDiagnostic`, `SingleFileComponentStyleInput`,
+  `SingleFileComponentStyleModuleClass`, `SingleFileComponentStyleVariableBinding`.
+
+## Boundaries
+
+- References `Assimalign.Viu.Syntax`, `.Syntax.SingleFileComponent`, `.Syntax.Templates`, and
+  `.Syntax.Css` — legal because this is a composition root, not a language library (a language
+  library may not reference another; a composition root may).
+- **No I/O, no reflection, no dynamic codegen.** The core is analyzer-sandbox-safe (netstandard2.0
+  analyzer TFM); the `ViuBundleCss` task performs the file I/O outside the sandbox.
+- **Deterministic, byte-stable output** (LF, ordinal ordering) — the guarantee that the generated
+  constant and the bundled file are byte-identical.

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -80,7 +80,7 @@ A consumer outside this repo points a `nuget.config` at the feed:
 ```xml
 <configuration>
     <packageSources>
-        <add key="viu-local" value="C:\Source\repos\assimalign\vuecs\_out\packages" />
+        <add key="viu-local" value="C:\Source\repos\assimalign\viu\_out\packages" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Rewrites the root README as the repository project map (mission, per-project tables for `libraries/`, `analyzers/`, `examples/`, `sdks/`+`frameworks/`, clone/build/run instructions verified against the tree).
- Backfills `docs/OVERVIEW.md` + `docs/DESIGN.md` for every library missing them (all 12 libraries now carry both; existing docs untouched, partial ones extended additively).
- Establishes `docs/adr/` with a numbered template and the five founding ADRs recorded from PLAN.md's founding decisions (source generators over reflection, Ref-first reactivity, batched interop, composition-only component model, no runtime template compilation).
- Adds `docs/CONTRIBUTING.md`, the documentation convention page (what belongs in OVERVIEW/DESIGN/ADRs and when they must be updated).
- Rider: retargets the stale `assimalign/vuecs` repo-slug statements in `docs/PLAN.md`, then sweeps the remaining post-rename `vuecs` references (work-items skill, rules, issue-template config, the generator diagnostic help-link base, the NuGet `RepositoryUrl`, `sdks/README.md`, and 18 issue links in UTILITY-CSS-DESIGN.md) — filed and tracked as #177.

All 173 relative markdown links verified to resolve. `dotnet build Assimalign.Viu.slnx`: 0 warnings, 0 errors; `Assimalign.Viu.Syntax.Generators.Tests`: 72/72 (the help-link change is not pinned by any snapshot).

Deferred (out of scope here, noted in CONTRIBUTING.md): the CI markdown link-check job belongs to a follow-up under [V01.01.13].

Closes #98
Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)