### PR TITLE
feat(tooling): establish WASM publish-size, trimming, and AOT budget gates [V01.01.12.06]

### DIFF
--- a/.github/workflows/budget-gates.yml
+++ b/.github/workflows/budget-gates.yml
@@ -1,0 +1,173 @@
+# WASM size, trimming, and AOT budget gates ([V01.01.12.06], #95): the Viu analog of
+# vuejs/core's size-check job (https://github.com/vuejs/core/blob/main/.github/workflows/size-data.yml).
+# Every published byte is network payload and every retained type is trimmer input, so these
+# gates enforce the framework's source-generator-first, reflection-free cost profile. Path-filtered
+# like the other area workflows; because the sample app pulls in every runtime area transitively, a
+# change to any library, the build system, or the gate's own files re-runs the gates.
+name: budget-gates
+
+on:
+  push:
+    branches: [main, 'release/**']
+    paths:
+      - 'examples/**'
+      - 'libraries/**'
+      - 'frameworks/**'
+      - 'sdks/**'
+      - 'analyzers/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - 'scripts/Measure-PublishBudget.ps1'
+      - 'scripts/budgets/**'
+      - 'scripts/tests/**'
+      - '.github/actions/**'
+      - '.github/workflows/budget-gates.yml'
+  pull_request:
+    branches: [main, 'release/**']
+    paths:
+      - 'examples/**'
+      - 'libraries/**'
+      - 'frameworks/**'
+      - 'sdks/**'
+      - 'analyzers/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - 'scripts/Measure-PublishBudget.ps1'
+      - 'scripts/budgets/**'
+      - 'scripts/tests/**'
+      - '.github/actions/**'
+      - '.github/workflows/budget-gates.yml'
+
+jobs:
+  gate-tests:
+    name: budget gate tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      # Fast, hermetic coverage of the gate's measurement/exclusion/gating/delta logic.
+      # No publish here, so this lane needs no wasm-tools workload.
+      - name: Build + test the budget gate
+        run: dotnet test scripts/tests/Assimalign.Viu.PublishBudget.Tests/Assimalign.Viu.PublishBudget.Tests.csproj --configuration Release -warnaserror
+
+  size:
+    name: publish-size + trimming gate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Base-branch checkout is measured with the head script + head manifest so the delta is
+      # apples-to-apples. Informational only (best-effort): the head-vs-manifest budget below is
+      # the authoritative gate.
+      - name: Checkout base branch (for size delta)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-tree
+
+      - name: Set up .NET (with wasm-tools)
+        uses: ./.github/actions/setup-dotnet-wasm
+        with:
+          install-wasm-tools: 'true'
+
+      - name: Measure base branch (informational delta)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        shell: pwsh
+        run: >-
+          ./scripts/Measure-PublishBudget.ps1
+          -RepositoryRoot base-tree
+          -NoGate
+          -ResultsPath _out/budgets/base-results.json
+
+      # Publishes each sample trimmed and measures the brotli-compressed wwwroot payload against
+      # the manifest. This step is BOTH the size gate (fails on any exceedance) and the trimming
+      # gate: the samples publish with PublishTrimmed=true + TrimmerSingleWarn=false
+      # (examples/Directory.Build.props) and the script publishes with -warnaserror, so any
+      # ILLink/trim-analyzer warning across the sample and every shipping library in its closure
+      # fails the build. Budgets change only through an explicit edit to
+      # scripts/budgets/PublishBudgets.json (no silent ratcheting).
+      - name: Publish (trimmed), measure size, enforce budget
+        shell: pwsh
+        run: >-
+          ./scripts/Measure-PublishBudget.ps1
+          -ResultsPath _out/budgets/head-results.json
+          -BaselineResultsPath _out/budgets/base-results.json
+
+      - name: Upload measurement results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-budget-results
+          path: _out/budgets/*-results.json
+          if-no-files-found: ignore
+
+  aot:
+    name: AOT compilation lane (optional)
+    # Optional cost-control lane. Runs on pushes to main and release branches (where branch
+    # protection can mark it a REQUIRED check), and on pull requests only when labelled
+    # 'aot-gate'. AOT relink is minutes-long, so it is not run on every PR by default.
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'aot-gate')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET (with wasm-tools)
+        uses: ./.github/actions/setup-dotnet-wasm
+        with:
+          install-wasm-tools: 'true'
+
+      # RunAOTCompilation is enabled via the scoped -p:ViuRunAotCompilation=true property
+      # (examples/Directory.Build.props) so it does not flow to the netstandard2.0 generators.
+      # -warnaserror fails the build on any AOT compiler error or warning.
+      - name: Publish sample with AOT compilation
+        run: >-
+          dotnet publish examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj
+          --configuration Release
+          -p:ViuRunAotCompilation=true
+          -warnaserror
+          --output _out/budgets/aot
+
+  startup:
+    name: startup-time gate (deferred, #87)
+    # WIRED-BUT-SKIPPED. The startup budget (time-to-first-render in a real headless browser) is
+    # a genuine gate requirement of [V01.01.12.06], but it depends on the Playwright end-to-end
+    # harness [V01.01.11.03] (#87), which is not built yet. A pure .NET timing harness is NOT an
+    # acceptable substitute (JS-interop initialization cost is part of what is budgeted), so no
+    # measurement is faked here. The job is skipped by default and turns on once the harness lands
+    # by setting the repository variable ENABLE_STARTUP_GATE=true.
+    #
+    # TODO([V01.01.11.03], #87): replace the placeholder step below with the real lane:
+    #   1. publish the sample trimmed (as the size job does);
+    #   2. serve wwwroot from a static file server;
+    #   3. drive it in headless Chromium/Firefox/WebKit via Microsoft.Playwright, measuring
+    #      time-to-first-render (navigation start -> first mounted DOM node) over enough
+    #      repetitions to be stable (e.g. median of >= 10 runs after a warm-up);
+    #   4. compare the median against startupBudgetMilliseconds in scripts/budgets/PublishBudgets.json
+    #      and fail on exceedance, mirroring the size gate's report + base-branch delta.
+    if: ${{ vars.ENABLE_STARTUP_GATE == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Startup gate placeholder
+        shell: pwsh
+        run: |
+          Write-Host 'Startup-time gate is deferred pending the Playwright e2e harness ([V01.01.11.03], #87).'
+          Write-Host 'Enable by setting repository variable ENABLE_STARTUP_GATE=true once the harness lands.'

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -60,6 +60,7 @@
 		<File Path=".github/workflows/area-shared.yml" />
 		<File Path=".github/workflows/area-syntax.yml" />
 		<File Path=".github/workflows/area-testing.yml" />
+		<File Path=".github/workflows/budget-gates.yml" />
 		<File Path=".github/workflows/webapp.yml" />
 	</Folder>
 	<Folder Name="/viu/analyzers/" />
@@ -137,8 +138,17 @@
 	</Folder>
 	<Folder Name="/viu/scripts/">
 		<File Path="scripts/Install-Local.ps1" />
+		<File Path="scripts/Measure-PublishBudget.ps1" />
 	</Folder>
-	<Folder Name="/viu/examples/" />
+	<Folder Name="/viu/scripts/budgets/">
+		<File Path="scripts/budgets/PublishBudgets.json" />
+	</Folder>
+	<Folder Name="/viu/scripts/tests/Assimalign.Viu.PublishBudget.Tests/">
+		<Project Path="scripts/tests/Assimalign.Viu.PublishBudget.Tests/Assimalign.Viu.PublishBudget.Tests.csproj" />
+	</Folder>
+	<Folder Name="/viu/examples/">
+		<File Path="examples/Directory.Build.props" />
+	</Folder>
 	<Folder Name="/viu/examples/Assimalign.Viu.WebApp/">
 		<Project Path="examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj" />
 	</Folder>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,0 +1,34 @@
+<Project>
+    <Import Project="..\Directory.Build.props" />
+
+    <!--
+        Sample WASM apps are the measurement subjects for the publish-size and
+        trimming budget gates ([V01.01.12.06], #95). Trimming is enabled here, not
+        on the gate's `dotnet publish` command line, so it stays scoped to the app
+        publish: a global -p:PublishTrimmed=true flows to the netstandard2.0
+        generator projects in the build graph and fails with NETSDK1124 (trimming
+        requires .NET Core 3.0+). TrimmerSingleWarn=false makes each ILLink /
+        trim-analyzer warning individually actionable, and the gate publishes with
+        -warnaserror so any trim warning fails the build across the sample and every
+        shipping library in its closure. Trimming only engages on publish, so an
+        ordinary `dotnet build` or `dotnet run` of the samples is unaffected.
+    -->
+    <PropertyGroup>
+        <PublishTrimmed>true</PublishTrimmed>
+        <TrimmerSingleWarn>false</TrimmerSingleWarn>
+        <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    </PropertyGroup>
+
+    <!--
+        Optional AOT-compilation lane ([V01.01.12.06], #95). RunAOTCompilation is
+        opt-in per sample publish, driven by -p:ViuRunAotCompilation=true so the
+        AOT relink is scoped to the sample apps: like PublishTrimmed, a bare global
+        -p:RunAOTCompilation=true would flow into the netstandard2.0 generator
+        projects. The AOT lane publishes with -warnaserror, so any AOT compiler
+        warning fails the build; the lane is optional on PRs and can be marked a
+        required check on release branches.
+    -->
+    <PropertyGroup Condition="'$(ViuRunAotCompilation)' == 'true'">
+        <RunAOTCompilation>true</RunAOTCompilation>
+    </PropertyGroup>
+</Project>

--- a/scripts/Measure-PublishBudget.ps1
+++ b/scripts/Measure-PublishBudget.ps1
@@ -1,0 +1,342 @@
+<#
+.SYNOPSIS
+    Publishes Viu sample applications with trimming enabled, measures the
+    brotli-compressed size of the published browser payload, and fails when a
+    sample exceeds the budget recorded in the checked-in manifest.
+
+.DESCRIPTION
+    The Viu analog of vuejs/core's size-check CI job
+    (https://github.com/vuejs/core/blob/main/.github/workflows/size-data.yml).
+    Every published byte is network payload for a WebAssembly app, so a
+    per-sample brotli budget is the enforcement mechanism for the framework's
+    source-generator-first, reflection-free architecture ([V01.01.12.06], #95).
+
+    The gate is deterministic and cross-platform (Windows local + GitHub Actions
+    ubuntu runners): it shells out to `dotnet publish` and computes brotli sizes
+    with the in-box .NET compression APIs, so it needs no external tooling beyond
+    the .NET SDK and the wasm-tools workload.
+
+    Trimming is configured by the samples themselves (examples/Directory.Build.props)
+    rather than a global publish property, because a global -p:PublishTrimmed=true
+    flows to the netstandard2.0 generator projects in the build graph and fails with
+    NETSDK1124. The gate publishes with -warnaserror, so any ILLink/trim-analyzer
+    warning fails the publish across the sample and every shipping library it pulls
+    in -- this is also the trimming-validation gate.
+
+    Budgets only ever change through an explicit edit to the manifest
+    (scripts/budgets/PublishBudgets.json) in the pull request under review. This
+    script never rewrites the manifest, so size growth is always a reviewed
+    decision -- there is no silent ratcheting.
+
+.PARAMETER ManifestPath
+    Path to the budget manifest. Defaults to scripts/budgets/PublishBudgets.json
+    alongside this script (i.e. the manifest of the tree that owns this script,
+    even when -RepositoryRoot points at a different checkout for base-branch delta
+    measurement).
+
+.PARAMETER SampleName
+    One or more sample names (matching the manifest) to measure. Defaults to every
+    sample in the manifest.
+
+.PARAMETER Configuration
+    Build configuration to publish. Defaults to Release; Debug builds are never a
+    valid measurement subject.
+
+.PARAMETER PublishDirectory
+    When supplied, the script measures this already-published directory instead of
+    invoking `dotnet publish`. Used by the tests (to feed deterministic fixtures)
+    and to re-measure a payload without republishing. Single-sample mode: combine
+    with -SampleName when the manifest holds more than one sample.
+
+.PARAMETER RepositoryRoot
+    Root of the source tree whose sample projects are published. Defaults to the
+    parent of this script's directory. Overridden by CI to point at a base-branch
+    checkout so the head manifest/method can measure base sources for the delta.
+
+.PARAMETER ResultsPath
+    When supplied, writes the machine-readable measurement results as JSON. CI uses
+    this to hand a base-branch measurement to a later head-branch run.
+
+.PARAMETER BaselineResultsPath
+    When supplied, a prior results JSON (typically the base branch) whose per-sample
+    sizes are shown as a delta column in the report.
+
+.PARAMETER NoGate
+    Measure and report only; never set a failing exit code. Used for the base-branch
+    measurement, which is informational, not a gate.
+
+.PARAMETER PublishOutputRoot
+    Directory that holds per-sample publish output. Defaults to a folder under the
+    repository's gitignored _out. Cleared per sample before publishing.
+
+.OUTPUTS
+    Exit code 0 when every measured sample is within budget (or -NoGate), 1 when any
+    sample exceeds its budget, 2 on a configuration/tooling error.
+#>
+[CmdletBinding()]
+param(
+    [string] $ManifestPath,
+    [string[]] $SampleName,
+    [string] $Configuration = 'Release',
+    [string] $PublishDirectory,
+    [string] $RepositoryRoot,
+    [string] $ResultsPath,
+    [string] $BaselineResultsPath,
+    [switch] $NoGate,
+    [string] $PublishOutputRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = $PSScriptRoot
+if (-not $RepositoryRoot) {
+    $RepositoryRoot = Split-Path $scriptRoot -Parent
+}
+$RepositoryRoot = (Resolve-Path $RepositoryRoot).Path
+if (-not $ManifestPath) {
+    $ManifestPath = Join-Path $scriptRoot 'budgets/PublishBudgets.json'
+}
+if (-not $PublishOutputRoot) {
+    $PublishOutputRoot = Join-Path $RepositoryRoot '_out/budgets'
+}
+
+# Files the browser never downloads on its own: pre-compressed duplicates the SDK
+# may emit (compressing a *.br/*.gz copy would double count) and source maps.
+$excludedPayloadExtensions = @('.br', '.gz', '.map')
+
+function Write-Report {
+    param([string] $Text)
+    # Report goes to the host so it stays visible in CI logs regardless of the
+    # object stream; measurement objects are returned separately.
+    Write-Host $Text
+}
+
+function Exit-WithError {
+    # Configuration / tooling failures exit with code 2 (distinct from an
+    # over-budget gate failure, which is code 1). Write straight to stderr rather
+    # than Write-Error so $ErrorActionPreference='Stop' cannot pre-empt the exit
+    # code with an unhandled terminating error.
+    param([string] $Message, [int] $Code = 2)
+    [Console]::Error.WriteLine("Measure-PublishBudget: $Message")
+    exit $Code
+}
+
+function Format-Bytes {
+    param([long] $Bytes)
+    if ($Bytes -ge 1MB) { return ('{0:N2} MB' -f ($Bytes / 1MB)) }
+    if ($Bytes -ge 1KB) { return ('{0:N2} KB' -f ($Bytes / 1KB)) }
+    return ("$Bytes B")
+}
+
+function Format-SignedBytes {
+    param([long] $Bytes)
+    $sign = if ($Bytes -ge 0) { '+' } else { '-' }
+    return ($sign + (Format-Bytes ([Math]::Abs($Bytes))))
+}
+
+function Get-BrotliByteCount {
+    param([string] $Path)
+    # Model the bytes on the wire: each asset is compressed independently, at the
+    # smallest-size brotli quality a production static host would serve.
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $buffer = [System.IO.MemoryStream]::new()
+    $brotli = [System.IO.Compression.BrotliStream]::new(
+        $buffer,
+        [System.IO.Compression.CompressionLevel]::SmallestSize,
+        $true)
+    try {
+        $brotli.Write($bytes, 0, $bytes.Length)
+    }
+    finally {
+        $brotli.Dispose()
+    }
+    $count = $buffer.Length
+    $buffer.Dispose()
+    return [long] $count
+}
+
+function Measure-PayloadDirectory {
+    param([string] $PayloadRoot)
+    # The published browser payload is everything under the app's wwwroot: the
+    # _framework runtime + assemblies, index.html, JS glue, and _content assets.
+    $compressed = [long] 0
+    $raw = [long] 0
+    $fileCount = 0
+    $files = Get-ChildItem -Path $PayloadRoot -Recurse -File
+    foreach ($file in $files) {
+        if ($excludedPayloadExtensions -contains $file.Extension.ToLowerInvariant()) {
+            continue
+        }
+        $compressed += Get-BrotliByteCount $file.FullName
+        $raw += $file.Length
+        $fileCount++
+    }
+    return [pscustomobject]@{
+        CompressedPublishSizeBytes = $compressed
+        RawPublishSizeBytes        = $raw
+        FileCount                  = $fileCount
+    }
+}
+
+function Resolve-PayloadRoot {
+    param([string] $PublishRoot)
+    # WebAssembly publish output places the browser payload under wwwroot; if a
+    # sample ever publishes a flat payload we fall back to the publish root.
+    $wwwroot = Join-Path $PublishRoot 'wwwroot'
+    if (Test-Path $wwwroot) {
+        return $wwwroot
+    }
+    return $PublishRoot
+}
+
+function Invoke-SamplePublish {
+    param(
+        [string] $ProjectPath,
+        [string] $OutputDirectory)
+    if (Test-Path $OutputDirectory) {
+        Remove-Item -Recurse -Force $OutputDirectory
+    }
+    New-Item -ItemType Directory -Force $OutputDirectory | Out-Null
+
+    # Trimming is enabled by examples/Directory.Build.props. -warnaserror doubles as
+    # the trimming-validation gate: any ILLink/trim-analyzer warning fails here.
+    Write-Report "  publishing $ProjectPath (trimmed, $Configuration)"
+    & dotnet publish $ProjectPath `
+        --configuration $Configuration `
+        -warnaserror `
+        --output $OutputDirectory
+    if ($LASTEXITCODE -ne 0) {
+        throw "Publish failed for $ProjectPath (exit $LASTEXITCODE). Trim warnings are treated as errors."
+    }
+}
+
+# --- Load the manifest ----------------------------------------------------------
+
+if (-not (Test-Path $ManifestPath)) {
+    Exit-WithError "Budget manifest not found: $ManifestPath"
+}
+$manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json
+$samples = @($manifest.samples)
+if ($SampleName) {
+    $samples = @($samples | Where-Object { $SampleName -contains $_.name })
+    if ($samples.Count -eq 0) {
+        Exit-WithError "No manifest sample matched -SampleName: $($SampleName -join ', ')"
+    }
+}
+if ($samples.Count -eq 0) {
+    Exit-WithError "Budget manifest defines no samples: $ManifestPath"
+}
+if ($PublishDirectory -and $samples.Count -gt 1) {
+    Exit-WithError '-PublishDirectory measures a single payload; narrow to one sample with -SampleName.'
+}
+
+$baseline = $null
+if ($BaselineResultsPath -and (Test-Path $BaselineResultsPath)) {
+    $baseline = Get-Content -Raw $BaselineResultsPath | ConvertFrom-Json
+}
+
+# --- Measure --------------------------------------------------------------------
+
+$results = New-Object System.Collections.Generic.List[object]
+foreach ($sample in $samples) {
+    $budgetBytes = [long] $sample.compressedPublishSizeBytes
+    if ($PublishDirectory) {
+        $payloadRoot = Resolve-PayloadRoot $PublishDirectory
+    }
+    else {
+        $projectPath = Join-Path $RepositoryRoot $sample.project
+        if (-not (Test-Path $projectPath)) {
+            Write-Report "  skipping $($sample.name): project not present in this tree ($projectPath)"
+            continue
+        }
+        $outputDirectory = Join-Path $PublishOutputRoot $sample.name
+        try {
+            Invoke-SamplePublish -ProjectPath $projectPath -OutputDirectory $outputDirectory
+        }
+        catch {
+            Exit-WithError "$($_.Exception.Message)"
+        }
+        $payloadRoot = Resolve-PayloadRoot $outputDirectory
+    }
+
+    $measurement = Measure-PayloadDirectory $payloadRoot
+    $actualBytes = [long] $measurement.CompressedPublishSizeBytes
+    $withinBudget = $actualBytes -le $budgetBytes
+
+    $baselineBytes = $null
+    if ($baseline) {
+        $baselineSample = $baseline.samples | Where-Object { $_.name -eq $sample.name } | Select-Object -First 1
+        if ($baselineSample) {
+            $baselineBytes = [long] $baselineSample.compressedPublishSizeBytes
+        }
+    }
+
+    $results.Add([pscustomobject]@{
+            name                       = $sample.name
+            compressedPublishSizeBytes = $actualBytes
+            rawPublishSizeBytes        = [long] $measurement.RawPublishSizeBytes
+            budgetBytes                = $budgetBytes
+            withinBudget               = $withinBudget
+            headroomBytes              = ($budgetBytes - $actualBytes)
+            fileCount                  = $measurement.FileCount
+            baselineBytes              = $baselineBytes
+        }) | Out-Null
+}
+
+# --- Report ---------------------------------------------------------------------
+
+Write-Report ''
+Write-Report "Viu publish-size budget report (brotli, $Configuration, trimmed)"
+Write-Report '================================================================'
+$header = '{0,-32} {1,12} {2,12} {3,10} {4,14}  {5}' -f 'Sample', 'Actual', 'Budget', 'Headroom', 'Delta vs base', 'Status'
+Write-Report $header
+Write-Report ('-' * $header.Length)
+
+$overCount = 0
+foreach ($result in $results) {
+    if (-not $result.withinBudget) { $overCount++ }
+    $headroomPercent = if ($result.budgetBytes -gt 0) { 100.0 * $result.headroomBytes / $result.budgetBytes } else { 0 }
+    $deltaText = 'n/a'
+    if ($null -ne $result.baselineBytes) {
+        $deltaText = Format-SignedBytes ($result.compressedPublishSizeBytes - $result.baselineBytes)
+    }
+    $status = if ($result.withinBudget) { 'PASS' } else { 'OVER BUDGET' }
+    Write-Report ('{0,-32} {1,12} {2,12} {3,9:N1}% {4,14}  {5}' -f `
+            $result.name,
+        (Format-Bytes $result.compressedPublishSizeBytes),
+        (Format-Bytes $result.budgetBytes),
+        $headroomPercent,
+        $deltaText,
+        $status)
+}
+Write-Report ('-' * $header.Length)
+$measuredCount = $results.Count
+$passedCount = $measuredCount - $overCount
+Write-Report ("Result: {0} ({1}/{2} within budget)" -f (($overCount -eq 0) ? 'PASS' : 'FAIL'), $passedCount, $measuredCount)
+if ($overCount -gt 0) {
+    Write-Report ''
+    Write-Report 'A sample exceeded its budget. This is a deliberate-decision gate:'
+    Write-Report '  - reduce the payload, or'
+    Write-Report "  - raise the budget in $ManifestPath as a reviewed change (no silent ratcheting)."
+}
+
+# --- Machine-readable results ---------------------------------------------------
+
+if ($ResultsPath) {
+    $resultsDirectory = Split-Path $ResultsPath -Parent
+    if ($resultsDirectory -and -not (Test-Path $resultsDirectory)) {
+        New-Item -ItemType Directory -Force $resultsDirectory | Out-Null
+    }
+    [pscustomobject]@{
+        configuration = $Configuration
+        generatedUtc  = (Get-Date).ToUniversalTime().ToString('o')
+        samples       = $results
+    } | ConvertTo-Json -Depth 6 | Set-Content -Path $ResultsPath -Encoding utf8
+    Write-Report "Wrote results: $ResultsPath"
+}
+
+if ($NoGate) {
+    exit 0
+}
+exit ($overCount -eq 0 ? 0 : 1)

--- a/scripts/budgets/PublishBudgets.json
+++ b/scripts/budgets/PublishBudgets.json
@@ -1,0 +1,33 @@
+{
+  "note": [
+    "Per-sample budget manifest for the Viu WASM size and startup gates ([V01.01.12.06], #95).",
+    "The Viu analog of vuejs/core's size-check job (https://github.com/vuejs/core/blob/main/.github/workflows/size-data.yml).",
+    "",
+    "compressedPublishSizeBytes: the brotli-compressed sum of the published wwwroot payload (post-trim,",
+    "Release), as measured by scripts/Measure-PublishBudget.ps1. Pre-compressed *.br/*.gz duplicates and",
+    "*.map files are excluded so nothing is double counted; every other published byte (the _framework",
+    "runtime + trimmed assemblies, ICU data, index.html, JS glue, and _content assets) is included.",
+    "",
+    "No silent ratcheting: CI never rewrites this file. A budget change is an explicit, reviewed edit in",
+    "the pull request, so payload growth is always a deliberate decision. Budgets are seeded from the",
+    "measured actual plus ~10% headroom; when a sample legitimately grows, raise its budget here.",
+    "",
+    "startupBudgetMilliseconds: the time-to-first-render ceiling for the headless-browser startup lane.",
+    "This value is PROVISIONAL and NOT YET ENFORCED -- it is not a measured number. The startup lane is",
+    "wired-but-skipped in .github/workflows/budget-gates.yml pending the Playwright e2e harness",
+    "([V01.01.11.03], #87), which owns real-browser measurement. Calibrate this from repeated headless",
+    "runs when that lane activates.",
+    "",
+    "Seed provenance: Assimalign.Viu.WebApp measured 2,097,190 bytes brotli (7,363,995 raw, 19 files) on",
+    "2026-07-19 with .NET SDK 10.0.302 / wasm-tools 10.0.110. CI (ubuntu x64) is the authority; if its",
+    "measurement differs materially from this Windows seed, recalibrate via an explicit edit here."
+  ],
+  "samples": [
+    {
+      "name": "Assimalign.Viu.WebApp",
+      "project": "examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj",
+      "compressedPublishSizeBytes": 2310000,
+      "startupBudgetMilliseconds": 5000
+    }
+  ]
+}

--- a/scripts/tests/Assimalign.Viu.PublishBudget.Tests/Assimalign.Viu.PublishBudget.Tests.csproj
+++ b/scripts/tests/Assimalign.Viu.PublishBudget.Tests/Assimalign.Viu.PublishBudget.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Tests for the publish-size budget gate ([V01.01.12.06], #95). The gate is a
+    cross-platform PowerShell script (scripts/Measure-PublishBudget.ps1); these
+    tests drive it over deterministic on-disk fixtures via pwsh and assert the
+    measurement, exclusion, gating, delta, and exit-code behavior. They never run
+    a real `dotnet publish`, so they stay fast and hermetic; the publish path is
+    covered by the budget-gates CI workflow itself. No project reference is needed
+    (the artifact under test is a script), so this project stays clear of the
+    ViuProjectReference name-resolution that only indexes libraries/ and analyzers/.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+</Project>

--- a/scripts/tests/Assimalign.Viu.PublishBudget.Tests/MeasurePublishBudgetTests.cs
+++ b/scripts/tests/Assimalign.Viu.PublishBudget.Tests/MeasurePublishBudgetTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.PublishBudget.Tests;
+
+// Behavioral coverage for the publish-size budget gate
+// (scripts/Measure-PublishBudget.ps1, [V01.01.12.06], #95). Each test builds a
+// deterministic on-disk payload fixture, invokes the gate through pwsh in
+// measure-only or gating mode, and asserts the exit code and machine-readable
+// results. The real `dotnet publish` path is intentionally out of scope here (it
+// is exercised by the budget-gates CI workflow); these tests pin the measurement,
+// exclusion, gating, and delta logic that the gate decision rests on.
+public sealed class MeasurePublishBudgetTests : IDisposable
+{
+    private const string SampleName = "Sample";
+
+    private readonly List<string> temporaryDirectories = new();
+
+    [Fact]
+    public void Gate_PayloadWithinBudget_ReportsPassAndExitsZero()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(4096)));
+        var manifest = CreateManifest(budgetBytes: 100_000_000);
+
+        var run = RunGate(manifest, "-PublishDirectory", payload);
+
+        run.ExitCode.ShouldBe(0);
+        run.Output.ShouldContain("PASS");
+        run.Output.ShouldContain("within budget");
+    }
+
+    [Fact]
+    public void Gate_PayloadOverBudget_ReportsOverBudgetAndExitsOne()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(4096)));
+        var manifest = CreateManifest(budgetBytes: 1);
+
+        var run = RunGate(manifest, "-PublishDirectory", payload);
+
+        run.ExitCode.ShouldBe(1);
+        run.Output.ShouldContain("OVER BUDGET");
+    }
+
+    [Fact]
+    public void Gate_OverBudgetWithNoGate_ExitsZeroForInformationalMeasurement()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(4096)));
+        var manifest = CreateManifest(budgetBytes: 1);
+
+        var run = RunGate(manifest, "-PublishDirectory", payload, "-NoGate");
+
+        run.ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Gate_BrotliMeasurement_IsSmallerThanRawAndNonZero()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(65_536)));
+        var manifest = CreateManifest(budgetBytes: 100_000_000);
+        var resultsPath = ReserveResultsPath();
+
+        var run = RunGate(manifest, "-PublishDirectory", payload, "-NoGate", "-ResultsPath", resultsPath);
+
+        run.ExitCode.ShouldBe(0);
+        var measured = ReadFirstSample(resultsPath);
+        measured.CompressedPublishSizeBytes.ShouldBeGreaterThan(0);
+        measured.CompressedPublishSizeBytes.ShouldBeLessThan(measured.RawPublishSizeBytes);
+    }
+
+    [Fact]
+    public void Gate_PrecompressedAndSourceMapFiles_AreExcludedFromThePayload()
+    {
+        // The SDK emits *.br/*.gz duplicates next to each asset; compressing those
+        // again (or counting *.map) would double count. Only the raw asset counts.
+        var payload = CreatePayload(
+            ("app.wasm", CompressibleBytes(2_000)),
+            ("app.wasm.br", CompressibleBytes(500_000)),
+            ("app.wasm.gz", CompressibleBytes(500_000)),
+            ("bundle.js.map", CompressibleBytes(500_000)));
+        var manifest = CreateManifest(budgetBytes: 100_000_000);
+        var resultsPath = ReserveResultsPath();
+
+        var run = RunGate(manifest, "-PublishDirectory", payload, "-NoGate", "-ResultsPath", resultsPath);
+
+        run.ExitCode.ShouldBe(0);
+        var measured = ReadFirstSample(resultsPath);
+        measured.FileCount.ShouldBe(1);
+        measured.RawPublishSizeBytes.ShouldBe(2_000);
+    }
+
+    [Fact]
+    public void Gate_WithBaselineResults_RecordsBaselineForDeltaReporting()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(4_096)));
+        var manifest = CreateManifest(budgetBytes: 100_000_000);
+        const long baselineBytes = 123_456;
+        var baselinePath = CreateBaselineResults(baselineBytes);
+        var resultsPath = ReserveResultsPath();
+
+        var run = RunGate(
+            manifest,
+            "-PublishDirectory",
+            payload,
+            "-NoGate",
+            "-BaselineResultsPath",
+            baselinePath,
+            "-ResultsPath",
+            resultsPath);
+
+        run.ExitCode.ShouldBe(0);
+        run.Output.ShouldNotContain("n/a");
+        var measured = ReadFirstSample(resultsPath);
+        measured.BaselineBytes.ShouldBe(baselineBytes);
+    }
+
+    [Fact]
+    public void Gate_MissingManifest_ExitsTwoForConfigurationError()
+    {
+        var payload = CreatePayload(("app.wasm", CompressibleBytes(1_024)));
+        var missingManifest = Path.Combine(CreateTemporaryDirectory(), "does-not-exist.json");
+
+        var run = RunGate(missingManifest, "-PublishDirectory", payload);
+
+        run.ExitCode.ShouldBe(2);
+    }
+
+    // --- fixtures ---------------------------------------------------------------
+
+    private static byte[] CompressibleBytes(int count)
+    {
+        // Highly compressible so the brotli size is always well under the raw size.
+        var bytes = new byte[count];
+        Array.Fill(bytes, (byte)'A');
+        return bytes;
+    }
+
+    private string CreatePayload(params (string Name, byte[] Content)[] files)
+    {
+        var root = CreateTemporaryDirectory();
+        var wwwroot = Path.Combine(root, "wwwroot");
+        Directory.CreateDirectory(wwwroot);
+        foreach (var file in files)
+        {
+            File.WriteAllBytes(Path.Combine(wwwroot, file.Name), file.Content);
+        }
+        return root;
+    }
+
+    private string CreateManifest(long budgetBytes)
+    {
+        var manifestPath = Path.Combine(CreateTemporaryDirectory(), "PublishBudgets.json");
+        var manifest = new
+        {
+            samples = new[]
+            {
+                new
+                {
+                    name = SampleName,
+                    project = "unused-in-publish-directory-mode.csproj",
+                    compressedPublishSizeBytes = budgetBytes,
+                    startupBudgetMilliseconds = 1_000,
+                },
+            },
+        };
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest), Encoding.UTF8);
+        return manifestPath;
+    }
+
+    private string CreateBaselineResults(long compressedPublishSizeBytes)
+    {
+        var baselinePath = Path.Combine(CreateTemporaryDirectory(), "baseline-results.json");
+        var baseline = new
+        {
+            configuration = "Release",
+            samples = new[]
+            {
+                new
+                {
+                    name = SampleName,
+                    compressedPublishSizeBytes,
+                },
+            },
+        };
+        File.WriteAllText(baselinePath, JsonSerializer.Serialize(baseline), Encoding.UTF8);
+        return baselinePath;
+    }
+
+    private string ReserveResultsPath()
+        => Path.Combine(CreateTemporaryDirectory(), "results.json");
+
+    private static SampleMeasurement ReadFirstSample(string resultsPath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(resultsPath));
+        var sample = document.RootElement.GetProperty("samples")[0];
+        long? baseline = sample.TryGetProperty("baselineBytes", out var baselineElement)
+            && baselineElement.ValueKind is not JsonValueKind.Null
+                ? baselineElement.GetInt64()
+                : null;
+        return new SampleMeasurement(
+            sample.GetProperty("compressedPublishSizeBytes").GetInt64(),
+            sample.GetProperty("rawPublishSizeBytes").GetInt64(),
+            sample.GetProperty("fileCount").GetInt32(),
+            baseline);
+    }
+
+    private GateRun RunGate(string manifestPath, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(LocateGateScript());
+        startInfo.ArgumentList.Add("-ManifestPath");
+        startInfo.ArgumentList.Add(manifestPath);
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start pwsh for the budget gate.");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return new GateRun(process.ExitCode, output.ToString());
+    }
+
+    private static string LocateGateScript()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var direct = Path.Combine(directory.FullName, "Measure-PublishBudget.ps1");
+            if (File.Exists(direct))
+            {
+                return direct;
+            }
+            var nested = Path.Combine(directory.FullName, "scripts", "Measure-PublishBudget.ps1");
+            if (File.Exists(nested))
+            {
+                return nested;
+            }
+            directory = directory.Parent;
+        }
+        throw new FileNotFoundException("Could not locate scripts/Measure-PublishBudget.ps1 above the test assembly.");
+    }
+
+    private string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "viu-budget-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(path);
+        temporaryDirectories.Add(path);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        foreach (var directory in temporaryDirectories)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private sealed record GateRun(int ExitCode, string Output);
+
+    private sealed record SampleMeasurement(
+        long CompressedPublishSizeBytes,
+        long RawPublishSizeBytes,
+        int FileCount,
+        long? BaselineBytes);
+}


### PR DESCRIPTION
## Summary
- Adds the checked-in budget manifest (`scripts/budgets/PublishBudgets.json`) and the cross-platform gate script (`scripts/Measure-PublishBudget.ps1`): publishes each manifest sample trimmed, sums the brotli-compressed `wwwroot` payload (excluding pre-compressed `*.br`/`*.gz` duplicates and `*.map`), and enforces actual-vs-budget with headroom reporting and a best-effort base-branch delta. Exit codes distinguish over-budget (1) from tooling/config failure (2). No silent ratcheting — CI never writes the manifest.
- Trimming gate: `examples/Directory.Build.props` scopes `PublishTrimmed=true` + `TrimmerSingleWarn=false` to sample apps (a global `-p:PublishTrimmed=true` flows into the netstandard2.0 generators and fails with NETSDK1124); the gate publishes with `-warnaserror`, so any ILLink/trim-analyzer warning across the sample and every shipping library in its closure fails the build. **Local result: 0 trim warnings.**
- Optional AOT lane: `-p:ViuRunAotCompilation=true` (same scoping model) with `-warnaserror`; runs on pushes to `main`/`release/**` and on PRs labelled `aot-gate`, so branch protection can require it on release branches. **Locally validated: AOT publish exit 0, zero warnings.**
- `budget-gates.yml` wires four lanes: hermetic gate tests (7/7), the size+trimming gate (with informational base delta), the label-gated AOT lane, and the **startup-time lane wired-but-skipped** — it needs a real headless browser (JS-interop startup cost is part of the budget), which arrives with the Playwright e2e harness [V01.01.11.03] (#87). Tracked as #182; the seeded `startupBudgetMilliseconds` is documented as provisional and unenforced.

## Seed numbers (Assimalign.Viu.WebApp, Release, trimmed)
- Measured: **2,097,190 bytes brotli** (7,363,995 raw, 19 payload files) on .NET SDK 10.0.302 / wasm-tools 10.0.110 (Windows).
- Budget: **2,310,000 bytes** (~10% headroom; gate reports PASS at 9.2%). The manifest notes CI (ubuntu x64) as the calibration authority.

Note for this introducing PR: the base-branch delta is artificially large (base `main` lacks the trimming config until merge) — it is `continue-on-error` and informational; head-vs-manifest is the authoritative gate.

Closes #95
Refs #182 (deferred startup lane, blocked by #87)

🤖 Generated with [Claude Code](https://claude.com/claude-code)