### PR TITLE
fix(runtime-dom): preserve transition class sequencing in buffered interop mode [V01.01.04.07.02]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
@@ -117,6 +117,37 @@ buffered is opt-in for this delivery.
 - **Differential proof**: the full renderer scenario battery runs through direct and buffered modes
   and asserts byte-identical serialized DOM; an instrumented apply counter proves one boundary
   crossing per flush over hundreds of mutations. Full 10k-row benchmarks belong to [V01.01.11.04].
+- **Transition sequencing barrier**: three opcodes (`AddTransitionClass`, `RemoveTransitionClass`,
+  `ForceReflow`) let the CSS-transition choreography ride the buffer without coalescing away the
+  browser's transition trigger — see the next section ([V01.01.04.07.02]).
+
+## Transition class sequencing under batching ([V01.01.04.07.02])
+
+A CSS transition is *sequencing*, not just final state: add `*-enter-from`/`*-enter-active`, force a
+reflow, then swap `*-from` → `*-to` on the next frame (upstream `Transition.ts` `forceReflow` +
+double-`requestAnimationFrame` `nextFrame`). Naive batching would coalesce a whole flush's writes into
+one style recalc — from- and to-classes applied together, the transition never triggered — and, worse,
+routing the class writes *direct to the bridge* while the node create/insert stay buffered references a
+handle the applier has not registered yet. The buffered `DomTransitionOperations`
+(`BufferedBrowserNodeOperations.Activate`) resolves both with two barrier kinds, and preserves
+batching everywhere else (one interop crossing per flush is unchanged):
+
+- **Reflow barrier — an in-drain command-buffer op.** `ForceReflow` encodes as opcode 23 (no
+  operands). Class writes stay buffered and ordered with the node ops; while draining the *single*
+  frame the applier performs a real `document.body.offsetHeight` read at the barrier's position, so a
+  leave's `*-leave-from` commits to its own style recalc before `*-leave-active` (upstream #2593). The
+  frame still crosses the boundary exactly once — the batching AC holds.
+- **Frame boundary — the `nextFrame` continuation.** The `*-to` swap is scheduled through the real
+  double-`requestAnimationFrame`; the buffered adaptor applies the continuation's writes when it runs,
+  two frames after the from/active frame committed, so the two class states land in distinct browser
+  frames and can never coalesce. `whenTransitionEnds`/`measurePosition`/`hasCssTransform` and the FLIP
+  ops force a flush and hit the live bridge (so `getComputedStyle`/`getBoundingClientRect` observe the
+  committed classes/layout); their resolve callbacks flush the finishing class removals.
+- **Proof.** `BufferedTransitionSequencingTests` drives the real renderer + real `<Transition>` through
+  the buffered applier and asserts, per flush, that from/active land in one frame, the to-swap in a
+  distinct later frame, and the leave reflow op lands *between* the from- and active-class writes.
+- FLIP *move* batching (one read pass, one reflow for N elements) is the separate #163; buffered FLIP
+  reads are correct here (forced flush) but not yet batched. `v-show` transition coalescing is #161.
 
 ## Non-goals (sequenced work)
 

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -60,11 +60,12 @@ internal static class BrowserNodeOperations
             SetCssVariables = static (element, names, values) => BrowserDomBridge.SetCssVariables(element, names, values),
         };
         // Installs the browser-backed transition operations the DOM <Transition>/<TransitionGroup>
-        // choreography writes through ([V01.01.04.07]). Class/timing/FLIP ops run direct (not through the
-        // command buffer): they are rAF-timed and read-then-write, and the JS side calls a single .NET
-        // resolve per completion. In buffered mode the same direct ops are used — full buffered-frame
-        // ordering of transition class writes is a documented follow-up (the deterministic test adapter
-        // pins the choreography here).
+        // choreography writes through ([V01.01.04.07]). This is the DIRECT-mode instance: each class/
+        // timing/FLIP op crosses the boundary immediately, and the JS side calls a single .NET resolve per
+        // completion. Buffered mode ([V01.01.04.07.02]) does NOT reuse these directly — it wraps this
+        // instance (BufferedBrowserNodeOperations.Activate) so class writes and the reflow ride the command
+        // buffer (ordered with the node ops, honoring the reflow + next-frame barriers) while the rAF/read/
+        // listener ops delegate here behind a forced flush.
         DomTransitionOperations.Current = new DomTransitionOperations
         {
             AddTransitionClass = static (element, cssClass) => BrowserDomBridge.AddTransitionClass(element, cssClass),

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
@@ -27,9 +27,35 @@ namespace Assimalign.Viu.RuntimeDom;
 /// apply call, which purges the invoker registry once — the same
 /// <see cref="BrowserEventInvokerRegistry.PurgeReleasedHandles"/> path the direct mode drives per op.
 /// </para>
-/// Ambient by activation: <see cref="Activate"/> points the flush seam, the event dispatcher, and the
-/// directive operations at this instance; <see cref="Deactivate"/> restores them. Single active
-/// buffered renderer per process (single-threaded JS event-loop model) — NOT thread-safe.
+/// <para>
+/// <b>Transition class sequencing</b> ([V01.01.04.07.02]). CSS transitions are browser-observable
+/// <em>sequencing</em>: add <c>*-enter-from</c>/<c>*-enter-active</c>, force a reflow, then swap
+/// <c>*-from</c> → <c>*-to</c> on the next frame — so the class writes cannot coalesce into one style
+/// recalc or the browser never fires the transition (upstream <c>Transition.ts</c> <c>forceReflow</c> +
+/// double-<c>requestAnimationFrame</c> <c>nextFrame</c>). <see cref="Activate"/> therefore installs a
+/// buffered <see cref="DomTransitionOperations"/> that preserves the ordering across two barrier kinds
+/// rather than regressing batching to synchronous per-op flushes:
+/// <list type="bullet">
+/// <item><b>The reflow barrier</b> is a first-class command-buffer op
+/// (<see cref="DomCommandOpcode.ForceReflow"/>, written by <see cref="DomCommandBuffer.WriteForceReflow"/>):
+/// class writes stay buffered and ordered with the node ops, and the applier performs a real reflow at
+/// the barrier's position while draining the <em>single</em> frame — so the frame still crosses the
+/// boundary exactly once and batching is untouched.</item>
+/// <item><b>The frame boundary</b> is <c>NextFrame</c>: its continuation (the <c>*-to</c> swap) is
+/// scheduled through the real double-<c>requestAnimationFrame</c> and its buffered writes are applied
+/// when it runs, two frames after the from/active frame committed — so the two land in distinct browser
+/// frames and can never coalesce.</item>
+/// </list>
+/// Transition reads and listener registrations (<c>NextFrame</c>'s scheduling, <c>WhenTransitionEnds</c>,
+/// <c>MeasurePosition</c>, <c>HasCssTransform</c>, the FLIP ops) force a flush and then hit the live
+/// bridge, so <c>getComputedStyle</c>/<c>getBoundingClientRect</c> observe the committed classes/layout;
+/// their resolve callbacks flush the finishing class removals. (FLIP <em>move</em> batching — reading all
+/// positions in one pass — is the separate #163.)
+/// </para>
+/// Ambient by activation: <see cref="Activate"/> points the flush seam, the event dispatcher, the
+/// directive operations, and the transition operations at this instance; <see cref="Deactivate"/>
+/// restores them. Single active buffered renderer per process (single-threaded JS event-loop model) —
+/// NOT thread-safe.
 /// </summary>
 [SupportedOSPlatform("browser")]
 internal sealed class BufferedBrowserNodeOperations
@@ -46,6 +72,7 @@ internal sealed class BufferedBrowserNodeOperations
     private Action? _previousFlushBoundary;
     private Func<int, bool, BrowserEvent, int>? _previousDispatcher;
     private BrowserDirectiveOperations? _previousDirectiveOperations;
+    private DomTransitionOperations? _previousTransitionOperations;
     private bool _isActive;
     private int _interopCallCount;
 
@@ -162,7 +189,7 @@ internal sealed class BufferedBrowserNodeOperations
     /// <param name="handle">The externally issued handle.</param>
     internal void ObserveForeignHandle(int handle) => _buffer.ObserveForeignHandle(handle);
 
-    /// <summary>Points the flush seam, event dispatch, and directive ops at this instance.</summary>
+    /// <summary>Points the flush seam, event dispatch, directive ops, and transition ops at this instance.</summary>
     internal void Activate()
     {
         if (_isActive)
@@ -173,8 +200,18 @@ internal sealed class BufferedBrowserNodeOperations
         _previousFlushBoundary = Scheduler.FlushBoundaryCallback;
         _previousDispatcher = BrowserNodeOperations.OverrideDispatcher;
         _previousDirectiveOperations = BrowserDirectiveOperations.Current;
+        _previousTransitionOperations = DomTransitionOperations.Current;
         Scheduler.FlushBoundaryCallback = ApplyPending;
         BrowserNodeOperations.OverrideDispatcher = _invokers.Dispatch;
+        // <Transition>/<TransitionGroup> class choreography writes through the buffered channel so the
+        // enter/leave class sequence stays ordered with the node ops and honors the reflow + next-frame
+        // barriers ([V01.01.04.07.02]). Reads/rAF/listener ops delegate to the direct (bridge-backed)
+        // operations captured above, forcing a flush first so they observe committed classes/layout.
+        DomTransitionOperations.Current = BuildBufferedTransitionOperations(
+            _previousTransitionOperations ?? throw new InvalidOperationException(
+                "No DomTransitionOperations installed to delegate reads/timing to. BrowserRuntime installs "
+                + "the browser-backed transition operations before a buffered app renders; a test must install "
+                + "one (recording) before Activate."));
         // v-model / v-show write through the same buffered leaf/invoker channels as the patch engine.
         BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
         {
@@ -206,7 +243,69 @@ internal sealed class BufferedBrowserNodeOperations
         Scheduler.FlushBoundaryCallback = _previousFlushBoundary;
         BrowserNodeOperations.OverrideDispatcher = _previousDispatcher;
         BrowserDirectiveOperations.Current = _previousDirectiveOperations;
+        DomTransitionOperations.Current = _previousTransitionOperations;
     }
+
+    // Wraps the direct (bridge-backed) transition operations for buffered mode. Class writes and the
+    // reflow barrier encode into the command buffer (ordered with the node ops, applied in one frame);
+    // rAF scheduling, reads, and listener registrations delegate to <paramref name="direct"/> but force
+    // the pending frame to commit first so they observe the classes/layout already written, and their
+    // continuations/resolves flush the writes they produce. See the class remarks ([V01.01.04.07.02]).
+    private DomTransitionOperations BuildBufferedTransitionOperations(DomTransitionOperations direct) => new()
+    {
+        AddTransitionClass = (element, cssClass) => _buffer.WriteAddTransitionClass(element, cssClass),
+        RemoveTransitionClass = (element, cssClass) => _buffer.WriteRemoveTransitionClass(element, cssClass),
+        ForceReflow = () => _buffer.WriteForceReflow(),
+        // The double-rAF stays real; the continuation's buffered *-to swap commits when it runs — two
+        // frames after the from/active frame — so the two class states land in distinct browser frames.
+        NextFrame = callback => direct.NextFrame(() =>
+        {
+            callback();
+            ApplyPending();
+        }),
+        // getComputedStyle must read the *-to class the continuation just wrote: flush first, then the
+        // resolve's finishing class removals (finishEnter/finishLeave) commit when the end event fires.
+        WhenTransitionEnds = (element, expectedType, explicitTimeout, resolve) =>
+        {
+            FlushPending();
+            direct.WhenTransitionEnds(element, expectedType, explicitTimeout, () =>
+            {
+                resolve();
+                ApplyPending();
+            });
+        },
+        // FLIP reads/writes force a flush so getBoundingClientRect and the clone read see committed DOM;
+        // batching the FLIP position pass into one read/write phase is the separate #163.
+        MeasurePosition = element =>
+        {
+            FlushPending();
+            return direct.MeasurePosition(element);
+        },
+        SetMoveTransform = (element, deltaX, deltaY) =>
+        {
+            FlushPending();
+            direct.SetMoveTransform(element, deltaX, deltaY);
+        },
+        ClearMoveStyles = element =>
+        {
+            FlushPending();
+            direct.ClearMoveStyles(element);
+        },
+        HasCssTransform = (element, root, moveClass) =>
+        {
+            FlushPending();
+            return direct.HasCssTransform(element, root, moveClass);
+        },
+        WhenMoveEnds = (element, resolve) =>
+        {
+            FlushPending();
+            direct.WhenMoveEnds(element, () =>
+            {
+                resolve();
+                ApplyPending();
+            });
+        },
+    };
 
     /// <summary>
     /// Creates the production instance over the real bridge and activates it. Reads force a flush and

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandBuffer.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandBuffer.cs
@@ -44,8 +44,11 @@ internal sealed class DomCommandBuffer
     /// <summary>The frame's leading byte — a sanity marker the applier validates.</summary>
     internal const byte Magic = 0xB6;
 
-    /// <summary>The frame format version — bump on any layout or opcode change so drift fails loudly.</summary>
-    internal const byte Version = 0x01;
+    /// <summary>
+    /// The frame format version — bump on any layout or opcode change so drift fails loudly. 0x02 added
+    /// the transition class/reflow-barrier opcodes ([V01.01.04.07.02]).
+    /// </summary>
+    internal const byte Version = 0x02;
 
     /// <summary>Header size: magic + version + opCount + nextHandle + stringTableOffset.</summary>
     internal const int HeaderSize = 2 + 4 + 4 + 4;
@@ -260,6 +263,27 @@ internal sealed class DomCommandBuffer
         WriteStringReference(eventName);
         WriteBoolean(capture);
     }
+
+    internal void WriteAddTransitionClass(int handle, string cssClass)
+    {
+        WriteOpcode(DomCommandOpcode.AddTransitionClass);
+        WriteInt32(handle);
+        WriteStringReference(cssClass);
+    }
+
+    internal void WriteRemoveTransitionClass(int handle, string cssClass)
+    {
+        WriteOpcode(DomCommandOpcode.RemoveTransitionClass);
+        WriteInt32(handle);
+        WriteStringReference(cssClass);
+    }
+
+    /// <summary>
+    /// Writes the operand-less reflow barrier (<see cref="DomCommandOpcode.ForceReflow"/>): the applier
+    /// performs a real synchronous reflow at this point in the frame drain so class writes before it
+    /// commit to their own style recalc before the writes after it ([V01.01.04.07.02]).
+    /// </summary>
+    internal void WriteForceReflow() => WriteOpcode(DomCommandOpcode.ForceReflow);
 
     // --- primitives ------------------------------------------------------------------------------
 

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandOpcode.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandOpcode.cs
@@ -75,4 +75,24 @@ internal enum DomCommandOpcode : byte
 
     /// <summary>Detach a listener: <c>[handle][event][capture:1]</c>.</summary>
     RemoveEventListener = 20,
+
+    /// <summary>
+    /// Add one transition CSS class: <c>[handle][class]</c> (upstream <c>addTransitionClass</c> —
+    /// <c>packages/runtime-dom/src/components/Transition.ts</c>). Buffered so the enter/leave class
+    /// choreography is ordered with the node create/insert ops in the same frame ([V01.01.04.07.02]).
+    /// </summary>
+    AddTransitionClass = 21,
+
+    /// <summary>Remove one transition CSS class: <c>[handle][class]</c> (upstream <c>removeTransitionClass</c>).</summary>
+    RemoveTransitionClass = 22,
+
+    /// <summary>
+    /// The reflow barrier — no operands. When the applier reaches it while draining a frame it performs
+    /// a real synchronous reflow (upstream <c>forceReflow</c>'s <c>document.body.offsetHeight</c> read),
+    /// committing every class write <em>before</em> it in the frame to its own style recalc before the
+    /// writes after it. This is what keeps a buffered leave's <c>*-leave-from</c> class from coalescing
+    /// with <c>*-leave-active</c> (upstream #2593) without splitting the flush — the frame still crosses
+    /// the interop boundary exactly once ([V01.01.04.07.02]).
+    /// </summary>
+    ForceReflow = 23,
 }

--- a/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
@@ -117,7 +117,7 @@ function applyRemove(childHandle, released) {
 // (the void ops below reuse the exact same dom.* leaves).
 
 const COMMAND_MAGIC = 0xB6
-const COMMAND_VERSION = 0x01
+const COMMAND_VERSION = 0x02 // 0x02 added the transition class / reflow-barrier opcodes ([V01.01.04.07.02])
 const textDecoder = new TextDecoder()
 
 // Register a node AS a handle the .NET side pre-allocated (a one-way buffered create cannot return
@@ -498,8 +498,12 @@ export const dom = {
     // --- transitions ([V01.01.04.07]) -------------------------------------------------------
     // The DOM-side contract of DomTransitionOperations: classList add/remove tracked in el.__vtc,
     // the double-rAF next frame, the forced reflow, transitionend/animationend end-detection, and
-    // the FLIP getBoundingClientRect/transform ops. Class/timing ops run outside the command buffer
-    // (they are rAF-timed and read-then-write); the .NET resolve/callback fires once per completion.
+    // the FLIP getBoundingClientRect/transform ops. In direct mode these are called one op per crossing;
+    // in buffered mode ([V01.01.04.07.02]) addTransitionClass/removeTransitionClass/forceReflow are also
+    // reached through the command-buffer opcodes (21/22/23) so the class sequence stays ordered with the
+    // node ops and the reflow barrier lands between the from- and to-class writes. rAF timing and the
+    // read/listener ops (nextFrame, whenTransitionEnds, measurePosition, the FLIP ops) stay direct — the
+    // buffered adaptor forces a flush before each so they observe committed classes/layout.
 
     addTransitionClass: (nodeHandle, cssClass) => {
         const el = getNode('addTransitionClass', nodeHandle)
@@ -643,6 +647,12 @@ export const dom = {
                 case 18: dom.removeStyleProperty(int(), str()); break
                 case 19: dom.addEventListener(int(), str(), flag(), flag(), flag()); break
                 case 20: dom.removeEventListener(int(), str(), flag()); break
+                // Transition class choreography ([V01.01.04.07.02]): class writes are ordered with the
+                // node ops, and the reflow barrier (23, no operands) does a real synchronous reflow mid-drain
+                // so a leave's *-leave-from commits before *-leave-active in the same single-crossing frame.
+                case 21: dom.addTransitionClass(int(), str()); break
+                case 22: dom.removeTransitionClass(int(), str()); break
+                case 23: dom.forceReflow(); break
                 default: fail('applyCommandBuffer', 0, `unknown opcode ${opcode}`)
             }
         }

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+using static Assimalign.Viu.RuntimeCore.VirtualNodeFactory;
+
+namespace Assimalign.Viu.RuntimeDom.Tests;
+
+// The heart of [V01.01.04.07.02]: a CSS <Transition> must actually animate under the batched interop
+// mode. Batching would otherwise coalesce a whole flush's writes into one style recalc, applying the
+// *-enter-from and *-enter-to classes together and eliminating the browser's transition trigger. This
+// battery drives the REAL renderer + REAL DOM <Transition> through the BUFFERED node-ops over the
+// in-memory command-buffer applier and proves the browser-observable sequence survives: from/active in
+// one frame, the to-swap in a distinct later frame, and the leave reflow barrier landing between the
+// from- and active-class writes inside a single one-crossing frame. Upstream contract: @vue/runtime-dom
+// components/Transition.ts forceReflow + double-requestAnimationFrame nextFrame
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/components/Transition.ts).
+// Browser-annotated like the other command-buffer tests (nothing crosses a real interop boundary — the
+// applier is the in-memory CommandBufferDecoder and the timing seam is a recording fake).
+[SupportedOSPlatform("browser")]
+public sealed class BufferedTransitionSequencingTests
+{
+    [Fact]
+    public void Enter_AppliesFromAndActiveInOneFrame_ThenSwapsToTheToClassInADistinctFrame()
+    {
+        using var world = new BufferedTransitionWorld();
+        var show = Reactive.Reference(false);
+        world.Render(Host(show, ("name", "fade")));
+
+        // Toggle in: the mount flush commits create + enter-from + enter-active together (the element
+        // mounts already carrying the from/active classes), but NOT the to-class — one boundary crossing.
+        show.Value = true;
+        world.RunUntilIdle();
+        var enterFrame = world.FirstTransitionFrameContaining("add:fade-enter-from");
+        enterFrame.ShouldBe(["add:fade-enter-from", "add:fade-enter-active"]);
+        enterFrame.ShouldNotContain("add:fade-enter-to"); // not coalesced into the mount frame
+        var div = world.Dom.FindFirstElement("div");
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-enter-from", "fade-enter-active"], ignoreOrder: true);
+
+        // Next frame (the real double-rAF continuation): the from -> to swap commits in its OWN frame,
+        // two frames after the from/active frame, so the browser sees a real class change and transitions.
+        world.AdvanceFrame();
+        var swapFrame = world.FirstTransitionFrameContaining("add:fade-enter-to");
+        swapFrame.ShouldBe(["remove:fade-enter-from", "add:fade-enter-to"]);
+        world.FrameIndexOf(swapFrame).ShouldBeGreaterThan(world.FrameIndexOf(enterFrame)); // distinct frames
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-enter-active", "fade-enter-to"], ignoreOrder: true);
+
+        // The transition end removes the to+active classes (finishEnter), also committed as its own frame.
+        world.FireTransitionEnd(div);
+        world.Dom.TransitionClasses(div).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Leave_LandsTheReflowBarrierBetweenFromAndActive_WithinOneFrame_ThenSwapsInADistinctFrame()
+    {
+        using var world = new BufferedTransitionWorld();
+        var show = Reactive.Reference(true);
+        world.Render(Host(show, ("name", "fade")));
+        var div = world.Dom.FindFirstElement("div");
+        world.Dom.ReflowCount.ShouldBe(0); // no appear -> the initial mount runs no choreography or reflow
+
+        // Toggle out: within a SINGLE flush the buffered adaptor commits leave-from, then a real reflow
+        // (the ForceReflow barrier op — document.body.offsetHeight), then leave-active, in that order —
+        // upstream #2593. The barrier does not split the flush; it is one op inside the one crossing.
+        show.Value = false;
+        world.RunUntilIdle();
+        var leaveFrame = world.FirstTransitionFrameContaining("add:fade-leave-from");
+        leaveFrame.ShouldBe(["add:fade-leave-from", "reflow", "add:fade-leave-active"]);
+        world.Dom.ReflowCount.ShouldBe(1);
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-leave-from", "fade-leave-active"], ignoreOrder: true);
+        world.Dom.IsMounted(div).ShouldBeTrue(); // removal deferred behind the leave animation
+
+        // Next frame: the from -> to swap is a distinct later frame (never coalesced with from/active).
+        world.AdvanceFrame();
+        var swapFrame = world.FirstTransitionFrameContaining("add:fade-leave-to");
+        swapFrame.ShouldBe(["remove:fade-leave-from", "add:fade-leave-to"]);
+        world.FrameIndexOf(swapFrame).ShouldBeGreaterThan(world.FrameIndexOf(leaveFrame));
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-leave-active", "fade-leave-to"], ignoreOrder: true);
+
+        // The transition end removes the leave classes and finally host-removes the element.
+        world.FireTransitionEnd(div);
+        world.Dom.IsMounted(div).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ClassAndReflowOps_NeverReachTheDirectBridge_InBufferedMode()
+    {
+        using var world = new BufferedTransitionWorld();
+        var show = Reactive.Reference(false);
+        world.Render(Host(show, ("name", "fade")));
+
+        show.Value = true;
+        world.RunUntilIdle();
+        world.AdvanceFrame();
+        world.FireTransitionEnd(world.Dom.FindFirstElement("div"));
+
+        // Every class write and every reflow went through the command buffer (opcodes 21/22/23), not the
+        // direct bridge delegates — otherwise a buffered create's handle would be unknown to the applier.
+        world.DirectClassWrites.ShouldBeEmpty();
+        world.DirectReflowCount.ShouldBe(0);
+    }
+
+    // A component rendering <Transition {props}> around a v-if div keyed "a" (mirrors TransitionTests.Host).
+    private static RenderComponent Host(Reference<bool> show, params (string Name, object? Value)[] transitionProperties)
+        => new((_, _) => () =>
+        {
+            var slots = new ComponentSlots();
+            slots["default"] = _ => show.Value
+                ? [Element("div", Properties(("key", "a")), "A")]
+                : [Comment()];
+            return Component(Transition.Instance, Properties(transitionProperties), slots);
+        });
+
+    // A DOM-free buffered world: the real renderer over BufferedBrowserNodeOperations, an in-memory
+    // command-buffer applier that records each frame's transition-op sequence, and a recording "direct"
+    // DomTransitionOperations standing in for the rAF/end-detection bridge (frames and end events are
+    // advanced on demand). The buffered adaptor wraps this recording instance exactly as production wraps
+    // the browser-backed one.
+    private sealed class BufferedTransitionWorld : IDisposable
+    {
+        private readonly InMemoryHandleDom _dom = new();
+        private readonly BufferedBrowserNodeOperations _buffered;
+        private readonly Renderer<int> _renderer;
+        private readonly TestSchedulerPump _pump;
+        private readonly DomTransitionOperations? _previousTransitionOperations;
+        private readonly int _container;
+        private readonly List<Action> _nextFrameQueue = [];
+        private readonly Dictionary<int, Action> _endResolvers = [];
+
+        public BufferedTransitionWorld()
+        {
+            Scheduler.Reset();
+            _pump = TestSchedulerPump.Install();
+            _container = _dom.CreateElement("root", null);
+
+            // Force BrowserNodeOperations' static constructor (which installs the bridge-backed transition
+            // ops) to run BEFORE we install the recording fake, so buffered Activate captures the fake
+            // rather than the bridge — the ctor would otherwise clobber Current mid-Activate.
+            _ = BrowserNodeOperations.OverrideDispatcher;
+            _previousTransitionOperations = DomTransitionOperations.Current;
+            DomTransitionOperations.Current = BuildRecordingDirectOperations();
+
+            _buffered = new BufferedBrowserNodeOperations(
+                (frame, length) =>
+                {
+                    var before = _dom.TransitionLog.Count;
+                    var released = CommandBufferDecoder.Apply(frame, length, _dom);
+                    var produced = _dom.TransitionLog.Count - before;
+                    if (produced > 0)
+                    {
+                        TransitionFrames.Add(_dom.TransitionLog.GetRange(before, produced));
+                    }
+                    // Sanity: the frame is versioned/well-formed (guards a silent header drift).
+                    frame[0].ShouldBe(DomCommandBuffer.Magic);
+                    frame[1].ShouldBe(DomCommandBuffer.Version);
+                    return released;
+                },
+                static _ => 0,
+                _dom.ParentNode,
+                _dom.NextSibling,
+                _dom.InsertStaticContent);
+            _buffered.Activate();
+            _buffered.ObserveForeignHandle(_container);
+            _renderer = RendererFactory.CreateRenderer(_buffered.Create());
+        }
+
+        /// <summary>The per-frame transition-op sequences ("add:x"/"remove:x"/"reflow"), one list per apply that produced any.</summary>
+        public List<List<string>> TransitionFrames { get; } = [];
+
+        /// <summary>Class writes that (incorrectly) reached the direct bridge instead of the buffer — must stay empty.</summary>
+        public List<string> DirectClassWrites { get; } = [];
+
+        /// <summary>Reflows that (incorrectly) reached the direct bridge instead of the barrier op — must stay zero.</summary>
+        public int DirectReflowCount { get; private set; }
+
+        /// <summary>The in-memory DOM the applier replays each frame onto.</summary>
+        public InMemoryHandleDom Dom => _dom;
+
+        public void Render(IComponentDefinition component)
+        {
+            _renderer.Render(Component(component), _container);
+            _pump.RunUntilIdle();
+        }
+
+        public void RunUntilIdle() => _pump.RunUntilIdle();
+
+        /// <summary>Runs the queued double-rAF continuations (the deterministic stand-in for the browser's next frame).</summary>
+        public void AdvanceFrame()
+        {
+            var pending = new List<Action>(_nextFrameQueue);
+            _nextFrameQueue.Clear();
+            foreach (var callback in pending)
+            {
+                callback();
+            }
+        }
+
+        /// <summary>Fires the transition-end for an element, completing its in-flight enter/leave.</summary>
+        public void FireTransitionEnd(int element)
+        {
+            if (_endResolvers.Remove(element, out var resolve))
+            {
+                resolve();
+            }
+        }
+
+        /// <summary>The first recorded frame whose op sequence contains <paramref name="op"/>.</summary>
+        public IReadOnlyList<string> FirstTransitionFrameContaining(string op)
+            => TransitionFrames.Find(frame => frame.Contains(op))
+               ?? throw new InvalidOperationException($"No applied frame contained '{op}'. Frames: "
+                   + string.Join(" | ", TransitionFrames.ConvertAll(frame => string.Join(",", frame))));
+
+        /// <summary>The apply/frame index of a recorded frame (its position in the flush order).</summary>
+        public int FrameIndexOf(IReadOnlyList<string> frame) => TransitionFrames.FindIndex(candidate => ReferenceEquals(candidate, frame));
+
+        public void Dispose()
+        {
+            _buffered.Deactivate();
+            DomTransitionOperations.Current = _previousTransitionOperations;
+            _pump.Dispose();
+            Scheduler.Reset();
+        }
+
+        private DomTransitionOperations BuildRecordingDirectOperations() => new()
+        {
+            // The buffered wrapper routes class writes and the reflow through the command buffer, so these
+            // direct delegates must never fire in buffered mode — recording them proves that contract.
+            AddTransitionClass = (_, cssClass) => DirectClassWrites.Add("add:" + cssClass),
+            RemoveTransitionClass = (_, cssClass) => DirectClassWrites.Add("remove:" + cssClass),
+            ForceReflow = () => DirectReflowCount++,
+            // The rAF scheduling and end-detection stay direct (the buffered wrapper flushes around them).
+            NextFrame = _nextFrameQueue.Add,
+            WhenTransitionEnds = (element, _, _, resolve) => _endResolvers[element] = resolve,
+            // FLIP ops are unused by <Transition>; stub them (their batching is #163).
+            MeasurePosition = _ => default,
+            SetMoveTransform = (_, _, _) => { },
+            ClearMoveStyles = _ => { },
+            HasCssTransform = (_, _, _) => false,
+            WhenMoveEnds = (_, resolve) => resolve(),
+        };
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
@@ -97,6 +97,16 @@ internal static class CommandBufferDecoder
                 case DomCommandOpcode.RemoveEventListener:
                     dom.RemoveEventListener(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!, ReadBool(span, ref cursor));
                     break;
+                case DomCommandOpcode.AddTransitionClass:
+                    dom.AddTransitionClass(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.RemoveTransitionClass:
+                    dom.RemoveTransitionClass(ReadInt(span, ref cursor), Str(strings, ReadInt(span, ref cursor))!);
+                    break;
+                case DomCommandOpcode.ForceReflow:
+                    // The reflow barrier carries no operands; the real applier reads document.body.offsetHeight.
+                    dom.ForceReflow();
+                    break;
                 default:
                     throw new InvalidOperationException($"Unknown command-buffer opcode {(byte)opcode}.");
             }

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
@@ -152,6 +152,66 @@ internal sealed class InMemoryHandleDom
     internal void RemoveEventListener(int handle, string eventName, bool capture)
         => Get(handle).Listeners.Remove(capture ? eventName + "|capture" : eventName);
 
+    // --- transition class choreography ([V01.01.04.07.02]) ---------------------------------------
+    // Mirrors viu-dom.js addTransitionClass/removeTransitionClass (each whitespace-separated token joins
+    // el.classList, tracked in the el.__vtc-style set) and forceReflow (document.body.offsetHeight). The
+    // reflow read is counted so a sequencing test can assert the barrier fired between class writes.
+
+    internal int ReflowCount { get; private set; }
+
+    /// <summary>
+    /// The ordered <c>add:</c>/<c>remove:</c>/<c>reflow</c> log the decoder appends as it replays a frame,
+    /// in exact op order — the browser-observable class/reflow sequence a sequencing test slices per apply.
+    /// </summary>
+    internal List<string> TransitionLog { get; } = [];
+
+    internal void AddTransitionClass(int handle, string cssClass)
+    {
+        TransitionLog.Add("add:" + cssClass);
+        var classes = Get(handle).TransitionClasses;
+        foreach (var token in cssClass.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            classes.Add(token);
+        }
+    }
+
+    internal void RemoveTransitionClass(int handle, string cssClass)
+    {
+        TransitionLog.Add("remove:" + cssClass);
+        var classes = Get(handle).TransitionClasses;
+        foreach (var token in cssClass.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            classes.Remove(token);
+        }
+    }
+
+    /// <summary>The reflow barrier: counts a real synchronous reflow so tests can pin the barrier's position.</summary>
+    internal void ForceReflow()
+    {
+        TransitionLog.Add("reflow");
+        ReflowCount++;
+    }
+
+    /// <summary>The transition classes currently on an element (upstream <c>el.__vtc</c>/<c>classList</c>).</summary>
+    internal IReadOnlyCollection<string> TransitionClasses(int handle) => Get(handle).TransitionClasses;
+
+    /// <summary>Whether the handle is still registered (not yet released by a remove/setElementText).</summary>
+    internal bool IsMounted(int handle) => _nodes.ContainsKey(handle);
+
+    /// <summary>The handle of the first live element with <paramref name="tag"/> in creation order, or 0.</summary>
+    internal int FindFirstElement(string tag)
+    {
+        for (var handle = 1; handle < _nextHandle; handle++)
+        {
+            if (_nodes.TryGetValue(handle, out var node) && node.Kind == NodeKind.Element
+                && string.Equals(node.Tag, tag, StringComparison.Ordinal))
+            {
+                return handle;
+            }
+        }
+        return 0;
+    }
+
     // --- serialization (deterministic total fingerprint) -----------------------------------------
 
     internal string Serialize(int handle)
@@ -291,5 +351,9 @@ internal sealed class InMemoryHandleDom
         internal Dictionary<string, string> Styles { get; } = new(StringComparer.Ordinal);
 
         internal Dictionary<string, string> Listeners { get; } = new(StringComparer.Ordinal);
+
+        // Transition classes are tracked apart from the bound `class` attribute (upstream el.__vtc), so
+        // they stay out of the structural Serialize() fingerprint the differential test compares.
+        internal HashSet<string> TransitionClasses { get; } = new(StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary
- Closes the correctness gap between the interop command buffer ([V01.01.04.05]) and DOM transitions ([V01.01.04.07]): buffered mode never overrode `DomTransitionOperations`, so transition class/reflow ops ran direct-to-bridge while node ops stayed buffered — risking class-write coalescing (no CSS transition trigger) and a **latent crash**: `beforeEnter`'s class add could reference a handle whose buffered `createElement` had not flushed yet.
- Barrier design (mirrors vuejs/core `Transition.ts` `forceReflow` + double-`requestAnimationFrame` `nextFrame`, linked in XML docs/tests):
  - **Reflow barrier as a first-class opcode** (`ForceReflow = 23`, operand-less): class writes stay buffered and ordered with node ops; the applier performs a real `document.body.offsetHeight` read mid-drain, so a leave's `*-leave-from` commits to its own style recalc before `*-leave-active` (upstream #2593) — the frame still crosses the interop boundary exactly once.
  - **Frame boundary via the nextFrame continuation-flush**: the `*-from`→`*-to` swap rides the real double-rAF and its buffered writes apply when the continuation runs — distinct browser frames by construction.
  - Class ops ride the buffer as opcodes 21/22; reads and listener registrations (`WhenTransitionEnds`, FLIP measure/transform, `HasCssTransform`) force a flush first so `getComputedStyle`/`getBoundingClientRect` observe committed state, and their resolves flush the finishing removals.
- Frame format version bumped `0x01`→`0x02` on both the C# writer and `viu-dom.js` applier (drift fails loudly); the JS cases reuse the exact `dom.*` leaves direct mode uses.
- **Non-transition batching is untouched**: the one-interop-call-per-flush test still passes; barriers only appear when a `<Transition>` renders.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · RuntimeDom tests **160 pass** (+3: enter from/active in one frame with the to-swap in a strictly later frame; leave frame pinned as `[from, reflow, active]`; zero class/reflow ops reaching the direct bridge) · RuntimeCore 217 pass · Testing 18 pass · WASM example builds.

Out of scope, already tracked: #163 (batched FLIP read pass — buffered FLIP reads are correct here via forced flush), #161 (persisted v-show transitions).

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)