### PR TITLE
fix(tooling): install the wasm-tools workload in the area-packaging workflow [V01.01.12.19.01]

### DIFF
--- a/.github/actions/setup-dotnet-wasm/action.yml
+++ b/.github/actions/setup-dotnet-wasm/action.yml
@@ -5,11 +5,13 @@
 name: Set up .NET for Viu
 description: >-
   .NET 10 SDK (pinned by global.json), NuGet + workload-pack caching, and optionally the
-  wasm-tools workload for WebAssembly app builds.
+  wasm-tools workload for builds that target browser-wasm.
 
 inputs:
   install-wasm-tools:
-    description: Install the wasm-tools workload (needed only for WebAssembly app builds).
+    description: >-
+      Install the wasm-tools workload. Needed by any job that builds for the browser-wasm
+      runtime identifier: WebAssembly app builds and the Assimalign.Viu.App runtime pack.
     required: false
     default: 'false'
 

--- a/.github/workflows/area-packaging.yml
+++ b/.github/workflows/area-packaging.yml
@@ -43,8 +43,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up .NET
+      # The runtime pack builds the framework closure with -p:RuntimeIdentifier=browser-wasm,
+      # which requires the wasm-tools workload (NETSDK1147 without it) — same as the app build.
+      - name: Set up .NET (with wasm-tools)
         uses: ./.github/actions/setup-dotnet-wasm
+        with:
+          install-wasm-tools: 'true'
 
       - name: Pack SDK, runtime pack, and ref pack
         shell: pwsh


### PR DESCRIPTION
## Summary
- The `area-packaging` pack job builds the `Assimalign.Viu.App` runtime pack with `-p:RuntimeIdentifier=browser-wasm`, which requires the **wasm-tools** workload — but the job called the `setup-dotnet-wasm` composite without `install-wasm-tools`, whose default is `'false'`. Every run since the workflow landed with #176 failed with `NETSDK1147` ("workloads must be installed: wasm-tools") → "Runtime pack failed for browser-wasm." Local runs masked it because developer machines have the workload.
- Fix: pass `install-wasm-tools: 'true'` exactly as `webapp.yml` does, with a comment pinning why the pack job needs it; correct the composite action's input description, which claimed the workload is needed *only* for WebAssembly app builds.
- The `area-packaging` run on **this PR** executes the updated workflow definition (the file is in its own path filter), so a green check here is the proof of the fix. PRs #178/#179 inherit the red check from main; once this merges I'll refresh those branches so their checks rerun green.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)