### PR TITLE
feat(store): add the setup-style store definition API on EffectScope [V01.01.09.01]

### DIFF
--- a/.github/workflows/area-router.yml
+++ b/.github/workflows/area-router.yml
@@ -1,0 +1,47 @@
+# Area build+test for Assimalign.Viu.Router ([V01.01.12.02], added by [V01.01.12.02.01]):
+# path-filtered so a PR only runs the areas it touches; shared build files trigger every area.
+# The build scope is the per-area slnx, keeping CI and local builds in lockstep. Jobs are
+# independent by design — cross-area contracts are enforced by project references at build
+# time, not workflow ordering.
+name: area-router
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Viu.Router/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-router.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Viu.Router/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-router.yml'
+
+jobs:
+  build-test:
+    name: build+test Router
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Viu.Router/Assimalign.Viu.Router.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Viu.Router/Assimalign.Viu.Router.slnx --configuration Release --no-build

--- a/.github/workflows/area-store.yml
+++ b/.github/workflows/area-store.yml
@@ -1,0 +1,47 @@
+# Area build+test for Assimalign.Viu.Store ([V01.01.12.02], added by [V01.01.12.02.01]):
+# path-filtered so a PR only runs the areas it touches; shared build files trigger every area.
+# The build scope is the per-area slnx, keeping CI and local builds in lockstep. Jobs are
+# independent by design — cross-area contracts are enforced by project references at build
+# time, not workflow ordering.
+name: area-store
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Viu.Store/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-store.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'libraries/Assimalign.Viu.Store/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/area-store.yml'
+
+jobs:
+  build-test:
+    name: build+test Store
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build libraries/Assimalign.Viu.Store/Assimalign.Viu.Store.slnx --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test libraries/Assimalign.Viu.Store/Assimalign.Viu.Store.slnx --configuration Release --no-build

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -268,6 +268,17 @@
 		<Project Path="libraries/Assimalign.Viu.Shared/test/Assimalign.Viu.Shared.GeneratorFixture/Assimalign.Viu.Shared.GeneratorFixture.csproj" />
 		<Project Path="libraries/Assimalign.Viu.Shared/test/Assimalign.Viu.Shared.Tests.csproj" />
 	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Store/" />
+	<Folder Name="/viu/libraries/Assimalign.Viu.Store/docs/">
+		<File Path="libraries/Assimalign.Viu.Store/docs/DESIGN.md" />
+		<File Path="libraries/Assimalign.Viu.Store/docs/OVERVIEW.md" />
+	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Store/src/">
+		<Project Path="libraries/Assimalign.Viu.Store/src/Assimalign.Viu.Store.csproj" />
+	</Folder>
+	<Folder Name="/viu/libraries/Assimalign.Viu.Store/test/">
+		<Project Path="libraries/Assimalign.Viu.Store/test/Assimalign.Viu.Store.Tests.csproj" />
+	</Folder>
 	<Folder Name="/viu/libraries/Assimalign.Viu.Testing/" />
 	<Folder Name="/viu/libraries/Assimalign.Viu.Testing/src/">
 		<Project Path="libraries/Assimalign.Viu.Testing/src/Assimalign.Viu.Testing.csproj" />

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ founding decisions, and wave strategy live in [`docs/PLAN.md`](docs/PLAN.md).
 Early, active development, delivered in waves (see [`docs/PLAN.md`](docs/PLAN.md) and the
 [project board](https://github.com/orgs/assimalign/projects/15) for the authoritative status). The
 reactive core, the platform-agnostic renderer with scheduler and component model, the browser DOM
-bridge, the template compiler front end, the `.viu` single-file-component pipeline, and the
-router's DOM-free route table and matcher are all in the tree at varying maturity; each library's
-`docs/OVERVIEW.md` states what it currently provides.
+bridge, the template compiler front end, the `.viu` single-file-component pipeline, the router's
+DOM-free route table and matcher, and the store's setup-style `defineStore`/`createPinia` definition
+API are all in the tree at varying maturity; each library's `docs/OVERVIEW.md` states what it
+currently provides.
 The demo is a reactively re-rendering stopwatch in
 [`examples/Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp).
 
@@ -44,6 +45,7 @@ carries a `docs/OVERVIEW.md` (what it is, its public surface, its Vue 3 counterp
 | [`Assimalign.Viu.RuntimeCore`](libraries/Assimalign.Viu.RuntimeCore) | [`@vue/runtime-core`](https://github.com/vuejs/core/tree/main/packages/runtime-core) — vnodes, renderer, scheduler, component model, built-ins | [OVERVIEW](libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md) |
 | [`Assimalign.Viu.RuntimeDom`](libraries/Assimalign.Viu.RuntimeDom) | [`@vue/runtime-dom`](https://github.com/vuejs/core/tree/main/packages/runtime-dom) — JS-interop DOM bridge, patchProp, events, v-model/v-show | [OVERVIEW](libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md) |
 | [`Assimalign.Viu.Router`](libraries/Assimalign.Viu.Router) | [`vue-router`](https://github.com/vuejs/router) — the DOM-free route table and path matcher today; history, RouterView/RouterLink, and guards follow ([V01.01.08]) | [OVERVIEW](libraries/Assimalign.Viu.Router/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Router/docs/DESIGN.md) |
+| [`Assimalign.Viu.Store`](libraries/Assimalign.Viu.Store) | [`pinia`](https://github.com/vuejs/pinia) — the setup-style `defineStore`/`createPinia` definition API on `EffectScope` today; state/getters/actions, SSR, and plugins follow ([V01.01.09]) | [OVERVIEW](libraries/Assimalign.Viu.Store/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Store/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax`](libraries/Assimalign.Viu.Syntax) | (shared base) — the located node/diagnostic primitives and registration-based parser pipeline every language library roots on | [OVERVIEW](libraries/Assimalign.Viu.Syntax/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax.Templates`](libraries/Assimalign.Viu.Syntax.Templates) | [`@vue/compiler-core`](https://github.com/vuejs/core/tree/main/packages/compiler-core) + [`compiler-dom`](https://github.com/vuejs/core/tree/main/packages/compiler-dom) — the Vue template language front end and C# render-function codegen | [OVERVIEW](libraries/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md) |
 | [`Assimalign.Viu.Syntax.SingleFileComponent`](libraries/Assimalign.Viu.Syntax.SingleFileComponent) | [`@vue/compiler-sfc`](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) — the `.viu` `@`-block container parser | [OVERVIEW](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md) · [DESIGN](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md) · [FORMAT](libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md) |

--- a/libraries/Assimalign.Viu.Router/Assimalign.Viu.Router.slnx
+++ b/libraries/Assimalign.Viu.Router/Assimalign.Viu.Router.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Viu.Router.csproj" />
+	<Project Path="test/Assimalign.Viu.Router.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Viu.Store/Assimalign.Viu.Store.slnx
+++ b/libraries/Assimalign.Viu.Store/Assimalign.Viu.Store.slnx
@@ -1,0 +1,4 @@
+<Solution>
+	<Project Path="src/Assimalign.Viu.Store.csproj" />
+	<Project Path="test/Assimalign.Viu.Store.Tests.csproj" />
+</Solution>

--- a/libraries/Assimalign.Viu.Store/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Store/docs/DESIGN.md
@@ -1,0 +1,133 @@
+# Assimalign.Viu.Store — design
+
+Why the store definition API is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md).
+Upstream counterpart: [`pinia`](https://github.com/vuejs/pinia) — `defineStore()`, `createPinia()`,
+and store lifetime (`packages/pinia/src/store.ts`, `createPinia.ts`, `rootStore.ts`). Store-lifetime
+reference: Vue 3 `effectScope` (https://vuejs.org/api/reactivity-advanced.html#effectscope).
+
+## Setup stores are typed closures, not Proxy objects
+
+Pinia has two authoring styles; Viu ports the **setup** style only, because it is the one that maps
+cleanly to C#. A Pinia option store (`state`/`getters`/`actions` objects) leans on the JS `Proxy` to
+turn plain objects into reactive state and to bind `this`. Viu has no `Proxy`, so the store is the
+object the setup delegate returns and closes over: its `Ref<T>` fields are state, its `Computed<T>`
+are getters, its methods are actions. The store definition captures that delegate at `DefineStore`
+time and invokes it directly — construction is a plain constructor call, never
+`Activator.CreateInstance` or attribute scanning, which is what keeps the whole path trimming- and
+NativeAOT-safe. The state/getter/action *members* are co-designed but delivered in `[V01.01.09.02]`;
+this feature fixes the surrounding contract (identity, single construction, scope-bound lifetime).
+
+## Lifetime: a detached root, per-store child scopes
+
+This is the heart of the feature and a faithful port of `createSetupStore`:
+
+- The registry (`StoreRegistry`, the C# `Pinia` root) owns one **detached** root `EffectScope`
+  (Pinia's `pinia._e = effectScope(true)`). Detached means it never attaches to whatever scope
+  happens to be active when the registry is constructed.
+- The first `UseStore` for a definition creates the store's own scope **as a child of that root**
+  (`_rootScope.Run(() => new EffectScope())`), then runs the setup **inside** that child scope
+  (`scope.Run(setup)`). Every `Computed`, `Watch`, and `WatchEffect` the setup creates registers with
+  the child scope.
+
+Two consequences fall out of this shape, and both are acceptance criteria:
+
+1. **Disposing the app stops every store.** `StoreRegistry.Dispose()` stops the root scope, which
+   cascades to every child store scope (`EffectScope` stops its children), so all setup watchers and
+   effects stop firing. This is the C# realization of "disposing the owning app disposes each store's
+   scope" — `.NET` servers are long-lived, so the registry, not a module reload, is what bounds store
+   lifetime.
+2. **The store is detached from the render tree.** Because the child scope is created while the
+   *root* is the active scope, it is captured by the root and **not** by whichever component scope
+   triggered the lazy `UseStore`. Unmounting that component (stopping its scope) leaves the store
+   fully reactive — stores are app-scoped and shared across components, exactly as in Pinia. This is
+   the sense in which each store "lives in its own detached `EffectScope`": detached from the render
+   tree, owned by the registry root. (`StoreScopeDisposalTests` pins this by resolving inside an
+   ambient scope, stopping it, and asserting the store's watcher still fires.)
+
+`StoreDefinition.Dispose(registry)` (the port of `store.$dispose()`) stops just that one store's
+child scope and forgets it, leaving siblings live; a later `UseStore` rebuilds it fresh.
+
+**Computeds are not scope-owned.** Per the upstream Vue 3.5 contract (and Viu's `EffectScope` /
+`Computed`), a scope never collects computeds — a computed created in setup keeps serving fresh
+values after the scope stops, detaching from its sources automatically when it loses its last
+subscriber. So "computeds no longer fire" is realized through the **watchers/effects** that observe
+them: stopping the store scope stops those observers, so nothing re-runs on a change. The disposal
+tests assert the run count of a scope-owned watcher freezes, which is the true scope guarantee.
+
+## Identity and single construction
+
+The registry keys instances by store id (`Dictionary<string, StoreEntry>`, Pinia's `pinia._s`). The
+first `UseStore` per registry runs setup once and caches the result; every later `UseStore` returns
+the identical instance (reference equality) without re-running setup. `TStore` is constrained to
+`class` so that "identical instance" is genuine reference identity with no boxing.
+
+## Id uniqueness is enforced, never silently aliased
+
+Each `StoreEntry` remembers the definition that created it (by reference). Resolving the **same**
+definition again is a cache hit; resolving a **different** definition under an id already claimed
+raises `DuplicateStoreIdException` (carrying the id) rather than clobbering or sharing state. Which
+definition wins is deterministic: the one resolved first owns the id.
+
+## Per-app isolation for SSR
+
+The registry is per app instance and holds no static state, so two apps (two registries) never share
+store state — the property multi-request server rendering needs, where one long-lived process serves
+concurrent requests. `StoreDefinitionTests` and `StoreApplicationIntegrationTests` assert two
+registries / two mounted apps resolve isolated instances. The one piece of ambient state,
+`Stores.ActiveRegistry` (Pinia's `activePinia`), is a client and testing convenience for
+argument-less `UseStore()` outside a component; server code passes the registry explicitly through
+`UseStore(registry)`, matching Pinia's SSR guidance.
+
+## Integration with the App API
+
+`App.Use` installs an `IPlugin<TNode>`. A registry is platform-agnostic, but `IPlugin<TNode>` is
+generic over the platform node, so `StoreRegistry.AsPlugin<TNode>()` wraps the registry in an
+internal `StorePlugin<TNode>` rather than making the registry itself generic. On install the plugin:
+
+- `app.Provide(StoreRegistry.InjectionKey, registry)` — provides the registry app-wide, so a
+  component's `UseStore()` resolves it through the existing provide/inject chain
+  (`AppContext.Provides` is the final inject fallback, `[V01.01.03.12]`). The key is a private
+  `InjectionKey<StoreRegistry>` singleton shared between the plugin (provider) and `UseStore()`
+  (injector), so no string keys and no reflection.
+- `Stores.SetActiveRegistry(registry)` — sets the ambient fallback for non-component resolution.
+
+`UseStore()` mirrors Pinia's resolution order: inside a component `Setup` it injects the app's
+registry (via `ComponentInstance.Current`); otherwise it falls back to the active registry; with
+neither it throws a descriptive `InvalidOperationException`.
+
+## Deliberate divergences from Pinia
+
+- **The registry is not itself the plugin.** In Pinia the `pinia` object has an `install` method, so
+  `app.use(pinia)` and `useStore(pinia)` take the same value. C#'s `IPlugin<TNode>` is generic over
+  the node type while the registry is not, so installation goes through
+  `registry.AsPlugin<TNode>()`. The registry stays the DI handle; the adapter is the bridge to
+  `App.Use`. Call `AsPlugin` once per app.
+- **Setup style only.** Option stores (`state`/`getters`/`actions` object literals) are a Proxy-bound
+  convenience with no clean C# analogue; Viu ports the setup form, which the source generator can
+  extend for `[Reactive]` state in later features.
+- **`$dispose` is on the definition, not the instance.** A Viu store is a user-defined `TStore` with
+  no mixed-in `$`-methods, so single-store disposal is `StoreDefinition.Dispose(registry)` rather
+  than `store.$dispose()`. Same effect: stop the store's scope and forget it.
+- **Ambient active registry is opt-in for resolution.** Installing sets `ActiveRegistry` (Pinia
+  parity), but the DI-friendly, SSR-safe path is the explicit `UseStore(registry)` — the ambient is a
+  convenience, not the recommended server path.
+
+## AOT / trimming: no runtime activation
+
+- **Typed setup delegates, not reflection.** Store construction is a captured `StoreSetup<TStore>`
+  invoked directly. There is no `Activator.CreateInstance`, no attribute scanning, and no dynamic
+  code generation anywhere in the path — the same constraint the Store epic (#75) and the repo AOT
+  rule impose.
+- **Identity-based injection key.** The registry is provided/injected under a reference-identity
+  `InjectionKey<StoreRegistry>`, never a reflected type token or string, so trimming cannot break the
+  wiring.
+
+## Non-goals (sequenced work)
+
+- State, getters, and actions as reactivity-integrated members, `Patch`, and `$state` —
+  `[V01.01.09.02]`.
+- SSR state serialization and client hydration (source-generated `System.Text.Json` contexts only) —
+  `[V01.01.09.03]`.
+- The store plugin system and the shipped storage-persistence plugin — `[V01.01.09.04]`.
+- Mutation/action subscriptions (`Subscribe`/`OnAction`) batched through the scheduler — part of the
+  members/subscriptions features above.

--- a/libraries/Assimalign.Viu.Store/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Store/docs/OVERVIEW.md
@@ -1,0 +1,85 @@
+# Assimalign.Viu.Store — overview
+
+State management for Viu — the role [`pinia`](https://pinia.vuejs.org) plays for Vue 3
+(https://github.com/vuejs/pinia). This first feature delivers the **store definition API**: the
+setup-syntax `DefineStore`/`UseStore` pair, the per-app store registry (Pinia's `createPinia()`
+root), and the `EffectScope`-owned lifetime that every later Store feature builds on. It is the C#
+port of `defineStore()`, `createPinia()`, and `store.$dispose()` (`packages/pinia/src/store.ts`,
+`createPinia.ts`, `rootStore.ts`).
+
+State, getters, and actions as first-class members (`[V01.01.09.02]`), SSR serialization and
+hydration (`[V01.01.09.03]`), and the store plugin/persistence system (`[V01.01.09.04]`) are later
+features of the Store area (#75) and are not part of this package yet. Here, a store is whatever
+object the setup delegate returns — it is expected to hold `Ref<T>` state, `Computed<T>` getters, and
+methods, and this feature guarantees that object's identity, single construction, and scope-bound
+lifetime.
+
+## What it contains
+
+Public surface (all under namespace `Assimalign.Viu.Store`):
+
+- **`Stores`** (static facade): the module-level entry point. `DefineStore(id, setup)` is the C# port
+  of `defineStore()`; `CreateRegistry()` is the port of `createPinia()`; `ActiveRegistry` /
+  `SetActiveRegistry(...)` are the port of `activePinia` / `setActivePinia()`.
+- **`StoreDefinition<TStore>`**: the C# port of the `useStore` function `defineStore` returns. Carries
+  the `Id`, resolves the instance with `UseStore(registry)` (DI-friendly) or `UseStore()` (ambient,
+  from a component's app context or the active registry), and disposes a single store with
+  `Dispose(registry)` (the port of `store.$dispose()`).
+- **`StoreRegistry`**: the per-app store root (the C# port of the `Pinia` instance). Owns a detached
+  root `EffectScope` and the id → instance map; `AsPlugin<TNode>()` bridges it onto an app through
+  `App.Use(...)`; `Dispose()` stops the whole subsystem; `Count` and `IsDisposed` round out the
+  surface. Directly constructible (`new StoreRegistry()`) so a DI container can own it.
+- **`StoreSetup<TStore>`** (`Delegates/`): the parameterless setup delegate that constructs the store
+  inside its effect scope — the C# port of the setup function passed to `defineStore`.
+- **`DuplicateStoreIdException`**: the deterministic failure when two different definitions claim the
+  same id in one registry (carries the offending `StoreId`), instead of silently aliasing state.
+
+Internal (`Internal/`, exercised through `InternalsVisibleTo` tests): `StorePlugin<TNode>` (the
+`IPlugin<TNode>` adapter that provides the registry app-wide and sets it active on install) and
+`StoreEntry` (a registry's per-store record: instance, owning scope, and owning definition).
+
+## Using it
+
+```csharp
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Store;
+
+// A setup-style store: state is a Ref, the getter is a Computed, the action is a method.
+sealed class CounterStore
+{
+    public Reference<int> Count { get; } = Reactive.Reference(0);
+    public Computed<int> Doubled { get; }
+    public CounterStore() => Doubled = Reactive.Computed(() => Count.Value * 2);
+    public void Increment() => Count.Value++;
+}
+
+// Define once (share the returned definition; declare it static readonly).
+static readonly StoreDefinition<CounterStore> UseCounter =
+    Stores.DefineStore("counter", () => new CounterStore());
+
+// Per app: create a registry and install it.
+var pinia = Stores.CreateRegistry();
+app.Use(pinia.AsPlugin<TNode>());          // provides the registry app-wide
+
+// Inside a component Setup — resolves the app's registry, no argument needed:
+var counter = UseCounter.UseStore();
+// From plain C#/DI — pass the registry handle explicitly:
+var same = UseCounter.UseStore(pinia);     // ReferenceEquals(counter, same) == true
+
+pinia.Dispose();                            // stops every store's scope
+```
+
+## Boundaries
+
+- References **only** `Assimalign.Viu.Reactivity` (for `EffectScope`/`Ref`/`Computed`) and
+  `Assimalign.Viu.RuntimeCore` (for `App`, `IPlugin`, provide/inject, and the current component
+  instance). It references **no DOM/JavaScript-interop assembly** — stores are platform-agnostic and
+  run in a plain .NET test host.
+- Trimming- and NativeAOT-safe: store construction goes through the typed setup delegate captured at
+  `DefineStore` time — never `Activator.CreateInstance` or attribute scanning — so there is no
+  reflection-based activation and no dynamic code generation.
+- Not thread-safe (single-threaded JS event-loop model). The registry is per app instance, so
+  server-side (multi-request) hosting stays isolated without global mutable state; the ambient
+  `ActiveRegistry` is a client/testing convenience — pass the registry explicitly on the server.
+- Design rationale, the Pinia counterpart mapping, and the deliberate C#/WASM divergences:
+  [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Store/src/Assimalign.Viu.Store.csproj
+++ b/libraries/Assimalign.Viu.Store/src/Assimalign.Viu.Store.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeCore" />
+  </ItemGroup>
+</Project>

--- a/libraries/Assimalign.Viu.Store/src/Delegates/StoreSetup{TStore}.cs
+++ b/libraries/Assimalign.Viu.Store/src/Delegates/StoreSetup{TStore}.cs
@@ -1,0 +1,23 @@
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// The setup delegate passed to <see cref="Stores.DefineStore{TStore}(string, StoreSetup{TStore})"/> —
+/// the C# port of the setup function in Pinia's setup-syntax store
+/// <c>defineStore(id, () =&gt; { ... })</c> (https://pinia.vuejs.org/core-concepts/#setup-stores,
+/// <c>packages/pinia/src/store.ts</c> <c>createSetupStore</c>). It runs exactly once per
+/// <see cref="StoreRegistry"/> the store is resolved in, inside that store's own
+/// <see cref="Assimalign.Viu.Reactivity.EffectScope"/>, and returns the store instance — the object
+/// whose refs are state, computeds are getters, and methods are actions ([V01.01.09.02] builds those
+/// members on top of this delegate).
+/// <para>
+/// Refs, computeds, watchers, and <c>watchEffect</c>s created while the delegate runs are collected by
+/// the store's scope, so disposing the store (or its owning app/registry) tears them all down. Because
+/// the delegate is captured at definition time and invoked directly, store construction is fully
+/// reflection-free (AOT/trimming-safe): there is no <c>Activator.CreateInstance</c> and no attribute
+/// scanning.
+/// </para>
+/// </summary>
+/// <typeparam name="TStore">The store instance type the setup produces.</typeparam>
+/// <returns>The newly constructed store instance.</returns>
+public delegate TStore StoreSetup<TStore>()
+    where TStore : class;

--- a/libraries/Assimalign.Viu.Store/src/DuplicateStoreIdException.cs
+++ b/libraries/Assimalign.Viu.Store/src/DuplicateStoreIdException.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// The deterministic error raised when two <em>different</em> <see cref="StoreDefinition{TStore}"/>
+/// instances are resolved against the same <see cref="StoreRegistry"/> under the same
+/// <see cref="StoreDefinition{TStore}.Id"/>. Store ids are unique per registry: aliasing two
+/// definitions onto one id would silently share (or clobber) state, so the second resolution fails
+/// here instead. The C# analogue of the uniqueness Pinia relies on when keying stores by id in
+/// <c>pinia._s</c> and of its dev-time "store … already used" guard
+/// (<c>packages/pinia/src/store.ts</c>). Resolving the <em>same</em> definition twice is not an
+/// error — it returns the cached instance.
+/// </summary>
+public sealed class DuplicateStoreIdException : Exception
+{
+    /// <summary>Creates a <see cref="DuplicateStoreIdException"/> for <paramref name="storeId"/>.</summary>
+    /// <param name="storeId">The store id that a different definition already registered.</param>
+    public DuplicateStoreIdException(string storeId)
+        : base($"A different store is already registered under id \"{storeId}\" in this registry. "
+            + "Store ids must be unique per registry: give the store a distinct id, or reuse the "
+            + "original definition instead of defining a second one with the same id.")
+    {
+        StoreId = storeId;
+    }
+
+    /// <summary>The store id that collided.</summary>
+    public string StoreId { get; }
+}

--- a/libraries/Assimalign.Viu.Store/src/Internal/StoreEntry.cs
+++ b/libraries/Assimalign.Viu.Store/src/Internal/StoreEntry.cs
@@ -1,0 +1,29 @@
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// A registry's record for one resolved store — its <see cref="Instance"/>, the
+/// <see cref="EffectScope"/> that owns the computeds and watchers created in setup, and the
+/// <see cref="Definition"/> that created it (held by reference so the registry can tell an id reused
+/// by a different definition from the same definition resolved again). The C# analogue of the entry
+/// Pinia keeps in <c>pinia._s</c> alongside the store's <c>scope</c>. Internal.
+/// </summary>
+internal sealed class StoreEntry
+{
+    public StoreEntry(object definition, object instance, EffectScope scope)
+    {
+        Definition = definition;
+        Instance = instance;
+        Scope = scope;
+    }
+
+    /// <summary>The definition that owns the id (reference identity drives duplicate-id detection).</summary>
+    public object Definition { get; }
+
+    /// <summary>The cached store instance.</summary>
+    public object Instance { get; }
+
+    /// <summary>The store's own effect scope (a child of the registry's root scope).</summary>
+    public EffectScope Scope { get; }
+}

--- a/libraries/Assimalign.Viu.Store/src/Internal/StorePlugin{TNode}.cs
+++ b/libraries/Assimalign.Viu.Store/src/Internal/StorePlugin{TNode}.cs
@@ -1,0 +1,33 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// The <see cref="IPlugin{TNode}"/> adapter that installs a <see cref="StoreRegistry"/> on an app —
+/// the C# bridge for Pinia's <c>app.use(pinia)</c> (<c>packages/pinia/src/createPinia.ts</c>
+/// <c>pinia.install</c>). Because <see cref="IPlugin{TNode}"/> is generic over the platform node
+/// while a registry is platform-agnostic, the registry is wrapped per node type by
+/// <see cref="StoreRegistry.AsPlugin{TNode}"/> instead of implementing the plugin interface itself.
+/// Installing provides the registry app-wide (so a component <c>Setup</c> can inject it) and makes it
+/// the ambient <see cref="Stores.ActiveRegistry"/>. Internal.
+/// </summary>
+/// <typeparam name="TNode">The app's platform node type.</typeparam>
+internal sealed class StorePlugin<TNode> : IPlugin<TNode>
+    where TNode : notnull
+{
+    private readonly StoreRegistry _registry;
+
+    public StorePlugin(StoreRegistry registry) => _registry = registry;
+
+    public void Install(Application<TNode> application, object? options)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        // Provide the registry app-wide (upstream: app.provide(piniaSymbol, pinia)) so UseStore() in a
+        // component Setup injects it, and set it active (upstream: setActivePinia(pinia)) so
+        // non-component resolution has a fallback.
+        application.Provide(StoreRegistry.InjectionKey, _registry);
+        Stores.SetActiveRegistry(_registry);
+    }
+}

--- a/libraries/Assimalign.Viu.Store/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.Store/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Assimalign.Viu.Store.Tests")]

--- a/libraries/Assimalign.Viu.Store/src/StoreDefinition{TStore}.cs
+++ b/libraries/Assimalign.Viu.Store/src/StoreDefinition{TStore}.cs
@@ -1,0 +1,107 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// A typed store definition — the C# port of the <c>useStore</c> function returned by Pinia's
+/// <c>defineStore(id, setup)</c> (https://pinia.vuejs.org/core-concepts/#setup-stores,
+/// <c>packages/pinia/src/store.ts</c>). It couples the store's <see cref="Id"/> with its setup
+/// delegate and resolves the store instance against a <see cref="StoreRegistry"/>: the first
+/// resolution per registry runs setup once inside the store's own effect scope; later resolutions
+/// return the identical instance.
+/// <para>
+/// Create definitions with <see cref="Stores.DefineStore{TStore}(string, StoreSetup{TStore})"/> and
+/// share the returned instance (declare it <c>static readonly</c>). Not thread-safe (single-threaded
+/// JS event-loop model).
+/// </para>
+/// </summary>
+/// <typeparam name="TStore">The store instance type the setup produces.</typeparam>
+public sealed class StoreDefinition<TStore>
+    where TStore : class
+{
+    private readonly StoreSetup<TStore> _setup;
+
+    internal StoreDefinition(string id, StoreSetup<TStore> setup)
+    {
+        Id = id;
+        _setup = setup;
+    }
+
+    /// <summary>The store's unique id within a registry (upstream: the first argument to <c>defineStore</c>).</summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Resolves this store from <paramref name="registry"/> — the DI-friendly form of Pinia's
+    /// <c>useStore(pinia)</c> that needs no component tree. The first call per registry runs setup
+    /// once and caches the instance inside its own scope; every later call returns that same instance
+    /// (reference equality).
+    /// </summary>
+    /// <param name="registry">The registry that owns the store instance.</param>
+    /// <returns>The store instance for <paramref name="registry"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="registry"/> is null.</exception>
+    /// <exception cref="DuplicateStoreIdException">A different definition already owns <see cref="Id"/> in <paramref name="registry"/>.</exception>
+    /// <exception cref="ObjectDisposedException"><paramref name="registry"/> has been disposed.</exception>
+    public TStore UseStore(StoreRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        return registry.Resolve(this);
+    }
+
+    /// <summary>
+    /// Resolves this store from the ambient registry — the C# port of Pinia's argument-less
+    /// <c>useStore()</c>. Inside a component <c>Setup</c> the registry is injected from the current
+    /// app context (the one installed with <c>App.Use</c>); outside a component it falls back to
+    /// <see cref="Stores.ActiveRegistry"/>. Prefer <see cref="UseStore(StoreRegistry)"/> on the
+    /// server, where the ambient registry is not request-isolated.
+    /// </summary>
+    /// <returns>The store instance for the ambient registry.</returns>
+    /// <exception cref="InvalidOperationException">No registry is available from the component context or as the active registry.</exception>
+    /// <exception cref="DuplicateStoreIdException">A different definition already owns <see cref="Id"/> in the resolved registry.</exception>
+    public TStore UseStore()
+    {
+        var registry = ResolveAmbientRegistry()
+            ?? throw new InvalidOperationException(
+                $"No store registry is available to resolve store \"{Id}\". Install one on the app with "
+                + "App.Use(registry.AsPlugin<TNode>()), pass a registry to UseStore(registry), or set one "
+                + "with Stores.SetActiveRegistry(...).");
+        return registry.Resolve(this);
+    }
+
+    /// <summary>
+    /// Disposes this store within <paramref name="registry"/> — the C# port of Pinia's
+    /// <c>store.$dispose()</c> (<c>packages/pinia/src/store.ts</c>). Stops the store's effect scope
+    /// (so its setup computeds and watchers stop firing) and forgets it, leaving the registry's other
+    /// stores untouched. A later <see cref="UseStore(StoreRegistry)"/> rebuilds a fresh instance.
+    /// No-op when the store was never resolved in <paramref name="registry"/>.
+    /// </summary>
+    /// <param name="registry">The registry holding the store instance.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="registry"/> is null.</exception>
+    public void Dispose(StoreRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        registry.DisposeStore(this);
+    }
+
+    internal TStore RunSetup() => _setup();
+
+    private static StoreRegistry? ResolveAmbientRegistry()
+    {
+        // Inside a component Setup: the registry provided app-wide by the store plugin (upstream:
+        // useStore injects piniaSymbol from the current component). The defaulted Inject overload
+        // treats a missing provide as a silent null rather than a dev "injection not found" warning;
+        // the (StoreRegistry)null! default keeps the key's non-nullable type argument (avoiding an
+        // InjectionKey<StoreRegistry?> variance mismatch) and selects the value overload unambiguously.
+        if (ComponentInstance.Current is not null)
+        {
+            StoreRegistry? injected = DependencyInjection.Inject(StoreRegistry.InjectionKey, (StoreRegistry)null!);
+            if (injected is not null)
+            {
+                return injected;
+            }
+        }
+        // Outside a component (plain C#/DI): the ambient active registry (upstream: activePinia).
+        return Stores.ActiveRegistry;
+    }
+}

--- a/libraries/Assimalign.Viu.Store/src/StoreRegistry.cs
+++ b/libraries/Assimalign.Viu.Store/src/StoreRegistry.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// The per-app store root — the C# port of the <c>Pinia</c> instance produced by <c>createPinia()</c>
+/// (<c>packages/pinia/src/createPinia.ts</c>, <c>rootStore.ts</c>). It owns a detached root
+/// <see cref="EffectScope"/> (Pinia's <c>pinia._e</c>) and the id → instance map (Pinia's
+/// <c>pinia._s</c>): the first resolution of a definition instantiates the store inside a child scope
+/// of the root and caches it; later resolutions return the cached instance.
+/// <para>
+/// Keeping the registry per app instance is what gives server-side (multi-request) hosting its
+/// isolation — two registries never share store state, so a long-lived .NET server serves concurrent
+/// requests without the global mutable state a fresh JS module graph would provide per request
+/// (https://pinia.vuejs.org/ssr/). Install a registry on an <see cref="Application{TNode}"/> with
+/// <c>App.Use(registry.AsPlugin&lt;TNode&gt;())</c>. Not thread-safe (single-threaded JS event-loop
+/// model): WASM needs no locks, and servers isolate by using one registry per request rather than a
+/// shared singleton.
+/// </para>
+/// </summary>
+public sealed class StoreRegistry : IDisposable
+{
+    // Pinia's pinia._e: a DETACHED root scope so it never attaches to whatever effect scope happens to
+    // be active when the registry is created. Each store's own scope is created as a CHILD of this
+    // root (see Resolve), so stopping the root cascades to every store — the app-level disposal path.
+    private readonly EffectScope _rootScope = new(detached: true);
+    private readonly Dictionary<string, StoreEntry> _stores = new(StringComparer.Ordinal);
+    private bool _disposed;
+
+    /// <summary>The injection key the store plugin provides this registry under, app-wide.</summary>
+    internal static readonly InjectionKey<StoreRegistry> InjectionKey = new("viu:store-registry");
+
+    /// <summary>Creates an empty registry. Equivalent to <see cref="Stores.CreateRegistry"/>.</summary>
+    public StoreRegistry()
+    {
+    }
+
+    /// <summary>The number of stores instantiated in this registry so far (upstream: <c>pinia._s.size</c>).</summary>
+    public int Count => _stores.Count;
+
+    /// <summary>Whether the registry has been disposed (its root scope stopped).</summary>
+    public bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Wraps this registry as an installable app plugin so it can be applied with
+    /// <c>App.Use(registry.AsPlugin&lt;TNode&gt;())</c> — the C# stand-in for the Pinia <c>pinia</c>
+    /// object being itself the plugin passed to <c>app.use(pinia)</c>. Installing provides this
+    /// registry app-wide (the final inject fallback) and makes it the ambient
+    /// <see cref="Stores.ActiveRegistry"/>. Call once per app.
+    /// </summary>
+    /// <typeparam name="TNode">The app's platform node type.</typeparam>
+    /// <returns>A plugin that installs this registry.</returns>
+    public IPlugin<TNode> AsPlugin<TNode>()
+        where TNode : notnull
+        => new StorePlugin<TNode>(this);
+
+    /// <summary>
+    /// Stops the root effect scope — cascading to every store's child scope, so all computeds and
+    /// watchers created in setup stop — clears the store map, and clears the ambient
+    /// <see cref="Stores.ActiveRegistry"/> if it points here. The C# realization of disposing the
+    /// owning app's store root (Pinia stops <c>pinia._e</c>). Idempotent.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        _rootScope.Stop();
+        _stores.Clear();
+        if (ReferenceEquals(Stores.ActiveRegistry, this))
+        {
+            Stores.SetActiveRegistry(null);
+        }
+    }
+
+    // Resolves (creating on first use) the store for `definition`. Mirrors createSetupStore: the store
+    // scope is created while the detached root is the active scope, so it becomes a child of the root
+    // and is NOT captured by any component scope active at the call site — the "detached from the
+    // render tree" property the ticket calls out. Setup runs once, inside that child scope.
+    internal TStore Resolve<TStore>(StoreDefinition<TStore> definition)
+        where TStore : class
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_stores.TryGetValue(definition.Id, out var existing))
+        {
+            // Same id claimed by a different definition is a collision (never silent aliasing); the
+            // same definition resolved again is a cache hit.
+            if (!ReferenceEquals(existing.Definition, definition))
+            {
+                throw new DuplicateStoreIdException(definition.Id);
+            }
+            return (TStore)existing.Instance;
+        }
+        var scope = _rootScope.Run(static () => new EffectScope(detached: false));
+        TStore instance;
+        try
+        {
+            instance = scope.Run(definition.RunSetup);
+        }
+        catch
+        {
+            // A throwing setup must not leave a live child scope (or a half-built entry) behind.
+            scope.Stop();
+            throw;
+        }
+        _stores[definition.Id] = new StoreEntry(definition, instance, scope);
+        return instance;
+    }
+
+    // Stops and forgets a single store (Pinia's store.$dispose), but only when `definition` is the one
+    // that owns the id, so a stale definition cannot dispose another store. A later resolution rebuilds
+    // the store fresh.
+    internal void DisposeStore<TStore>(StoreDefinition<TStore> definition)
+        where TStore : class
+    {
+        if (_stores.TryGetValue(definition.Id, out var entry) && ReferenceEquals(entry.Definition, definition))
+        {
+            entry.Scope.Stop();
+            _stores.Remove(definition.Id);
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Store/src/Stores.cs
+++ b/libraries/Assimalign.Viu.Store/src/Stores.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Assimalign.Viu.Store;
+
+/// <summary>
+/// The entry-point facade for Viu's store system — the C# port of the module-level surface of Pinia
+/// (https://pinia.vuejs.org, github.com/vuejs/pinia): <see cref="DefineStore{TStore}"/> mirrors
+/// <c>defineStore()</c>, <see cref="CreateRegistry"/> mirrors <c>createPinia()</c>, and
+/// <see cref="ActiveRegistry"/>/<see cref="SetActiveRegistry"/> mirror <c>activePinia</c>/
+/// <c>setActivePinia()</c> (<c>packages/pinia/src/rootStore.ts</c>).
+/// <para>
+/// <see cref="ActiveRegistry"/> is ambient <c>static</c> state and is NOT thread-safe by design (the
+/// single-threaded JS event-loop model). On a multi-request server do not rely on it: create one
+/// <see cref="StoreRegistry"/> per request and resolve stores through
+/// <see cref="StoreDefinition{TStore}.UseStore(StoreRegistry)"/> so requests stay isolated
+/// (https://pinia.vuejs.org/ssr/).
+/// </para>
+/// </summary>
+public static class Stores
+{
+    private static StoreRegistry? _activeRegistry;
+
+    /// <summary>
+    /// Defines a setup-style store: couples a unique <paramref name="id"/> with a
+    /// <paramref name="setup"/> delegate that constructs the store — the C# port of Pinia's
+    /// <c>defineStore(id, setup)</c> (https://pinia.vuejs.org/core-concepts/#setup-stores,
+    /// <c>packages/pinia/src/store.ts</c>). Defining a store does not run <paramref name="setup"/>;
+    /// the first <see cref="StoreDefinition{TStore}.UseStore(StoreRegistry)"/> per registry does, and
+    /// exactly once per registry.
+    /// </summary>
+    /// <typeparam name="TStore">The store instance type the setup produces.</typeparam>
+    /// <param name="id">The store's unique id within any registry it is used in.</param>
+    /// <param name="setup">The delegate that constructs the store inside its effect scope.</param>
+    /// <returns>The typed store definition (the C# port of the <c>useStore</c> that <c>defineStore</c> returns).</returns>
+    /// <exception cref="ArgumentException"><paramref name="id"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="setup"/> is null.</exception>
+    public static StoreDefinition<TStore> DefineStore<TStore>(string id, StoreSetup<TStore> setup)
+        where TStore : class
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        ArgumentNullException.ThrowIfNull(setup);
+        return new StoreDefinition<TStore>(id, setup);
+    }
+
+    /// <summary>
+    /// Creates a store registry — the per-app root that owns every store's lifetime, the C# port of
+    /// Pinia's <c>createPinia()</c> (<c>packages/pinia/src/createPinia.ts</c>). Install it on an app
+    /// with <c>App.Use(registry.AsPlugin&lt;TNode&gt;())</c>, or pass it directly to
+    /// <see cref="StoreDefinition{TStore}.UseStore(StoreRegistry)"/> for DI-style resolution.
+    /// Equivalent to <c>new StoreRegistry()</c>.
+    /// </summary>
+    /// <returns>A fresh, empty registry.</returns>
+    public static StoreRegistry CreateRegistry() => new();
+
+    /// <summary>
+    /// The ambient registry that <see cref="StoreDefinition{TStore}.UseStore()"/> falls back to
+    /// outside a component context — the C# port of Pinia's <c>activePinia</c>
+    /// (<c>packages/pinia/src/rootStore.ts</c>). Set when a registry is installed via <c>App.Use</c>.
+    /// Ambient and NOT thread-safe; see the type remarks on server isolation.
+    /// </summary>
+    public static StoreRegistry? ActiveRegistry => _activeRegistry;
+
+    /// <summary>
+    /// Sets the ambient <see cref="ActiveRegistry"/> — the C# port of Pinia's
+    /// <c>setActivePinia(pinia)</c>. Installing a registry via <c>App.Use</c> calls this; call it
+    /// directly (or with <see langword="null"/> to clear) in tests or non-component bootstrap code.
+    /// </summary>
+    /// <param name="registry">The registry to make ambient, or null to clear.</param>
+    public static void SetActiveRegistry(StoreRegistry? registry) => _activeRegistry = registry;
+}

--- a/libraries/Assimalign.Viu.Store/test/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.Store/test/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// The store system uses ambient static state (the active registry) and drives the reactivity engine's
+// ambient scope/subscriber — the single-threaded JS event-loop model — so tests must not run in
+// parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/libraries/Assimalign.Viu.Store/test/Assimalign.Viu.Store.Tests.csproj
+++ b/libraries/Assimalign.Viu.Store/test/Assimalign.Viu.Store.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Store" />
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+  </ItemGroup>
+</Project>

--- a/libraries/Assimalign.Viu.Store/test/StoreApplicationIntegrationTests.cs
+++ b/libraries/Assimalign.Viu.Store/test/StoreApplicationIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Store.Tests;
+
+// Pins the per-app install path (Pinia's app.use(pinia), packages/pinia/src/createPinia.ts) and the
+// two UseStore resolution modes: from a component Setup via the current app context, and from plain
+// C# via a registry handle. Exercised through the in-memory test renderer (DOM-free).
+public sealed class StoreApplicationIntegrationTests : IDisposable
+{
+    private readonly TestSchedulerPump _pump = TestSchedulerPump.Install();
+
+    public void Dispose()
+    {
+        _pump.RunUntilIdle();
+        _pump.Dispose();
+        Stores.SetActiveRegistry(null);
+    }
+
+    [Fact]
+    public void InstalledViaAppUse_ResolvesTheSameStore_InComponentSetup_AsFromDI()
+    {
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+        CounterStore? resolvedInSetup = null;
+
+        var root = new SetupComponent
+        {
+            SetupFunction = () =>
+            {
+                // Inside Setup with no explicit registry: resolves via the current app context.
+                resolvedInSetup = useCounter.UseStore();
+                return static () => VirtualNodeFactory.Text("root");
+            },
+        };
+
+        var renderer = new TestRenderer();
+        var application = renderer.Renderer.CreateApplication(root);
+        application.Use(registry.AsPlugin<TestNode>());
+        application.Mount(renderer.CreateContainer());
+
+        resolvedInSetup.ShouldNotBeNull();
+        // The component-context resolution and the DI resolution are the identical instance.
+        resolvedInSetup.ShouldBeSameAs(useCounter.UseStore(registry));
+        registry.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Install_SetsTheAmbientActiveRegistry()
+    {
+        var registry = new StoreRegistry();
+        var renderer = new TestRenderer();
+        var application = renderer.Renderer.CreateApplication(
+            new SetupComponent { SetupFunction = static () => static () => VirtualNodeFactory.Text("x") });
+
+        application.Use(registry.AsPlugin<TestNode>());
+
+        Stores.ActiveRegistry.ShouldBeSameAs(registry);
+    }
+
+    [Fact]
+    public void TwoApplications_EachWithItsOwnRegistry_ResolveIsolatedStoresInSetup()
+    {
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+
+        CounterStore MountWith(StoreRegistry registry)
+        {
+            CounterStore? resolved = null;
+            var root = new SetupComponent
+            {
+                SetupFunction = () =>
+                {
+                    resolved = useCounter.UseStore();
+                    return static () => VirtualNodeFactory.Text("root");
+                },
+            };
+            var renderer = new TestRenderer();
+            var application = renderer.Renderer.CreateApplication(root);
+            application.Use(registry.AsPlugin<TestNode>());
+            application.Mount(renderer.CreateContainer());
+            return resolved!;
+        }
+
+        var registry1 = new StoreRegistry();
+        var registry2 = new StoreRegistry();
+        var store1 = MountWith(registry1);
+        var store2 = MountWith(registry2);
+
+        store1.ShouldNotBeSameAs(store2);    // per-app instances (server request isolation)
+        store1.Increment();
+        store1.Count.Value.ShouldBe(1);
+        store2.Count.Value.ShouldBe(0);      // isolated per app
+    }
+
+    [Fact]
+    public void UseStore_WithNoRegistryAvailable_Throws()
+    {
+        Stores.SetActiveRegistry(null);
+        var useOrphan = Stores.DefineStore("orphan", () => new CounterStore());
+
+        Should.Throw<InvalidOperationException>(() => useOrphan.UseStore());
+    }
+}

--- a/libraries/Assimalign.Viu.Store/test/StoreDefinitionTests.cs
+++ b/libraries/Assimalign.Viu.Store/test/StoreDefinitionTests.cs
@@ -1,0 +1,83 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Store.Tests;
+
+// Pins Pinia's defineStore()/useStore() pair (https://pinia.vuejs.org/core-concepts/,
+// packages/pinia/src/store.ts): a definition couples an id with a setup, the first resolution per
+// registry runs setup once, and later resolutions return the identical instance.
+public sealed class StoreDefinitionTests
+{
+    [Fact]
+    public void DefineStore_ReturnsTypedDefinition_CarryingTheId()
+    {
+        var definition = Stores.DefineStore("counter", () => new CounterStore());
+
+        definition.Id.ShouldBe("counter");
+    }
+
+    [Fact]
+    public void UseStore_TwiceInOneRegistry_ReturnsSameInstance_AndRunsSetupExactlyOnce()
+    {
+        var setupRuns = 0;
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () =>
+        {
+            setupRuns++;
+            return new CounterStore();
+        });
+
+        var first = useCounter.UseStore(registry);
+        var second = useCounter.UseStore(registry);
+
+        first.ShouldBeSameAs(second);        // identical instance (reference equality)
+        setupRuns.ShouldBe(1);               // setup ran exactly once per app/registry
+        registry.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseStore_AcrossTwoRegistries_ReturnsIsolatedInstances_WithSeparateSetupRuns()
+    {
+        // Two registries model two app instances (SSR request isolation): no shared state, setup per
+        // app.
+        var setupRuns = 0;
+        var useCounter = Stores.DefineStore("counter", () =>
+        {
+            setupRuns++;
+            return new CounterStore();
+        });
+        var registryA = new StoreRegistry();
+        var registryB = new StoreRegistry();
+
+        var storeA = useCounter.UseStore(registryA);
+        var storeB = useCounter.UseStore(registryB);
+
+        storeA.ShouldNotBeSameAs(storeB);
+        setupRuns.ShouldBe(2);               // once per registry
+
+        storeA.Increment();
+        storeA.Count.Value.ShouldBe(1);
+        storeB.Count.Value.ShouldBe(0);      // fully isolated state
+    }
+
+    [Fact]
+    public void DefineStore_NullOrEmptyId_Throws()
+    {
+        Should.Throw<ArgumentException>(() => Stores.DefineStore("", () => new CounterStore()));
+        Should.Throw<ArgumentException>(() => Stores.DefineStore(null!, () => new CounterStore()));
+    }
+
+    [Fact]
+    public void DefineStore_NullSetup_Throws()
+        => Should.Throw<ArgumentNullException>(() => Stores.DefineStore<CounterStore>("counter", null!));
+
+    [Fact]
+    public void UseStore_NullRegistry_Throws()
+    {
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+
+        Should.Throw<ArgumentNullException>(() => useCounter.UseStore(null!));
+    }
+}

--- a/libraries/Assimalign.Viu.Store/test/StoreRegistryTests.cs
+++ b/libraries/Assimalign.Viu.Store/test/StoreRegistryTests.cs
@@ -1,0 +1,73 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Store.Tests;
+
+// Pins the per-registry root behavior (Pinia's createPinia() / pinia._s / pinia._e): id uniqueness,
+// disposal, and instantiated-store counting.
+public sealed class StoreRegistryTests
+{
+    [Fact]
+    public void Resolve_TwoDefinitionsWithSameId_ThrowsDuplicateStoreId()
+    {
+        var registry = new StoreRegistry();
+        var first = Stores.DefineStore("counter", () => new CounterStore());
+        var second = Stores.DefineStore("counter", () => new CounterStore());
+
+        first.UseStore(registry);            // claims the id
+
+        var error = Should.Throw<DuplicateStoreIdException>(() => second.UseStore(registry));
+        error.StoreId.ShouldBe("counter");
+        registry.Count.ShouldBe(1);          // the collision did not register a second store
+    }
+
+    [Fact]
+    public void SameDefinition_ResolvedTwice_IsNotADuplicate()
+    {
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+
+        Should.NotThrow(() =>
+        {
+            useCounter.UseStore(registry);
+            useCounter.UseStore(registry);
+        });
+    }
+
+    [Fact]
+    public void Resolve_AfterDispose_ThrowsObjectDisposed()
+    {
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+        registry.Dispose();
+
+        registry.IsDisposed.ShouldBeTrue();
+        Should.Throw<ObjectDisposedException>(() => useCounter.UseStore(registry));
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var registry = new StoreRegistry();
+        Stores.DefineStore("counter", () => new CounterStore()).UseStore(registry);
+
+        Should.NotThrow(() =>
+        {
+            registry.Dispose();
+            registry.Dispose();
+        });
+    }
+
+    [Fact]
+    public void Count_ReflectsInstantiatedStores()
+    {
+        var registry = new StoreRegistry();
+
+        registry.Count.ShouldBe(0);
+        Stores.DefineStore("a", () => new CounterStore()).UseStore(registry);
+        Stores.DefineStore("b", () => new CounterStore()).UseStore(registry);
+        registry.Count.ShouldBe(2);
+    }
+}

--- a/libraries/Assimalign.Viu.Store/test/StoreScopeDisposalTests.cs
+++ b/libraries/Assimalign.Viu.Store/test/StoreScopeDisposalTests.cs
@@ -1,0 +1,86 @@
+using Assimalign.Viu.Reactivity;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Store.Tests;
+
+// Pins the effectScope ownership Pinia gets from effectScope()
+// (https://vuejs.org/api/reactivity-advanced.html#effectscope, packages/pinia/src/store.ts): a store
+// lives in its own scope, disposing the store or its registry stops that scope, and the store scope
+// is detached from whatever scope is active at first use. Run counts (not just values) prove the
+// teardown, per the repo testing rule for reactive semantics.
+public sealed class StoreScopeDisposalTests
+{
+    [Fact]
+    public void DisposingRegistry_StopsSetupWatchers_SoTheyNoLongerFire()
+    {
+        var registry = new StoreRegistry();
+        var store = Stores.DefineStore("counter", () => new CounterStore()).UseStore(registry);
+
+        store.Increment();                   // 0 -> 1
+        store.WatcherRuns.ShouldBe(1);       // the scope-owned watcher fired
+        store.Doubled.Value.ShouldBe(2);     // the computed getter tracked the change
+
+        registry.Dispose();
+
+        store.Increment();                   // 1 -> 2, but the store's scope is stopped
+        store.WatcherRuns.ShouldBe(1);       // frozen: the setup watcher no longer fires
+    }
+
+    [Fact]
+    public void DisposingOneStore_StopsItsScope_ButLeavesOtherStoresLive()
+    {
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+        var useOther = Stores.DefineStore("other", () => new CounterStore());
+        var counter = useCounter.UseStore(registry);
+        var other = useOther.UseStore(registry);
+
+        useCounter.Dispose(registry);        // dispose only the counter store
+        registry.Count.ShouldBe(1);          // counter forgotten; other remains
+
+        counter.Increment();
+        counter.WatcherRuns.ShouldBe(0);     // counter's watcher is stopped
+
+        other.Increment();
+        other.WatcherRuns.ShouldBe(1);       // other store is unaffected
+    }
+
+    [Fact]
+    public void DisposedStore_IsRebuiltFresh_OnNextUse()
+    {
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+        var first = useCounter.UseStore(registry);
+        first.Increment();
+
+        useCounter.Dispose(registry);
+        var second = useCounter.UseStore(registry);
+
+        second.ShouldNotBeSameAs(first);     // a new instance
+        second.Count.Value.ShouldBe(0);      // with fresh state
+    }
+
+    [Fact]
+    public void StoreScope_IsDetachedFromTheScopeActiveAtFirstUse()
+    {
+        // Resolving a store inside an ambient scope (e.g. a component's) must NOT capture the store
+        // into that scope: stopping the ambient scope leaves the store fully reactive. Only the
+        // registry (or the store itself) owns the store's lifetime.
+        var registry = new StoreRegistry();
+        var useCounter = Stores.DefineStore("counter", () => new CounterStore());
+        CounterStore store = null!;
+
+        var ambient = Reactive.EffectScope();
+        ambient.Run(() => store = useCounter.UseStore(registry));
+        ambient.Stop();
+
+        store.Increment();
+        store.WatcherRuns.ShouldBe(1);       // survived the ambient scope stop
+
+        registry.Dispose();
+        store.Increment();
+        store.WatcherRuns.ShouldBe(1);       // only registry disposal stops it
+    }
+}

--- a/libraries/Assimalign.Viu.Store/test/StoreTestSupport.cs
+++ b/libraries/Assimalign.Viu.Store/test/StoreTestSupport.cs
@@ -1,0 +1,49 @@
+using System;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Store.Tests;
+
+/// <summary>
+/// A minimal setup-style store used across the store tests: a counter whose getter is a
+/// <see cref="Computed{T}"/> and whose change is observed by a scope-owned <c>Watch</c>, so run
+/// counts can prove scope teardown. The computed and watcher are created in the constructor, which
+/// runs inside the store's effect scope, exactly as members declared in a Pinia setup store are.
+/// </summary>
+internal sealed class CounterStore
+{
+    public CounterStore()
+    {
+        Count = Reactive.Reference(0);
+        Doubled = Reactive.Computed(() => Count.Value * 2);
+        // A scope-owned watcher on the computed getter (sync flush, not immediate): fires on every
+        // change until the store's scope stops.
+        Reactive.Watch(() => Doubled.Value, (_, _, _) => WatcherRuns++);
+    }
+
+    /// <summary>The reactive state ref (a Pinia state member).</summary>
+    public Reference<int> Count { get; }
+
+    /// <summary>The computed getter over <see cref="Count"/> (a Pinia getter).</summary>
+    public Computed<int> Doubled { get; }
+
+    /// <summary>How many times the scope-owned watcher fired (a per-instance run count).</summary>
+    public int WatcherRuns { get; private set; }
+
+    /// <summary>Mutates state (a Pinia action).</summary>
+    public void Increment() => Count.Value++;
+}
+
+/// <summary>
+/// A component definition whose <c>Setup</c> is supplied by a delegate — the store tests need to run
+/// code with a current <see cref="ComponentInstance"/> and app context. Mirrors the RuntimeCore test
+/// helper of the same shape.
+/// </summary>
+internal sealed class SetupComponent : IComponentDefinition
+{
+    public required Func<Func<VirtualNode?>> SetupFunction { get; init; }
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => SetupFunction();
+}


### PR DESCRIPTION
## Summary
- Opens the Store area with the new `Assimalign.Viu.Store` library — the C# port of Pinia's `defineStore()`/`createPinia()`/`$dispose` (setup-style stores only; option stores need `Proxy` and are deliberately out, per the AOT-first model).
- Public surface: `Stores.DefineStore<TStore>(id, setup)` → typed `StoreDefinition<TStore>` with `UseStore()` (component setup via provide/inject, or ambient registry) and `UseStore(registry)` (DI-friendly); `StoreRegistry` is the per-app Pinia root, installed with `app.Use(registry.AsPlugin<TNode>())`.
- Lifetime is a faithful `createSetupStore` port: the registry owns a **detached** root `EffectScope` (Pinia's `pinia._e`); each store's scope is a **child** of that root created under `rootScope.Run`, so stores escape the calling component scope yet registry disposal cascades. Setup failures stop the child scope (no half-built entries); per-store `Dispose` is ownership-checked and a later resolution rebuilds fresh.
- Duplicate ids across *different* definitions throw a deterministic `DuplicateStoreIdException` (the issue's explicit divergence from Pinia's silent id-keyed aliasing); the same definition twice is a cache hit.
- Also fixes a CI coverage gap discovered in review ([#185](https://github.com/assimalign/viu/issues/185)): Router (merged via #179) and Store both lacked the per-area slnx + workflow the build-system rule requires, so neither test suite ran in CI. Adds `area-router`/`area-store` workflows and per-area slnx files following the established pattern — both appear as checks on this PR.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · Store tests **19/19** (reference identity + setup-once, frozen watcher run-counts after disposal, per-store disposal isolation, rebuild-after-dispose, two-app isolation, both `UseStore` resolution modes, duplicate-id semantics) · per-area solutions build+test green in Release exactly as the new workflows run them (Router 70/70, Store 19/19).

Divergences from Pinia are documented in `docs/DESIGN.md` (plugin adapter via `AsPlugin<TNode>` forced by generic `IPlugin<TNode>`; setup-style only; `$dispose` on the definition; `TStore : class` for genuine reference identity).

Closes #76
Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)