### PR TITLE
feat(router): add the DOM-free route table and matcher [V01.01.08.01]

### DIFF
--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -15,7 +15,7 @@ win** — link the reference in the code, test, or issue that pins the behavior.
 
 - Inverted library layout: `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name **is** the
   assembly / package id. `src/` holds the shipping project, `test/` its test project. No area wrapper
-  folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug remains
+  folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug is
   `assimalign/viu`).
 - Examples live in `examples/`; repo planning docs in `docs/`; the consumer-facing MSBuild SDK in
   `sdks/` and the `Assimalign.Viu.App` shared-framework pack producers in `frameworks/` (see

--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -16,7 +16,7 @@ win** — link the reference in the code, test, or issue that pins the behavior.
 - Inverted library layout: `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name **is** the
   assembly / package id. `src/` holds the shipping project, `test/` its test project. No area wrapper
   folders. Package root is `Assimalign.Viu.*` (product name "Viu"; the GitHub repo slug remains
-  `assimalign/vuecs`).
+  `assimalign/viu`).
 - Examples live in `examples/`; repo planning docs in `docs/`; the consumer-facing MSBuild SDK in
   `sdks/` and the `Assimalign.Viu.App` shared-framework pack producers in `frameworks/` (see
   [build-system.md](build-system.md)).

--- a/.claude/skills/viu-work-items/SKILL.md
+++ b/.claude/skills/viu-work-items/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: viu-work-items
-description: Create and link GitHub work items (area epics / features / tasks) in the assimalign/vuecs Project #15 using the gh CLI — following the V01.01.NN WBS scheme, native parent/sub-issue links, and the Summary / Acceptance Criteria body template. Use whenever new development is requested, and ESPECIALLY when scope creep is discovered mid-branch: file the out-of-scope work as its own tracked work item so one PR can attach and close several items. Triggers include "create a work item", "file an issue for this", "capture this scope creep", "track this extra change", "open a Viu issue", "this is out of scope — log it", or "assemble the Closes list for my PR". Use only in the assimalign/vuecs repo.
+description: Create and link GitHub work items (area epics / features / tasks) in the assimalign/viu Project #15 using the gh CLI — following the V01.01.NN WBS scheme, native parent/sub-issue links, and the Summary / Acceptance Criteria body template. Use whenever new development is requested, and ESPECIALLY when scope creep is discovered mid-branch: file the out-of-scope work as its own tracked work item so one PR can attach and close several items. Triggers include "create a work item", "file an issue for this", "capture this scope creep", "track this extra change", "open a Viu issue", "this is out of scope — log it", or "assemble the Closes list for my PR". Use only in the assimalign/viu repo.
 ---
 
 # Viu Work Items
@@ -141,7 +141,7 @@ Closing a parent feature does not close its sub-issues and vice-versa, so list e
 
 ## Guardrails
 
-- **Only operate on `assimalign/vuecs`** and Project #15. Confirm `gh auth status` has the `project` scope.
+- **Only operate on `assimalign/viu`** and Project #15. Confirm `gh auth status` has the `project` scope.
   Project #15 also lists `assimalign/cohesion` items — never modify those from this repo.
 - **Never invent a WBS code** — always derive the next child from existing siblings (the script does this; if
   doing it by hand, list the parent's children and take max+1, zero-padded to two digits).

--- a/.claude/skills/viu-work-items/reference/project-schema.md
+++ b/.claude/skills/viu-work-items/reference/project-schema.md
@@ -8,7 +8,7 @@ understanding the model. If an ID stops working, re-run the discovery commands a
 
 | Thing | Value |
 | --- | --- |
-| Repo | `assimalign/vuecs` |
+| Repo | `assimalign/viu` |
 | Org / owner | `assimalign` |
 | Project | **#15 "Viu"** |
 | Project node id | `PVT_kwDOA9eCcc4BdkOB` |
@@ -55,7 +55,7 @@ in the branch names the **feature** currently in flight.
 
 (Program root: `#1 [V01.01.00] Viu - Framework Libraries`.)
 
-(Re-list with: `gh issue list --repo assimalign/vuecs --state open --search '"Framework -" in:title' --json number,title`)
+(Re-list with: `gh issue list --repo assimalign/viu --state open --search '"Framework -" in:title' --json number,title`)
 
 ## Custom fields (single-select)
 
@@ -89,7 +89,7 @@ W06 enterprise polish.
 
 ```bash
 # By label (issues CLI):
-gh issue list --repo assimalign/vuecs --label scope-creep --state all --json number,title,state
+gh issue list --repo assimalign/viu --label scope-creep --state all --json number,title,state
 # By field on the board: filter or group Project #15 by Origin (DiscoveredTask / DiscoveredFeature).
 ```
 
@@ -111,7 +111,7 @@ gh issue list --repo assimalign/vuecs --label scope-creep --state all --json num
 ## Manual recipe (when not using the helper script)
 
 ```bash
-REPO=assimalign/vuecs ; OWNER=assimalign ; PROJ=15
+REPO=assimalign/viu ; OWNER=assimalign ; PROJ=15
 PROJECT_ID=PVT_kwDOA9eCcc4BdkOB
 
 # 1. Find the parent + its node id (feature for a task, area epic for a sibling feature)

--- a/.claude/skills/viu-work-items/scripts/New-ViuWorkItem.ps1
+++ b/.claude/skills/viu-work-items/scripts/New-ViuWorkItem.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Create a GitHub work item (feature / task) in the assimalign/vuecs Project #15,
+    Create a GitHub work item (feature / task) in the assimalign/viu Project #15,
     following the V01.01.NN WBS scheme, native parent/sub-issue links, and the
     Summary / Acceptance Criteria body template — classifying scope creep and reusing
     existing items instead of creating duplicates.
@@ -120,7 +120,7 @@ Set-StrictMode -Version Latest
 
 # --- Constants -------------------------------------------------------------------------------
 $Owner       = 'assimalign'
-$Repo        = 'assimalign/vuecs'
+$Repo        = 'assimalign/viu'
 $ProjectNum  = 15
 $WbsPattern  = 'V\d{2}(?:\.\d{2})+'      # viu WBS codes are V-prefixed
 $AreaPattern = 'Framework - (.+)$'       # area-epic title convention

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Viu work-item helper (preferred)
-    url: https://github.com/assimalign/vuecs/blob/main/.claude/skills/viu-work-items/SKILL.md
+    url: https://github.com/assimalign/viu/blob/main/.claude/skills/viu-work-items/SKILL.md
     about: >-
       Prefer New-ViuWorkItem.ps1 — it computes the next WBS code, links the native
       sub-issue, adds the item to Project #15, and tags its Origin. Use the forms below only

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -218,6 +218,17 @@
 	<Folder Name="/viu/libraries/Assimalign.Viu.Reactivity/test/">
 		<Project Path="libraries/Assimalign.Viu.Reactivity/test/Assimalign.Viu.Reactivity.Tests.csproj" />
 	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Router/" />
+	<Folder Name="/viu/libraries/Assimalign.Viu.Router/docs/">
+		<File Path="libraries/Assimalign.Viu.Router/docs/DESIGN.md" />
+		<File Path="libraries/Assimalign.Viu.Router/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Router/src/">
+		<Project Path="libraries/Assimalign.Viu.Router/src/Assimalign.Viu.Router.csproj" />
+	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Router/test/">
+		<Project Path="libraries/Assimalign.Viu.Router/test/Assimalign.Viu.Router.Tests.csproj" />
+	</Folder>
 	<Folder Name="/viu/libraries/Assimalign.Viu.RuntimeCore/" />
 	<Folder Name="/viu/libraries/Assimalign.Viu.RuntimeCore/src/">
 		<Project Path="libraries/Assimalign.Viu.RuntimeCore/src/Assimalign.Viu.RuntimeCore.csproj" />

--- a/README.md
+++ b/README.md
@@ -2,39 +2,134 @@
 
 A faithful re-implementation of [Vue.js 3](https://vuejs.org) in C#/.NET, running in the browser
 through the .NET WebAssembly build tools (`Microsoft.NET.Sdk.WebAssembly`, `JSImport`/`JSExport`
-interop) — compiler-informed virtual DOM, Ref-first reactivity, and Roslyn source generators where
-Vue uses JS `Proxy` and runtime template compilation.
+interop). Viu mirrors Vue 3's package boundaries as `Assimalign.Viu.*` class libraries and tracks
+[vuejs/core](https://github.com/vuejs/core) (v3.5.x) semantics, with three deliberate C#/WASM
+divergences at its core:
+
+- **Roslyn source generators** stand in for everything Vue does with the JavaScript `Proxy` and
+  runtime `new Function` — WASM is AOT/trimming territory, so reflection-based serialization and
+  dynamic code generation are forbidden.
+- **Ref-first reactivity** replaces Proxy-based reactive objects; `[Reactive]` partial classes are
+  source-generated.
+- **Batched JS-interop** is the performance budget: the interop boundary is the dominant cost, so
+  DOM mutations batch and static content is stringified aggressively.
+
+These are recorded as architecture decisions in [`docs/adr/`](docs/adr/); the full architecture map,
+founding decisions, and wave strategy live in [`docs/PLAN.md`](docs/PLAN.md).
 
 ## Status
 
-Early development. The current code proves the rendering seam: a platform-agnostic virtual DOM
-renderer (`VirtualDomRenderer<TNode>` over an injected adapter) patching the real browser DOM from
-C# through a handle-based JS-interop bridge. See the stopwatch demo in
+Early, active development, delivered in waves (see [`docs/PLAN.md`](docs/PLAN.md) and the
+[project board](https://github.com/orgs/assimalign/projects/15) for the authoritative status). The
+reactive core, the platform-agnostic renderer with scheduler and component model, the browser DOM
+bridge, the template compiler front end, and the `.viu` single-file-component pipeline are all in
+the tree at varying maturity; each library's `docs/OVERVIEW.md` states what it currently provides.
+The demo is a reactively re-rendering stopwatch in
 [`examples/Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp).
 
-Libraries use the `Assimalign.Viu.*` package root with the inverted layout
-`libraries/Assimalign.Viu.<Name>/{src|test}`.
+## Repository map
 
-Viu apps consume the framework through an MSBuild project SDK — a complete app csproj is
-`<Project Sdk="Assimalign.Viu.Sdk">` — which chains `Microsoft.NET.Sdk.WebAssembly` and delivers
-the framework libraries plus the `[Reactive]`/`.viu` source generators via the
-`Assimalign.Viu.App` shared framework (`.Ref` targeting pack + `.Runtime.browser-wasm` runtime
-pack). See [`sdks/README.md`](sdks/README.md).
+Framework libraries use the inverted layout `libraries/Assimalign.Viu.<Name>/{src,test,docs}` — the
+folder name **is** the assembly and package id (no area wrapper folders). Each shipping library
+carries a `docs/OVERVIEW.md` (what it is, its public surface, its Vue 3 counterpart) and a
+`docs/DESIGN.md` (why it is shaped that way, the vuejs/core module it ports, and known deltas).
+
+### Framework libraries (`libraries/`)
+
+| Library | Vue 3 counterpart | Docs |
+| --- | --- | --- |
+| [`Assimalign.Viu.Shared`](libraries/Assimalign.Viu.Shared) | [`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared) — PatchFlags/ShapeFlags/SlotFlags, class/style normalization, DOM knowledge tables | [OVERVIEW](libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Shared/docs/DESIGN.md) |
+| [`Assimalign.Viu.Reactivity`](libraries/Assimalign.Viu.Reactivity) | [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity) — dependencies, Ref/Computed, effects, scopes, watch, reactive collections | [OVERVIEW](libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md) |
+| [`Assimalign.Viu.RuntimeCore`](libraries/Assimalign.Viu.RuntimeCore) | [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core) — vnodes, renderer, scheduler, component model, built-ins | [OVERVIEW](libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md) |
+| [`Assimalign.Viu.RuntimeDom`](libraries/Assimalign.Viu.RuntimeDom) | [`@vue/runtime-dom`](https://github.com/vuejs/core/tree/main/packages/runtime-dom) — JS-interop DOM bridge, patchProp, events, v-model/v-show | [OVERVIEW](libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax`](libraries/Assimalign.Viu.Syntax) | (shared base) — the located node/diagnostic primitives and registration-based parser pipeline every language library roots on | [OVERVIEW](libraries/Assimalign.Viu.Syntax/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.Templates`](libraries/Assimalign.Viu.Syntax.Templates) | [`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) + [`compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom) — the Vue template language front end and C# render-function codegen | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.SingleFileComponent`](libraries/Assimalign.Viu.Syntax.SingleFileComponent) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) — the `.viu` `@`-block container parser | [OVERVIEW](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md) · [FORMAT](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md) |
+| [`Assimalign.Viu.Syntax.Css`](libraries/Assimalign.Viu.Syntax.Css) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) `compileStyle()` — CSS tokenizer, rule parser, and scoped-CSS rewrite | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Css/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.Html`](libraries/Assimalign.Viu.Syntax.Html) | (Vite HTML entry processing) — the `.html` host-page language (scaffold) | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md) |
+| [`Assimalign.Viu.Syntax.JavaScript`](libraries/Assimalign.Viu.Syntax.JavaScript) | (interop-glue JavaScript) — the `.js` language around the interop boundary (scaffold) | [OVERVIEW](libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md) |
+| [`Assimalign.Viu.Testing`](libraries/Assimalign.Viu.Testing) | [`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test) + [`@vue/test-utils`](https://test-utils.vuejs.org) — the in-memory renderer and component test harness | [OVERVIEW](libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Testing/docs/DESIGN.md) |
+| [`Assimalign.Viu.Tooling.Css`](libraries/Assimalign.Viu.Tooling.Css) | (build-time composition core, no direct Vue peer) — shared `.viu` `@style` compilation and bundling used by both build-time hosts | [OVERVIEW](libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Tooling.Css/docs/DESIGN.md) |
+
+### Source generators and build tasks (`analyzers/`)
+
+These are build-time (netstandard2.0) components — the sanctioned replacement for Vue's `Proxy` and
+runtime template compilation. They never ship in the runtime assemblies.
+
+| Project | Role |
+| --- | --- |
+| `Assimalign.Viu.Reactivity.Generators` | Emits the property wrappers for `[Reactive]`/`[ShallowReactive]` partial classes (Vue's `reactive()`, source-generated). |
+| `Assimalign.Viu.Syntax.Generators` | The incremental generator that compiles `.viu` single-file components and templates to C# render methods (the composition root that registers the template and style parsers). |
+| `Assimalign.Viu.Tooling.Tasks` | The `ViuBundleCss` MSBuild task that writes the compiled `.viu` `@style` output to a physical stylesheet (outside the analyzer sandbox). |
+
+### Examples (`examples/`)
+
+| Sample | What it shows |
+| --- | --- |
+| [`Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp) | A browser WASM app: a stopwatch rendered from C# through the handle-based DOM bridge. Its `?diagnostics=1` mode runs the interop marshaling benchmark behind [RuntimeDom ADR-0001](libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md). |
+
+### Packaging (`sdks/`, `frameworks/`)
+
+External apps consume Viu through an MSBuild project SDK, not project references — a complete app
+csproj is `<Project Sdk="Assimalign.Viu.Sdk">`. The SDK chains `Microsoft.NET.Sdk.WebAssembly` and
+delivers the framework as the `Assimalign.Viu.App` shared framework (the
+`Microsoft.AspNetCore.App.Ref`/`.Runtime.<rid>` model, mirrored from `assimalign/cohesion`). See
+[`sdks/README.md`](sdks/README.md) for the full consumer surface and the local development loop.
+
+| Path | Produces | Role |
+| --- | --- | --- |
+| `sdks/Assimalign.Viu.Sdk` | `Assimalign.Viu.Sdk` | The project SDK: chains the WebAssembly SDK, registers the `Assimalign.Viu.App` framework reference, and ships the `.viu`/CSS build wiring and the `viu-dom.js` bridge. |
+| `frameworks/Assimalign.Viu.App.Refs` | `Assimalign.Viu.App.Ref` | The targeting pack: reference assemblies, `FrameworkList.xml`, and the generators (delivered as analyzers). |
+| `frameworks/Assimalign.Viu.App.Runtime` | `Assimalign.Viu.App.Runtime.browser-wasm` | The per-RID runtime pack: implementation assemblies for `browser-wasm`. |
+
+In-repo projects dogfood the framework through `ViuProjectReference` (see
+[`.claude/rules/build-system.md`](.claude/rules/build-system.md)); the SDK is the external-consumer
+surface.
+
+## Getting started
+
+### Prerequisites
+
+- The [.NET SDK](https://dotnet.microsoft.com/download) pinned in [`global.json`](global.json)
+  (currently `10.0.301`).
+- The WebAssembly tools workload, needed to build and run the browser sample:
+  ```sh
+  dotnet workload install wasm-tools
+  ```
+
+### Clone and build
+
+```sh
+git clone https://github.com/assimalign/viu.git
+cd viu
+dotnet build Assimalign.Viu.slnx
+```
+
+### Test
+
+Each library's tests live beside it under `test/`:
+
+```sh
+dotnet test libraries/Assimalign.Viu.Reactivity/test/
+dotnet test libraries/Assimalign.Viu.RuntimeCore/test/
+```
+
+### Run the demo
+
+```sh
+dotnet run --project examples/Assimalign.Viu.WebApp
+```
 
 ## Plan and tracking
 
 - [Delivery plan](docs/PLAN.md) — architecture mapping (Vue 3 package → Viu library), founding
-  design decisions, and the wave strategy
+  design decisions, and the wave strategy.
+- [Architecture decisions](docs/adr/) — the append-only decision log (founding C#/WASM divergences).
+- [Documentation conventions](docs/CONTRIBUTING.md) — where `OVERVIEW.md`, `DESIGN.md`, and ADRs
+  live, what belongs in each, and when they must be updated.
 - [Project board](https://github.com/orgs/assimalign/projects/15) — the authoritative backlog
-  (`[V01.01.*]` WBS items: program → area epics → features → tasks)
-- Work-item intake: [`.claude/skills/viu-work-items`](.claude/skills/viu-work-items/SKILL.md)
-
-## Build
-
-```sh
-dotnet build Assimalign.Viu.slnx
-dotnet run --project examples/Assimalign.Viu.WebApp
-```
+  (`[V01.01.*]` WBS items: program → area epics → features → tasks).
+- Work-item intake: [`.claude/skills/viu-work-items`](.claude/skills/viu-work-items/SKILL.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ founding decisions, and wave strategy live in [`docs/PLAN.md`](docs/PLAN.md).
 Early, active development, delivered in waves (see [`docs/PLAN.md`](docs/PLAN.md) and the
 [project board](https://github.com/orgs/assimalign/projects/15) for the authoritative status). The
 reactive core, the platform-agnostic renderer with scheduler and component model, the browser DOM
-bridge, the template compiler front end, and the `.viu` single-file-component pipeline are all in
-the tree at varying maturity; each library's `docs/OVERVIEW.md` states what it currently provides.
+bridge, the template compiler front end, the `.viu` single-file-component pipeline, and the
+router's DOM-free route table and matcher are all in the tree at varying maturity; each library's
+`docs/OVERVIEW.md` states what it currently provides.
 The demo is a reactively re-rendering stopwatch in
 [`examples/Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp).
 
@@ -42,6 +43,7 @@ carries a `docs/OVERVIEW.md` (what it is, its public surface, its Vue 3 counterp
 | [`Assimalign.Viu.Reactivity`](libraries/Assimalign.Viu.Reactivity) | [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity) — dependencies, Ref/Computed, effects, scopes, watch, reactive collections | [OVERVIEW](libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md) |
 | [`Assimalign.Viu.RuntimeCore`](libraries/Assimalign.Viu.RuntimeCore) | [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core) — vnodes, renderer, scheduler, component model, built-ins | [OVERVIEW](libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md) |
 | [`Assimalign.Viu.RuntimeDom`](libraries/Assimalign.Viu.RuntimeDom) | [`@vue/runtime-dom`](https://github.com/vuejs/core/tree/main/packages/runtime-dom) — JS-interop DOM bridge, patchProp, events, v-model/v-show | [OVERVIEW](libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md) |
+| [`Assimalign.Viu.Router`](libraries/Assimalign.Viu.Router) | [`vue-router`](https://github.com/vuejs/router) — the DOM-free route table and path matcher today; history, RouterView/RouterLink, and guards follow ([V01.01.08]) | [OVERVIEW](libraries/Assimalign.Viu.Router/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Router/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax`](libraries/Assimalign.Viu.Syntax) | (shared base) — the located node/diagnostic primitives and registration-based parser pipeline every language library roots on | [OVERVIEW](libraries/Assimalign.Viu.Syntax/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax.Templates`](libraries/Assimalign.Viu.Syntax.Templates) | [`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) + [`compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom) — the Vue template language front end and C# render-function codegen | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax.SingleFileComponent`](libraries/Assimalign.Viu.Syntax.SingleFileComponent) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) — the `.viu` `@`-block container parser | [OVERVIEW](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md) · [FORMAT](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md) |

--- a/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentDiagnostics.cs
+++ b/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentDiagnostics.cs
@@ -30,7 +30,7 @@ internal static class SingleFileComponentDiagnostics
     // The stable per-id help-link target: the VIU diagnostic catalog documents every descriptor's ID,
     // origin, severity, and configuration ([V01.01.05.08]). Each descriptor links its own heading anchor.
     private const string HelpLinkBase =
-        "https://github.com/assimalign/vuecs/blob/main/analyzers/Assimalign.Viu.Syntax.Generators/docs/DIAGNOSTICS.md";
+        "https://github.com/assimalign/viu/blob/main/analyzers/Assimalign.Viu.Syntax.Generators/docs/DIAGNOSTICS.md";
 
     private static string HelpLink(string id) => HelpLinkBase + "#" + id.ToLowerInvariant();
 

--- a/build/Targets/Build.Branding.props
+++ b/build/Targets/Build.Branding.props
@@ -3,6 +3,6 @@
         <Company>Assimalign</Company>
         <Copyright>© Assimalign $([System.DateTime]::Now.ToString(`yyyy`))</Copyright>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/assimalign/vuecs</RepositoryUrl>
+        <RepositoryUrl>https://github.com/assimalign/viu</RepositoryUrl>
     </PropertyGroup>
 </Project>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Documentation conventions
+
+This page defines Viu's documentation system: where each kind of document lives, what belongs in it,
+and when it must be updated. It exists so every WBS area documents itself the same way without having
+to re-decide. The canonical *working* conventions (C# style, build system, testing) live under
+[`.claude/rules/`](../.claude/rules/); this page covers the prose-documentation layout and lifecycle
+and complements [`.claude/rules/documentation.md`](../.claude/rules/documentation.md).
+
+## The map
+
+| Document | Location | What it holds |
+| --- | --- | --- |
+| Root `README.md` | repository root | The project mission, the repository map (every project under `libraries/`, `analyzers/`, `examples/`, `sdks/`, `frameworks/`), and clone/build/run instructions. |
+| `PLAN.md` | [`docs/PLAN.md`](PLAN.md) | The authoritative narrative: the Vue 3 → Viu architecture map, the founding design decisions, and the wave strategy. The GitHub [Project #15](https://github.com/orgs/assimalign/projects/15) board is the authoritative *backlog*. |
+| Architecture decision records | [`docs/adr/`](adr/) | The append-only log of repo-wide, cross-cutting decisions (see [`adr/README.md`](adr/README.md)). |
+| Per-library `OVERVIEW.md` | `libraries/Assimalign.Viu.<Name>/docs/OVERVIEW.md` | What the library **is**. |
+| Per-library `DESIGN.md` | `libraries/Assimalign.Viu.<Name>/docs/DESIGN.md` | **Why** the library is shaped the way it is. |
+| Per-library topic docs | `libraries/Assimalign.Viu.<Name>/docs/*.md` | Focused specs or local ADRs (e.g. `FORMAT.md`, a library-local `ADR-000N-*.md`). |
+| XML doc comments | in source, on every public member | The API-level reference and the pinned Vue 3 counterpart links. |
+
+## What belongs in `OVERVIEW.md`
+
+The reader-facing description of the library. Keep it concise and accurate — describe what exists,
+not what is planned.
+
+- **Purpose** — one or two sentences: the role it plays, phrased against its Vue 3 counterpart.
+- **Public surface** — the entry points and currency types a consumer touches (the facade, the key
+  public types), with a one-line note on each. Not an exhaustive member list — that is the XML docs.
+- **Vue 3 package counterpart** — name it and link it (`@vue/<pkg>` on `vuejs.org` or the
+  `github.com/vuejs/core/tree/main/packages/<pkg>` path). A scaffold says so plainly.
+- **Boundaries** — allowed dependency direction; any interop/AOT/generator constraint; a pointer to
+  `DESIGN.md`.
+
+## What belongs in `DESIGN.md`
+
+The rationale and the divergences — why the shape, not the shape itself.
+
+- **Upstream counterpart** — the specific `vuejs/core` package/module this ports, named and linked so
+  parity review is mechanical (e.g. `@vue/reactivity`'s `ref.ts`).
+- **Design rationale** — the internal structure and the forces behind it (the interop budget, the
+  AOT/trimming constraint, the single-threaded model, the incremental-generator caching contract).
+- **Known deltas / divergences from Vue 3** — every deliberate departure from upstream, why it was
+  forced, and the test that pins the *chosen* behavior. A repo-wide divergence links its ADR under
+  [`docs/adr/`](adr/); a library-local one is documented here.
+- **Non-goals** — what is intentionally out of scope, sequenced to the work item that will add it.
+
+## When documents must be updated
+
+- **Same change as the code.** An `OVERVIEW.md`/`DESIGN.md` that lags the code actively misleads;
+  update it in the commit that changes the public surface or the design it describes.
+- **New public type or behavior mirroring Vue 3** — add the XML doc comment with the counterpart
+  link, and reflect any new entry point in `OVERVIEW.md`.
+- **A deliberate divergence from vuejs/core v3.5** — record it (XML docs + a `DESIGN.md` non-goal or
+  delta) and pin it with a test that asserts the chosen behavior (see
+  [`.claude/rules/deviations.md`](../.claude/rules/deviations.md)).
+- **A cross-cutting or repo-wide decision** — add an ADR (never edit a past one; supersede it — see
+  [`adr/README.md`](adr/README.md)).
+
+## Where new things go
+
+- **A new library** — `libraries/Assimalign.Viu.<Name>/{src,test,docs}` (folder name = assembly id,
+  no area wrapper folders). Seed `docs/OVERVIEW.md` and `docs/DESIGN.md` with the code. Wire the
+  csprojs per [`.claude/rules/build-system.md`](../.claude/rules/build-system.md) ("Adding a new
+  library") and add a row to the root `README.md` repository map.
+- **A new sample** — `examples/Assimalign.Viu.<Name>/`, referenced from the root `README.md`
+  Examples table; keep the demo's own `README` or in-code notes describing what it shows.
+- **A new ADR** — copy [`adr/template.md`](adr/template.md) to `adr/NNNN-kebab-title.md` (next number),
+  and add it to the [`adr/README.md`](adr/README.md) index.
+- **Work items** — every change traces to a `[V01.01.NN…]` WBS item on Project #15; capture
+  mid-branch scope creep with the `viu-work-items` skill (see
+  [`.claude/rules/workflow.md`](../.claude/rules/workflow.md)).
+
+## Links must resolve
+
+Every relative link in a Markdown doc must point at a real file, and every Vue 3 reference should
+point at a stable `vuejs.org` or `vuejs/core` URL. Verify links before committing. (Automated
+link-checking in CI is planned under the Documentation area, [V01.01.13]; until it lands, this is a
+manual check.)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -33,9 +33,9 @@ Package boundaries map 1:1 to .NET class libraries using the inverted layout
 `libraries/Assimalign.Viu.<Name>/{src|test}` — the folder name is the assembly/package id, with no
 area wrapper folders (project decision, 2026-07-16). The product name is **Viu** and the package
 root is **`Assimalign.Viu.*`** (renamed from Vue/Vuecs 2026-07-19, `V01.01.12.18`/#173, aligning
-the brand with the `.viu` SFC extension; the GitHub repo slug remains `assimalign/vuecs`, and
-upstream Vue.js references — `@vue/*` names, vuejs.org links, the `vue:` template prefix — are
-deliberately untouched):
+the brand with the `.viu` SFC extension; the GitHub repo slug is now `assimalign/viu` (renamed
+from `assimalign/vuecs`), and upstream Vue.js references — `@vue/*` names, vuejs.org links, the
+`vue:` template prefix — are deliberately untouched):
 
 | Area (WBS) | Viu library | Vue 3 counterpart |
 | --- | --- | --- |
@@ -133,7 +133,7 @@ Work is tracked exactly like the sibling Cohesion repo:
   (`.claude/skills/viu-work-items/`) files discovered work as its own item with
   `Origin=DiscoveredTask|DiscoveredFeature` and the `scope-creep` label, so one PR closes everything
   it actually resolved and creep stays measurable.
-- Project #15 carries viu work only (`V`-prefixed WBS codes, repo `assimalign/vuecs`).
+- Project #15 carries viu work only (`V`-prefixed WBS codes, repo `assimalign/viu`).
 
 ### Wave narrative
 

--- a/docs/UTILITY-CSS-DESIGN.md
+++ b/docs/UTILITY-CSS-DESIGN.md
@@ -1,7 +1,7 @@
 # Build-time utility-first CSS engine — design
 
 Scoping deliverable for **[V01.01.12.10] Scope the build-time utility-first CSS engine**
-([#129](https://github.com/assimalign/vuecs/issues/129)). This is a design document plus a proposed
+([#129](https://github.com/assimalign/viu/issues/129)). This is a design document plus a proposed
 work-item breakdown, **not** an implementation — no engine code ships on this branch.
 
 The engine is an in-house, Tailwind-style utility-first CSS system built entirely at **build time**:
@@ -43,10 +43,10 @@ MSBuild pipeline — and no single library's `docs/DESIGN.md` owns the whole pic
   [documentation](../.claude/rules/documentation.md), [deviations](../.claude/rules/deviations.md)
 - Landed architecture this builds on:
   [`Assimalign.Viu.Syntax` DESIGN](../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) (the
-  registration seam, [#127](https://github.com/assimalign/vuecs/issues/127)) and
+  registration seam, [#127](https://github.com/assimalign/viu/issues/127)) and
   [`Assimalign.Viu.Syntax.Css` DESIGN](../libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md) (the
   tokenizer/tree/selector parser/scoped rewriter,
-  [#60](https://github.com/assimalign/vuecs/issues/60))
+  [#60](https://github.com/assimalign/viu/issues/60))
 
 ---
 
@@ -54,12 +54,12 @@ MSBuild pipeline — and no single library's `docs/DESIGN.md` owns the whole pic
 
 Viu already compiles `.viu` single-file components at build time through the
 `Assimalign.Viu.Syntax.*` cluster and the `SingleFileComponentGenerator`
-([#58](https://github.com/assimalign/vuecs/issues/58)). The utility-first CSS engine is the **flagship
+([#58](https://github.com/assimalign/viu/issues/58)). The utility-first CSS engine is the **flagship
 second consumer** of the same machinery — the role a Tailwind Vite plugin plays alongside
 `@vitejs/plugin-vue` in a Vue build. It reuses three landed foundations:
 
 1. **The registration seam** ([`Assimalign.Viu.Syntax`](../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md),
-   [#127](https://github.com/assimalign/vuecs/issues/127)). `AggregateSyntaxParserOptions<T>.RegisterParser(SyntaxSourcePredicate, SyntaxParser)`
+   [#127](https://github.com/assimalign/viu/issues/127)). `AggregateSyntaxParserOptions<T>.RegisterParser(SyntaxSourcePredicate, SyntaxParser)`
    is the seam a composition root uses to attach a parser to a block name, `lang`, or file type
    without the container library referencing it. The utility engine registers its own extraction
    pass here — "language libraries never reference each other; the composition root constructs the
@@ -68,7 +68,7 @@ second consumer** of the same machinery — the role a Tailwind Vite plugin play
    use.
 
 2. **The CSS AST and emitters** ([`Assimalign.Viu.Syntax.Css`](../libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md),
-   [#60](https://github.com/assimalign/vuecs/issues/60)). The two-phase tokenizer (`CssTokenizer`) →
+   [#60](https://github.com/assimalign/viu/issues/60)). The two-phase tokenizer (`CssTokenizer`) →
    context-directed rule parser (`CssParseEngine`), the record-graph tree (`CssStylesheetNode`,
    `CssQualifiedRuleNode`, `CssDeclarationNode`, …), the flat selector model, and the deterministic
    canonical serializer behind `CssScopedRewriter` are all reusable. The Css DESIGN already names
@@ -79,7 +79,7 @@ second consumer** of the same machinery — the role a Tailwind Vite plugin play
 
 3. **The incremental generator pipeline and its MSBuild integration**
    (`SingleFileComponentGenerator`, `.props`/`.targets`,
-   [#58](https://github.com/assimalign/vuecs/issues/58)). `.viu` files already flow in as
+   [#58](https://github.com/assimalign/viu/issues/58)). `.viu` files already flow in as
    `AdditionalFiles`; every pipeline stage is a value-equatable record; the RS1035 content-file
    limitation (a source generator emits C#, not files, and `System.IO` is banned in the analyzer
    sandbox) is already documented, with the extracted CSS surfacing as the generated `ExtractedStyles`
@@ -390,12 +390,12 @@ Css library owns rule-level CSS parsing and serialization; each higher feature o
 | **Programmatic rule construction** (new, [§7](#7-work-item-breakdown) V01.01.12.11) | `Assimalign.Viu.Syntax.Css` | **utility engine** (scoped CSS never needed it because it rewrites an existing tree) |
 | Scoped `[data-v-…]` selector rewrite (`CssScopedRewriter`) | `Assimalign.Viu.Syntax.Css` | scoped CSS; utility engine **only in optional scoped-utility mode** |
 | Candidate grammar + resolver | utility engine core | — (owned) |
-| Local module-class hashing + `v-bind()`→`var()` rewrite | CSS Modules ([#62](https://github.com/assimalign/vuecs/issues/62)) | — (owned) |
+| Local module-class hashing + `v-bind()`→`var()` rewrite | CSS Modules ([#62](https://github.com/assimalign/viu/issues/62)) | — (owned) |
 
 The utility engine **reuses** the tokenizer/tree/serializer and **adds** a construction surface; it
 does not modify or fork the parser.
 
-### 5.2 Composition with scoped CSS ([#60](https://github.com/assimalign/vuecs/issues/60), landed)
+### 5.2 Composition with scoped CSS ([#60](https://github.com/assimalign/viu/issues/60), landed)
 
 Tailwind utilities are **global by design** — `bg-blue-500` means the same thing everywhere. So the
 utility stylesheet is emitted **once, globally, un-scoped** — it is *not* rewritten with any
@@ -407,7 +407,7 @@ scoped-utility mode** (per-component utilities that *are* rewritten with the com
 reuse `CssScopedRewriter` unchanged — this is the "for its own scoping, `CssScopedRewriter`" reuse the
 Css DESIGN anticipates — but it is off by default and deferred (OQ-6).
 
-### 5.3 Composition with CSS Modules and `v-bind()` ([#62](https://github.com/assimalign/vuecs/issues/62), in flight)
+### 5.3 Composition with CSS Modules and `v-bind()` ([#62](https://github.com/assimalign/viu/issues/62), in flight)
 
 Designed against #62's **issue contract**, not its in-progress code:
 
@@ -423,7 +423,7 @@ Designed against #62's **issue contract**, not its in-progress code:
   (`bg-[var(--brand)]`) — which just works, because the arbitrary value is emitted verbatim.
 - Hash determinism: where the utility engine ever needs a component-scoped hash (scoped-utility mode,
   OQ-6), it uses the **same FNV-1a-over-project-relative-path scheme** as `StyleScopeId`
-  ([#60](https://github.com/assimalign/vuecs/issues/60)), so all three features agree on hashing.
+  ([#60](https://github.com/assimalign/viu/issues/60)), so all three features agree on hashing.
 
 ### 5.4 `@apply`
 
@@ -473,7 +473,7 @@ sets, keyed so it is skipped when no per-file set changed.
   hit). Edits that add a genuinely new utility re-run only stages 4–6 over the whole (small) set.
 - The **`ViuBundleCss`** task is gated by MSBuild `Inputs`/`Outputs`, so a no-op build does no CSS
   file work.
-- A **budget** to hold the line (validated by the [#95](https://github.com/assimalign/vuecs/issues/95)
+- A **budget** to hold the line (validated by the [#95](https://github.com/assimalign/viu/issues/95)
   size/AOT gates, extended per V01.01.12.16): full generation for the reference sample stays within a
   low-tens-of-milliseconds share of the build, and the runtime WASM payload gains **zero** bytes of
   CSS-generation code (only the static `.css` asset, which is not in the WASM module).
@@ -483,11 +483,11 @@ sets, keyed so it is skipped when no per-file set changed.
 ## 7. Work-item breakdown
 
 Proposed as **sibling features under area [V01.01.12] Framework - Tooling**
-([#89](https://github.com/assimalign/vuecs/issues/89)) — the parent area of this scoping feature
+([#89](https://github.com/assimalign/viu/issues/89)) — the parent area of this scoping feature
 [V01.01.12.10]. The existing Tooling features run `.01`–`.10`
-(`.08` = [#104](https://github.com/assimalign/vuecs/issues/104),
-`.09` = [#125](https://github.com/assimalign/vuecs/issues/125),
-`.10` = [#129](https://github.com/assimalign/vuecs/issues/129), this item), so the next free feature
+(`.08` = [#104](https://github.com/assimalign/viu/issues/104),
+`.09` = [#125](https://github.com/assimalign/viu/issues/125),
+`.10` = [#129](https://github.com/assimalign/viu/issues/129), this item), so the next free feature
 codes are **`.11`+**. Tasks under a feature take `<feature>.NN`. Codes and metadata are **proposals**
 for the orchestrator to validate against the live board before filing via the
 [`viu-work-items` skill](../.claude/skills/viu-work-items/SKILL.md); the skill computes the next
@@ -515,7 +515,7 @@ scoped CSS (W04) also wants bundling and they unblock everything else. The engin
 
 Each feature body below is **file-ready** (repo issue-body standard: `## Summary` →
 `## Acceptance Criteria` → `### Standards and Compliance` → `### Architectural boundaries`, per
-[#62](https://github.com/assimalign/vuecs/issues/62)/[#129](https://github.com/assimalign/vuecs/issues/129)).
+[#62](https://github.com/assimalign/viu/issues/62)/[#129](https://github.com/assimalign/viu/issues/129)).
 Representative child tasks are listed for the two largest features (`.15`, `.16`).
 
 ---
@@ -902,7 +902,7 @@ implementation is not blocked.
 
 ## 9. Acceptance-criteria traceability
 
-Mapping each [#129](https://github.com/assimalign/vuecs/issues/129) acceptance criterion to where this
+Mapping each [#129](https://github.com/assimalign/viu/issues/129) acceptance criterion to where this
 document satisfies it.
 
 | #129 criterion | Satisfied in |

--- a/docs/adr/0001-source-generators-over-reflection.md
+++ b/docs/adr/0001-source-generators-over-reflection.md
@@ -1,0 +1,67 @@
+# ADR-0001: Roslyn source generators over reflection and dynamic code generation
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** Repo-wide — every `Assimalign.Viu.*` runtime library and every build-time generator.
+
+## Context
+
+Viu targets the browser through the .NET WebAssembly build tools, which is AOT and trimming
+territory (mono-wasm today, NativeAOT-shaped constraints throughout). Two pillars of Vue 3 are
+unavailable or unsafe there:
+
+- Vue models `reactive(obj)` with a JavaScript [`Proxy`](https://vuejs.org/guide/extras/reactivity-in-depth.html),
+  which has no AOT-safe .NET equivalent (a `DispatchProxy`/`Reflection.Emit` analogue is dynamic
+  codegen).
+- Vue's full build compiles templates at runtime with `new Function` (see
+  [ADR-0005](0005-no-runtime-template-compilation.md)) — impossible in WASM.
+
+Reflection-based serialization, `Reflection.Emit`, compiled expression trees, and linker-unfriendly
+activation (`Activator.CreateInstance` over discovered types) are all trimming-hostile: the linker
+cannot prove what stays reachable, so it either bloats output or breaks at runtime.
+
+## Decision
+
+**Roslyn source generators are the sanctioned mechanism for everything Vue achieves with `Proxy` or
+runtime `new Function`.** Concretely, repo-wide:
+
+- No reflection-based serialization, no dynamic code generation, no linker-unfriendly activation
+  paths. Shipping libraries set `<IsAotCompatible>true</IsAotCompatible>`.
+- Compile-time metaprogramming is a Roslyn incremental source generator. Component and reactive
+  metadata are emitted at build time, never discovered by reflection at runtime; component
+  factories are source-generated, never reflection-activated.
+
+Deviating from AOT/trimming safety requires explicit confirmation and a documented, test-pinned
+exception (see [`.claude/rules/deviations.md`](../../.claude/rules/deviations.md)).
+
+## Consequences
+
+- `reactive()` becomes `[Reactive]`/`[ShallowReactive]` partial classes whose property wrappers are
+  emitted by `Assimalign.Viu.Reactivity.Generators` (see [ADR-0002](0002-ref-first-reactivity.md)).
+- `.viu` single-file components and templates compile through `Assimalign.Viu.Syntax.Generators`
+  (see [ADR-0005](0005-no-runtime-template-compilation.md)).
+- Generator inputs and outputs must be **value-equatable** so the incremental-generator cache holds
+  — this shapes the whole `Assimalign.Viu.Syntax.*` cluster (immutable records, `SyntaxList<T>`; see
+  [`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax/docs/DESIGN.md)).
+- Generators run in netstandard2.0 analyzer hosts with no file/network I/O and are delivered to SDK
+  consumers through the `Assimalign.Viu.App.Ref` targeting pack's `analyzers/dotnet/cs/` (see
+  [`docs/PLAN.md`](../PLAN.md) founding decision 8).
+- Each area publishes a representative WASM consumer with trimming validation; size and startup
+  budgets gate CI from W03.
+
+## Alternatives considered
+
+- **Reflection / dynamic codegen** (`Reflection.Emit`, compiled expression trees, `DispatchProxy`) —
+  the most direct port of Vue's `Proxy`, rejected outright: forbidden by the AOT/trimming constraint.
+- **MSBuild tasks for all codegen** — rejected for the reactive and template generators because it
+  forfeits IDE integration and incrementality. The generators stay Roslyn incremental generators;
+  MSBuild tasks are used only where a generator legally cannot act — emitting a *content* file
+  (RS1035), as the `ViuBundleCss` task does (`docs/PLAN.md` founding decision 8).
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decisions 2, 3, 6, and 8.
+- [`.claude/rules/general-rules.md`](../../.claude/rules/general-rules.md) — the AOT/trimming hard
+  constraints.
+- Vue 3: [reactivity in depth](https://vuejs.org/guide/extras/reactivity-in-depth.html),
+  [rendering mechanism](https://vuejs.org/guide/extras/rendering-mechanism.html).

--- a/docs/adr/0002-ref-first-reactivity.md
+++ b/docs/adr/0002-ref-first-reactivity.md
@@ -1,0 +1,58 @@
+# ADR-0002: Ref-first reactivity instead of JavaScript `Proxy`
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.Reactivity` and every consumer of it (`RuntimeCore`, the compiler's
+  expression-binding contract).
+
+## Context
+
+Vue 3's public reactivity story leads with `reactive(obj)` — a deep [`Proxy`](https://vuejs.org/api/reactivity-core.html#reactive)
+that intercepts every property read and write and auto-unwraps refs on access — and treats `ref()`
+as the primitive for standalone values. The `Proxy` is unavailable AOT/trimming-safe in WASM (see
+[ADR-0001](0001-source-generators-over-reflection.md)). However, Vue 3.5's *own* ref internals are a
+plain getter/setter over a dependency with explicit track-on-read / trigger-on-write, plus a
+version-counter and doubly-linked-list dependency graph — all of which port to C# directly.
+
+## Decision
+
+**`Ref<T>`-style references are the primary reactive primitive; there is no `Proxy`.**
+
+- `Reference<T>` (Vue's `ref()`), `ShallowReference<T>` (`shallowRef()`), `CustomReference<T>`
+  (`customRef()`), and `Computed<T>` (`computed()`) are plain C# types with a settable `Value`
+  property that tracks on read and triggers on write. The static `Reactive` facade mirrors the
+  `@vue/reactivity` API surface (refs, computeds, effects, scopes, tracking control, batching).
+- `reactive(obj)` becomes a `[Reactive]` partial class whose per-property reactive wrappers are
+  emitted by `Assimalign.Viu.Reactivity.Generators` — not a runtime-proxied object.
+- Reactive collections are dedicated types — `ReactiveList<T>`, `ReactiveDictionary<TKey,TValue>`,
+  `ReactiveSet<T>` — implementing the BCL collection interfaces, **not** proxied BCL types.
+- The dependency engine ports Vue 3.5's version-counter + doubly-linked-list subscriber design.
+- The model is single-threaded (the JS event loop); ambient tracking state is `static` and not
+  thread-safe by design.
+
+## Consequences
+
+- **The compiler, not a runtime proxy, decides every access form.** With no `Proxy` to auto-unwrap
+  refs, a template that reads a ref must emit `.Value`, and — because `Ref<T>.Value` is a settable
+  property — compound assignment and increment (`count++`, `count += 1`) rewrite cleanly to
+  `count.Value …`. This is the expression-binding contract pinned in
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md);
+  a change to `Ref<T>.Value` requires a matching change there.
+- No implicit deep reactivity: authors reach for `[Reactive]` classes or reactive collections
+  explicitly, which is more predictable but less magical than a deep `Proxy`.
+- Escape hatches and introspection (`unref`/`isRef`, raw markers) are provided explicitly rather
+  than falling out of proxy identity.
+
+## Alternatives considered
+
+- **A `Proxy` analogue** (`DispatchProxy`, `Reflection.Emit`) — rejected under
+  [ADR-0001](0001-source-generators-over-reflection.md): trimming-unsafe.
+- **Proxied BCL collections** — impossible without a `Proxy`; dedicated reactive collection types
+  give the same reactivity with AOT-safe, allocation-predictable code.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 2.
+- [`Assimalign.Viu.Reactivity/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md).
+- Vue 3: [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity),
+  [Reactivity API: Core](https://vuejs.org/api/reactivity-core.html).

--- a/docs/adr/0003-batched-interop-dom-operations.md
+++ b/docs/adr/0003-batched-interop-dom-operations.md
@@ -1,0 +1,62 @@
+# ADR-0003: Batched JS-interop DOM operations as the performance budget
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.RuntimeDom`, `Assimalign.Viu.RuntimeCore` (renderer, scheduler, block
+  tree), `Assimalign.Viu.Shared` (the flag vocabulary), and the compiler's static-optimization
+  passes.
+
+## Context
+
+In a browser WASM app every DOM mutation crosses the .NET ↔ JavaScript interop boundary, and that
+marshaling is the framework's dominant per-operation cost — far more so than the equivalent property
+access in Vue's JavaScript runtime. Vue's [compiler-informed rendering](https://vuejs.org/guide/extras/rendering-mechanism.html)
+(patch flags, shape flags, the block tree that flattens dynamic descendants) exists to skip work;
+on WASM each skipped patch visit is additionally a **marshaling round-trip avoided**, so the same
+idea pays off more.
+
+## Decision
+
+**The interop boundary is Viu's performance budget, and the runtime is organized to spend as few
+crossings as possible and keep each one cheap.**
+
+- Decision logic lives in .NET; the JS side is a dumb applier. Patch operations batch into a
+  command buffer applied by **one** JS call per scheduler flush.
+- Events use the invoker pattern: one delegated JS listener per (element, event); a re-rendered
+  handler is a .NET delegate swap on the invoker — zero `addEventListener`/`removeEventListener`
+  interop between renders.
+- Static content is stringified aggressively and inserted via `innerHTML` (`insertStaticContent`),
+  collapsing many node ops into one.
+- The compiler and runtime share the `PatchFlags`/`ShapeFlags`/`SlotFlags` bitmask vocabulary (in
+  `Assimalign.Viu.Shared`); the renderer patches only what the flags mark dynamic, and the block
+  tree flattens dynamic nodes so patching skips the static structure.
+- JS-side handles and event listeners are always cleaned up deterministically (two-sided release).
+
+## Consequences
+
+- Node identity crosses the boundary as **int handles**, not `JSObject` proxies — the measured,
+  RuntimeDom-local realization of this budget, recorded in
+  [`Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md).
+- The command buffer requires primitive-typed ops (opcode + int + string), which int handles
+  satisfy and proxies would not.
+- The compiler carries static hoisting and stringification passes (`cacheStatic` / `stringifyStatic`)
+  whose payoff is counted in avoided interop calls — see
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md).
+- WASM size and startup budgets gate CI from W03; a benchmark suite ([V01.01.11.04]) re-measures
+  interop cost under AOT.
+
+## Alternatives considered
+
+- **Per-operation interop** (a JS call per node op) — the naive port, rejected: it spends the exact
+  resource that is scarcest.
+- **`JSObject` proxy per node** — natural JS ergonomics, but measured ~2× slower for node
+  creation/teardown and incompatible with the batched command buffer; see the RuntimeDom ADR-0001
+  measurement.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decisions 1 and 4.
+- [`Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md),
+  [`DESIGN.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md), and its
+  [ADR-0001](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md).
+- Vue 3: [rendering mechanism](https://vuejs.org/guide/extras/rendering-mechanism.html).

--- a/docs/adr/0004-composition-only-component-model.md
+++ b/docs/adr/0004-composition-only-component-model.md
@@ -1,0 +1,59 @@
+# ADR-0004: Composition-only component model (no Options API, mixins, or global properties)
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (foundational C#/WASM premise; formally recorded under [V01.01.13.01], #98)
+- **Scope:** `Assimalign.Viu.RuntimeCore` — the component instance, setup model, app API, and
+  provide/inject.
+
+## Context
+
+Vue 3 supports two authoring styles: the [Options API](https://vuejs.org/guide/typescript/options-api.html)
+(`data`/`methods`/`computed` merged onto a `this` context) and the
+[Composition API](https://vuejs.org/guide/extras/composition-api-faq.html) (`setup()` returning
+reactive state). It also offers [mixins](https://vuejs.org/api/options-composition.html#mixins) for
+sharing option fragments and
+[`app.config.globalProperties`](https://vuejs.org/api/application.html#app-config-globalproperties)
+for injecting ambient members onto every component's `this`.
+
+The Options API and mixins depend on runtime option resolution and `this`-based merging; global
+properties inject untyped ambient members. All three fight static typing and add reflection-shaped
+runtime machinery — a poor fit for an AOT/trimming target and for C#'s type system.
+
+## Decision
+
+**Viu ships a composition-only component model.**
+
+- No Options API and no mixins: component logic is expressed in a setup function returning reactive
+  state (refs, computeds) and handlers.
+- No `app.config.globalProperties`: cross-cutting values are supplied through **typed
+  provide/inject** (`InjectionKey<T>`, app-level `Provide<T>`) and plugins (`IPlugin<TNode>`).
+- `Application<TNode>` (the C# port of `createAppAPI(render)`) and `ApplicationConfiguration`
+  deliberately exclude a global-properties bag; `ApplicationConfiguration` carries the error
+  handler, warn handler, and performance flag only. This exclusion is called out in
+  `Application<TNode>`'s own XML docs, which reference this ADR.
+
+## Consequences
+
+- Composition functions and typed provide/inject replace every Options-API and mixin use case;
+  shared behavior is a plain function, and shared state is an injected, typed value.
+- Cross-cutting registration (components, directives, app-level provides) flows through the app API
+  and plugins, all typed.
+- Easier: static typing end to end, trimming safety, and no `this`-merge order ambiguity. Harder:
+  there is no drop-in Options API path for Vue authors migrating Options-style components — that is
+  the accepted cost of the divergence.
+
+## Alternatives considered
+
+- **Support the Options API and mixins** — rejected: runtime option merging is untyped, reflection-
+  shaped, and reintroduces the `this`-merge ambiguity even Vue's own guidance steers larger apps
+  away from.
+- **Provide `globalProperties`** — rejected: untyped ambient state that the trimmer cannot reason
+  about; typed provide/inject covers the same need with compile-time safety.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 5.
+- [`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md)
+  and `Application<TNode>` / `ApplicationConfiguration`.
+- Vue 3: [Composition API FAQ](https://vuejs.org/guide/extras/composition-api-faq.html),
+  [provide/inject](https://vuejs.org/guide/components/provide-inject.html).

--- a/docs/adr/0005-no-runtime-template-compilation.md
+++ b/docs/adr/0005-no-runtime-template-compilation.md
@@ -1,0 +1,56 @@
+# ADR-0005: No runtime template compilation (build-time source generators only)
+
+- **Status:** Accepted
+- **Date:** 2026-07-17 (the build-time `.viu` compilation container was decided this date, `docs/PLAN.md`
+  founding decision 3; formally recorded as an ADR under [V01.01.13.01], #98, on 2026-07-19)
+- **Scope:** `Assimalign.Viu.Syntax.Templates`, `Assimalign.Viu.Syntax.SingleFileComponent`, and the
+  `Assimalign.Viu.Syntax.Generators` composition root.
+
+## Context
+
+Vue's full build compiles templates to render functions at runtime with `new Function` (its
+in-browser compiler). That path is impossible in WASM — dynamic code generation is forbidden AOT
+(see [ADR-0001](0001-source-generators-over-reflection.md)). Vue's own guidance already prefers a
+build step so the runtime ships without the compiler; Viu makes the build step mandatory.
+
+## Decision
+
+**Templates and `.viu` single-file components compile at build time only, via Roslyn source
+generators; there is no runtime compilation path.**
+
+- The template front end (`Assimalign.Viu.Syntax.Templates`) tokenizes, parses, transforms, and
+  emits a C# render method; `Assimalign.Viu.Syntax.Generators` is the incremental generator that
+  drives it and stitches the output into the component's partial class.
+- There is no runtime `compile(templateString)` API — a template that is not present at build time
+  cannot be rendered.
+- The `.viu` container uses `@template`/`@script`/`@style` `@`-block syntax — a deliberate divergence
+  from Vue's tag-based SFC container (decided 2026-07-17). The **markup inside `@template` remains
+  standard Vue template syntax**; only the container framing differs. The container is specified in
+  [`Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md).
+
+## Consequences
+
+- Compilation is compiler-grade tooling: diagnostics carry template source locations mapped back to
+  the `.viu` file (Roslyn `#line`), so C# errors in a template expression point at the real line and
+  column — the tooling story reaches Razor-grade because it *is* a compiler.
+- The JavaScript-to-C# serialization divergences (no comma operator, no object literals with
+  arbitrary keys, `.Value` unwrapping, `undefined`→`null`, …) are documented and test-pinned in
+  [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md).
+- Compiler-informed patch flags, block trees, and static hoisting all fall out of build-time
+  compilation and feed the interop budget ([ADR-0003](0003-batched-interop-dom-operations.md)).
+- Dynamic, string-sourced templates are unsupported by design.
+
+## Alternatives considered
+
+- **A runtime compiler** (`new Function` equivalent) — impossible/forbidden AOT.
+- **A runtime template interpreter** — technically AOT-safe but rejected: it forfeits compiler-
+  informed patch flags and static hoisting, adds per-render cost, and gives up the build-time
+  diagnostics that make the authoring experience strong.
+
+## References
+
+- [`docs/PLAN.md`](../PLAN.md) — founding decision 3.
+- [`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md)
+  and [`Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md).
+- Vue 3: [render functions](https://vuejs.org/guide/extras/render-function.html),
+  [SFC spec](https://vuejs.org/api/sfc-spec.html).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture decision records
+
+This is Viu's append-only log of architecture decisions — the *why* behind the choices that shape
+the framework, especially the deliberate C#/WASM divergences from Vue 3. The narrative summary of
+these decisions lives in [`docs/PLAN.md`](../PLAN.md) ("Founding design decisions"); this directory
+records each one as a standalone, citable document a future session can act on without that
+conversation's context.
+
+## Conventions
+
+- **Numbering.** ADRs are numbered sequentially from `0001`, zero-padded to four digits. The
+  filename is `NNNN-kebab-case-title.md`; the document title is `# ADR-NNNN: <decision>`.
+- **Append-only.** An ADR is never rewritten to change a past decision. To change course, add a new
+  ADR that supersedes the old one: set the new ADR's status to `Accepted`, set the old ADR's status
+  to `Superseded by ADR-NNNN` with a link to the new record, and link both ways. History is
+  preserved, not edited.
+  (Correcting a typo or a broken link is fine; reversing the recorded decision is not.)
+- **Template.** Copy [`template.md`](template.md) for a new record.
+- **When to write one.** Any decision with lasting architectural consequence — a divergence from
+  vuejs/core semantics, a cross-cutting constraint, a technology or boundary choice. Small, local
+  choices belong in the relevant `DESIGN.md`, not here.
+
+## Repo-level versus library-level ADRs
+
+This directory holds **repo-wide and cross-cutting** decisions. A decision that is contained within
+a single library — measured, library-specific, and unlikely to be cited elsewhere — may instead live
+in that library's `docs/` folder as a local ADR. The existing example is
+[`Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md`](../../libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md)
+(int-handle node identity over `JSObject` proxies), which is the RuntimeDom-local realization of the
+repo-wide budget recorded here in [ADR-0003](0003-batched-interop-dom-operations.md). Library-local
+ADRs keep their own numbering within their library folder.
+
+## Index
+
+| ADR | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-source-generators-over-reflection.md) | Roslyn source generators over reflection and dynamic code generation | Accepted |
+| [0002](0002-ref-first-reactivity.md) | Ref-first reactivity instead of JavaScript `Proxy` | Accepted |
+| [0003](0003-batched-interop-dom-operations.md) | Batched JS-interop DOM operations as the performance budget | Accepted |
+| [0004](0004-composition-only-component-model.md) | Composition-only component model (no Options API, mixins, or global properties) | Accepted |
+| [0005](0005-no-runtime-template-compilation.md) | No runtime template compilation (build-time source generators only) | Accepted |
+
+See also [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for how ADRs fit into the wider documentation
+convention.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,34 @@
+# ADR-NNNN: <short decision title, stated as the decision>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN (link the superseding record) | Deprecated
+- **Date:** YYYY-MM-DD (the date the decision was made; keep the original when superseding)
+- **Work item:** [V01.01.NN.MM] (#issue), when the decision was made under one
+- **Scope:** which area(s) the decision governs (repo-wide, or specific `Assimalign.Viu.*` libraries)
+
+## Context
+
+The forces at play: what problem this decides, the constraints that bound it (AOT/trimming, the
+WASM interop budget, upstream Vue 3 parity, the single-threaded model), and the relevant upstream
+Vue 3 behavior. Link the authoritative reference — vuejs.org or the specific `vuejs/core` source
+file/module — so the parity baseline the decision diverges from (or preserves) is explicit.
+
+## Decision
+
+The decision itself, in active voice ("We use X"), specific enough that a future session can apply
+it without this conversation's context. State the rule, not just the sentiment.
+
+## Consequences
+
+What becomes easier and what becomes harder. Include the follow-on obligations the decision creates
+(new seams to maintain, tests that pin the chosen behavior, budgets to gate) and the deltas from
+Vue 3 that the decision commits Viu to.
+
+## Alternatives considered
+
+Each seriously weighed option and why it was not chosen. For a measured decision, cite the
+measurement (link the harness/benchmark). This is where a superseding ADR will look first.
+
+## References
+
+- Vue 3 counterpart(s): vuejs.org guide / `vuejs/core` package or source file.
+- Related ADRs, `docs/PLAN.md` founding decisions, per-library `DESIGN.md` sections.

--- a/libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Reactivity/docs/DESIGN.md
@@ -1,0 +1,54 @@
+# Assimalign.Viu.Reactivity — design
+
+Why the reactive core is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterpart: [`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity) (v3.5).
+
+## Ref-first, no `Proxy`
+
+The founding divergence is [ADR-0002](../../../docs/adr/0002-ref-first-reactivity.md): Vue's public
+lead is the deep `Proxy` (`reactive(obj)`), which is not AOT/trimming-safe in WASM. Viu leads with
+references instead. `Reference<T>` and `Computed<T>` are plain getter/setter types that track on read
+and trigger on write — Vue 3.5's own ref internals port directly. `reactive(obj)` becomes a
+`[Reactive]` partial class whose property wrappers a source generator emits, and reactive collections
+are dedicated types rather than proxied BCL collections.
+
+## The dependency engine
+
+The engine ports Vue 3.5's **version-counter + doubly-linked-list** design: a `Dependency` holds
+subscribers, a `Subscriber` holds its dependencies, and the `Link` nodes between them (internal) are
+reused across runs so a stable dependency set allocates nothing on re-track. Batching
+(`StartBatch`/`EndBatch`) coalesces triggers so multiple writes produce at most one run per effect;
+`PauseTracking`/`ResetTracking` gate collection.
+
+`Subscriber` is a **`public abstract` class with `internal` members and a `private protected`
+constructor** — opaque and un-subclassable externally, but a real base so the engine's hot path
+(per-trigger notification) dispatches through a vtable virtual call rather than interface dispatch,
+which is measurably costlier on mono-wasm / NativeAOT (the repo's "dispatch on hot paths" rule).
+Concrete leaves (`ReactiveEffect`, `Computed<T>`) are `sealed` so the JIT can devirtualize.
+
+## The compiler contract
+
+Because there is no runtime `Proxy` to auto-unwrap refs, the *compiler* decides every access form,
+and `Ref<T>.Value` being a **settable property** is what makes it work: `count.Value` serves both
+reads and writes, so `count++` and `count += 1` rewrite cleanly. This library owns the `Value`
+semantics; the template compiler's expression-binding table
+([`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../Assimalign.Viu.Syntax.Templates/docs/DESIGN.md))
+is pinned to it — a change to `Value` requires a matching change there.
+
+## Deltas from Vue 3
+
+- **`.Value` in read and write positions** replaces Vue's read-time `unref` plus `isRef`-guarded
+  assignment (forced by, and enabled by, C# properties).
+- **`effect()` stops the effect if its first run throws** before rethrowing (upstream `effect()`
+  parity), so a failed effect leaves no live subscriptions.
+- **The abstract-base hot-path model** (over interfaces) is a deliberate C#/WASM performance shape
+  with no upstream analogue — JavaScript has no equivalent dispatch cost.
+- **Reactive collections are concrete types**, not proxied BCL types; behavior tracks the mutation
+  triggers Vue's collection handlers fire.
+
+## Non-goals
+
+- No deep implicit reactivity without `[Reactive]` or a reactive collection — reactivity is opted
+  into explicitly.
+- Reactivity escape hatches and introspection beyond the current surface are sequenced work
+  ([V01.01.02.09]).

--- a/libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md
@@ -1,0 +1,38 @@
+# Assimalign.Viu.Reactivity — overview
+
+The reactive core of Viu — the C# port of
+[`@vue/reactivity`](https://github.com/vuejs/core/tree/main/packages/reactivity): dependencies,
+refs, computeds, effects, effect scopes, watch, reactive collections, and source-generated reactive
+objects. It is Ref-first — there is no JavaScript `Proxy` (see
+[ADR-0002](../../../docs/adr/0002-ref-first-reactivity.md)). Area: `V01.01.02`.
+
+## Public surface
+
+- **`Reactive`** (static facade) — the `@vue/reactivity` API surface: `Reference`/`ShallowReference`/
+  `CustomReference`/`Computed`, `Effect`, `EffectScope`, `OnScopeDispose`, `TriggerReference`,
+  `PauseTracking`/`ResetTracking`, and `StartBatch`/`EndBatch`.
+- **References** — `Reference<T>` (Vue's `ref()`), `ShallowReference<T>` (`shallowRef()`),
+  `CustomReference<T>` (`customRef()`), and `Computed<T>` (`computed()`, lazy versioned caching).
+  All expose a settable `Value` and implement `IReference` / `IReference<T>`.
+- **Effects and scopes** — `ReactiveEffect` (the effect runner with scheduler injection),
+  `EffectScope` (hierarchical disposal, `effectScope()`), `Dependency` (the tracked-dependency
+  primitive), and `Subscriber` (the opaque `public abstract` base for effect-like subscribers).
+- **Watch** — `WatchOptions`, `WatchHandle`, `WatchJob`, `WatchFlushMode`, the `WatchCallback<T>` and
+  `OnCleanup` delegates, and the `IWatchScheduler` seam a host (the runtime scheduler) plugs into.
+- **Source-generated reactive objects** — the `[Reactive]` / `[ShallowReactive]` attributes
+  (`ReactiveAttribute` / `ShallowReactiveAttribute`); a companion source generator emits the
+  reactive property wrappers for the annotated partial class (Vue's `reactive()`).
+- **Reactive collections** — `ReactiveList<T>`, `ReactiveDictionary<TKey,TValue>`, `ReactiveSet<T>`
+  (dedicated reactive types implementing the BCL collection interfaces).
+- **Traversal and introspection** — `ReactiveTraversal`, `IReactiveTraversable`, `IReactiveObject`,
+  `IReadonlyReactive`.
+
+## Boundaries
+
+- **No `Assimalign.Viu.*` project references** — a standalone base alongside `Assimalign.Viu.Shared`.
+  Ships as a net10.0 runtime library with `IsAotCompatible=true`, and **carries the `[Reactive]`
+  source generator as an analyzer** so any consumer that references this library gets `[Reactive]`
+  support with no extra wiring.
+- **Single-threaded** (the JS event-loop model): ambient tracking state is `static` and not
+  thread-safe by design.
+- Design rationale, the dependency-engine port, and the compiler contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Router/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Router/docs/DESIGN.md
@@ -1,0 +1,107 @@
+# Assimalign.Viu.Router — design
+
+Why the matcher is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterpart: `vue-router` v4's matcher (`packages/router/src/matcher/` in
+https://github.com/vuejs/router). Matching-syntax reference:
+https://router.vuejs.org/guide/essentials/route-matching-syntax.html.
+
+## The matcher is a pure port
+
+vue-router's `createRouterMatcher` is deliberately independent of the browser so it can be
+unit-tested without a DOM — the same property the router epic (#69) calls out. This package keeps
+that property literal: it references no other Viu library and no interop assembly, so the whole
+table-build/resolve path runs in a plain .NET test host. The navigation pipeline, history, and
+components (#69, later features) will sit *on top of* this and supply the browser coupling.
+
+The port is faithful to upstream at three levels, each pinned by tests and code links:
+
+1. **Tokenizer** (`PathTokenizer` ⇄ `tokenizePath`): the character-by-character state machine,
+   including the `> 1` "a repeatable param must be alone" guard (so `/user-:id+` is legal but
+   `/:a:b:c+` is not), the escaped-`)` handling inside custom patterns, and the special cases
+   `""` → `[[]]` and `/` → one empty-value `Static` token.
+2. **Compiler + ranker** (`PathParserFactory` ⇄ `tokensToParser`, `PathScore` /
+   `PathParserScoreComparer` ⇄ `PathScore` / `comparePathParserScore`): the regular-expression
+   string, the per-segment score arrays, and the two-level comparison are reproduced value-for-value
+   — including the fractional strict/case-sensitive bonuses (0.7, 0.25) that must stay below 1 so
+   they only break ties.
+3. **Resolution + insertion** (`RouteMatcher` ⇄ `createRouterMatcher`): the score-sorted matcher
+   list, the binary-search insertion with the equal-score ancestor rule, path- and name-based
+   resolve, and the parent-to-child matched chain.
+
+## Ranking: specificity, never table order
+
+The matcher list is kept sorted by descending score, and `Resolve(path)` returns the first (most
+specific) matcher whose pattern matches. Because the score comes from the pattern's shape — static
+segments (`+Static`) outweigh dynamic (`+Dynamic`), a custom pattern earns `+BonusCustomPattern`,
+and the catch-all `(.*)` takes the large `BonusWildcard` penalty that also cancels its custom-pattern
+bonus — the order routes were registered never changes the winner. The ranking tests register the
+least-specific route first on purpose to prove it.
+
+The one subtle case is the **empty-path default child**. A child with `path: ""` compiles to the
+same full path (and therefore the same score) as its parent, so `findInsertionIndex` places it
+*ahead of* the equally scored parent (`getInsertionAncestor`). Navigating to the parent path then
+resolves the child and yields the two-entry `[parent, child]` matched chain — the layout-with-
+default-view pattern.
+
+## Deliberate divergences from vue-router
+
+- **Every record is currently matchable.** Upstream's `isMatchable` gates the insertion-ancestor
+  rule on a record having a name, components, or a redirect. Components and redirects are later
+  Router features, so there is nothing yet to gate on; treating every record as matchable is what
+  keeps the empty-path-child ordering working and is sufficient for every criterion in this ticket.
+  When components/redirect land, `RouteMatcher.IsMatchable` is the single place to reintroduce the
+  gate.
+- **No `currentLocation` parameter inheritance.** Upstream's named resolve can inherit params from
+  the current location for relative navigation. That needs a "current route", which is a
+  navigation-pipeline concern (`[V01.01.08.04]`). Named resolution here interpolates exactly the
+  parameters passed in (projected to the route's declared keys) and raises
+  `MissingRequiredParameter` otherwise.
+- **Path only.** The matcher resolves the path portion. Query strings and fragments are normalized
+  and merged at the router level, not here.
+- **Typed accessors replace `string | string[]` at the edge.** Internally a repeatable value stays
+  an ordered `string[]` and a single value stays a `string` (matching upstream `PathParams`, including
+  the quirk that an unmatched optional-repeatable parameter parses to an empty *string*, not an empty
+  array). Consumers read through `GetString` / `GetInteger` / `GetStrings`, which parse on demand —
+  no boxed `object`, no reflection over a dictionary. `GetInteger` on a non-integer raises
+  `FormatException` and a missing key raises `KeyNotFoundException` (idiomatic .NET), while
+  route-definition and interpolation failures raise the typed `RouteMatcherException`.
+
+## AOT / trimming: no runtime codegen
+
+WASM has no `new Function`/`eval` and reflection-emit is off the table, so nothing here compiles code
+at runtime:
+
+- **Path patterns compile to interpreted `Regex`.** A route table is runtime data, so each pattern
+  string is assembled at table-build time and handed to `new Regex(...)` with the interpreted engine
+  (never `RegexOptions.Compiled`, which relies on reflection emit). The interpreted engine is fully
+  trimming- and NativeAOT-safe. This mirrors vue-router, whose `tokensToParser` likewise builds a
+  `RegExp` from a runtime string.
+- **The one compile-time-constant pattern uses `[GeneratedRegex]`.** `REGEX_CHARS_RE` (escaping
+  literal path text) is known at build time, so `RegularExpressionPatterns` emits it through the
+  Roslyn regex source generator — the AOT-preferred path — rather than constructing it reflectively.
+  The valid-parameter-name check is a direct character test, needing no regular expression at all.
+- **Custom parameter patterns should use non-capturing groups** (`(?:…)`), exactly as vue-router
+  expects: the compiler wraps each parameter in a single capturing group and maps capturing groups
+  to keys positionally, so a capturing group inside a user pattern would shift that mapping. Invalid
+  custom patterns are validated at table-build time and raise `InvalidCustomPattern`.
+- **`.NET` end-anchor nuance.** `.NET`'s `$` also matches immediately before a trailing newline,
+  whereas JavaScript's `$` (no `m` flag) matches only at the very end. Route paths never contain
+  newlines, so this is inert; noted here so a future reader does not mistake it for a bug.
+
+## Value semantics for cheap comparison
+
+The navigation pipeline and reactivity layer need to compare and snapshot locations cheaply, so
+`RouteLocation` and `RouteParameters` implement value equality (locations compare their matched
+records by identity; parameters compare structurally and hash order-independently). `RouteRecord`
+keeps reference identity on purpose — the matched chain points at the exact record instances the
+consumer supplied.
+
+## Non-goals (sequenced work)
+
+- History integration (browser/hash/memory behind `IRouterHistory`) — `[V01.01.08.02]`.
+- `RouterView` / `RouterLink` components — `[V01.01.08.03]`.
+- Async navigation pipeline and guards (redirect, cancellation), plus `currentLocation` param
+  inheritance and route removal — `[V01.01.08.04]`.
+- Lazy route components and scroll behavior — `[V01.01.08.05]`.
+- Components, redirects, aliases, and per-record `strict`/`sensitive` overrides on `RouteRecord`
+  (only global `PathMatchingOptions` today).

--- a/libraries/Assimalign.Viu.Router/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Router/docs/OVERVIEW.md
@@ -1,0 +1,80 @@
+# Assimalign.Viu.Router — overview
+
+The client router for Viu — the role `vue-router` v4 plays for Vue 3
+(https://github.com/vuejs/router). This first feature delivers the **route table and matcher**: the
+pure, DOM-free core that, given a set of route records and a location (a path or a named target),
+resolves an immutable `RouteLocation` with its parent-to-child matched chain and parsed parameters.
+It is the C# port of vue-router's `createRouterMatcher` and its path-parser ranking model
+(`packages/router/src/matcher/`).
+
+History integration, `RouterView`/`RouterLink`, the async navigation pipeline with guards, and lazy
+routes are later features of the Router area (#69, `[V01.01.08.02]`–`[V01.01.08.05]`) and are not
+part of this package yet.
+
+## What it contains
+
+Public surface (all under namespace `Assimalign.Viu.Router`):
+
+- **`RouteMatcher`** (entry point): the route table and matcher. Construct it from a set of
+  `RouteRecord`s (`new RouteMatcher(routes)`), then `Resolve(path)` for path resolution or
+  `ResolveNamed(name, parameters)` for named resolution. `AddRoute`, `HasNamedRoute`, and
+  `GetRoutes` round out the surface. The C# port of the object returned by `createRouterMatcher`.
+- **`IRouteMatcher`** (`Abstraction/`): the resolve/add/query contract the later navigation pipeline
+  depends on, implemented by `RouteMatcher`.
+- **`RouteRecord`**: an immutable route definition — `Path`, optional `Name`, nested `Children`,
+  and arbitrary `Meta`. A reference type with identity semantics (the same instance appears in every
+  matched chain it participates in). The C# port of vue-router's route record.
+- **`RouteLocation`**: the immutable resolution result — `Path`, `Name`, `Parameters`, the
+  parent-to-child `Matched` record chain, merged `Meta`, and `IsMatched`. Value equality so a
+  navigation layer can compare/snapshot cheaply. Mirrors the object returned by the matcher's
+  `resolve`.
+- **`RouteParameters`**: an immutable parameter set with typed, boxing-free, reflection-free
+  accessors — `GetString`/`TryGetString`, `GetInteger`/`TryGetInteger`, `GetStrings` (for
+  repeatable params) — plus immutable `With`/`WithMany` builders. Mirrors vue-router's `RouteParams`.
+- **`PathMatchingOptions`**: `Strict` and `Sensitive` matching toggles (vue-router's `strict` /
+  `sensitive`), defaulting to non-strict and case-insensitive.
+- **`RouteMatcherException`** + **`RouteMatcherError`**: the typed failure for invalid route
+  definitions (bad path, unclosed/invalid custom pattern, repeatable-not-alone) and resolution
+  failures (named route not found, missing required parameter, array for a non-repeatable
+  parameter).
+
+Internal (`Internal/`, exercised through `InternalsVisibleTo` tests): the path parser — `PathToken`
+/ `PathTokenKind` / `PathTokenizer` (the C# port of `tokenizePath`), `PathParserFactory` (the port
+of `tokensToParser`), `PathParser` (the compiled regular expression + score + keys, with
+`TryParse`/`Stringify`), `PathScore` + `PathParserScoreComparer` (the ranking model),
+`PathParameterKey`, `RouteParameterValue`, `RouteRecordMatcher`, and `RegularExpressionPatterns`
+(the `[GeneratedRegex]` escape helper).
+
+## Using it
+
+```csharp
+using Assimalign.Viu.Router;
+
+var matcher = new RouteMatcher(
+[
+    new RouteRecord("/", name: "home"),
+    new RouteRecord("/users", name: "users", children:
+    [
+        new RouteRecord(":id", name: "user"),           // -> /users/:id
+    ]),
+    new RouteRecord("/:pathMatch(.*)*", name: "not-found"),
+]);
+
+RouteLocation location = matcher.Resolve("/users/42");
+// location.Name == "user"
+// location.Parameters.GetInteger("id") == 42
+// location.Matched == [users record, user record]   (parent-to-child)
+
+string path = matcher.ResolveNamed("user", RouteParameters.Empty.With("id", "42")).Path;
+// path == "/users/42"
+```
+
+## Boundaries
+
+- References **no other Viu library** and **no JavaScript-interop assembly** — the matcher is pure
+  and runs in a plain .NET test host (a boundary the test suite asserts by reflection).
+- Trimming- and NativeAOT-safe: no reflection-based serialization, no dynamic code generation. Path
+  patterns compile to interpreted regular expressions; the one compile-time-constant pattern uses
+  the `[GeneratedRegex]` source generator.
+- Design rationale, the ranking model, and the deliberate C#/WASM divergences from vue-router:
+  [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Router/src/Abstraction/IRouteMatcher.cs
+++ b/libraries/Assimalign.Viu.Router/src/Abstraction/IRouteMatcher.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Resolves locations against a route table. The public contract of the C# port of vue-router's
+/// route matcher (the object returned by <c>createRouterMatcher</c>,
+/// <c>packages/router/src/matcher/index.ts</c>). Implemented by <see cref="RouteMatcher"/>. A
+/// later router feature (the navigation pipeline) depends on this abstraction rather than the
+/// concrete matcher.
+/// </summary>
+/// <remarks>
+/// The matcher is pure: it has no dependency on the DOM, JavaScript interop, or the runtime
+/// renderer, and is fully exercisable in a plain .NET test host.
+/// </remarks>
+public interface IRouteMatcher
+{
+    /// <summary>Adds a route record (and its children) to the table. Mirrors <c>addRoute</c>.</summary>
+    /// <param name="record">The route record to add.</param>
+    void AddRoute(RouteRecord record);
+
+    /// <summary>
+    /// Resolves a path to a location. Mirrors the path branch of <c>resolve</c>: the highest-ranked
+    /// matching route wins. A path that matches nothing yields a location with an empty matched
+    /// chain (it does not throw).
+    /// </summary>
+    /// <param name="path">The path to resolve (path portion only — no query or fragment).</param>
+    RouteLocation Resolve(string path);
+
+    /// <summary>Resolves a named route with no parameters.</summary>
+    /// <param name="name">The route name.</param>
+    /// <exception cref="RouteMatcherException">
+    /// No route with that name exists, or a required parameter is missing.
+    /// </exception>
+    RouteLocation ResolveNamed(string name);
+
+    /// <summary>
+    /// Resolves a named route, interpolating <paramref name="parameters"/> into the full path.
+    /// Mirrors the name branch of <c>resolve</c>.
+    /// </summary>
+    /// <param name="name">The route name.</param>
+    /// <param name="parameters">The parameter values to interpolate.</param>
+    /// <exception cref="RouteMatcherException">
+    /// No route with that name exists, a required parameter is missing, or an array was supplied for
+    /// a non-repeatable parameter.
+    /// </exception>
+    RouteLocation ResolveNamed(string name, RouteParameters parameters);
+
+    /// <summary>Whether a route with the given name exists in the table.</summary>
+    /// <param name="name">The route name.</param>
+    bool HasNamedRoute(string name);
+
+    /// <summary>
+    /// The records of every registered matcher, ordered by descending specificity. Mirrors
+    /// <c>getRoutes</c>.
+    /// </summary>
+    IReadOnlyList<RouteRecord> GetRoutes();
+}

--- a/libraries/Assimalign.Viu.Router/src/Assimalign.Viu.Router.csproj
+++ b/libraries/Assimalign.Viu.Router/src/Assimalign.Viu.Router.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+</Project>

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathParameterKey.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathParameterKey.cs
@@ -1,0 +1,30 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Describes one capturing parameter in a compiled path pattern — its name and the modifiers that
+/// govern how its captured value is read back. The C# port of vue-router's
+/// <c>PathParserParamKey</c> (<c>packages/router/src/matcher/pathParserRanker.ts</c>). Keys are
+/// stored in pattern order so the i-th capturing group maps to the i-th key.
+/// </summary>
+internal readonly struct PathParameterKey
+{
+    /// <summary>Creates a parameter key.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="repeatable">Whether the parameter is repeatable (its captured value splits on <c>/</c>).</param>
+    /// <param name="optional">Whether the parameter is optional (its capturing group may not participate).</param>
+    public PathParameterKey(string name, bool repeatable, bool optional)
+    {
+        Name = name;
+        Repeatable = repeatable;
+        Optional = optional;
+    }
+
+    /// <summary>The parameter name.</summary>
+    public string Name { get; }
+
+    /// <summary>Whether the captured value should be split on <c>/</c> into multiple values.</summary>
+    public bool Repeatable { get; }
+
+    /// <summary>Whether the parameter is optional.</summary>
+    public bool Optional { get; }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathParser.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathParser.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// A compiled path pattern: a regular expression, a specificity <see cref="Score"/>, the ordered
+/// parameter <see cref="Keys"/>, and the token segments used to interpolate params back into a
+/// path. The C# port of vue-router's <c>PathParser</c>
+/// (<c>packages/router/src/matcher/pathParserRanker.ts</c>) — its <see cref="TryParse"/> mirrors
+/// <c>parse</c> and <see cref="Stringify"/> mirrors <c>stringify</c>.
+/// </summary>
+/// <remarks>
+/// The regular expression is built from runtime route-table data and constructed with the
+/// interpreted engine (never <see cref="RegexOptions.Compiled"/>, which relies on reflection
+/// emit), keeping the parser trimming- and NativeAOT-safe. See DESIGN.md.
+/// </remarks>
+internal sealed class PathParser
+{
+    private readonly Regex regularExpression;
+    private readonly PathToken[][] segments;
+
+    public PathParser(Regex regularExpression, double[][] score, PathParameterKey[] keys, PathToken[][] segments)
+    {
+        this.regularExpression = regularExpression;
+        Score = score;
+        Keys = keys;
+        this.segments = segments;
+    }
+
+    /// <summary>The specificity score, one inner array per path segment (see <see cref="PathScore"/>).</summary>
+    public double[][] Score { get; }
+
+    /// <summary>The parameters captured by this pattern, in capturing-group order.</summary>
+    public PathParameterKey[] Keys { get; }
+
+    /// <summary>The compiled regular expression source (for diagnostics and tests).</summary>
+    public string Pattern => regularExpression.ToString();
+
+    /// <summary>
+    /// Attempts to match <paramref name="path"/> and extract its parameters. Mirrors vue-router's
+    /// <c>parse</c>: a captured value for a repeatable key is split on <c>/</c> into multiple
+    /// values; every other value is stored as a single string (an empty capture stays a single
+    /// empty string, matching upstream).
+    /// </summary>
+    /// <param name="path">The path to match.</param>
+    /// <param name="parameters">The extracted parameters when the match succeeds.</param>
+    /// <returns><see langword="true"/> when the pattern matches; otherwise <see langword="false"/>.</returns>
+    public bool TryParse(string path, out RouteParameters parameters)
+    {
+        var match = regularExpression.Match(path);
+        if (!match.Success)
+        {
+            parameters = RouteParameters.Empty;
+            return false;
+        }
+
+        var values = new Dictionary<string, RouteParameterValue>(Keys.Length, StringComparer.Ordinal);
+        for (var groupIndex = 1; groupIndex < match.Groups.Count && groupIndex - 1 < Keys.Length; groupIndex++)
+        {
+            var group = match.Groups[groupIndex];
+            var value = group.Success ? group.Value : string.Empty;
+            var key = Keys[groupIndex - 1];
+            values[key.Name] = value.Length > 0 && key.Repeatable
+                ? RouteParameterValue.Multiple(value.Split('/'))
+                : RouteParameterValue.Single(value);
+        }
+
+        parameters = RouteParameters.FromValues(values);
+        return true;
+    }
+
+    /// <summary>
+    /// Interpolates <paramref name="parameters"/> into a concrete path. Mirrors vue-router's
+    /// <c>stringify</c>, including optional-parameter slash elision and the array/repeatable checks.
+    /// </summary>
+    /// <param name="parameters">The parameter values to substitute.</param>
+    /// <returns>The generated path.</returns>
+    /// <exception cref="RouteMatcherException">
+    /// A required parameter had no value (<see cref="RouteMatcherError.MissingRequiredParameter"/>),
+    /// or an array was supplied for a non-repeatable parameter
+    /// (<see cref="RouteMatcherError.ParameterNotRepeatable"/>).
+    /// </exception>
+    public string Stringify(RouteParameters parameters)
+    {
+        var path = new StringBuilder();
+        var avoidDuplicatedSlash = false;
+
+        foreach (var segment in segments)
+        {
+            if (!avoidDuplicatedSlash || !EndsWithSlash(path))
+            {
+                path.Append('/');
+            }
+            avoidDuplicatedSlash = false;
+
+            foreach (var token in segment)
+            {
+                if (token.Kind == PathTokenKind.Static)
+                {
+                    path.Append(token.Value);
+                    continue;
+                }
+
+                var hasValue = parameters.TryGetRawValue(token.Value, out var value);
+                var isArray = hasValue && value.IsMultiple;
+                if (isArray && !token.Repeatable)
+                {
+                    throw new RouteMatcherException(
+                        RouteMatcherError.ParameterNotRepeatable,
+                        $"Provided param \"{token.Value}\" is an array but it is not repeatable (* or + modifiers).");
+                }
+
+                var text = isArray
+                    ? string.Join("/", value.MultipleValues)
+                    : hasValue ? value.SingleValue : string.Empty;
+
+                if (text.Length == 0)
+                {
+                    if (token.Optional)
+                    {
+                        // Only elide the slash when the optional param is alone in its segment.
+                        if (segment.Length < 2)
+                        {
+                            if (EndsWithSlash(path))
+                            {
+                                path.Length -= 1;
+                            }
+                            else
+                            {
+                                avoidDuplicatedSlash = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        throw new RouteMatcherException(
+                            RouteMatcherError.MissingRequiredParameter,
+                            $"Missing required param \"{token.Value}\".");
+                    }
+                }
+
+                path.Append(text);
+            }
+        }
+
+        return path.Length == 0 ? "/" : path.ToString();
+    }
+
+    private static bool EndsWithSlash(StringBuilder builder)
+        => builder.Length > 0 && builder[^1] == '/';
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathParserFactory.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathParserFactory.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Turns tokenized path segments into a compiled <see cref="PathParser"/> — building the regular
+/// expression, the specificity score, and the parameter keys in one pass. The C# port of
+/// vue-router's <c>tokensToParser</c> (<c>packages/router/src/matcher/pathParserRanker.ts</c>).
+/// </summary>
+internal static class PathParserFactory
+{
+    // Upstream BASE_PARAM_PATTERN — a lazy "anything but a slash" match.
+    private const string BaseParameterPattern = "[^/]+?";
+
+    // Upstream catch-all pattern whose presence earns the wildcard penalty.
+    private const string WildcardPattern = ".*";
+
+    /// <summary>Compiles tokenized segments into a <see cref="PathParser"/>.</summary>
+    /// <param name="segments">The segments produced by <see cref="PathTokenizer.Tokenize"/>.</param>
+    /// <param name="options">Strict / case-sensitive matching options.</param>
+    /// <exception cref="RouteMatcherException">A custom parameter pattern was not a valid regular expression.</exception>
+    public static PathParser Compile(List<List<PathToken>> segments, PathMatchingOptions options)
+    {
+        // The top-level matcher always anchors both ends (upstream start/end default to true).
+        var strict = options.Strict;
+        var sensitive = options.Sensitive;
+
+        var score = new List<double[]>();
+        var pattern = new StringBuilder("^");
+        var keys = new List<PathParameterKey>();
+        var storedSegments = new PathToken[segments.Count][];
+
+        for (var segmentIndex = 0; segmentIndex < segments.Count; segmentIndex++)
+        {
+            var segment = segments[segmentIndex];
+            storedSegments[segmentIndex] = segment.ToArray();
+
+            // An empty segment (root "/" or a trailing slash) scores the Root bonus.
+            var segmentScores = new List<double>();
+            if (segment.Count == 0)
+            {
+                segmentScores.Add(PathScore.Root);
+                if (strict)
+                {
+                    pattern.Append('/');
+                }
+            }
+
+            for (var tokenIndex = 0; tokenIndex < segment.Count; tokenIndex++)
+            {
+                var token = segment[tokenIndex];
+                var subSegmentScore = PathScore.Segment + (sensitive ? PathScore.BonusCaseSensitive : 0);
+
+                if (token.Kind == PathTokenKind.Static)
+                {
+                    if (tokenIndex == 0)
+                    {
+                        pattern.Append('/');
+                    }
+                    pattern.Append(EscapeStaticText(token.Value));
+                    subSegmentScore += PathScore.Static;
+                }
+                else
+                {
+                    keys.Add(new PathParameterKey(token.Value, token.Repeatable, token.Optional));
+
+                    var innerPattern = token.CustomPattern.Length == 0 ? BaseParameterPattern : token.CustomPattern;
+                    if (!string.Equals(innerPattern, BaseParameterPattern, StringComparison.Ordinal))
+                    {
+                        subSegmentScore += PathScore.BonusCustomPattern;
+                        ValidateCustomPattern(token.Value, innerPattern);
+                    }
+
+                    // A repeatable param captures one-or-more slash-separated occurrences.
+                    var subPattern = token.Repeatable
+                        ? $"((?:{innerPattern})(?:/(?:{innerPattern}))*)"
+                        : $"({innerPattern})";
+
+                    if (tokenIndex == 0)
+                    {
+                        // Make the leading slash itself optional only when the optional param is the
+                        // whole segment (upstream: `optional && segment.length < 2`).
+                        subPattern = token.Optional && segment.Count < 2
+                            ? $"(?:/{subPattern})"
+                            : "/" + subPattern;
+                    }
+
+                    if (token.Optional)
+                    {
+                        subPattern += "?";
+                    }
+
+                    pattern.Append(subPattern);
+
+                    subSegmentScore += PathScore.Dynamic;
+                    if (token.Optional)
+                    {
+                        subSegmentScore += PathScore.BonusOptional;
+                    }
+                    if (token.Repeatable)
+                    {
+                        subSegmentScore += PathScore.BonusRepeatable;
+                    }
+                    if (string.Equals(innerPattern, WildcardPattern, StringComparison.Ordinal))
+                    {
+                        subSegmentScore += PathScore.BonusWildcard;
+                    }
+                }
+
+                segmentScores.Add(subSegmentScore);
+            }
+
+            score.Add(segmentScores.ToArray());
+        }
+
+        // The strict bonus lands only on the last sub-segment of the last segment.
+        if (strict && score.Count > 0)
+        {
+            var lastSegment = score[^1];
+            lastSegment[^1] += PathScore.BonusStrict;
+        }
+
+        if (!strict)
+        {
+            pattern.Append("/?");
+        }
+
+        // The top-level matcher is anchored at the end.
+        pattern.Append('$');
+
+        var regexOptions = RegexOptions.CultureInvariant | (sensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
+        var regularExpression = new Regex(pattern.ToString(), regexOptions);
+
+        return new PathParser(regularExpression, score.ToArray(), keys.ToArray(), storedSegments);
+    }
+
+    // Upstream: token.value.replace(REGEX_CHARS_RE, '\\$&').
+    private static string EscapeStaticText(string value)
+        => value.Length == 0
+            ? value
+            : RegularExpressionPatterns.RegularExpressionSpecialCharacters()
+                .Replace(value, static match => "\\" + match.Value);
+
+    private static void ValidateCustomPattern(string parameterName, string innerPattern)
+    {
+        try
+        {
+            _ = new Regex($"({innerPattern})");
+        }
+        catch (ArgumentException exception)
+        {
+            throw new RouteMatcherException(
+                RouteMatcherError.InvalidCustomPattern,
+                $"Invalid custom RegExp for param \"{parameterName}\" ({innerPattern}): {exception.Message}");
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathParserScoreComparer.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathParserScoreComparer.cs
@@ -1,0 +1,88 @@
+using System;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Compares two compiled path patterns by their specificity score. The C# port of vue-router's
+/// <c>compareScoreArray</c> and <c>comparePathParserScore</c>
+/// (<c>packages/router/src/matcher/pathParserRanker.ts</c>). A negative result means the first
+/// pattern is more specific (should sort earlier); positive means less specific; zero means equal.
+/// </summary>
+/// <remarks>
+/// This is what makes ranking table-order-independent: static segments outrank dynamic ones,
+/// dynamic outrank the catch-all wildcard, and a longer, more-constrained pattern outranks a
+/// shorter or looser one regardless of the order routes were added.
+/// </remarks>
+internal static class PathParserScoreComparer
+{
+    /// <summary>
+    /// Compares two full scores (one inner array per path segment). Mirrors
+    /// <c>comparePathParserScore</c>.
+    /// </summary>
+    public static double CompareScore(double[][] left, double[][] right)
+    {
+        var index = 0;
+        while (index < left.Length && index < right.Length)
+        {
+            var comparison = CompareScoreArray(left[index], right[index]);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+            index++;
+        }
+
+        if (Math.Abs(right.Length - left.Length) == 1)
+        {
+            if (IsLastScoreNegative(left))
+            {
+                return 1;
+            }
+            if (IsLastScoreNegative(right))
+            {
+                return -1;
+            }
+        }
+
+        // When every shared segment ties, the pattern with more segments sorts first.
+        return right.Length - left.Length;
+    }
+
+    // Mirrors compareScoreArray: element-wise until they differ, then a length tie-break that keeps
+    // a single static segment sorted ahead of a longer sub-segmented one.
+    private static double CompareScoreArray(double[] left, double[] right)
+    {
+        var index = 0;
+        while (index < left.Length && index < right.Length)
+        {
+            var difference = right[index] - left[index];
+            if (difference != 0)
+            {
+                return difference;
+            }
+            index++;
+        }
+
+        if (left.Length < right.Length)
+        {
+            return left.Length == 1 && left[0] == PathScore.Static + PathScore.Segment ? -1 : 1;
+        }
+        if (left.Length > right.Length)
+        {
+            return right.Length == 1 && right[0] == PathScore.Static + PathScore.Segment ? 1 : -1;
+        }
+        return 0;
+    }
+
+    // Mirrors isLastScoreNegative: whether the final sub-segment of the final segment is a penalty
+    // (a wildcard/optional/repeatable), used to order a catch-all below its more-specific siblings.
+    private static bool IsLastScoreNegative(double[][] score)
+    {
+        if (score.Length == 0)
+        {
+            return false;
+        }
+        var last = score[^1];
+        return last.Length > 0 && last[^1] < 0;
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathScore.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathScore.cs
@@ -1,0 +1,63 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The specificity weights used to rank compiled path patterns. The C# port of vue-router's
+/// <c>PathScore</c> const enum (<c>packages/router/src/matcher/pathParserRanker.ts</c>),
+/// reproduced value-for-value so ranking matches upstream exactly: static segments outrank
+/// dynamic, dynamic outrank the catch-all wildcard, and custom patterns edge out the bare
+/// parameter pattern.
+/// </summary>
+/// <remarks>
+/// Held as <see cref="double"/> because the strict and case-sensitive bonuses are fractional
+/// (0.7 and 0.25) and must stay below 1 so they never overturn a whole-weight difference. The
+/// weights are declared exactly as upstream multiples of <see cref="Multiplier"/> so the
+/// derivation stays legible against the reference.
+/// </remarks>
+internal static class PathScore
+{
+    /// <summary>The base multiplier every other weight is expressed against. Upstream <c>_multiplier = 10</c>.</summary>
+    public const double Multiplier = 10;
+
+    /// <summary>Score of the empty root segment "/". Upstream <c>Root = 9 * _multiplier</c>.</summary>
+    public const double Root = 9 * Multiplier;
+
+    /// <summary>Base score every populated segment starts from. Upstream <c>Segment = 4 * _multiplier</c>.</summary>
+    public const double Segment = 4 * Multiplier;
+
+    /// <summary>Score contributed by a sub-segment of tokens. Upstream <c>SubSegment = 3 * _multiplier</c>.</summary>
+    public const double SubSegment = 3 * Multiplier;
+
+    /// <summary>Bonus for a static token. Upstream <c>Static = 4 * _multiplier</c>.</summary>
+    public const double Static = 4 * Multiplier;
+
+    /// <summary>Bonus for a dynamic parameter token. Upstream <c>Dynamic = 2 * _multiplier</c>.</summary>
+    public const double Dynamic = 2 * Multiplier;
+
+    /// <summary>Extra bonus when a parameter supplies a custom pattern. Upstream <c>BonusCustomRegExp = 1 * _multiplier</c>.</summary>
+    public const double BonusCustomPattern = 1 * Multiplier;
+
+    /// <summary>
+    /// Penalty for a catch-all wildcard (<c>(.*)</c>); it also cancels the custom-pattern bonus so
+    /// a wildcard always ranks below any other dynamic segment. Upstream
+    /// <c>BonusWildcard = -4 * _multiplier - BonusCustomRegExp</c>.
+    /// </summary>
+    public const double BonusWildcard = (-4 * Multiplier) - BonusCustomPattern;
+
+    /// <summary>Penalty for a repeatable parameter (<c>+</c>/<c>*</c>). Upstream <c>BonusRepeatable = -2 * _multiplier</c>.</summary>
+    public const double BonusRepeatable = -2 * Multiplier;
+
+    /// <summary>Penalty for an optional parameter (<c>?</c>/<c>*</c>). Upstream <c>BonusOptional = -0.8 * _multiplier</c>.</summary>
+    public const double BonusOptional = -0.8 * Multiplier;
+
+    /// <summary>
+    /// Fractional bonus applied once to the last score when strict matching is on; kept under 1 so
+    /// it only breaks ties. Upstream <c>BonusStrict = 0.07 * _multiplier</c>.
+    /// </summary>
+    public const double BonusStrict = 0.07 * Multiplier;
+
+    /// <summary>
+    /// Fractional bonus per segment when case-sensitive matching is on; kept under 1 so it only
+    /// breaks ties. Upstream <c>BonusCaseSensitive = 0.025 * _multiplier</c>.
+    /// </summary>
+    public const double BonusCaseSensitive = 0.025 * Multiplier;
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathToken.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathToken.cs
@@ -1,0 +1,57 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// A single token within one path segment — either literal text or a dynamic parameter. The C#
+/// port of vue-router's <c>Token</c> union (<c>TokenStatic</c> / <c>TokenParam</c>) from
+/// <c>packages/router/src/matcher/pathTokenizer.ts</c>.
+/// </summary>
+/// <remarks>
+/// A <see langword="readonly struct"/> so a tokenized path allocates only its backing arrays, never
+/// a boxed token per character run — the tokenizer runs once per route record at table-build time.
+/// </remarks>
+internal readonly struct PathToken
+{
+    private PathToken(PathTokenKind kind, string value, string customPattern, bool optional, bool repeatable)
+    {
+        Kind = kind;
+        Value = value;
+        CustomPattern = customPattern;
+        Optional = optional;
+        Repeatable = repeatable;
+    }
+
+    /// <summary>Whether this token is literal text (<see cref="PathTokenKind.Static"/>) or a parameter.</summary>
+    public PathTokenKind Kind { get; }
+
+    /// <summary>
+    /// For a <see cref="PathTokenKind.Static"/> token, the literal text; for a
+    /// <see cref="PathTokenKind.Parameter"/> token, the parameter name (upstream <c>value</c>).
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// The user-supplied custom pattern for a parameter (the <c>\d+</c> in <c>:id(\d+)</c>), or the
+    /// empty string when none was supplied (upstream <c>regexp</c>). Only meaningful for
+    /// <see cref="PathTokenKind.Parameter"/> tokens.
+    /// </summary>
+    public string CustomPattern { get; }
+
+    /// <summary>Whether the parameter is optional — the <c>?</c> or <c>*</c> modifier (upstream <c>optional</c>).</summary>
+    public bool Optional { get; }
+
+    /// <summary>Whether the parameter is repeatable — the <c>+</c> or <c>*</c> modifier (upstream <c>repeatable</c>).</summary>
+    public bool Repeatable { get; }
+
+    /// <summary>Creates a literal-text token.</summary>
+    /// <param name="value">The literal text.</param>
+    public static PathToken Static(string value)
+        => new(PathTokenKind.Static, value, customPattern: string.Empty, optional: false, repeatable: false);
+
+    /// <summary>Creates a dynamic-parameter token.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="customPattern">The custom pattern, or the empty string for the default <c>[^/]+?</c>.</param>
+    /// <param name="optional">Whether the parameter is optional (<c>?</c>/<c>*</c>).</param>
+    /// <param name="repeatable">Whether the parameter is repeatable (<c>+</c>/<c>*</c>).</param>
+    public static PathToken Parameter(string name, string customPattern, bool optional, bool repeatable)
+        => new(PathTokenKind.Parameter, name, customPattern, optional, repeatable);
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathTokenKind.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathTokenKind.cs
@@ -1,0 +1,20 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The kind of a single <see cref="PathToken"/> produced by the <see cref="PathTokenizer"/>.
+/// The C# port of vue-router's <c>TokenType</c>
+/// (<c>packages/router/src/matcher/pathTokenizer.ts</c>).
+/// </summary>
+/// <remarks>
+/// Upstream also declares a <c>Group</c> member, but the current vue-router tokenizer never emits
+/// it (grouping is expressed by escaping the closing parenthesis inside a custom pattern instead),
+/// so the port models only the two kinds the tokenizer actually produces.
+/// </remarks>
+internal enum PathTokenKind
+{
+    /// <summary>Literal path text, e.g. the <c>users</c> in <c>/users/:id</c> (upstream <c>Static</c>).</summary>
+    Static,
+
+    /// <summary>A dynamic parameter, e.g. the <c>:id</c> in <c>/users/:id</c> (upstream <c>Param</c>).</summary>
+    Parameter,
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/PathTokenizer.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/PathTokenizer.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Splits a route path string into segments of <see cref="PathToken"/>s. The C# port of
+/// vue-router's <c>tokenizePath</c> (<c>packages/router/src/matcher/pathTokenizer.ts</c>),
+/// reproducing its character-by-character state machine so that dynamic (<c>:id</c>), optional
+/// (<c>:id?</c>), repeatable (<c>:id+</c>/<c>:id*</c>), and custom-pattern (<c>:id(\d+)</c>)
+/// parameters — plus sub-segment mixes like <c>/user-:id</c> — tokenize identically to upstream.
+/// </summary>
+/// <remarks>
+/// This is compile-time-free tokenization (no regular expressions, no reflection), so it is fully
+/// trimming- and NativeAOT-safe. It runs once per route record when the table is built.
+/// </remarks>
+internal static class PathTokenizer
+{
+    // Upstream ROOT_TOKEN: tokenizePath("/") is a single segment holding one empty Static token,
+    // which the ranker scores as Segment + Static (not the empty-segment Root bonus).
+    private static readonly PathToken[] RootSegment = [PathToken.Static(string.Empty)];
+
+    private enum TokenizerState
+    {
+        Static,
+        Parameter,
+        ParameterCustomPattern,
+        ParameterCustomPatternEnd,
+        EscapeNext,
+    }
+
+    /// <summary>
+    /// Tokenizes <paramref name="path"/> into segments (outer list) of tokens (inner list). An
+    /// empty path yields one empty segment (<c>[[]]</c>); <c>"/"</c> yields one root segment.
+    /// </summary>
+    /// <param name="path">The route path, e.g. <c>/users/:id(\d+)</c>.</param>
+    /// <exception cref="RouteMatcherException">
+    /// The path did not start with <c>/</c>, a repeatable parameter was not alone in its segment,
+    /// or a custom pattern was left unclosed.
+    /// </exception>
+    public static List<List<PathToken>> Tokenize(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (path.Length == 0)
+        {
+            // Upstream: `if (!path) return [[]]` — one empty segment.
+            return [[]];
+        }
+        if (path == "/")
+        {
+            return [[.. RootSegment]];
+        }
+        if (path[0] != '/')
+        {
+            throw new RouteMatcherException(
+                RouteMatcherError.InvalidRoutePath,
+                $"Route paths should start with a \"/\": \"{path}\" should be \"/{path}\".");
+        }
+
+        var state = TokenizerState.Static;
+        var previousState = state;
+        var tokens = new List<List<PathToken>>();
+        List<PathToken>? segment = null;
+        var buffer = new StringBuilder();
+        var customPattern = new StringBuilder();
+
+        void FinalizeSegment()
+        {
+            if (segment is not null)
+            {
+                tokens.Add(segment);
+            }
+            segment = [];
+        }
+
+        void ConsumeBuffer(char triggeringCharacter)
+        {
+            if (buffer.Length == 0)
+            {
+                return;
+            }
+            var value = buffer.ToString();
+            if (state == TokenizerState.Static)
+            {
+                segment!.Add(PathToken.Static(value));
+            }
+            else if (state is TokenizerState.Parameter
+                or TokenizerState.ParameterCustomPattern
+                or TokenizerState.ParameterCustomPatternEnd)
+            {
+                var repeatable = triggeringCharacter is '*' or '+';
+                var optional = triggeringCharacter is '*' or '?';
+                // Upstream checks `segment.length > 1` — counting only the tokens already pushed
+                // ahead of this parameter — so a static prefix like "/user-:id+" is allowed.
+                if (segment!.Count > 1 && repeatable)
+                {
+                    throw new RouteMatcherException(
+                        RouteMatcherError.RepeatableParameterNotAlone,
+                        $"A repeatable param (\"{value}\") must be alone in its segment. eg: \"/:ids+\".");
+                }
+                segment.Add(PathToken.Parameter(value, customPattern.ToString(), optional, repeatable));
+            }
+            buffer.Clear();
+        }
+
+        var index = 0;
+        while (index < path.Length)
+        {
+            var character = path[index++];
+
+            if (character == '\\' && state != TokenizerState.ParameterCustomPattern)
+            {
+                previousState = state;
+                state = TokenizerState.EscapeNext;
+                continue;
+            }
+
+            switch (state)
+            {
+                case TokenizerState.Static:
+                    if (character == '/')
+                    {
+                        ConsumeBuffer(character);
+                        FinalizeSegment();
+                    }
+                    else if (character == ':')
+                    {
+                        ConsumeBuffer(character);
+                        state = TokenizerState.Parameter;
+                    }
+                    else
+                    {
+                        buffer.Append(character);
+                    }
+                    break;
+
+                case TokenizerState.EscapeNext:
+                    buffer.Append(character);
+                    state = previousState;
+                    break;
+
+                case TokenizerState.Parameter:
+                    if (character == '(')
+                    {
+                        state = TokenizerState.ParameterCustomPattern;
+                    }
+                    else if (IsValidParameterNameCharacter(character))
+                    {
+                        buffer.Append(character);
+                    }
+                    else
+                    {
+                        ConsumeBuffer(character);
+                        state = TokenizerState.Static;
+                        // Reprocess this character unless it was a consumed modifier.
+                        if (character is not ('*' or '?' or '+'))
+                        {
+                            index--;
+                        }
+                    }
+                    break;
+
+                case TokenizerState.ParameterCustomPattern:
+                    if (character == ')')
+                    {
+                        // A ')' preceded by a backslash is an escaped literal, not the end.
+                        if (customPattern.Length > 0 && customPattern[^1] == '\\')
+                        {
+                            customPattern[^1] = character;
+                        }
+                        else
+                        {
+                            state = TokenizerState.ParameterCustomPatternEnd;
+                        }
+                    }
+                    else
+                    {
+                        customPattern.Append(character);
+                    }
+                    break;
+
+                case TokenizerState.ParameterCustomPatternEnd:
+                    ConsumeBuffer(character);
+                    state = TokenizerState.Static;
+                    if (character is not ('*' or '?' or '+'))
+                    {
+                        index--;
+                    }
+                    customPattern.Clear();
+                    break;
+            }
+        }
+
+        if (state == TokenizerState.ParameterCustomPattern)
+        {
+            throw new RouteMatcherException(
+                RouteMatcherError.UnfinishedCustomPattern,
+                $"Unfinished custom RegExp for param \"{buffer}\".");
+        }
+
+        ConsumeBuffer('\0');
+        FinalizeSegment();
+
+        return tokens;
+    }
+
+    // Upstream VALID_PARAM_RE = /[a-zA-Z0-9_]/ — checked directly to avoid a regular expression.
+    private static bool IsValidParameterNameCharacter(char character)
+        => char.IsAsciiLetterOrDigit(character) || character == '_';
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/RegularExpressionPatterns.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/RegularExpressionPatterns.cs
@@ -1,0 +1,20 @@
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Compile-time regular expressions used while building path patterns. These patterns are constant
+/// and known at build time, so they use <see cref="GeneratedRegexAttribute"/> (the Roslyn regex
+/// source generator) — the AOT- and trimming-preferred path, which emits the matcher as source
+/// rather than constructing it reflectively at runtime.
+/// </summary>
+internal static partial class RegularExpressionPatterns
+{
+    /// <summary>
+    /// The characters that must be escaped when literal path text is embedded into a regular
+    /// expression. The C# port of vue-router's <c>REGEX_CHARS_RE</c>
+    /// (<c>packages/router/src/matcher/pathParserRanker.ts</c>): <c>. + * ? ^ $ { } ( ) [ ] / \</c>.
+    /// </summary>
+    [GeneratedRegex(@"[.+*?^${}()[\]/\\]")]
+    public static partial Regex RegularExpressionSpecialCharacters();
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/RouteParameterValue.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/RouteParameterValue.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The stored value of a single route parameter — either one string or, for a repeatable
+/// parameter, an ordered array of strings. Mirrors vue-router's <c>PathParams</c> value union
+/// (<c>string | string[]</c>) from <c>packages/router/src/matcher/pathParserRanker.ts</c>.
+/// </summary>
+/// <remarks>
+/// A <see langword="readonly struct"/> holding raw strings only — never a boxed <see cref="object"/>
+/// and never a boxed <see cref="int"/>. Typed reads (integers, etc.) are parsed on demand by
+/// <see cref="RouteParameters"/>, so no boxing occurs on the storage path.
+/// </remarks>
+internal readonly struct RouteParameterValue : IEquatable<RouteParameterValue>
+{
+    private readonly string singleValue;
+    private readonly string[]? multipleValues;
+
+    private RouteParameterValue(string singleValue, string[]? multipleValues)
+    {
+        this.singleValue = singleValue;
+        this.multipleValues = multipleValues;
+    }
+
+    /// <summary>Creates a single-string value.</summary>
+    public static RouteParameterValue Single(string value)
+        => new(value ?? string.Empty, null);
+
+    /// <summary>Creates a repeatable (multi-string) value.</summary>
+    public static RouteParameterValue Multiple(string[] values)
+        => new(string.Empty, values ?? []);
+
+    /// <summary>Whether this value holds multiple strings (a repeatable parameter).</summary>
+    public bool IsMultiple => multipleValues is not null;
+
+    /// <summary>The single string value (empty when this is a multiple value).</summary>
+    public string SingleValue => singleValue;
+
+    /// <summary>The ordered strings for a repeatable value (empty when this is a single value).</summary>
+    public IReadOnlyList<string> MultipleValues => multipleValues ?? (IReadOnlyList<string>)Array.Empty<string>();
+
+    /// <inheritdoc/>
+    public bool Equals(RouteParameterValue other)
+    {
+        if (IsMultiple != other.IsMultiple)
+        {
+            return false;
+        }
+        if (IsMultiple)
+        {
+            var left = multipleValues!;
+            var right = other.multipleValues!;
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+            for (var index = 0; index < left.Length; index++)
+            {
+                if (!string.Equals(left[index], right[index], StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return string.Equals(singleValue, other.singleValue, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+        => obj is RouteParameterValue other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        if (!IsMultiple)
+        {
+            return StringComparer.Ordinal.GetHashCode(singleValue);
+        }
+        var hash = new HashCode();
+        hash.Add(multipleValues!.Length);
+        foreach (var value in multipleValues!)
+        {
+            hash.Add(value, StringComparer.Ordinal);
+        }
+        return hash.ToHashCode();
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/RouteRecordMatcher.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/RouteRecordMatcher.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// One entry in the matcher table: a <see cref="RouteRecord"/> paired with its compiled
+/// <see cref="PathParser"/>, its parent link, and its child matchers. The C# port of vue-router's
+/// <c>RouteRecordMatcher</c> (<c>packages/router/src/matcher/pathMatcher.ts</c>). The parent link
+/// is what lets a resolved location report the full parent-to-child matched chain.
+/// </summary>
+internal sealed class RouteRecordMatcher
+{
+    public RouteRecordMatcher(RouteRecord record, string normalizedPath, PathParser parser, RouteRecordMatcher? parent)
+    {
+        Record = record;
+        NormalizedPath = normalizedPath;
+        Parser = parser;
+        Parent = parent;
+        Children = [];
+    }
+
+    /// <summary>The originating route record.</summary>
+    public RouteRecord Record { get; }
+
+    /// <summary>The fully resolved path (child paths joined onto their parent's path).</summary>
+    public string NormalizedPath { get; }
+
+    /// <summary>The compiled pattern used to match and interpolate this route.</summary>
+    public PathParser Parser { get; }
+
+    /// <summary>The parent matcher, or <see langword="null"/> for a top-level route.</summary>
+    public RouteRecordMatcher? Parent { get; }
+
+    /// <summary>The child matchers registered under this record.</summary>
+    public List<RouteRecordMatcher> Children { get; }
+}

--- a/libraries/Assimalign.Viu.Router/src/PathMatchingOptions.cs
+++ b/libraries/Assimalign.Viu.Router/src/PathMatchingOptions.cs
@@ -1,0 +1,30 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Options that tune how paths are matched. The C# port of the matcher-relevant subset of
+/// vue-router's <c>PathParserOptions</c> (<c>packages/router/src/matcher/pathParserRanker.ts</c>).
+/// The <c>start</c>/<c>end</c> options are not exposed because the top-level matcher always anchors
+/// the full path.
+/// </summary>
+/// <remarks>
+/// Immutable; use object initializers with <c>init</c> setters. The defaults match vue-router:
+/// non-strict (a trailing slash is tolerated) and case-insensitive.
+/// </remarks>
+public sealed class PathMatchingOptions
+{
+    /// <summary>The default options: non-strict, case-insensitive (matching vue-router's defaults).</summary>
+    public static PathMatchingOptions Default { get; } = new();
+
+    /// <summary>
+    /// When <see langword="true"/>, a trailing slash is significant (<c>/users</c> and
+    /// <c>/users/</c> are distinct). When <see langword="false"/> (the default), a trailing slash is
+    /// tolerated. Upstream <c>strict</c>.
+    /// </summary>
+    public bool Strict { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, matching is case-sensitive. When <see langword="false"/> (the
+    /// default), matching ignores case. Upstream <c>sensitive</c>.
+    /// </summary>
+    public bool Sensitive { get; init; }
+}

--- a/libraries/Assimalign.Viu.Router/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.Router/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Assimalign.Viu.Router.Tests")]

--- a/libraries/Assimalign.Viu.Router/src/RouteLocation.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteLocation.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// An immutable resolved location: the concrete path, the optional matched route name, the parsed
+/// parameters, the parent-to-child matched record chain, and merged metadata. The C# port of the
+/// resolved-location shape returned by vue-router's matcher <c>resolve</c>
+/// (<c>packages/router/src/matcher/index.ts</c>); see also
+/// https://router.vuejs.org/guide/essentials/nested-routes.html for <c>route.matched</c> semantics.
+/// </summary>
+/// <remarks>
+/// Value equality (path, name, parameters, and the matched chain compared by record identity) so a
+/// navigation pipeline can detect same-location navigations and snapshot the current route cheaply.
+/// A path resolution that matched nothing returns an instance with an empty
+/// <see cref="Matched"/> chain rather than throwing.
+/// </remarks>
+public sealed class RouteLocation : IEquatable<RouteLocation>
+{
+    internal RouteLocation(
+        string path,
+        string? name,
+        RouteParameters parameters,
+        IReadOnlyList<RouteRecord> matched,
+        IReadOnlyDictionary<string, object?> meta)
+    {
+        Path = path;
+        Name = name;
+        Parameters = parameters;
+        Matched = matched;
+        Meta = meta;
+    }
+
+    /// <summary>The concrete resolved path.</summary>
+    public string Path { get; }
+
+    /// <summary>The name of the matched leaf record, or <see langword="null"/> when unnamed or unmatched.</summary>
+    public string? Name { get; }
+
+    /// <summary>The parsed route parameters.</summary>
+    public RouteParameters Parameters { get; }
+
+    /// <summary>
+    /// The matched record chain ordered parent-to-child (upstream <c>route.matched</c>). Empty when
+    /// no route matched.
+    /// </summary>
+    public IReadOnlyList<RouteRecord> Matched { get; }
+
+    /// <summary>The metadata merged across the matched chain (parent first, child overrides).</summary>
+    public IReadOnlyDictionary<string, object?> Meta { get; }
+
+    /// <summary>Whether any route matched.</summary>
+    public bool IsMatched => Matched.Count > 0;
+
+    /// <summary>The matched leaf record (the deepest matched child), or <see langword="null"/> when unmatched.</summary>
+    public RouteRecord? Route => Matched.Count > 0 ? Matched[^1] : null;
+
+    /// <inheritdoc/>
+    public bool Equals(RouteLocation? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+        if (!string.Equals(Path, other.Path, StringComparison.Ordinal)
+            || !string.Equals(Name, other.Name, StringComparison.Ordinal)
+            || !Parameters.Equals(other.Parameters)
+            || Matched.Count != other.Matched.Count)
+        {
+            return false;
+        }
+        for (var index = 0; index < Matched.Count; index++)
+        {
+            if (!ReferenceEquals(Matched[index], other.Matched[index]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+        => Equals(obj as RouteLocation);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Path, StringComparer.Ordinal);
+        hash.Add(Name, StringComparer.Ordinal);
+        hash.Add(Parameters);
+        hash.Add(Matched.Count);
+        return hash.ToHashCode();
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/RouteMatcher.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteMatcher.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// A route table and matcher: builds compiled, ranked matchers from a set of route records and
+/// resolves paths and named routes to immutable <see cref="RouteLocation"/>s. The C# port of the
+/// object returned by vue-router's <c>createRouterMatcher</c>
+/// (<c>packages/router/src/matcher/index.ts</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Matchers are kept sorted by descending specificity, so path resolution returns the highest-ranked
+/// match and route-table order never overrides specificity (static beats dynamic beats catch-all).
+/// An empty-path child is ordered ahead of its parent so navigating to the parent path resolves the
+/// default child — the parent-to-child matched chain of <see cref="RouteLocation.Matched"/>.
+/// </para>
+/// <para>
+/// Pure and DOM-free: no interop, renderer, or reflection. The path patterns compile to interpreted
+/// regular expressions (trimming- and NativeAOT-safe). Not thread-safe: build the table before
+/// resolving, matching the router's single-threaded (JS event-loop) model.
+/// </para>
+/// </remarks>
+public sealed class RouteMatcher : IRouteMatcher
+{
+    private static readonly IReadOnlyDictionary<string, object?> EmptyMeta =
+        new Dictionary<string, object?>(0);
+
+    private readonly List<RouteRecordMatcher> matchers = [];
+    private readonly Dictionary<string, RouteRecordMatcher> namedMatchers = new(StringComparer.Ordinal);
+    private readonly PathMatchingOptions options;
+
+    /// <summary>Creates an empty matcher with default options.</summary>
+    public RouteMatcher()
+        : this(Array.Empty<RouteRecord>(), options: null)
+    {
+    }
+
+    /// <summary>Creates a matcher from a set of route records with default options.</summary>
+    /// <param name="routes">The top-level route records.</param>
+    public RouteMatcher(IEnumerable<RouteRecord> routes)
+        : this(routes, options: null)
+    {
+    }
+
+    /// <summary>Creates a matcher from a set of route records.</summary>
+    /// <param name="routes">The top-level route records.</param>
+    /// <param name="options">Matching options, or <see langword="null"/> for the defaults.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="routes"/> is <see langword="null"/>.</exception>
+    /// <exception cref="RouteMatcherException">A route path or custom parameter pattern is invalid.</exception>
+    public RouteMatcher(IEnumerable<RouteRecord> routes, PathMatchingOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        this.options = options ?? PathMatchingOptions.Default;
+        foreach (var route in routes)
+        {
+            AddRoute(route);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddRoute(RouteRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        AddRecord(record, parent: null);
+    }
+
+    /// <inheritdoc/>
+    public RouteLocation Resolve(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        foreach (var candidate in matchers)
+        {
+            if (candidate.Parser.TryParse(path, out var parameters))
+            {
+                return BuildLocation(candidate, path, parameters);
+            }
+        }
+        return new RouteLocation(path, name: null, RouteParameters.Empty, Array.Empty<RouteRecord>(), EmptyMeta);
+    }
+
+    /// <inheritdoc/>
+    public RouteLocation ResolveNamed(string name)
+        => ResolveNamed(name, RouteParameters.Empty);
+
+    /// <inheritdoc/>
+    public RouteLocation ResolveNamed(string name, RouteParameters parameters)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(parameters);
+        if (!namedMatchers.TryGetValue(name, out var matcher))
+        {
+            throw new RouteMatcherException(
+                RouteMatcherError.NamedRouteNotFound,
+                $"Route with name \"{name}\" does not exist.");
+        }
+
+        // stringify enforces required/repeatable parameters and throws a descriptive error.
+        var path = matcher.Parser.Stringify(parameters);
+        var resolvedParameters = ProjectParameters(matcher, parameters);
+        var matched = BuildMatchedChain(matcher);
+        var meta = BuildMeta(matched);
+        return new RouteLocation(path, matcher.Record.Name, resolvedParameters, matched, meta);
+    }
+
+    /// <inheritdoc/>
+    public bool HasNamedRoute(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return namedMatchers.ContainsKey(name);
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<RouteRecord> GetRoutes()
+    {
+        var records = new RouteRecord[matchers.Count];
+        for (var index = 0; index < matchers.Count; index++)
+        {
+            records[index] = matchers[index].Record;
+        }
+        return records;
+    }
+
+    // Test seam: the ranked matcher table.
+    internal IReadOnlyList<RouteRecordMatcher> Matchers => matchers;
+
+    private void AddRecord(RouteRecord record, RouteRecordMatcher? parent)
+    {
+        var normalizedPath = NormalizePath(record.Path, parent);
+        var tokens = PathTokenizer.Tokenize(normalizedPath);
+        var parser = PathParserFactory.Compile(tokens, options);
+        var matcher = new RouteRecordMatcher(record, normalizedPath, parser, parent);
+
+        parent?.Children.Add(matcher);
+        if (record.Name is { Length: > 0 } name)
+        {
+            // Last registration wins, mirroring vue-router's map assignment.
+            namedMatchers[name] = matcher;
+        }
+        InsertMatcher(matcher);
+
+        foreach (var child in record.Children)
+        {
+            AddRecord(child, matcher);
+        }
+    }
+
+    // Mirrors vue-router's parent-path joining for non-absolute child paths.
+    private static string NormalizePath(string path, RouteRecordMatcher? parent)
+    {
+        if (parent is null)
+        {
+            return path;
+        }
+        if (path.Length > 0 && path[0] == '/')
+        {
+            return path;
+        }
+        var parentPath = parent.NormalizedPath;
+        if (path.Length == 0)
+        {
+            return parentPath;
+        }
+        var connector = parentPath.Length > 0 && parentPath[^1] == '/' ? string.Empty : "/";
+        return parentPath + connector + path;
+    }
+
+    // Mirrors insertMatcher/findInsertionIndex: binary search by score, then place an empty-path
+    // child ahead of an equally scored matchable ancestor so the child wins.
+    private void InsertMatcher(RouteRecordMatcher matcher)
+    {
+        var lower = 0;
+        var upper = matchers.Count;
+        while (lower != upper)
+        {
+            var mid = (lower + upper) >> 1;
+            var order = PathParserScoreComparer.CompareScore(matcher.Parser.Score, matchers[mid].Parser.Score);
+            if (order < 0)
+            {
+                upper = mid;
+            }
+            else
+            {
+                lower = mid + 1;
+            }
+        }
+
+        var ancestor = GetInsertionAncestor(matcher);
+        if (ancestor is not null && upper > 0)
+        {
+            var ancestorIndex = matchers.LastIndexOf(ancestor, upper - 1);
+            if (ancestorIndex >= 0)
+            {
+                upper = ancestorIndex;
+            }
+        }
+
+        matchers.Insert(upper, matcher);
+    }
+
+    private static RouteRecordMatcher? GetInsertionAncestor(RouteRecordMatcher matcher)
+    {
+        var ancestor = matcher.Parent;
+        while (ancestor is not null)
+        {
+            if (IsMatchable(ancestor)
+                && PathParserScoreComparer.CompareScore(matcher.Parser.Score, ancestor.Parser.Score) == 0)
+            {
+                return ancestor;
+            }
+            ancestor = ancestor.Parent;
+        }
+        return null;
+    }
+
+    // Upstream gates on name/components/redirect. Components and redirects are later router
+    // features (see DESIGN.md), so every record is currently matchable — which is what keeps an
+    // empty-path default child ordered ahead of its parent.
+    private static bool IsMatchable(RouteRecordMatcher matcher)
+        => matcher is not null;
+
+    private static RouteLocation BuildLocation(RouteRecordMatcher matcher, string path, RouteParameters parameters)
+    {
+        var matched = BuildMatchedChain(matcher);
+        var meta = BuildMeta(matched);
+        return new RouteLocation(path, matcher.Record.Name, parameters, matched, meta);
+    }
+
+    private static IReadOnlyList<RouteRecord> BuildMatchedChain(RouteRecordMatcher matcher)
+    {
+        var chain = new List<RouteRecord>();
+        var current = matcher;
+        while (current is not null)
+        {
+            chain.Insert(0, current.Record);
+            current = current.Parent;
+        }
+        return chain;
+    }
+
+    private static IReadOnlyDictionary<string, object?> BuildMeta(IReadOnlyList<RouteRecord> matched)
+    {
+        if (matched.Count == 0)
+        {
+            return EmptyMeta;
+        }
+        var meta = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var record in matched)
+        {
+            foreach (var (key, value) in record.Meta)
+            {
+                meta[key] = value;
+            }
+        }
+        return meta;
+    }
+
+    // The leaf matcher's keys span the whole path, so they are the full parameter key set; keep only
+    // those (dropping any extraneous provided params) for the resolved location.
+    private static RouteParameters ProjectParameters(RouteRecordMatcher matcher, RouteParameters provided)
+    {
+        var keys = matcher.Parser.Keys;
+        if (keys.Length == 0)
+        {
+            return RouteParameters.Empty;
+        }
+        var projected = new Dictionary<string, RouteParameterValue>(keys.Length, StringComparer.Ordinal);
+        foreach (var key in keys)
+        {
+            if (provided.TryGetRawValue(key.Name, out var value))
+            {
+                projected[key.Name] = value;
+            }
+        }
+        return RouteParameters.FromValues(projected);
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/RouteMatcherError.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteMatcherError.cs
@@ -1,0 +1,54 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Identifies why a <see cref="RouteMatcherException"/> was raised. Groups both route-definition
+/// failures (raised while a route table is being built) and resolution failures (raised while a
+/// location is being resolved). The C# port of the matcher-relevant subset of vue-router's
+/// <c>ErrorTypes</c> (<c>packages/router/src/errors.ts</c>) plus the descriptive <c>Error</c>s
+/// thrown by the tokenizer and path parser (<c>packages/router/src/matcher/</c>).
+/// </summary>
+public enum RouteMatcherError
+{
+    /// <summary>
+    /// A route path was malformed — most commonly it did not begin with <c>/</c>. Raised while the
+    /// table is built. Mirrors the tokenizer's "Route paths should start with a /" error.
+    /// </summary>
+    InvalidRoutePath,
+
+    /// <summary>
+    /// A repeatable parameter (<c>+</c>/<c>*</c>) shared its segment with other tokens, which
+    /// vue-router forbids. Mirrors the tokenizer's "A repeatable param must be alone in its
+    /// segment" error.
+    /// </summary>
+    RepeatableParameterNotAlone,
+
+    /// <summary>
+    /// A custom parameter pattern opened with <c>(</c> but never closed. Mirrors the tokenizer's
+    /// "Unfinished custom RegExp for param" error.
+    /// </summary>
+    UnfinishedCustomPattern,
+
+    /// <summary>
+    /// A custom parameter pattern (<c>:id(...)</c>) was not a valid regular expression. Mirrors the
+    /// "Invalid custom RegExp for param" error raised by <c>tokensToParser</c>.
+    /// </summary>
+    InvalidCustomPattern,
+
+    /// <summary>
+    /// A named route was requested that is not present in the table. Mirrors vue-router's
+    /// <c>MATCHER_NOT_FOUND</c>.
+    /// </summary>
+    NamedRouteNotFound,
+
+    /// <summary>
+    /// A required parameter had no value while interpolating a named route into a path. Mirrors the
+    /// path parser's "Missing required param" error.
+    /// </summary>
+    MissingRequiredParameter,
+
+    /// <summary>
+    /// An array of values was supplied for a parameter that is not repeatable. Mirrors the path
+    /// parser's "Provided param ... is an array but it is not repeatable" error.
+    /// </summary>
+    ParameterNotRepeatable,
+}

--- a/libraries/Assimalign.Viu.Router/src/RouteMatcherException.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteMatcherException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The exception raised when a route table cannot be built or a location cannot be resolved. The
+/// C# port of the errors vue-router surfaces from its matcher — both the descriptive
+/// <c>Error</c>s thrown by the tokenizer/path parser
+/// (<c>packages/router/src/matcher/pathTokenizer.ts</c>,
+/// <c>pathParserRanker.ts</c>) and the coded <c>MATCHER_NOT_FOUND</c> navigation error
+/// (<c>packages/router/src/errors.ts</c>). The specific cause is carried by <see cref="Error"/>.
+/// </summary>
+public sealed class RouteMatcherException : Exception
+{
+    /// <summary>Creates a <see cref="RouteMatcherException"/>.</summary>
+    /// <param name="error">The specific cause.</param>
+    /// <param name="message">A human-readable description of the failure.</param>
+    public RouteMatcherException(RouteMatcherError error, string message)
+        : base(message)
+    {
+        Error = error;
+    }
+
+    /// <summary>The specific cause of the failure.</summary>
+    public RouteMatcherError Error { get; }
+}

--- a/libraries/Assimalign.Viu.Router/src/RouteParameters.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteParameters.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// An immutable set of resolved route parameters with typed accessors. The C# port of vue-router's
+/// <c>RouteParams</c> / <c>PathParams</c> (<c>packages/router/src/matcher/pathParserRanker.ts</c>).
+/// Each parameter is stored as its raw string (or, for a repeatable parameter, an ordered array of
+/// strings); typed reads such as <see cref="GetInteger"/> parse on demand.
+/// </summary>
+/// <remarks>
+/// Reads never box: values are stored as strings and parsed to <see cref="int"/> only when
+/// requested, so there is no boxed <see cref="object"/> on the storage path and no reflection.
+/// Instances have value equality so the navigation pipeline can compare and snapshot them cheaply.
+/// </remarks>
+public sealed class RouteParameters : IEquatable<RouteParameters>
+{
+    private readonly Dictionary<string, RouteParameterValue> values;
+
+    internal RouteParameters(Dictionary<string, RouteParameterValue> values)
+    {
+        this.values = values;
+    }
+
+    /// <summary>The empty parameter set.</summary>
+    public static RouteParameters Empty { get; } =
+        new(new Dictionary<string, RouteParameterValue>(0, StringComparer.Ordinal));
+
+    internal static RouteParameters FromValues(Dictionary<string, RouteParameterValue> values)
+        => values.Count == 0 ? Empty : new RouteParameters(values);
+
+    /// <summary>The number of parameters.</summary>
+    public int Count => values.Count;
+
+    /// <summary>The parameter names.</summary>
+    public IReadOnlyCollection<string> Names => values.Keys;
+
+    /// <summary>Whether a parameter with the given name is present.</summary>
+    /// <param name="name">The parameter name.</param>
+    public bool ContainsParameter(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return values.ContainsKey(name);
+    }
+
+    /// <summary>
+    /// Reads a parameter as a string. A repeatable parameter's values are joined with <c>/</c>.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <exception cref="KeyNotFoundException">No parameter with that name is present.</exception>
+    public string GetString(string name)
+    {
+        if (TryGetString(name, out var value))
+        {
+            return value;
+        }
+        throw new KeyNotFoundException($"Route parameter \"{name}\" was not present.");
+    }
+
+    /// <summary>Attempts to read a parameter as a string.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The string value when present; otherwise the empty string.</param>
+    public bool TryGetString(string name, out string value)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        if (values.TryGetValue(name, out var raw))
+        {
+            value = raw.IsMultiple ? string.Join("/", raw.MultipleValues) : raw.SingleValue;
+            return true;
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Reads a parameter as an <see cref="int"/>, parsed with the invariant culture. Never boxes.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <exception cref="KeyNotFoundException">No parameter with that name is present.</exception>
+    /// <exception cref="FormatException">The parameter value is not a valid integer.</exception>
+    public int GetInteger(string name)
+    {
+        var text = GetString(name);
+        if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+        {
+            return result;
+        }
+        throw new FormatException($"Route parameter \"{name}\" value \"{text}\" is not a valid integer.");
+    }
+
+    /// <summary>Attempts to read a parameter as an <see cref="int"/> (invariant culture).</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The parsed integer when present and valid; otherwise <c>0</c>.</param>
+    public bool TryGetInteger(string name, out int value)
+    {
+        if (TryGetString(name, out var text)
+            && int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+        {
+            return true;
+        }
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Reads a parameter as an ordered list of strings — the natural shape for a repeatable
+    /// parameter (<c>:ids+</c>/<c>:ids*</c>). A single non-empty value yields a one-element list; an
+    /// absent or empty value yields an empty list.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    public IReadOnlyList<string> GetStrings(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        if (!values.TryGetValue(name, out var raw))
+        {
+            return Array.Empty<string>();
+        }
+        if (raw.IsMultiple)
+        {
+            return raw.MultipleValues;
+        }
+        return raw.SingleValue.Length == 0 ? Array.Empty<string>() : [raw.SingleValue];
+    }
+
+    /// <summary>Returns a copy with a single-valued parameter added or replaced.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The string value.</param>
+    public RouteParameters With(string name, string value)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(value);
+        var copy = new Dictionary<string, RouteParameterValue>(values, StringComparer.Ordinal)
+        {
+            [name] = RouteParameterValue.Single(value),
+        };
+        return new RouteParameters(copy);
+    }
+
+    /// <summary>Returns a copy with a repeatable (multi-valued) parameter added or replaced.</summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="parameterValues">The ordered string values.</param>
+    public RouteParameters WithMany(string name, params string[] parameterValues)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(parameterValues);
+        var copy = new Dictionary<string, RouteParameterValue>(values, StringComparer.Ordinal)
+        {
+            [name] = RouteParameterValue.Multiple([.. parameterValues]),
+        };
+        return new RouteParameters(copy);
+    }
+
+    internal bool TryGetRawValue(string name, out RouteParameterValue value)
+        => values.TryGetValue(name, out value);
+
+    /// <inheritdoc/>
+    public bool Equals(RouteParameters? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+        if (values.Count != other.values.Count)
+        {
+            return false;
+        }
+        foreach (var (name, value) in values)
+        {
+            if (!other.values.TryGetValue(name, out var otherValue) || !value.Equals(otherValue))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+        => Equals(obj as RouteParameters);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        // Order-independent so two equal sets built in any order hash alike.
+        var accumulator = 0;
+        foreach (var (name, value) in values)
+        {
+            accumulator ^= HashCode.Combine(StringComparer.Ordinal.GetHashCode(name), value.GetHashCode());
+        }
+        return accumulator;
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/RouteRecord.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteRecord.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// An immutable route definition: a path, an optional name, optional nested children, and optional
+/// metadata. The C# port of vue-router's route record (the <c>RouteRecordRaw</c> input and the
+/// normalized <c>RouteRecord</c>; see https://router.vuejs.org and
+/// <c>packages/router/src/types/index.ts</c>). Component wiring, redirects, and guards belong to
+/// later router features and are intentionally not modeled here.
+/// </summary>
+/// <remarks>
+/// A reference type with identity semantics: the same instance appears in every resolved
+/// <see cref="RouteLocation.Matched"/> chain it participates in, so consumers can compare matched
+/// records by reference. Child paths that do not start with <c>/</c> are joined onto the parent's
+/// path; an empty child path resolves to the parent's path (the empty-path default child).
+/// </remarks>
+public sealed class RouteRecord
+{
+    private static readonly IReadOnlyDictionary<string, object?> EmptyMeta =
+        new Dictionary<string, object?>(0);
+
+    /// <summary>Creates a route record.</summary>
+    /// <param name="path">
+    /// The route path. Top-level paths should start with <c>/</c>. A child path without a leading
+    /// <c>/</c> is joined onto its parent's path; an empty child path maps to the parent's path.
+    /// </param>
+    /// <param name="name">An optional unique route name, used for named resolution.</param>
+    /// <param name="children">Optional nested child records.</param>
+    /// <param name="meta">Optional arbitrary metadata (upstream <c>meta</c>).</param>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    public RouteRecord(
+        string path,
+        string? name = null,
+        IReadOnlyList<RouteRecord>? children = null,
+        IReadOnlyDictionary<string, object?>? meta = null)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        Path = path;
+        Name = name;
+        Children = children is null || children.Count == 0 ? Array.Empty<RouteRecord>() : [.. children];
+        Meta = meta ?? EmptyMeta;
+    }
+
+    /// <summary>The route path as declared (before parent joining). Upstream <c>path</c>.</summary>
+    public string Path { get; }
+
+    /// <summary>The optional unique route name. Upstream <c>name</c>.</summary>
+    public string? Name { get; }
+
+    /// <summary>The nested child records. Upstream <c>children</c>.</summary>
+    public IReadOnlyList<RouteRecord> Children { get; }
+
+    /// <summary>Arbitrary metadata carried by the record and merged into resolved locations. Upstream <c>meta</c>.</summary>
+    public IReadOnlyDictionary<string, object?> Meta { get; }
+}

--- a/libraries/Assimalign.Viu.Router/test/Assimalign.Viu.Router.Tests.csproj
+++ b/libraries/Assimalign.Viu.Router/test/Assimalign.Viu.Router.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Router" />
+  </ItemGroup>
+</Project>

--- a/libraries/Assimalign.Viu.Router/test/NamedRouteResolutionTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/NamedRouteResolutionTests.cs
@@ -1,0 +1,97 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins vue-router's named-route resolution (the name branch of resolve, packages/router/src/
+// matcher/index.ts). Reference: https://router.vuejs.org/guide/essentials/named-routes.html
+public class NamedRouteResolutionTests
+{
+    [Fact]
+    public void ResolveNamed_InterpolatesParametersIntoFullPath()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var location = matcher.ResolveNamed("user", RouteParameters.Empty.With("id", "42"));
+
+        location.Path.ShouldBe("/users/42");
+        location.Name.ShouldBe("user");
+        location.Parameters.GetString("id").ShouldBe("42");
+        location.IsMatched.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ResolveNamed_NestedRoute_InterpolatesAndChainsMatched()
+    {
+        var child = new RouteRecord(":postId", name: "post");
+        var parent = new RouteRecord("/blog", name: "blog", children: [child]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.ResolveNamed("post", RouteParameters.Empty.With("postId", "7"));
+
+        location.Path.ShouldBe("/blog/7");
+        location.Matched.ShouldBe(new[] { parent, child });
+    }
+
+    [Fact]
+    public void ResolveNamed_OptionalParameterOmitted_ProducesShorterPath()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id?", name: "users")]);
+
+        matcher.ResolveNamed("users").Path.ShouldBe("/users");
+        matcher.ResolveNamed("users", RouteParameters.Empty.With("id", "42")).Path.ShouldBe("/users/42");
+    }
+
+    [Fact]
+    public void ResolveNamed_RepeatableParameter_JoinsValues()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/files/:segments+", name: "files")]);
+
+        matcher.ResolveNamed("files", RouteParameters.Empty.WithMany("segments", "a", "b", "c"))
+            .Path.ShouldBe("/files/a/b/c");
+    }
+
+    [Fact]
+    public void ResolveNamed_UnknownName_ThrowsDescriptiveError()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var exception = Should.Throw<RouteMatcherException>(() => matcher.ResolveNamed("does-not-exist"));
+
+        exception.Error.ShouldBe(RouteMatcherError.NamedRouteNotFound);
+        exception.Message.ShouldContain("does-not-exist");
+    }
+
+    [Fact]
+    public void ResolveNamed_MissingRequiredParameter_ThrowsDescriptiveError()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var exception = Should.Throw<RouteMatcherException>(() => matcher.ResolveNamed("user"));
+
+        exception.Error.ShouldBe(RouteMatcherError.MissingRequiredParameter);
+        exception.Message.ShouldContain("id");
+    }
+
+    [Fact]
+    public void HasNamedRoute_ReflectsRegistration()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        matcher.HasNamedRoute("user").ShouldBeTrue();
+        matcher.HasNamedRoute("ghost").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ResolveNamed_DropsParametersNotDeclaredByTheRoute()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var location = matcher.ResolveNamed(
+            "user",
+            RouteParameters.Empty.With("id", "42").With("unused", "value"));
+
+        location.Parameters.ContainsParameter("id").ShouldBeTrue();
+        location.Parameters.ContainsParameter("unused").ShouldBeFalse();
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/NestedRouteTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/NestedRouteTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins vue-router's nested-route resolution and route.matched semantics.
+// Reference: https://router.vuejs.org/guide/essentials/nested-routes.html
+public class NestedRouteTests
+{
+    [Fact]
+    public void Resolve_NestedRoute_BuildsParentToChildMatchedChain()
+    {
+        var child = new RouteRecord(":id", name: "user");
+        var parent = new RouteRecord("/users", name: "users", children: [child]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/users/42");
+
+        location.Matched.Count.ShouldBe(2);
+        location.Matched[0].ShouldBeSameAs(parent);
+        location.Matched[1].ShouldBeSameAs(child);
+        location.Name.ShouldBe("user");
+        location.Parameters.GetString("id").ShouldBe("42");
+    }
+
+    [Fact]
+    public void Resolve_ChildPath_JoinsOntoParentPath()
+    {
+        var child = new RouteRecord("settings", name: "user-settings");
+        var parent = new RouteRecord("/users/:id", children: [child]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/users/42/settings");
+
+        location.Name.ShouldBe("user-settings");
+        location.Parameters.GetString("id").ShouldBe("42");
+        location.Matched.Select(record => record).ShouldBe(new[] { parent, child });
+    }
+
+    [Fact]
+    public void Resolve_EmptyPathChild_ResolvesWhenNavigatingToParentPath()
+    {
+        // The empty-path default child must win over the bare parent path, yielding a two-entry
+        // matched chain — the classic layout-with-default-view case.
+        var defaultChild = new RouteRecord(string.Empty, name: "dashboard-home");
+        var parent = new RouteRecord("/dashboard", name: "dashboard", children: [defaultChild]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/dashboard");
+
+        location.Matched.Count.ShouldBe(2);
+        location.Matched[0].ShouldBeSameAs(parent);
+        location.Matched[1].ShouldBeSameAs(defaultChild);
+        location.Name.ShouldBe("dashboard-home");
+    }
+
+    [Fact]
+    public void Resolve_DeeplyNestedRoute_ChainsEveryAncestor()
+    {
+        var grandchild = new RouteRecord("edit", name: "post-edit");
+        var child = new RouteRecord(":postId", name: "post", children: [grandchild]);
+        var parent = new RouteRecord("/blog", name: "blog", children: [child]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/blog/7/edit");
+
+        location.Matched.ShouldBe(new[] { parent, child, grandchild });
+        location.Name.ShouldBe("post-edit");
+        location.Parameters.GetInteger("postId").ShouldBe(7);
+    }
+
+    [Fact]
+    public void Resolve_AbsoluteChildPath_DoesNotJoinParent()
+    {
+        // A child path starting with '/' is absolute and is not joined onto the parent.
+        var absoluteChild = new RouteRecord("/top-level", name: "top");
+        var parent = new RouteRecord("/parent", children: [absoluteChild]);
+        var matcher = new RouteMatcher([parent]);
+
+        matcher.Resolve("/top-level").Name.ShouldBe("top");
+        matcher.Resolve("/parent/top-level").IsMatched.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Resolve_ParentWithNonEmptyChildOnly_MatchesParentAlone()
+    {
+        var child = new RouteRecord("details", name: "details");
+        var parent = new RouteRecord("/item", name: "item", children: [child]);
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/item");
+
+        location.Matched.ShouldBe(new[] { parent });
+        location.Name.ShouldBe("item");
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/PathParserTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/PathParserTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins vue-router's tokensToParser parse/stringify (packages/router/src/matcher/pathParserRanker.ts).
+public class PathParserTests
+{
+    private static PathParser Compile(string path, PathMatchingOptions? options = null)
+        => PathParserFactory.Compile(PathTokenizer.Tokenize(path), options ?? PathMatchingOptions.Default);
+
+    private static RouteParameters Parse(string path, string candidate)
+    {
+        Compile(path).TryParse(candidate, out var parameters).ShouldBeTrue();
+        return parameters;
+    }
+
+    [Fact]
+    public void TryParse_StaticPath_MatchesExactly()
+    {
+        var parser = Compile("/users/list");
+
+        parser.TryParse("/users/list", out _).ShouldBeTrue();
+        parser.TryParse("/users/other", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_NonStrict_ToleratesTrailingSlash()
+    {
+        var parser = Compile("/users");
+
+        parser.TryParse("/users", out _).ShouldBeTrue();
+        parser.TryParse("/users/", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryParse_Strict_RejectsTrailingSlash()
+    {
+        var parser = Compile("/users", new PathMatchingOptions { Strict = true });
+
+        parser.TryParse("/users", out _).ShouldBeTrue();
+        parser.TryParse("/users/", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_CaseInsensitiveByDefault_CaseSensitiveWhenRequested()
+    {
+        Compile("/Users").TryParse("/users", out _).ShouldBeTrue();
+        Compile("/Users", new PathMatchingOptions { Sensitive = true }).TryParse("/users", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_DynamicParameter_CapturesValue()
+    {
+        var parameters = Parse("/users/:id", "/users/42");
+
+        parameters.GetString("id").ShouldBe("42");
+    }
+
+    [Fact]
+    public void TryParse_MissingRequiredParameter_DoesNotMatch()
+    {
+        Compile("/users/:id").TryParse("/users", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_OptionalParameter_MatchesWithAndWithout()
+    {
+        var parser = Compile("/users/:id?");
+
+        parser.TryParse("/users", out var without).ShouldBeTrue();
+        without.GetString("id").ShouldBe(string.Empty);
+
+        parser.TryParse("/users/42", out var with).ShouldBeTrue();
+        with.GetString("id").ShouldBe("42");
+    }
+
+    [Fact]
+    public void TryParse_CustomPattern_ConstrainsTheValue()
+    {
+        var parser = Compile(@"/:id(\d+)");
+
+        parser.TryParse("/42", out var parameters).ShouldBeTrue();
+        parameters.GetString("id").ShouldBe("42");
+        parser.TryParse("/abc", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_RepeatableParameter_SplitsOnSlash()
+    {
+        var parser = Compile("/:chapters+");
+
+        parser.TryParse("/a/b/c", out var many).ShouldBeTrue();
+        many.GetStrings("chapters").ShouldBe(new[] { "a", "b", "c" });
+
+        parser.TryParse("/a", out var one).ShouldBeTrue();
+        one.GetStrings("chapters").ShouldBe(new[] { "a" });
+
+        // '+' requires at least one occurrence.
+        parser.TryParse("/", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_OptionalRepeatableParameter_MatchesEmpty()
+    {
+        var parser = Compile("/:chapters*");
+
+        parser.TryParse("/", out var empty).ShouldBeTrue();
+        empty.GetStrings("chapters").ShouldBeEmpty();
+
+        parser.TryParse("/a/b", out var many).ShouldBeTrue();
+        many.GetStrings("chapters").ShouldBe(new[] { "a", "b" });
+    }
+
+    [Fact]
+    public void TryParse_CatchAllWildcard_MatchesAnyPath()
+    {
+        var parser = Compile("/:pathMatch(.*)*");
+
+        parser.TryParse("/anything/at/all", out var parameters).ShouldBeTrue();
+        parameters.GetStrings("pathMatch").ShouldBe(new[] { "anything", "at", "all" });
+    }
+
+    [Fact]
+    public void Stringify_InterpolatesRequiredParameter()
+    {
+        Compile("/users/:id").Stringify(RouteParameters.Empty.With("id", "42")).ShouldBe("/users/42");
+    }
+
+    [Fact]
+    public void Stringify_OmitsOptionalParameterWhenAbsent()
+    {
+        Compile("/users/:id?").Stringify(RouteParameters.Empty).ShouldBe("/users");
+    }
+
+    [Fact]
+    public void Stringify_JoinsRepeatableValues()
+    {
+        Compile("/:chapters+")
+            .Stringify(RouteParameters.Empty.WithMany("chapters", "a", "b", "c"))
+            .ShouldBe("/a/b/c");
+    }
+
+    [Fact]
+    public void Stringify_MissingRequiredParameter_Throws()
+    {
+        var exception = Should.Throw<RouteMatcherException>(
+            () => Compile("/users/:id").Stringify(RouteParameters.Empty));
+
+        exception.Error.ShouldBe(RouteMatcherError.MissingRequiredParameter);
+    }
+
+    [Fact]
+    public void Stringify_ArrayForNonRepeatableParameter_Throws()
+    {
+        var exception = Should.Throw<RouteMatcherException>(
+            () => Compile("/users/:id").Stringify(RouteParameters.Empty.WithMany("id", "a", "b")));
+
+        exception.Error.ShouldBe(RouteMatcherError.ParameterNotRepeatable);
+    }
+
+    [Fact]
+    public void Compile_InvalidCustomPattern_Throws()
+    {
+        var exception = Should.Throw<RouteMatcherException>(() => Compile("/:id([)"));
+
+        exception.Error.ShouldBe(RouteMatcherError.InvalidCustomPattern);
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/PathTokenizerTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/PathTokenizerTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins vue-router's tokenizePath (packages/router/src/matcher/pathTokenizer.ts). Route matching
+// syntax reference: https://router.vuejs.org/guide/essentials/route-matching-syntax.html
+public class PathTokenizerTests
+{
+    [Fact]
+    public void Tokenize_EmptyPath_ProducesOneEmptySegment()
+    {
+        // Upstream: `if (!path) return [[]]`.
+        var segments = PathTokenizer.Tokenize(string.Empty);
+
+        segments.Count.ShouldBe(1);
+        segments[0].ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Tokenize_Root_ProducesSingleEmptyStaticToken()
+    {
+        // Upstream ROOT_TOKEN: "/" is one segment holding a Static token with an empty value.
+        var segments = PathTokenizer.Tokenize("/");
+
+        segments.Count.ShouldBe(1);
+        segments[0].Count.ShouldBe(1);
+        segments[0][0].Kind.ShouldBe(PathTokenKind.Static);
+        segments[0][0].Value.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Tokenize_StaticSegments_SplitOnSlash()
+    {
+        var segments = PathTokenizer.Tokenize("/users/list");
+
+        segments.Count.ShouldBe(2);
+        segments[0][0].Value.ShouldBe("users");
+        segments[1][0].Value.ShouldBe("list");
+    }
+
+    [Fact]
+    public void Tokenize_DynamicParameter_ProducesParameterToken()
+    {
+        var segments = PathTokenizer.Tokenize("/users/:id");
+
+        var parameter = segments[1][0];
+        parameter.Kind.ShouldBe(PathTokenKind.Parameter);
+        parameter.Value.ShouldBe("id");
+        parameter.Optional.ShouldBeFalse();
+        parameter.Repeatable.ShouldBeFalse();
+        parameter.CustomPattern.ShouldBe(string.Empty);
+    }
+
+    [Theory]
+    // '?' => optional only, '+' => repeatable only, '*' => optional and repeatable.
+    [InlineData("/:id?", true, false)]
+    [InlineData("/:id+", false, true)]
+    [InlineData("/:id*", true, true)]
+    public void Tokenize_Modifiers_SetOptionalAndRepeatable(string path, bool optional, bool repeatable)
+    {
+        var parameter = PathTokenizer.Tokenize(path)[0][0];
+
+        parameter.Kind.ShouldBe(PathTokenKind.Parameter);
+        parameter.Optional.ShouldBe(optional);
+        parameter.Repeatable.ShouldBe(repeatable);
+    }
+
+    [Fact]
+    public void Tokenize_CustomPattern_CapturesInnerRegularExpression()
+    {
+        var parameter = PathTokenizer.Tokenize(@"/:id(\d+)")[0][0];
+
+        parameter.Kind.ShouldBe(PathTokenKind.Parameter);
+        parameter.Value.ShouldBe("id");
+        parameter.CustomPattern.ShouldBe(@"\d+");
+    }
+
+    [Fact]
+    public void Tokenize_SubSegment_MixesStaticAndParameterInOneSegment()
+    {
+        // /user-:id -> a single segment with a Static token followed by a Parameter token.
+        var segment = PathTokenizer.Tokenize("/user-:id")[0];
+
+        segment.Count.ShouldBe(2);
+        segment[0].Kind.ShouldBe(PathTokenKind.Static);
+        segment[0].Value.ShouldBe("user-");
+        segment[1].Kind.ShouldBe(PathTokenKind.Parameter);
+        segment[1].Value.ShouldBe("id");
+    }
+
+    [Fact]
+    public void Tokenize_StaticPrefixBeforeRepeatable_IsAllowed()
+    {
+        // Upstream guard is `segment.length > 1`, so one preceding static token is fine.
+        var segment = PathTokenizer.Tokenize("/user-:id+")[0];
+
+        segment.Count.ShouldBe(2);
+        segment[1].Repeatable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Tokenize_PathWithoutLeadingSlash_Throws()
+    {
+        var exception = Should.Throw<RouteMatcherException>(() => PathTokenizer.Tokenize("users"));
+
+        exception.Error.ShouldBe(RouteMatcherError.InvalidRoutePath);
+    }
+
+    [Fact]
+    public void Tokenize_RepeatableNotAloneInSegment_Throws()
+    {
+        // Two preceding tokens then a repeatable trips the "> 1" guard.
+        var exception = Should.Throw<RouteMatcherException>(() => PathTokenizer.Tokenize("/:a:b:c+"));
+
+        exception.Error.ShouldBe(RouteMatcherError.RepeatableParameterNotAlone);
+    }
+
+    [Fact]
+    public void Tokenize_UnfinishedCustomPattern_Throws()
+    {
+        var exception = Should.Throw<RouteMatcherException>(() => PathTokenizer.Tokenize(@"/:id(\d+"));
+
+        exception.Error.ShouldBe(RouteMatcherError.UnfinishedCustomPattern);
+    }
+
+    [Fact]
+    public void Tokenize_TrailingSlash_ProducesTrailingEmptySegment()
+    {
+        // /users/ -> [[users], []]; the empty trailing segment is what the ranker scores as Root.
+        var segments = PathTokenizer.Tokenize("/users/");
+
+        segments.Count.ShouldBe(2);
+        segments[0][0].Value.ShouldBe("users");
+        segments[1].ShouldBeEmpty();
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/RouteMatcherResolveTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouteMatcherResolveTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// General resolution behavior of the matcher facade (the C# port of createRouterMatcher's resolve,
+// packages/router/src/matcher/index.ts) plus the ticket's dependency-boundary guarantee.
+public class RouteMatcherResolveTests
+{
+    [Fact]
+    public void Resolve_UnmatchedPath_ReturnsEmptyMatchedWithoutThrowing()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var location = matcher.Resolve("/no/such/path");
+
+        location.IsMatched.ShouldBeFalse();
+        location.Matched.ShouldBeEmpty();
+        location.Name.ShouldBeNull();
+        location.Path.ShouldBe("/no/such/path");
+    }
+
+    [Fact]
+    public void AddRoute_AfterConstruction_ExtendsTheTable()
+    {
+        var matcher = new RouteMatcher();
+
+        matcher.AddRoute(new RouteRecord("/about", name: "about"));
+
+        matcher.Resolve("/about").Name.ShouldBe("about");
+    }
+
+    [Fact]
+    public void Resolve_MergesMetaAcrossMatchedChain_ChildOverridesParent()
+    {
+        var child = new RouteRecord(
+            ":id",
+            name: "user",
+            meta: new Dictionary<string, object?> { ["title"] = "User", ["layout"] = "user" });
+        var parent = new RouteRecord(
+            "/users",
+            name: "users",
+            children: [child],
+            meta: new Dictionary<string, object?> { ["layout"] = "admin" });
+        var matcher = new RouteMatcher([parent]);
+
+        var location = matcher.Resolve("/users/42");
+
+        location.Meta["title"].ShouldBe("User");
+        location.Meta["layout"].ShouldBe("user");
+    }
+
+    [Fact]
+    public void Resolve_SameLocation_ProducesValueEqualResults()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        var first = matcher.Resolve("/users/42");
+        var second = matcher.Resolve("/users/42");
+
+        first.ShouldBe(second);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Resolve_DifferentParameters_AreNotEqual()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/users/:id", name: "user")]);
+
+        matcher.Resolve("/users/42").ShouldNotBe(matcher.Resolve("/users/7"));
+    }
+
+    [Fact]
+    public void GetRoutes_ReturnsEveryRegisteredRecord()
+    {
+        var child = new RouteRecord(":id", name: "user");
+        var parent = new RouteRecord("/users", name: "users", children: [child]);
+        var matcher = new RouteMatcher([parent, new RouteRecord("/about", name: "about")]);
+
+        var routes = matcher.GetRoutes();
+
+        routes.ShouldContain(parent);
+        routes.ShouldContain(child);
+        routes.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Resolve_RootPath_MatchesRootRecord()
+    {
+        var matcher = new RouteMatcher([new RouteRecord("/", name: "home")]);
+
+        matcher.Resolve("/").Name.ShouldBe("home");
+    }
+
+    [Fact]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Test-only reflection over assembly references to assert the matcher's dependency boundary; the test project is never trimmed or AOT-published.")]
+    public void MatcherAssembly_HasNoDomInteropOrRendererDependency()
+    {
+        // Acceptance criterion: the matcher assembly depends on no other Viu library and on no
+        // JavaScript-interop assembly, so it stays unit-testable in a plain .NET host.
+        var referenced = typeof(RouteMatcher).Assembly
+            .GetReferencedAssemblies()
+            .Select(assembly => assembly.Name ?? string.Empty)
+            .ToArray();
+
+        referenced.ShouldNotContain(name => name.StartsWith("Assimalign.", StringComparison.Ordinal));
+        referenced.ShouldNotContain(name => name.Contains("JavaScript", StringComparison.Ordinal));
+        referenced.ShouldNotContain(name => name.Contains("Runtime", StringComparison.Ordinal)
+            && name.Contains("Viu", StringComparison.Ordinal));
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/RouteParametersTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouteParametersTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Typed, boxing-free, reflection-free parameter accessors — the C# counterpart of vue-router's
+// RouteParams (packages/router/src/matcher/pathParserRanker.ts, PathParams).
+public class RouteParametersTests
+{
+    [Fact]
+    public void With_IsImmutable_AndDoesNotMutateTheSource()
+    {
+        var original = RouteParameters.Empty;
+        var extended = original.With("id", "42");
+
+        original.Count.ShouldBe(0);
+        extended.Count.ShouldBe(1);
+        extended.GetString("id").ShouldBe("42");
+    }
+
+    [Fact]
+    public void GetInteger_ParsesInvariantInteger()
+    {
+        RouteParameters.Empty.With("id", "42").GetInteger("id").ShouldBe(42);
+    }
+
+    [Fact]
+    public void GetInteger_NonInteger_ThrowsFormatException()
+    {
+        Should.Throw<FormatException>(() => RouteParameters.Empty.With("id", "abc").GetInteger("id"));
+    }
+
+    [Fact]
+    public void GetString_MissingParameter_ThrowsKeyNotFound()
+    {
+        Should.Throw<KeyNotFoundException>(() => RouteParameters.Empty.GetString("missing"));
+    }
+
+    [Fact]
+    public void TryGetString_And_TryGetInteger_ReportPresence()
+    {
+        var parameters = RouteParameters.Empty.With("id", "7");
+
+        parameters.TryGetString("id", out var text).ShouldBeTrue();
+        text.ShouldBe("7");
+        parameters.TryGetInteger("id", out var number).ShouldBeTrue();
+        number.ShouldBe(7);
+
+        parameters.TryGetString("missing", out _).ShouldBeFalse();
+        parameters.TryGetInteger("missing", out var fallback).ShouldBeFalse();
+        fallback.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetStrings_ReturnsRepeatableValues()
+    {
+        var parameters = RouteParameters.Empty.WithMany("chapters", "one", "two");
+
+        parameters.GetStrings("chapters").ShouldBe(new[] { "one", "two" });
+    }
+
+    [Fact]
+    public void GetStrings_SingleValue_ReturnsOneElement()
+    {
+        RouteParameters.Empty.With("id", "42").GetStrings("id").ShouldBe(new[] { "42" });
+    }
+
+    [Fact]
+    public void GetStrings_MissingParameter_ReturnsEmpty()
+    {
+        RouteParameters.Empty.GetStrings("missing").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Equality_IsValueBased_AndOrderIndependent()
+    {
+        var left = RouteParameters.Empty.With("a", "1").With("b", "2");
+        var right = RouteParameters.Empty.With("b", "2").With("a", "1");
+
+        left.ShouldBe(right);
+        left.GetHashCode().ShouldBe(right.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DistinguishesSingleFromRepeatable()
+    {
+        var single = RouteParameters.Empty.With("id", "42");
+        var repeatable = RouteParameters.Empty.WithMany("id", "42");
+
+        single.ShouldNotBe(repeatable);
+    }
+
+    [Fact]
+    public void Names_ReportsEveryParameter()
+    {
+        var parameters = RouteParameters.Empty.With("a", "1").With("b", "2");
+
+        parameters.Names.ShouldBe(new[] { "a", "b" }, ignoreOrder: true);
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/RouteRankingTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouteRankingTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins vue-router's ranking model (comparePathParserScore, packages/router/src/matcher/
+// pathParserRanker.ts): static beats dynamic beats catch-all, independent of table order.
+// Reference: https://router.vuejs.org/guide/essentials/route-matching-syntax.html
+public class RouteRankingTests
+{
+    private static IReadOnlyList<string> OrderedPaths(RouteMatcher matcher)
+        => matcher.Matchers.Select(entry => entry.NormalizedPath).ToArray();
+
+    [Fact]
+    public void Resolve_StaticSegment_OutranksDynamicSegment()
+    {
+        // Dynamic added first — specificity, not order, must decide.
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/users/:id", name: "user"),
+            new RouteRecord("/users/new", name: "new-user"),
+        ]);
+
+        matcher.Resolve("/users/new").Name.ShouldBe("new-user");
+        matcher.Resolve("/users/42").Name.ShouldBe("user");
+    }
+
+    [Fact]
+    public void Resolve_DynamicSegment_OutranksCatchAllWildcard()
+    {
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/:pathMatch(.*)*", name: "not-found"),
+            new RouteRecord("/users/:id", name: "user"),
+        ]);
+
+        matcher.Resolve("/users/42").Name.ShouldBe("user");
+        matcher.Resolve("/something/else").Name.ShouldBe("not-found");
+    }
+
+    [Fact]
+    public void Resolve_TableOrder_DoesNotOverrideSpecificity()
+    {
+        // Deliberately register least-specific first.
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/:pathMatch(.*)*", name: "not-found"),
+            new RouteRecord("/users/:id", name: "user"),
+            new RouteRecord("/users/new", name: "new-user"),
+        ]);
+
+        matcher.Resolve("/users/new").Name.ShouldBe("new-user");
+        matcher.Resolve("/users/42").Name.ShouldBe("user");
+        matcher.Resolve("/anything").Name.ShouldBe("not-found");
+    }
+
+    [Fact]
+    public void Matchers_AreOrderedByDescendingSpecificity()
+    {
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/:pathMatch(.*)*"),
+            new RouteRecord("/users/:id"),
+            new RouteRecord("/users/new"),
+        ]);
+
+        // Static-most-specific first; catch-all last, regardless of insertion order.
+        OrderedPaths(matcher).ShouldBe(new[] { "/users/new", "/users/:id", "/:pathMatch(.*)*" });
+    }
+
+    [Fact]
+    public void Resolve_CustomPattern_OutranksBareDynamicParameter()
+    {
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/users/:id", name: "user"),
+            new RouteRecord(@"/users/:id(\d+)", name: "numeric-user"),
+        ]);
+
+        // The numeric constraint is more specific, so it wins when it matches...
+        matcher.Resolve("/users/42").Name.ShouldBe("numeric-user");
+        // ...and falls through to the bare parameter when it does not.
+        matcher.Resolve("/users/abc").Name.ShouldBe("user");
+    }
+
+    [Fact]
+    public void Resolve_RootAndStaticSegments_RankAboveDynamicRoot()
+    {
+        var matcher = new RouteMatcher(
+        [
+            new RouteRecord("/:slug"),
+            new RouteRecord("/about", name: "about"),
+        ]);
+
+        matcher.Resolve("/about").Name.ShouldBe("about");
+        matcher.Resolve("/anything-else").Name.ShouldBeNull();
+        matcher.Resolve("/anything-else").IsMatched.ShouldBeTrue();
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -1,0 +1,63 @@
+# Assimalign.Viu.RuntimeCore — design
+
+Why the platform-agnostic runtime is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md).
+Upstream counterpart: [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core).
+
+## The renderer is platform-agnostic by construction
+
+`RendererFactory.CreateRenderer(options)` (Vue's `createRenderer(RendererOptions)`) builds the
+mount/patch/unmount pipeline over an injected `RendererOptions<TNode>` — the platform node-ops
+(create/insert/remove/text, `patchProp`, static-content insert). **The core never performs interop
+itself.** `TNode` is the platform node type: `int` handles for the browser
+(`Assimalign.Viu.RuntimeDom`), `TestNode` for the in-memory renderer (`Assimalign.Viu.Testing`).
+This single seam is what lets the browser and the DOM-free test host share one renderer, and it is
+the exact shape upstream's `createRenderer` takes.
+
+## Compiler-informed patching, decoupled from the compiler
+
+The renderer reads the `PatchFlags`/`ShapeFlags` a vnode carries (from `Assimalign.Viu.Shared`) and
+patches only what the flags mark dynamic; the block tree (`BlockToken`) flattens dynamic descendants
+so the static structure is skipped. On WASM this is the interop budget in action (see
+[ADR-0003](../../../docs/adr/0003-batched-interop-dom-operations.md)).
+
+Compiler-generated render methods bind to `RenderHelpers` **by name** (`_openBlock`,
+`_createElementBlock`, …) through a `using static`, so this library and the template compiler share a
+contract without a project reference in either direction. The helper members deliberately carry the
+upstream-aliased names (a generated-code-only exception to the whole-word naming rule — the names
+*are* the contract). The counterpart contract lives in
+[`Assimalign.Viu.Syntax.Templates/docs/DESIGN.md`](../../Assimalign.Viu.Syntax.Templates/docs/DESIGN.md);
+build-time compilation is [ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md).
+
+## Scheduler and reactive re-render
+
+A component's render is a `RenderEffect<TNode>` — a `ReactiveEffect` (from
+`Assimalign.Viu.Reactivity`) whose scheduler enqueues the component's update job on the `Scheduler`.
+The `Scheduler` batches jobs into flush phases with `NextTick`; the internal `RuntimeWatchScheduler`
+bridges Reactivity's `IWatchScheduler` seam to the same queue so `ViuWatch` flushes with rendering.
+This is how the stopwatch re-renders reactively instead of polling.
+
+## Composition-only component model
+
+Per [ADR-0004](../../../docs/adr/0004-composition-only-component-model.md), the component model is
+composition-only: a `ComponentInstance` runs a setup function; props/emits/slots/lifecycle are
+typed; cross-cutting values flow through typed provide/inject (`InjectionKey<T>`) and plugins
+(`IPlugin<TNode>`). `Application<TNode>` and `ApplicationConfiguration` deliberately omit an
+`app.config.globalProperties` bag.
+
+## Deltas from Vue 3
+
+- **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*
+  members of `RenderHelpers`; they ship as `DomRenderHelpers` in `Assimalign.Viu.RuntimeDom`, so
+  runtime-core stays DOM-free and a real DOM directive can never mis-bind onto a runtime-core marker
+  (see [`Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md`](../../Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md)).
+- **`RenderHelpers` uses upstream-aliased member names** in generated code — a documented,
+  generated-code-only naming deviation.
+- **Hot-path dispatch** favors sealed types and abstract bases over interfaces where the JIT's
+  devirtualization matters on mono-wasm — a C#/WASM performance shape with no JS analogue.
+- Not thread-safe (single-threaded JS event-loop model).
+
+## Non-goals (sequenced work)
+
+- `Suspense` — [V01.01.03.20] (W06).
+- DOM `Transition`/`TransitionGroup` and custom elements — `Assimalign.Viu.RuntimeDom`.
+- Server-side rendering and hydration — `Assimalign.Viu.ServerRenderer` (a later area).

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Assimalign.Viu.RuntimeCore — overview
+
+The platform-agnostic runtime — the C# port of
+[`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core): the virtual
+DOM model, the renderer factory, the scheduler, the component model, provide/inject, the runtime
+directive system, and the built-in component scaffolding. It performs no DOM or JS interop itself —
+a platform package supplies the node-ops (the browser's `Assimalign.Viu.RuntimeDom`, tests'
+`Assimalign.Viu.Testing`). Area: `V01.01.03`.
+
+## Public surface
+
+- **Virtual DOM model** (`src/` root) — `VirtualNode` (the unified vnode: element / component /
+  text / comment / static / fragment via `VirtualNodeType` + a shape-flag bitmask),
+  `VirtualNodeFactory`, `VirtualNodeProperties`.
+- **Renderer** (`Rendering/`) — `RendererFactory.CreateRenderer(options)` (Vue's `createRenderer`),
+  `Renderer<TNode>` (the mount/patch/unmount pipeline), `RendererOptions<TNode>` (the injected
+  platform node-ops), `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
+- **Scheduler** (`Scheduling/`) — `Scheduler` (batched flush phases and `NextTick`) and
+  `SchedulerJob`.
+- **Component model** (`Components/`) — `ComponentInstance`, `ComponentSetupContext`,
+  `ComponentProperties` / `ComponentPropertyDefinition` (props declaration and validation),
+  `ComponentAttributes` (attrs fallthrough), `ComponentEmitDefinition` (emits), `ComponentSlots`,
+  `Lifecycle` (the hook registration facade), `DynamicComponents`, and the transition scaffolding
+  (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
+- **Application / plugins** — `Application<TNode>` (Vue's `createApp` shell: one root mounted into
+  one container), `ApplicationConfiguration` (error/warn handlers, performance flag),
+  `IComponentDefinition`, `IPlugin<TNode>`.
+- **Provide / inject** (`DependencyInjection/`) — `DependencyInjection` and the typed
+  `InjectionKey<T>`.
+- **Directives** (`Directives/`) — `IDirective`, `Directive`, `Directives`, `DirectiveBinding`,
+  `DirectiveArgument`, plus the `DirectiveHook` delegate.
+- **Watch** (`Watch/`) — `ViuWatch`, the runtime-scheduler-integrated `watch`/`watchEffect` over the
+  `Assimalign.Viu.Reactivity` primitives.
+- **`RenderHelpers`** — the static helper surface (`_openBlock`, `_createElementBlock`,
+  `_toDisplayString`, `_renderList`, …) that compiler-generated render methods bind to **by name**.
+
+## Boundaries
+
+- References **`Assimalign.Viu.Shared`** (the flag vocabulary) and **`Assimalign.Viu.Reactivity`**
+  only; it never references a platform/DOM package. Ships as a net10.0 runtime library with
+  `IsAotCompatible=true`.
+- **Composition-only** component model — no Options API, no mixins, no `app.config.globalProperties`
+  (see [ADR-0004](../../../docs/adr/0004-composition-only-component-model.md)).
+- Design rationale, the renderer seam, and the render-helper contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Shared/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Shared/docs/DESIGN.md
@@ -1,0 +1,42 @@
+# Assimalign.Viu.Shared — design
+
+Why the shared base is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterpart: [`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared).
+
+## The flags are a cross-boundary contract
+
+`PatchFlags`, `ShapeFlags`, and `SlotFlags` are not merely enums — they are the vocabulary the
+build-time compiler and the runtime share (PLAN founding decision 1). The compiler *stamps* a vnode
+with the flags describing what can change; the runtime *reads* them to patch only that and to skip
+static structure. On WASM this is doubly valuable: every patch visit skipped is a JS-interop
+round-trip avoided (see [ADR-0003](../../../docs/adr/0003-batched-interop-dom-operations.md)).
+
+Because two independently built artifacts must agree on every bit, the flag values are **pinned
+numerically to the upstream `@vue/shared` constants**, and the definition files are compiled into
+both sides from one source: `PatchFlags.cs` and `SlotFlags.cs` (and `Internal/DomKnowledgeData.cs`)
+are `<Compile Include>` links in the netstandard2.0 `Assimalign.Viu.Syntax.*` generator projects.
+There is no second copy to drift. Their paths are frozen; moving one means updating every linking
+csproj in the same change.
+
+## Pure data and pure functions only
+
+The library holds only bitmask enums, static lookup tables, and pure normalization functions. It has
+no vnodes, no reactivity, no renderer state — those belong to the layers above. This is what lets
+everything depend on it without a cycle, and what keeps it trivially AOT/trimming-safe.
+
+## Deltas from Vue 3
+
+- The flag enums are `[Flags]` C# enums with the upstream bit values; the extension methods
+  (`PatchFlagsExtensions`, `ShapeFlagsExtensions`) provide the `flag & X` tests upstream writes
+  inline in JavaScript.
+- Normalization ports `normalizeClass`/`normalizeStyle`/`toDisplayString`/`looseEqual`/`toNumber`
+  with C# type handling in place of JavaScript's coercions; the *observable* results track upstream.
+- Naming spells out whole words except the approved acronyms (DOM/HTML/CSS/SSR/AOT/JSON/WASM), so
+  identifiers read `DisplayStringFormatter`, not `ToDisplayString`-style abbreviations, while the XML
+  docs name the upstream function each ports.
+
+## Non-goals
+
+- No runtime types (vnodes, components, effects) — those are `RuntimeCore`/`Reactivity`.
+- No platform/DOM interop — `DomKnowledge` is static knowledge only; the live DOM bridge is
+  `Assimalign.Viu.RuntimeDom`.

--- a/libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Shared/docs/OVERVIEW.md
@@ -1,0 +1,35 @@
+# Assimalign.Viu.Shared — overview
+
+The dependency-free base of the framework — the role
+[`@vue/shared`](https://github.com/vuejs/core/tree/main/packages/shared) plays for Vue 3. It holds
+the bitmask vocabulary the compiler and runtime both speak, the class/style/display normalization
+helpers, and the DOM knowledge tables. It references no other `Assimalign.Viu.*` library; everything
+else in the framework sits above it. Area: `V01.01.01`.
+
+## What it contains
+
+- **The flag vocabulary** (currency types, `src/` root):
+  - **`PatchFlags`** (+ `PatchFlagsExtensions`, `PatchFlagNames`) — the compiler's patch hints
+    telling the runtime what on a vnode can change ([`@vue/shared` `patchFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/patchFlags.ts)).
+  - **`ShapeFlags`** (+ `ShapeFlagsExtensions`) — what a vnode *is* (element / component / text /
+    slot children shape), as a bitmask ([`shapeFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/shapeFlags.ts)).
+  - **`SlotFlags`** — slot stability classification ([`slotFlags.ts`](https://github.com/vuejs/core/blob/main/packages/shared/src/slotFlags.ts)).
+- **Normalization** (`Normalization/`):
+  - **`StyleAndClassNormalization`** — `normalizeClass` / `normalizeStyle` (string/array/map forms).
+  - **`DisplayStringFormatter`** — `toDisplayString` (interpolation stringification).
+  - **`LooseEquality`** — `looseEqual` / `looseIndexOf`.
+  - **`NumberCoercion`** — `toNumber` / `looseToNumber`.
+- **DOM knowledge** (`Dom/DomKnowledge`, backed by `Internal/DomKnowledgeData`) — the HTML, SVG, and
+  MathML tag and attribute tables ([V01.01.01.03]) the compiler and DOM runtime consult instead of
+  probing a live element.
+
+## Boundaries
+
+- **No `Assimalign.Viu.*` dependencies** — this is the root of the dependency graph. Ships as a
+  net10.0 runtime library with `IsAotCompatible=true`.
+- The flag definitions are the **contract between the build-time compiler and the runtime**. A few
+  source files (`PatchFlags.cs`, `SlotFlags.cs`, `Internal/DomKnowledgeData.cs`) are shared-source
+  compiled into the netstandard2.0 `Assimalign.Viu.Syntax.*` generators so both sides use identical
+  bit values (their paths are frozen — see
+  [`.claude/rules/general-rules.md`](../../../.claude/rules/general-rules.md)).
+- Design rationale and the parity contract: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.Html/docs/DESIGN.md
@@ -1,0 +1,30 @@
+# Assimalign.Viu.Syntax.Html — design
+
+Why the HTML scaffold exists and how it is shaped. What it is: see [OVERVIEW.md](OVERVIEW.md).
+Upstream analogue: Vite's HTML entry processing (there is no `@vue/compiler-*` HTML-document parser;
+Vue's template markup is a different language, handled by `Assimalign.Viu.Syntax.Templates`).
+
+## Why a scaffold now
+
+The library exists to **pin the seam** before the parser is built: the project shape, the
+`SyntaxParser<T>` registration dispatch, and the value-equatable result contract that the shared
+`Assimalign.Viu.Syntax` pipeline requires (see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). Registering a
+scaffold now means the host-page rewrite work item can grow the parser in place without moving the
+seam or churning the composition roots that depend on it.
+
+`ParseCore` returns a single `HtmlDocumentNode` spanning the whole source, upholding the
+`SourceLocation` exact-slice invariant; the whole-source span is replaced by real tokenizer positions
+when element-level parsing lands.
+
+## Constraints (inherited from the cluster)
+
+- **netstandard2.0** analyzer TFM, no file/network I/O, no reflection-based serialization, no dynamic
+  code generation. Parsing is recoverable — malformed input never throws.
+- Results are immutable and value-equatable so incremental generators cache on them.
+
+## Non-goals (until the work item lands)
+
+- Element-, attribute-, and text-level parsing per the WHATWG model.
+- Host-page entry rewriting (static-web-asset injection) — the consumer-facing feature this parser
+  will back.

--- a/libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.Html/docs/OVERVIEW.md
@@ -1,0 +1,26 @@
+# Assimalign.Viu.Syntax.Html — overview
+
+The `.html` language of the `Assimalign.Viu.Syntax.*` cluster — the parser build tooling registers
+for HTML documents, above all the WASM host page (`wwwroot/index.html`), the role Vite's HTML entry
+processing plays in a Vue build. Vue *template* markup is the separate
+`Assimalign.Viu.Syntax.Templates` parser, not this one. Area: `V01.01.05` (Syntax cluster).
+
+> **Scaffold.** The parser currently produces a single located `HtmlDocumentNode` carrying the raw
+> source, with no diagnostics — enough to pin the pipeline seam and the caching contract. Element-
+> level parsing per the [WHATWG HTML parsing model](https://html.spec.whatwg.org/multipage/parsing.html)
+> lands with its own work item.
+
+## Public surface
+
+- **`HtmlSyntaxParser`** — the `SyntaxParser<HtmlSyntaxNode>` build tooling registers for `.html`
+  sources.
+- **`HtmlDocumentNode`** — the located document node (currently the whole-source root).
+- **`HtmlSyntaxNode`** / **`HtmlSyntaxNodeKind`** — the node base and its kind projection.
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; a build-time library on the netstandard2.0 analyzer TFM
+  that runs inside Roslyn generator hosts.
+- Parsing is recoverable and value-equatable (the incremental-generator caching contract), following
+  the shared pipeline in [`Assimalign.Viu.Syntax/docs/OVERVIEW.md`](../../Assimalign.Viu.Syntax/docs/OVERVIEW.md).
+- Design notes and the scaffold's rationale: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.JavaScript/docs/DESIGN.md
@@ -1,0 +1,31 @@
+# Assimalign.Viu.Syntax.JavaScript — design
+
+Why the JavaScript scaffold exists and how it is shaped. What it is: see [OVERVIEW.md](OVERVIEW.md).
+There is no `@vue/compiler-*` counterpart — Viu's component logic is C#, so this library covers only
+the plain `.js` around the interop boundary (the role a Vite build's JS handling plays for glue and
+host-page scripts).
+
+## Why a scaffold now
+
+The library exists to **pin the seam** before the parser is built: the project shape, the
+`SyntaxParser<T>` registration dispatch, and the value-equatable result contract the shared
+`Assimalign.Viu.Syntax` pipeline requires (see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). A registered
+scaffold lets the interop-tooling work item grow the parser in place without disturbing the seam or
+its composition roots.
+
+`ParseCore` returns a single `JavaScriptProgramNode` spanning the whole source, upholding the
+`SourceLocation` exact-slice invariant; the whole-source span is replaced by real tokenizer positions
+when statement-level parsing lands.
+
+## Constraints (inherited from the cluster)
+
+- **netstandard2.0** analyzer TFM, no file/network I/O, no reflection-based serialization, no dynamic
+  code generation. Parsing is recoverable — malformed input never throws.
+- Results are immutable and value-equatable so incremental generators cache on them.
+
+## Non-goals (until the work item lands)
+
+- Statement- and expression-level parsing per ECMA-262.
+- Any transformation of interop glue or host-page scripts — this parser only locates and slices
+  today.

--- a/libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.JavaScript/docs/OVERVIEW.md
@@ -1,0 +1,25 @@
+# Assimalign.Viu.Syntax.JavaScript — overview
+
+The `.js` language of the `Assimalign.Viu.Syntax.*` cluster — the parser build tooling registers for
+JavaScript around the JS-interop boundary (interop glue modules, host-page scripts). Component logic
+is C# (Roslyn's domain) and template expressions stay in `Assimalign.Viu.Syntax.Templates`, so this
+library is scoped to the plain `.js` files a Viu build touches. Area: `V01.01.05` (Syntax cluster).
+
+> **Scaffold.** The parser currently produces a single located `JavaScriptProgramNode` carrying the
+> raw source, with no diagnostics — enough to pin the pipeline seam and the caching contract.
+> Statement-level parsing per [ECMA-262](https://tc39.es/ecma262/) lands with its own work item.
+
+## Public surface
+
+- **`JavaScriptSyntaxParser`** — the `SyntaxParser<JavaScriptSyntaxNode>` build tooling registers for
+  `.js`/`.mjs` sources.
+- **`JavaScriptProgramNode`** — the located program node (currently the whole-source root).
+- **`JavaScriptSyntaxNode`** / **`JavaScriptSyntaxNodeKind`** — the node base and its kind projection.
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; a build-time library on the netstandard2.0 analyzer TFM
+  that runs inside Roslyn generator hosts.
+- Parsing is recoverable and value-equatable (the incremental-generator caching contract), following
+  the shared pipeline in [`Assimalign.Viu.Syntax/docs/OVERVIEW.md`](../../Assimalign.Viu.Syntax/docs/OVERVIEW.md).
+- Design notes and the scaffold's rationale: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
@@ -1,0 +1,54 @@
+# Assimalign.Viu.Syntax.SingleFileComponent — design
+
+Why the `.viu` parser is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md); the exact
+grammar is [FORMAT.md](FORMAT.md). Upstream counterpart:
+[`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) `parse()`
+(`packages/compiler-sfc/src/parse.ts`).
+
+## The `@`-block container is a deliberate divergence
+
+Vue wraps SFC blocks in HTML-like tags (`<template>`, `<script>`, `<style>`); a `.viu` file uses
+`@`-block container syntax instead (decided 2026-07-17). Only the **container** differs — block
+*semantics* follow the Vue SFC spec unchanged, and the markup inside `@template` remains standard Vue
+template syntax. This is one half of [ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md)
+(build-time-only compilation); the full rule set and its rationale are in [FORMAT.md](FORMAT.md).
+
+## Slice, don't parse
+
+The parser only slices the file into blocks and records spans — it never re-parses, trims, or
+normalizes block content. The termination rule is purely structural ("column 0 is structural": a
+line whose first column is `}` closes a block), so it needs no knowledge of C#, CSS, or HTML syntax.
+Downstream libraries parse the block contents: the template compiler
+(`Assimalign.Viu.Syntax.Templates`) for `@template`, the CSS library for `@style`, and script
+analysis for `@script` ([V01.01.06.03]).
+
+## The registration seam
+
+`SingleFileComponentSyntaxParser` is an `AggregateSyntaxParser` over the shared
+`Assimalign.Viu.Syntax` pipeline: it exposes each block as a `SyntaxSource` (content, block name,
+`lang`) so a composition root (the generator, a build task, a test) can register the parsers the
+build embeds — without this library referencing any of them. A registration-free parse is just the
+plain container parse, preserving `@vue/compiler-sfc` parity (`parse()` never looks inside block
+content).
+
+## Value equality and recoverable diagnostics
+
+The descriptor and every block are immutable records with structural equality, so identical file
+content yields equal (and equally hashed) descriptors — the prerequisite for incremental-generator
+caching ([V01.01.06.02], and see
+[`Assimalign.Viu.Syntax/docs/DESIGN.md`](../../Assimalign.Viu.Syntax/docs/DESIGN.md)). Parsing is
+recoverable: malformed input is reported through diagnostics and the parser never throws for bad
+content.
+
+## Deltas from Vue 3
+
+- **`@`-block container** instead of tag-based blocks (above; specified in [FORMAT.md](FORMAT.md)).
+- **Viu-defined error codes** (`SingleFileComponentErrorCode`, 1000-based). Unlike the template
+  compiler, which mirrors vuejs/core's numbering, the `@`-block container is a Viu divergence with no
+  upstream codes to align to.
+
+## Non-goals
+
+- **Script analysis.** Every `@script` block is treated uniformly (at most one per file); the Vue
+  `<script setup>` distinction and script analysis are [V01.01.06.03].
+- **Parsing block interiors.** By design — that belongs to the per-language parsers.

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
@@ -1,0 +1,35 @@
+# Assimalign.Viu.Syntax.SingleFileComponent — overview
+
+The build-time parser for the `.viu` single-file component (SFC) — the Viu counterpart of Vue's
+`.vue` files and the role [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc)
+`parse()` plays: it slices a `.viu` file into its blocks and records their source spans. It does
+**not** parse the contents of a block — the template markup, C#, and CSS inside are parsed by other
+libraries. Area: `V01.01.06`.
+
+The exact container syntax (the `@template`/`@script`/`@style` `@`-block grammar, the column-0
+termination rule, options, diagnostics) is specified in [FORMAT.md](FORMAT.md) — the authoritative
+spec that the test suite pins.
+
+## Public surface
+
+- **`SingleFileComponentParser`** (static) — `Parse(string)` returns a `SingleFileComponentParseResult`
+  (an `SingleFileComponentDescriptor` plus recoverable diagnostics). This is the authoritative,
+  `@vue/compiler-sfc`-parity entry point.
+- **`SingleFileComponentDescriptor`** — the parsed file, mirroring Vue's `SFCDescriptor`: `Template`
+  (0/1), `Script` (0/1), `Styles` (0..n, source order), `CustomBlocks`, and `Source`.
+- **The block model** (`Blocks/`) — `SingleFileComponentBlock` and its
+  `Template`/`Script`/`Style`/`CustomBlock` kinds, `SingleFileComponentBlockKind`, and
+  `SingleFileComponentBlockOption`. Each block carries its raw content and exact-slice source spans.
+- **`SingleFileComponentSyntaxParser`** — the `AggregateSyntaxParser<SingleFileComponentBlock>`
+  adapter (`ParseComponent`): same slicing, but each block is exposed to the registration seam as a
+  `SyntaxSource` so build tooling can attach the template/style/custom parsers.
+- **Diagnostics** (`Diagnostics/`) — `SingleFileComponentError` and the Viu-defined
+  `SingleFileComponentErrorCode` (1000-based).
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only; it never references the template, CSS, or any other
+  language library — the composition root wires those in through the aggregate registration seam.
+- Build-time library: targets the netstandard2.0 analyzer TFM and runs inside Roslyn generator hosts;
+  `IsAotCompatible` does not apply (a documented deviation for this TFM).
+- Design rationale and the divergences: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
@@ -1,0 +1,44 @@
+# Assimalign.Viu.Syntax.Templates — overview
+
+The Vue template language front end — the C# port of
+[`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) plus
+[`@vue/compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom): it tokenizes
+and parses Vue template markup into a located AST, runs the transform pipeline (structural and
+directive transforms, expression binding, static optimization), and generates a **C# render method**.
+It is a build-time library that runs inside the source generator ([V01.01.05.05]/[V01.01.06.02]);
+there is no runtime compilation (see
+[ADR-0005](../../../docs/adr/0005-no-runtime-template-compilation.md)). Area: `V01.01.05`.
+
+The rationale, the JavaScript-to-C# codegen divergences, and the runtime-helper contract are
+detailed in [DESIGN.md](DESIGN.md); this page is the surface map.
+
+## Public surface
+
+- **Parsing** (`Parsing/`) — `TemplateParser.Parse` (the authoritative, `@vue/compiler-core`-parity
+  entry), `TemplateSyntaxParser` (the registration adapter over the shared pipeline),
+  `TemplateSyntaxParserResult`, `ParserOptions`, `TemplateParseMode`, `WhitespaceStrategy`.
+- **The AST** (`Ast/`, plus root-level `TemplateSyntaxNode` / `TemplateChildNode` / `ExpressionNode`
+  / `PropertyNode` / `NodeType`) — `RootNode`, `ElementNode`, `AttributeNode`, `DirectiveNode`,
+  `InterpolationNode`, `TextNode`, `CommentNode`, `SimpleExpressionNode`, `CompoundExpressionNode`,
+  and the `ElementType` / `ElementNamespace` / `ConstantType` classifiers. `NodeType` is pinned
+  numerically to `@vue/compiler-core`'s `NodeTypes`.
+- **Transforms** (`Transforms/`) — `Transformer`, `TransformContext`, `TransformOptions`,
+  `TransformResult`, `TemplateExpressionCompiler`, and the `NodeTransform` / `DirectiveTransform`
+  delegates.
+- **Binding** (`Binding/`) — `BindingMetadata`, `BindingType`, `BindingRewriteMode`, and the CSS
+  module accessors (`CssModuleAccessor`, `CssModuleAccessors`) that let the compiler resolve
+  `$style.x`.
+- **Code generation** (`CodeGeneration/`) — `RenderFunctionEmitter` (Vue's `generate`), its
+  options/result, `RenderSourceMapping` (the `#line` correspondence), and the code-generation IR.
+- **Diagnostics** (`Diagnostics/`) — `CompilerError` and `CompilerErrorCode` (numeric parity with
+  vuejs/core).
+
+## Boundaries
+
+- Roots on **`Assimalign.Viu.Syntax`** only. It does **not** reference the runtime: the emitted
+  render method binds to `Assimalign.Viu.RuntimeCore`'s `RenderHelpers` (and the DOM directive
+  helpers in `Assimalign.Viu.RuntimeDom`) **by name**, so the contract flows one way (see
+  [`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../Assimalign.Viu.RuntimeCore/docs/DESIGN.md)).
+- Build-time library on the netstandard2.0 analyzer TFM; runs in Roslyn generator hosts.
+- Everything a parse or transform produces is value-equatable to preserve the incremental-generator
+  caching contract.

--- a/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
@@ -1,0 +1,43 @@
+# Assimalign.Viu.Testing — design
+
+Why the testing package is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
+counterparts: [`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test)
+and [`@vue/test-utils`](https://test-utils.vuejs.org).
+
+## A second platform for the one renderer
+
+`Assimalign.Viu.RuntimeCore`'s renderer is platform-agnostic: it drives whatever
+`RendererOptions<TNode>` it is given (see
+[`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../Assimalign.Viu.RuntimeCore/docs/DESIGN.md)).
+`TestNodeOperations.Create(log)` supplies node-ops over a plain in-memory tree
+(`TestElement`/`TestText`/`TestComment`), so component behavior is exercised through the *same*
+mount/patch/unmount pipeline the browser uses — just with no DOM and no interop. This is exactly
+`@vue/runtime-test`'s role, and it is why a component tested here behaves as it will in the browser.
+
+## The op log is the assertion surface
+
+Every node operation the renderer issues lands in `TestNodeOperationLog` as a `TestNodeOperation`
+(`@vue/runtime-test`'s `nodeOps` op log). Tests assert *what the renderer did* — which inserts,
+removes, and text writes happened, in order — not only the final tree. `TestNodeSerializer` renders
+the tree to a string for snapshot-style assertions. Container creation is intentionally **not**
+logged, so the log isolates the renderer's own work.
+
+## Determinism is owned by the mount
+
+`ViuTest.Mount` takes ownership of the scheduler lifecycle for the mount: it resets the `Scheduler`
+and installs a `TestSchedulerPump` so flushes are captured and async update helpers are
+reproducible, with no reliance on an ambient `SynchronizationContext`. The returned `ComponentWrapper`
+is `IDisposable`; disposing it (a `using`) unmounts and returns the scheduler to baseline, so one
+test cannot leak reactive subscriptions or queued jobs into the next.
+
+## Deltas from Vue 3
+
+- **No jsdom.** `@vue/test-utils` normally mounts into a jsdom DOM; Viu's platform here is a pure
+  in-memory node tree, keeping the whole harness dependency-light and AOT-clean.
+- **Component instances are caller-supplied**, constructed by source-generated factories — never
+  reflection-activated — so the harness stays trimming/AOT-safe.
+
+## Non-goals (sequenced work)
+
+- The end-to-end browser test harness — [V01.01.11.03].
+- The performance benchmark suite — [V01.01.11.04].

--- a/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
@@ -1,0 +1,34 @@
+# Assimalign.Viu.Testing — overview
+
+The DOM-free testing package — the C# counterpart of
+[`@vue/runtime-test`](https://github.com/vuejs/core/tree/main/packages/runtime-test) (the in-memory
+renderer and node-op log) plus [`@vue/test-utils`](https://test-utils.vuejs.org) (the `mount` entry
+and the component wrapper). Everything runs on a plain CoreCLR test host — no browser, no WASM
+toolchain, no JS interop. Area: `V01.01.11`.
+
+## Public surface
+
+- **`ViuTest`** (static) — `Mount<TComponent>(component, options?)` (Vue's `mount`): renders a
+  component against the in-memory renderer and returns a `ComponentWrapper`. The caller supplies the
+  component instance (source-generated factories, never reflection activation).
+- **`TestRenderer`** — the ready-to-use in-memory renderer (`@vue/runtime-test`'s `render` + `nodeOps`
+  pair): `Render`, `CreateContainer`, the underlying `Renderer<TestNode>`, and the `OperationLog`
+  every node operation is recorded into.
+- **The in-memory node tree** (`Nodes/`) — `TestNode` (abstract), `TestElement`, `TestText`,
+  `TestComment`; `TestNodeOperations` (the `RendererOptions<TestNode>` factory); the op log
+  (`TestNodeOperationLog`, `TestNodeOperation`, `TestNodeOperationType`); `TestNodeSerializer`
+  (tree-to-string for snapshot assertions); and `TestEventDispatcher`.
+- **Wrappers** (`Wrappers/`) — `ComponentWrapper` (`IDisposable`: query, interact, assert, and
+  unmount on dispose), `ElementWrapper`, and `ComponentMountOptions` (props, slots, provides,
+  registered components, stubs).
+- **`TestSchedulerPump`** — the deterministic scheduler pump the mount installs so async update
+  helpers are reproducible.
+
+## Boundaries
+
+- References **`Assimalign.Viu.RuntimeCore`** (and transitively Shared/Reactivity) only. Ships as a
+  net10.0 library with `IsAotCompatible=true`.
+- It is a **platform package** in the same sense as `Assimalign.Viu.RuntimeDom` — it supplies a
+  `RendererOptions<TNode>` (here `TNode = TestNode`) to the shared renderer — but its platform is an
+  in-memory tree instead of the browser DOM.
+- Design rationale and the determinism model: [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Tooling.Css/docs/OVERVIEW.md
@@ -1,0 +1,39 @@
+# Assimalign.Viu.Tooling.Css — overview
+
+The shared, build-time CSS composition core for `.viu` `@style` blocks. It compiles a component's
+styles (scoped CSS, CSS Modules, and `v-bind()` rewrites) and bundles a project's components into one
+deterministic stylesheet. It exists so the two build-time hosts that need this logic — the
+`Assimalign.Viu.Syntax.Generators` source generator (which emits the styles as a C# constant) and the
+`ViuBundleCss` MSBuild task (which writes the physical file) — run **one** implementation and cannot
+drift. Area: `V01.01.12.12`.
+
+This is tooling / composition-root code, not a peer `Assimalign.Viu.Syntax.*` language library — the
+reason it is *allowed* to reference several language libraries. The rationale, the RS1035 / no-I/O
+constraint, and the byte-stable bundle layout are in [DESIGN.md](DESIGN.md); the broader utility-CSS
+plan is [`docs/UTILITY-CSS-DESIGN.md`](../../../docs/UTILITY-CSS-DESIGN.md).
+
+## Public surface
+
+- **`SingleFileComponentStyleCompiler`** — the compilation itself: `Compile(parse, scopeId)` (for the
+  generator, which already holds the parse) and `CompileFile(parser, text, path, projectDirectory)`
+  (for the task). Returns a `SingleFileComponentStyleCompilation`.
+- **`SingleFileComponentStyleBundler`** — composes a project's components into one deterministic
+  bundle string (stable ordering, LF-only layout). Pure: the caller performs file I/O and hands in
+  the already-read text via `SingleFileComponentStyleInput`.
+- **`StyleScopeId`** — the `data-v-<hash>` scope-id derivation both hosts resolve identically.
+- **`SingleFileComponentParserFactory`** — the shared `.viu` parser composition (`Create()` /
+  `CreateForStyleExtraction()`), so the task can parse only `@style` without loading the template
+  compiler.
+- **Result and input types** — `SingleFileComponentStyleCompilation`,
+  `SingleFileComponentStyleDiagnostic`, `SingleFileComponentStyleInput`,
+  `SingleFileComponentStyleModuleClass`, `SingleFileComponentStyleVariableBinding`.
+
+## Boundaries
+
+- References `Assimalign.Viu.Syntax`, `.Syntax.SingleFileComponent`, `.Syntax.Templates`, and
+  `.Syntax.Css` — legal because this is a composition root, not a language library (a language
+  library may not reference another; a composition root may).
+- **No I/O, no reflection, no dynamic codegen.** The core is analyzer-sandbox-safe (netstandard2.0
+  analyzer TFM); the `ViuBundleCss` task performs the file I/O outside the sandbox.
+- **Deterministic, byte-stable output** (LF, ordinal ordering) — the guarantee that the generated
+  constant and the bundled file are byte-identical.

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -80,7 +80,7 @@ A consumer outside this repo points a `nuget.config` at the feed:
 ```xml
 <configuration>
     <packageSources>
-        <add key="viu-local" value="C:\Source\repos\assimalign\vuecs\_out\packages" />
+        <add key="viu-local" value="C:\Source\repos\assimalign\viu\_out\packages" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Opens the Router area with the new `Assimalign.Viu.Router` library (`libraries/Assimalign.Viu.Router/{src,test,docs}`, registered in the slnx): the C# port of vue-router v4's `createRouterMatcher` and its path-parser ranking model.
- Nested route records resolve to parent-to-child `Matched` chains (including empty-path default children via the insertion-ancestor rule); dynamic `:id`, optional `:id?`, repeatable `:id+`/`:id*`, and custom-pattern `:id(\d+)` parameters; ranking constants ported value-for-value from `pathParserRanker.ts` so static > dynamic > catch-all regardless of table order; named-route resolution with param interpolation and descriptive typed errors; boxing-free typed parameter accessors on an immutable `RouteLocation`.
- Zero dependencies (no DOM/interop/renderer — asserted by test); AOT/trimming-safe: interpreted `Regex` for user path patterns (documented in DESIGN.md), `[GeneratedRegex]` for the static escape pattern, no reflection.
- Interim divergences documented in `docs/DESIGN.md` behind named seams: all records currently matchable (upstream gates on name/components/redirect — components/redirect arrive with later Router features) and no `currentLocation` param inheritance (arrives with navigation, [V01.01.08.04]).

**Stacked on #178** (docs-skeleton) — merge that first; this branch carries it as its base so the rewritten README gains its Router row here (`docs/CONTRIBUTING.md` convention: a new library adds its repository-map row with the code).

`dotnet build Assimalign.Viu.slnx`: 0 warnings, 0 errors · `dotnet test libraries/Assimalign.Viu.Router/test/`: 70/70 passed.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)