### PR TITLE
feat(router): implement history integration with memory, web, and hash modes [V01.01.08.02]

### DIFF
--- a/libraries/Assimalign.Viu.Router/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Router/docs/DESIGN.md
@@ -1,9 +1,11 @@
 # Assimalign.Viu.Router — design
 
-Why the matcher is shaped the way it is. What it is: see [OVERVIEW.md](OVERVIEW.md). Upstream
-counterpart: `vue-router` v4's matcher (`packages/router/src/matcher/` in
+Why the matcher and the history layer are shaped the way they are. What they are: see
+[OVERVIEW.md](OVERVIEW.md). Upstream counterpart: `vue-router` v4's matcher
+(`packages/router/src/matcher/`) and history (`packages/router/src/history/`, in
 https://github.com/vuejs/router). Matching-syntax reference:
-https://router.vuejs.org/guide/essentials/route-matching-syntax.html.
+https://router.vuejs.org/guide/essentials/route-matching-syntax.html; history-mode reference:
+https://router.vuejs.org/guide/essentials/history-mode.html.
 
 ## The matcher is a pure port
 
@@ -96,9 +98,70 @@ records by identity; parameters compare structurally and hash order-independentl
 keeps reference identity on purpose — the matched chain points at the exact record instances the
 consumer supplied.
 
+## History: the policy is split from the interop edge
+
+The web and hash histories (`[V01.01.08.02]`, the C# port of `packages/router/src/history/`) are
+split in two so the browser one is testable without a browser:
+
+- **`BrowserRouterHistory` is the policy** — base prepend/strip, the push/replace/`popstate` state
+  machine, listener bookkeeping — and touches no DOM. Every environment effect is delegated to an
+  injected **`IBrowserHistoryInterop`**. This mirrors `Assimalign.Viu.RuntimeDom`'s
+  `BrowserEventInvokerRegistry`, which takes its bridge calls as delegates so it is unit-testable
+  with recorded doubles. A `FakeBrowserHistoryInterop` records every crossing and can simulate a
+  `popstate`, so base handling, the state round-trip, delta/direction, listener teardown, and the
+  interop-call count are all pinned on a plain .NET host.
+- **`JavaScriptBrowserHistoryInterop` is the thin edge** — `[JSImport]` bindings to
+  `wwwroot/viu-history.js` — and does nothing but flatten the policy's URLs and states into
+  primitive interop calls. The JS module is a dumb applier: the only decision it makes is reading the
+  live `window.scrollX/Y` for the leaving entry (the one piece of state the DOM owns).
+
+`createWebHashHistory` is not a second implementation: as upstream, it only computes a `#`-carrying
+base and hands it to the same web policy (`RouterHistory.ResolveHashBase` → `BrowserRouterHistory`).
+
+## History state: one position counter, computed in C#
+
+`RouterHistoryState` is a flat, primitives-only payload (the port of upstream's `StateEntry`). The
+monotonic `Position` counter is assigned by `RouterHistoryStateBuilder` — `+1` per push, preserved
+across a replace, seeded from `history.length - 1` at bootstrap — **in C#**, not read from
+`window.history.length` per call, so the identical arithmetic runs in memory and in the browser and
+is unit-tested in isolation. A `popstate`'s signed distance is `arrived.Position - leaving.Position`,
+which yields the `NavigationDirection`. State crosses the boundary as primitives only: a null
+adjacency link and an absent scroll encode as an empty string / `false` flag, never a marshaled
+object graph (`BrowserHistorySnapshotMarshaller` pins the wire format).
+
+## History: batching and leak-free teardown
+
+- **Reads are one crossing.** `ReadSnapshot()` returns the raw `location` components *and* the current
+  entry's state together — no per-property getters. The policy caches location and state and never
+  re-reads them per navigation; a test asserts exactly one snapshot read across a push/replace/go/pop
+  sequence (the batched-read criterion).
+- **Writes are one crossing.** A push is two History-API operations (amend the leaving entry, then
+  push the new one), but the `Push` edge collapses them into a single interop call; a replace is one.
+- **`popstate` is one `[JSExport]`**, routed by a subscription id (`BrowserHistoryInteropDispatch`,
+  the history analogue of `BrowserEventDispatch`). The id lets many histories coexist and lets
+  `Destroy` unsubscribe the exact JS listener — no leak across instances, which matters because test
+  hosts create many.
+
+## History: deliberate divergences from vue-router
+
+- **Memory carries a full state per entry.** Upstream's memory history keeps `state = {}`; this port
+  stores a real `RouterHistoryState` on every memory entry so the position counter round-trips and
+  memory is a faithful reference model for the web state semantics — the `[V01.01.08.02]` requirement
+  that memory reproduce the same push/replace/go behavior. Memory still skips the browser's
+  amend-the-leaving-entry step (upstream memory does too), so a memory entry's `Forward` link is not
+  back-patched.
+- **Root-relative write URLs.** The browser edge writes `base + location` (web) or the `#…` slice
+  (hash) rather than upstream's absolute `location.protocol + '//' + location.host + base + to`.
+  `pushState` resolves the root-relative form identically and it keeps the write path DOM-free (no
+  protocol/host read). The dropped branch is upstream's `<base>`-element write-time special case
+  (`document.querySelector('base')`), an intentional simplification noted at the call site.
+- **Scroll is the one JS-owned field.** The leaving entry's scroll anchor is read from the live window
+  by the interop at apply time (the policy cannot read the DOM); every other field is C#-computed, and
+  memory — having no DOM — leaves scroll `null`. Scroll *restoration* (consuming the anchors) is
+  `[V01.01.08.05]`.
+
 ## Non-goals (sequenced work)
 
-- History integration (browser/hash/memory behind `IRouterHistory`) — `[V01.01.08.02]`.
 - `RouterView` / `RouterLink` components — `[V01.01.08.03]`.
 - Async navigation pipeline and guards (redirect, cancellation), plus `currentLocation` param
   inheritance and route removal — `[V01.01.08.04]`.

--- a/libraries/Assimalign.Viu.Router/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Router/docs/OVERVIEW.md
@@ -1,15 +1,19 @@
 # Assimalign.Viu.Router — overview
 
 The client router for Viu — the role `vue-router` v4 plays for Vue 3
-(https://github.com/vuejs/router). This first feature delivers the **route table and matcher**: the
-pure, DOM-free core that, given a set of route records and a location (a path or a named target),
-resolves an immutable `RouteLocation` with its parent-to-child matched chain and parsed parameters.
-It is the C# port of vue-router's `createRouterMatcher` and its path-parser ranking model
-(`packages/router/src/matcher/`).
+(https://github.com/vuejs/router). Two features have landed:
 
-History integration, `RouterView`/`RouterLink`, the async navigation pipeline with guards, and lazy
-routes are later features of the Router area (#69, `[V01.01.08.02]`–`[V01.01.08.05]`) and are not
-part of this package yet.
+- The **route table and matcher** (`[V01.01.08.01]`): the pure, DOM-free core that, given a set of
+  route records and a location (a path or a named target), resolves an immutable `RouteLocation`
+  with its parent-to-child matched chain and parsed parameters. The C# port of vue-router's
+  `createRouterMatcher` and its path-parser ranking model (`packages/router/src/matcher/`).
+- **History integration** (`[V01.01.08.02]`): the `IRouterHistory` abstraction with three modes —
+  memory, web (HTML5 History API), and hash — behind the `RouterHistory` factory. The C# port of
+  vue-router's `packages/router/src/history/`.
+
+`RouterView`/`RouterLink`, the async navigation pipeline with guards, and lazy routes are later
+features of the Router area (#69, `[V01.01.08.03]`–`[V01.01.08.05]`) and are not part of this package
+yet.
 
 ## What it contains
 
@@ -45,6 +49,37 @@ of `tokensToParser`), `PathParser` (the compiled regular expression + score + ke
 `PathParameterKey`, `RouteParameterValue`, `RouteRecordMatcher`, and `RegularExpressionPatterns`
 (the `[GeneratedRegex]` escape helper).
 
+## History integration
+
+The history layer (all under namespace `Assimalign.Viu.Router`) — the C# port of vue-router's
+`RouterHistory` (`packages/router/src/history/`):
+
+- **`IRouterHistory`** (`Abstraction/`): the history contract — `Base`, `Location`, `State`,
+  `Push`/`Replace`/`Go`, `Listen`, `CreateHref`, `Destroy`. Locations are the base-stripped path
+  the matcher resolves; the configured base is prepended on write and stripped on read.
+- **`RouterHistory`** (static facade): `CreateMemory`, `CreateWeb`, `CreateWebHash`, and the
+  browser-only `InitializeAsync`. The C# port of `createMemoryHistory`/`createWebHistory`/
+  `createWebHashHistory`. Memory is pure and needs no initialization; web and hash drive the History
+  API over interop and require `InitializeAsync` first.
+- **`RouterHistoryState`**: the flat, primitives-only state carried on each entry — the adjacency
+  links (`Back`/`Current`/`Forward`), the `Replaced` flag, the monotonic `Position` counter, and an
+  optional `Scroll` anchor. The C# port of vue-router's `StateEntry`.
+- **`NavigationType`** / **`NavigationDirection`** / **`NavigationInformation`** / **`ScrollPosition`**:
+  the value types a history reports to its listeners (pop vs push, back/forward/unknown, the signed
+  delta) and the saved scroll offset. Ports of the same-named vue-router types.
+- **`NavigationCallback`** (`Delegates/`): the listener signature for browser-initiated navigation
+  (a `popstate`, or a memory `Go`).
+
+Internal (`Internal/`): `MemoryRouterHistory` (the pure, interop-free port of `createMemoryHistory`),
+`BrowserRouterHistory` (the DOM-free web/hash **policy** — base handling, state machine, listener
+bookkeeping — driving an injected `IBrowserHistoryInterop`), the pure helpers
+`HistoryPathNormalization` (base normalize/strip, `createHref`, `createCurrentLocation`, hash base)
+and `RouterHistoryStateBuilder` (the `buildState`/push/replace arithmetic), the batched-read
+`BrowserHistorySnapshot` + `BrowserHistorySnapshotMarshaller`, and the thin browser edge —
+`JavaScriptBrowserHistoryInterop` (`[JSImport]` bindings to `wwwroot/viu-history.js`) and
+`BrowserHistoryInteropDispatch` (the single `[JSExport]` the `popstate` listener calls back into,
+routed by subscription id).
+
 ## Using it
 
 ```csharp
@@ -69,12 +104,27 @@ string path = matcher.ResolveNamed("user", RouteParameters.Empty.With("id", "42"
 // path == "/users/42"
 ```
 
+```csharp
+// Memory history — pure, no browser, no initialization.
+IRouterHistory history = RouterHistory.CreateMemory();
+history.Push("/users/42");
+// history.Location == "/users/42", history.State.Position == 1
+
+// Web history — clean URLs over the History API (browser only).
+await RouterHistory.InitializeAsync();
+IRouterHistory web = RouterHistory.CreateWeb("/app/");   // base prepended on write, stripped on read
+web.Listen((to, from, information) => { /* resolve `to` through the matcher */ });
+```
+
 ## Boundaries
 
-- References **no other Viu library** and **no JavaScript-interop assembly** — the matcher is pure
-  and runs in a plain .NET test host (a boundary the test suite asserts by reflection).
+- References **no other Viu library** — the matcher and the memory history run in a plain .NET test
+  host (a boundary the test suite asserts by reflection). `[V01.01.08.02]` added a browser history
+  edge over the framework's `System.Runtime.InteropServices.JavaScript` primitive, gated by
+  `[SupportedOSPlatform("browser")]`; the matcher and memory mode reference **no interop** and the
+  web/hash **policy** is exercised off-browser through an injected seam.
 - Trimming- and NativeAOT-safe: no reflection-based serialization, no dynamic code generation. Path
   patterns compile to interpreted regular expressions; the one compile-time-constant pattern uses
-  the `[GeneratedRegex]` source generator.
+  the `[GeneratedRegex]` source generator. History state marshals as a flat primitives-only payload.
 - Design rationale, the ranking model, and the deliberate C#/WASM divergences from vue-router:
   [DESIGN.md](DESIGN.md).

--- a/libraries/Assimalign.Viu.Router/src/Abstraction/IRouterHistory.cs
+++ b/libraries/Assimalign.Viu.Router/src/Abstraction/IRouterHistory.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The history integration behind the router: it owns the current location and its state, applies
+/// application-initiated navigations (<see cref="Push"/>/<see cref="Replace"/>), relays
+/// browser-initiated ones to listeners, and normalizes a configured base path in and out. The C#
+/// port of vue-router's <c>RouterHistory</c> interface
+/// (<c>packages/router/src/history/common.ts</c>), implemented by the memory, web (HTML5 History
+/// API), and hash modes created through <see cref="RouterHistory"/>.
+/// </summary>
+/// <remarks>
+/// Locations are the base-stripped path portion the matcher ([V01.01.08.01]) resolves — a leading
+/// <c>/</c> path plus any query and fragment. The configured <see cref="Base"/> is prepended when
+/// writing to the environment and stripped when reading back, so consumers never see it. Not
+/// thread-safe: the router targets the single-threaded JS event loop.
+/// </remarks>
+public interface IRouterHistory
+{
+    /// <summary>
+    /// The normalized base path prepended to every location written to the environment and stripped
+    /// from every location read back. Mirrors <c>RouterHistory.base</c> — leading-slash-forced and
+    /// trailing-slash-trimmed (an empty string means "no base").
+    /// </summary>
+    string Base { get; }
+
+    /// <summary>
+    /// The current base-stripped location. Mirrors <c>RouterHistory.location</c>. Updated
+    /// synchronously by <see cref="Push"/>/<see cref="Replace"/> and by browser back/forward before
+    /// listeners fire.
+    /// </summary>
+    string Location { get; }
+
+    /// <summary>
+    /// The state of the current entry (position counter, adjacency, scroll anchor). Mirrors
+    /// <c>RouterHistory.state</c>.
+    /// </summary>
+    RouterHistoryState State { get; }
+
+    /// <summary>
+    /// Pushes a new entry for <paramref name="location"/>, making it current and advancing the
+    /// position counter. Mirrors <c>RouterHistory.push</c> (<c>history.pushState</c> in web mode).
+    /// </summary>
+    /// <param name="location">The base-stripped location to navigate to.</param>
+    /// <param name="data">Optional extra state to merge onto the new entry, or <see langword="null"/>.</param>
+    void Push(string location, RouterHistoryState? data = null);
+
+    /// <summary>
+    /// Replaces the current entry with one for <paramref name="location"/>, preserving the position
+    /// counter. Mirrors <c>RouterHistory.replace</c> (<c>history.replaceState</c> in web mode).
+    /// </summary>
+    /// <param name="location">The base-stripped location to navigate to.</param>
+    /// <param name="data">Optional extra state to merge onto the entry, or <see langword="null"/>.</param>
+    void Replace(string location, RouterHistoryState? data = null);
+
+    /// <summary>
+    /// Moves through history by <paramref name="delta"/> entries (negative is backward). Mirrors
+    /// <c>RouterHistory.go</c> (<c>history.go</c> in web mode). When
+    /// <paramref name="triggerListeners"/> is <see langword="false"/>, the resulting navigation does
+    /// not notify listeners — used by the router to reposition history silently.
+    /// </summary>
+    /// <param name="delta">The signed number of entries to move.</param>
+    /// <param name="triggerListeners">Whether the resulting navigation notifies listeners.</param>
+    void Go(int delta, bool triggerListeners = true);
+
+    /// <summary>
+    /// Registers a listener for browser-initiated navigations (back/forward, memory <c>go</c>).
+    /// Mirrors <c>RouterHistory.listen</c> and returns an idempotent unsubscribe delegate.
+    /// </summary>
+    /// <param name="callback">The listener to register.</param>
+    /// <returns>A delegate that removes <paramref name="callback"/> when invoked.</returns>
+    Action Listen(NavigationCallback callback);
+
+    /// <summary>
+    /// Builds a value suitable for an anchor's <c>href</c> for <paramref name="location"/>, prefixing
+    /// the base (and reducing it to the leading <c>#</c> fragment in hash mode). Mirrors
+    /// <c>RouterHistory.createHref</c>.
+    /// </summary>
+    /// <param name="location">The base-stripped location.</param>
+    string CreateHref(string location);
+
+    /// <summary>
+    /// Tears the history down: removes every registered listener and, in web/hash mode, unsubscribes
+    /// the underlying <c>popstate</c> handler so no interop listener leaks. Mirrors
+    /// <c>RouterHistory.destroy</c>.
+    /// </summary>
+    void Destroy();
+}

--- a/libraries/Assimalign.Viu.Router/src/Assimalign.Viu.Router.csproj
+++ b/libraries/Assimalign.Viu.Router/src/Assimalign.Viu.Router.csproj
@@ -2,5 +2,9 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Required by the [JSImport]/[JSExport] interop source generator (SYSLIB1074) for the
+         browser history edge (Internal/JavaScriptBrowserHistoryInterop, BrowserHistoryInteropDispatch);
+         the memory history and the whole matcher stay interop-free. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/libraries/Assimalign.Viu.Router/src/Delegates/NavigationCallback.cs
+++ b/libraries/Assimalign.Viu.Router/src/Delegates/NavigationCallback.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// A listener invoked when the history location changes outside an application-initiated
+/// <see cref="IRouterHistory.Push"/>/<see cref="IRouterHistory.Replace"/> — a browser back/forward
+/// (<c>popstate</c>) or a memory <see cref="IRouterHistory.Go"/>. The C# port of vue-router's
+/// <c>NavigationCallback</c> (<c>packages/router/src/history/common.ts</c>); the navigation
+/// pipeline ([V01.01.08.04]) registers one to drive resolution and guards on browser navigation.
+/// </summary>
+/// <param name="to">The location navigated to (base already stripped).</param>
+/// <param name="from">The location navigated from.</param>
+/// <param name="information">The navigation type, direction, and signed distance.</param>
+public delegate void NavigationCallback(string to, string from, NavigationInformation information);

--- a/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistoryInteropDispatch.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistoryInteropDispatch.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The single <c>[JSExport]</c> entry a browser <c>popstate</c> calls back into (the history
+/// analogue of <c>BrowserEventDispatch</c>): the one JS listener per history instance forwards the
+/// arrived entry's location and state as flat primitives in this one call, and the dispatch routes
+/// it — by the subscription id issued at <see cref="Register"/> — to that instance's handler. Keying
+/// on an id (rather than a single ambient handler) lets many histories coexist and lets
+/// <see cref="Unregister"/> drop a torn-down one so no handler leaks across instances (test hosts
+/// create many). Single-threaded by design — invoked only on the JS event loop.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static partial class BrowserHistoryInteropDispatch
+{
+    private static readonly Dictionary<int, Action<BrowserHistorySnapshot>> Handlers = [];
+    private static int nextSubscriptionId = 1;
+
+    /// <summary>Registers a popstate handler and returns its subscription id.</summary>
+    /// <param name="handler">The policy's popstate handler.</param>
+    internal static int Register(Action<BrowserHistorySnapshot> handler)
+    {
+        var id = nextSubscriptionId++;
+        Handlers[id] = handler;
+        return id;
+    }
+
+    /// <summary>Drops a subscription so its handler is never invoked again.</summary>
+    /// <param name="subscriptionId">The id returned by <see cref="Register"/>.</param>
+    internal static void Unregister(int subscriptionId)
+        => Handlers.Remove(subscriptionId);
+
+    /// <summary>
+    /// The <c>[JSExport]</c> the JS <c>popstate</c> listener invokes with the arrived entry's raw
+    /// location components and state as primitives (no <c>JSObject</c> reads, no per-property calls).
+    /// </summary>
+    [JSExport]
+    internal static void DispatchPopState(
+        int subscriptionId,
+        string pathname,
+        string search,
+        string hash,
+        string host,
+        int historyLength,
+        bool hasState,
+        string? back,
+        string current,
+        string? forward,
+        bool replaced,
+        int position,
+        bool hasScroll,
+        double scrollLeft,
+        double scrollTop)
+    {
+        if (!Handlers.TryGetValue(subscriptionId, out var handler))
+        {
+            return;
+        }
+        var state = hasState
+            ? new RouterHistoryState(
+                Back: back,
+                Current: current,
+                Forward: forward,
+                Replaced: replaced,
+                Position: position,
+                Scroll: hasScroll ? new ScrollPosition(scrollLeft, scrollTop) : null)
+            : null;
+        handler(new BrowserHistorySnapshot(pathname, search, hash, host, historyLength, state));
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistorySnapshot.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistorySnapshot.cs
@@ -1,0 +1,29 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// One batched read of the browser environment: the raw <c>location</c> components plus the current
+/// entry's state, gathered in a single interop crossing so the web history never issues chatty
+/// per-property getters (the [V01.01.08.02] batched-read criterion). Also the shape the
+/// <c>popstate</c> dispatch reconstructs for a browser back/forward.
+/// </summary>
+/// <remarks>
+/// The raw components mirror the <c>Location</c> fields vue-router's <c>createCurrentLocation</c>
+/// reads (<c>packages/router/src/history/html5.ts</c>); the policy strips the base off them itself
+/// (<see cref="HistoryPathNormalization.CreateCurrentLocation"/>) rather than doing it JS-side.
+/// </remarks>
+/// <param name="Pathname">The raw <c>location.pathname</c>.</param>
+/// <param name="Search">The raw <c>location.search</c> (with any leading <c>?</c>).</param>
+/// <param name="Hash">The raw <c>location.hash</c> (with any leading <c>#</c>).</param>
+/// <param name="Host">The raw <c>location.host</c> (empty for a <c>file://</c> URL) — used for hash-base defaulting.</param>
+/// <param name="HistoryLength">The current <c>window.history.length</c>, used to seed the initial position.</param>
+/// <param name="State">
+/// The current entry's state, or <see langword="null"/> when the environment had no Viu-written state
+/// (a fresh entry, or one created before the history was constructed).
+/// </param>
+internal readonly record struct BrowserHistorySnapshot(
+    string Pathname,
+    string Search,
+    string Hash,
+    string Host,
+    int HistoryLength,
+    RouterHistoryState? State);

--- a/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistorySnapshotMarshaller.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/BrowserHistorySnapshotMarshaller.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Globalization;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// Decodes the flat, primitives-only array a single batched read returns from the JS edge into a
+/// <see cref="BrowserHistorySnapshot"/>. Isolating the wire format here (rather than inside the
+/// browser-only interop) keeps the state round-trip — the [V01.01.08.02] position/scroll criterion —
+/// unit-testable in a plain .NET host with a hand-built array standing in for the JS payload.
+/// </summary>
+/// <remarks>
+/// The payload is a single <c>string[]</c> (one interop crossing, no per-property getters): raw
+/// <c>location</c> components, a history length, then the current entry's state. A <see langword="null"/>
+/// link (<c>back</c>/<c>forward</c>) and an absent state or scroll are encoded as an empty string plus
+/// a boolean flag, so the array never carries a null element to marshal.
+/// </remarks>
+internal static class BrowserHistorySnapshotMarshaller
+{
+    /// <summary>The number of slots in the flat snapshot array.</summary>
+    internal const int FieldCount = 14;
+
+    private const int PathnameIndex = 0;
+    private const int SearchIndex = 1;
+    private const int HashIndex = 2;
+    private const int HostIndex = 3;
+    private const int HistoryLengthIndex = 4;
+    private const int HasStateIndex = 5;
+    private const int BackIndex = 6;
+    private const int CurrentIndex = 7;
+    private const int ForwardIndex = 8;
+    private const int ReplacedIndex = 9;
+    private const int PositionIndex = 10;
+    private const int HasScrollIndex = 11;
+    private const int ScrollLeftIndex = 12;
+    private const int ScrollTopIndex = 13;
+
+    /// <summary>
+    /// Decodes a batched-read payload. An empty <c>back</c>/<c>forward</c> slot decodes to
+    /// <see langword="null"/>; a false <c>hasState</c> flag yields a snapshot with no state.
+    /// </summary>
+    /// <param name="raw">The flat array from <c>history.readSnapshot()</c> (length <see cref="FieldCount"/>).</param>
+    /// <exception cref="ArgumentException"><paramref name="raw"/> has the wrong length.</exception>
+    internal static BrowserHistorySnapshot Decode(string[] raw)
+    {
+        ArgumentNullException.ThrowIfNull(raw);
+        if (raw.Length != FieldCount)
+        {
+            throw new ArgumentException(
+                $"History snapshot payload must have {FieldCount} fields but had {raw.Length}.",
+                nameof(raw));
+        }
+
+        var state = DecodeFlag(raw[HasStateIndex])
+            ? new RouterHistoryState(
+                Back: EmptyToNull(raw[BackIndex]),
+                Current: raw[CurrentIndex],
+                Forward: EmptyToNull(raw[ForwardIndex]),
+                Replaced: DecodeFlag(raw[ReplacedIndex]),
+                Position: DecodeInteger(raw[PositionIndex]),
+                Scroll: DecodeFlag(raw[HasScrollIndex])
+                    ? new ScrollPosition(DecodeDouble(raw[ScrollLeftIndex]), DecodeDouble(raw[ScrollTopIndex]))
+                    : null)
+            : null;
+
+        return new BrowserHistorySnapshot(
+            Pathname: raw[PathnameIndex],
+            Search: raw[SearchIndex],
+            Hash: raw[HashIndex],
+            Host: raw[HostIndex],
+            HistoryLength: DecodeInteger(raw[HistoryLengthIndex]),
+            State: state);
+    }
+
+    private static string? EmptyToNull(string value)
+        => value.Length == 0 ? null : value;
+
+    private static bool DecodeFlag(string value)
+        => value == "1";
+
+    private static int DecodeInteger(string value)
+        => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result) ? result : 0;
+
+    private static double DecodeDouble(string value)
+        => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result) ? result : 0d;
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/BrowserRouterHistory.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/BrowserRouterHistory.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The browser history <em>policy</em>: it owns the current location and state, composes URLs from
+/// the configured base, runs the push/replace/popstate state machine, and books navigation
+/// listeners — all without touching the DOM. Every environment effect is delegated to an injected
+/// <see cref="IBrowserHistoryInterop"/>. The C# port of vue-router's <c>useHistoryStateNavigation</c>
+/// and <c>useHistoryListeners</c> composed by <c>createWebHistory</c>
+/// (<c>packages/router/src/history/html5.ts</c>). Web and hash modes share this class; they differ
+/// only in the base handed to it (a hash base carries a <c>#</c>), exactly as
+/// <c>createWebHashHistory</c> just forwards a hash base to <c>createWebHistory</c>.
+/// </summary>
+/// <remarks>
+/// Because the browser edge is an injected seam, the whole policy — base prepend/strip, the state
+/// round-trip, the <c>popstate</c> delta/direction computation, listener bookkeeping, and the
+/// single-crossing batched reads/writes — is unit-testable with a fake interop and no browser. Not
+/// thread-safe (single-threaded JS event-loop model).
+/// </remarks>
+internal sealed class BrowserRouterHistory : IRouterHistory
+{
+    private readonly IBrowserHistoryInterop interop;
+    private readonly List<NavigationCallback> listeners = [];
+
+    private string currentLocation;
+    private RouterHistoryState currentState;
+    // Upstream pauseState: the location a silent go() is leaving, so its popstate is swallowed.
+    private string? pausedLocation;
+
+    internal BrowserRouterHistory(IBrowserHistoryInterop interop, string normalizedBase)
+    {
+        this.interop = interop;
+        Base = normalizedBase;
+
+        var snapshot = interop.ReadSnapshot();
+        currentLocation = HistoryPathNormalization.CreateCurrentLocation(
+            Base, snapshot.Pathname, snapshot.Search, snapshot.Hash);
+
+        if (snapshot.State is { } existingState)
+        {
+            currentState = existingState;
+        }
+        else
+        {
+            // Fresh navigation with no prior state: seed the current entry (upstream seeds
+            // position = history.length - 1 and replaces the entry in place).
+            currentState = RouterHistoryStateBuilder.BuildInitial(currentLocation, snapshot.HistoryLength - 1);
+            interop.Replace(BuildUrl(currentLocation), currentState);
+        }
+
+        // One popstate listener per history instance; torn down in Destroy.
+        interop.Subscribe(OnPopState);
+    }
+
+    /// <inheritdoc/>
+    public string Base { get; }
+
+    /// <inheritdoc/>
+    public string Location => currentLocation;
+
+    /// <inheritdoc/>
+    public RouterHistoryState State => currentState;
+
+    /// <inheritdoc/>
+    public void Push(string location, RouterHistoryState? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        // Rewrite the leaving entry to point forward at `location` (the interop fills its live scroll
+        // anchor), then push the new entry — both in a single interop crossing.
+        var amendedCurrent = currentState with { Forward = location, Scroll = null };
+        var newState = RouterHistoryStateBuilder.BuildForPush(currentState, location, data?.Scroll);
+        interop.Push(BuildUrl(currentLocation), amendedCurrent, BuildUrl(location), newState);
+        currentState = newState;
+        currentLocation = location;
+    }
+
+    /// <inheritdoc/>
+    public void Replace(string location, RouterHistoryState? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        var newState = RouterHistoryStateBuilder.BuildForReplace(currentState, location, data?.Scroll);
+        interop.Replace(BuildUrl(location), newState);
+        currentState = newState;
+        currentLocation = location;
+    }
+
+    /// <inheritdoc/>
+    public void Go(int delta, bool triggerListeners = true)
+    {
+        if (!triggerListeners)
+        {
+            // Swallow the popstate this go() will provoke (upstream pauseListeners()).
+            pausedLocation = currentLocation;
+        }
+        interop.Go(delta);
+    }
+
+    /// <inheritdoc/>
+    public Action Listen(NavigationCallback callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        listeners.Add(callback);
+        return () => listeners.Remove(callback);
+    }
+
+    /// <inheritdoc/>
+    public string CreateHref(string location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        return HistoryPathNormalization.CreateHref(Base, location);
+    }
+
+    /// <inheritdoc/>
+    public void Destroy()
+    {
+        listeners.Clear();
+        interop.Unsubscribe();
+    }
+
+    // The popstate handler (upstream popStateHandler): reconcile the arrived entry, honour a paused
+    // silent go, compute the signed delta from the position counters, then notify listeners.
+    private void OnPopState(BrowserHistorySnapshot snapshot)
+    {
+        var to = HistoryPathNormalization.CreateCurrentLocation(
+            Base, snapshot.Pathname, snapshot.Search, snapshot.Hash);
+        var from = currentLocation;
+        var fromState = currentState;
+
+        var delta = 0;
+        if (snapshot.State is { } arrivedState)
+        {
+            currentLocation = to;
+            currentState = arrivedState;
+            if (pausedLocation is not null && string.Equals(pausedLocation, from, StringComparison.Ordinal))
+            {
+                // A silent go(delta, triggerListeners: false) — state is reconciled, listeners are not.
+                pausedLocation = null;
+                return;
+            }
+            delta = arrivedState.Position - fromState.Position;
+        }
+        else
+        {
+            // An entry with no Viu state (created before this history, or a bare hash change):
+            // synthesize one in place so subsequent navigations have a position to count from.
+            Replace(to);
+        }
+
+        NotifyListeners(to, from, delta);
+    }
+
+    private void NotifyListeners(string to, string from, int delta)
+    {
+        var direction = delta > 0
+            ? NavigationDirection.Forward
+            : delta < 0
+                ? NavigationDirection.Back
+                : NavigationDirection.Unknown;
+        var information = new NavigationInformation(NavigationType.Pop, direction, delta);
+        // Snapshot so a listener that unsubscribes mid-notification does not disturb iteration.
+        foreach (var callback in listeners.ToArray())
+        {
+            callback(to, from, information);
+        }
+    }
+
+    // Compose the URL written to the environment: root-relative `base + location` for web mode, or
+    // the `#…` fragment slice for hash mode (upstream changeLocation's non-<base>-element branch).
+    private string BuildUrl(string location)
+    {
+        var hashIndex = Base.IndexOf('#');
+        return hashIndex >= 0 ? Base[hashIndex..] + location : Base + location;
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/HistoryPathNormalization.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/HistoryPathNormalization.cs
@@ -1,0 +1,168 @@
+using System;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The pure base-path arithmetic shared by the web and hash histories: normalize a configured base,
+/// strip it off a read location, prepend it (or reduce it to the leading <c>#</c>) for an
+/// <c>href</c>, compute the hash-mode base, and derive the current base-stripped location from raw
+/// URL components. The C# port of vue-router's <c>normalizeBase</c>/<c>stripBase</c>/<c>createHref</c>
+/// (<c>packages/router/src/history/common.ts</c>, <c>location.ts</c>) and the
+/// <c>createCurrentLocation</c>/hash-base logic of <c>html5.ts</c>/<c>hash.ts</c>.
+/// </summary>
+/// <remarks>
+/// Every method is a total function of its string inputs — no DOM, no interop — so base handling is
+/// unit-testable in a plain .NET host. The browser edge supplies the raw URL components
+/// (<c>location.pathname</c>/<c>search</c>/<c>hash</c>/<c>host</c>) and this class does the policy.
+/// </remarks>
+internal static class HistoryPathNormalization
+{
+    /// <summary>
+    /// Removes a single trailing <c>/</c>. The C# port of upstream's
+    /// <c>removeTrailingSlash = path =&gt; path.replace(/\/$/, '')</c>.
+    /// </summary>
+    internal static string RemoveTrailingSlash(string path)
+        => path.Length > 0 && path[^1] == '/' ? path[..^1] : path;
+
+    /// <summary>
+    /// Normalizes a configured base: defaults an empty base to <c>"/"</c>, forces a leading <c>/</c>
+    /// unless it already starts with <c>/</c> or <c>#</c>, then trims a trailing slash — so
+    /// <c>"/app/"</c> and <c>"app"</c> both become <c>"/app"</c> and <c>"/"</c> becomes <c>""</c>
+    /// (the "no base" sentinel). The C# port of <c>normalizeBase</c>; the browser <c>&lt;base&gt;</c>
+    /// href default is resolved by the caller (see <see cref="StripBaseHrefOrigin"/>) before this.
+    /// </summary>
+    /// <param name="rawBase">The configured base, or <see langword="null"/>/empty for the default.</param>
+    internal static string NormalizeBase(string? rawBase)
+    {
+        var value = string.IsNullOrEmpty(rawBase) ? "/" : rawBase;
+        if (value[0] != '/' && value[0] != '#')
+        {
+            value = "/" + value;
+        }
+        return RemoveTrailingSlash(value);
+    }
+
+    /// <summary>
+    /// Strips a leading <c>scheme://host</c> from a <c>&lt;base href&gt;</c> so only the path portion
+    /// remains. The reflection-free C# port of upstream's <c>base.replace(/^\w+:\/\/[^/]+/, '')</c>
+    /// applied to the document base element's href default.
+    /// </summary>
+    /// <param name="href">The raw <c>&lt;base&gt;</c> href.</param>
+    internal static string StripBaseHrefOrigin(string href)
+    {
+        var schemeIndex = href.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIndex <= 0 || !IsScheme(href.AsSpan(0, schemeIndex)))
+        {
+            return href;
+        }
+        var hostStart = schemeIndex + 3;
+        var pathSlash = href.IndexOf('/', hostStart);
+        return pathSlash >= 0 ? href[pathSlash..] : string.Empty;
+    }
+
+    /// <summary>
+    /// Strips the base off the beginning of a read pathname, case-insensitively, collapsing an
+    /// exact-base match to <c>"/"</c>. The C# port of <c>stripBase</c>
+    /// (<c>packages/router/src/location.ts</c>).
+    /// </summary>
+    /// <param name="pathname">The raw <c>location.pathname</c>.</param>
+    /// <param name="base">The normalized base (empty means "no base").</param>
+    internal static string StripBase(string pathname, string @base)
+    {
+        if (string.IsNullOrEmpty(@base)
+            || !pathname.StartsWith(@base, StringComparison.OrdinalIgnoreCase))
+        {
+            return pathname;
+        }
+        var stripped = pathname[@base.Length..];
+        return stripped.Length == 0 ? "/" : stripped;
+    }
+
+    /// <summary>
+    /// Builds an <c>href</c> value: <c>base + location</c> for a plain base, or (when the base carries
+    /// a <c>#</c> after at least one leading character, i.e. hash mode) the leading <c>#</c> plus the
+    /// location. The C# port of <c>createHref</c> and its <c>BEFORE_HASH_RE</c> = <c>/^[^#]+#/</c>
+    /// replacement (<c>packages/router/src/history/common.ts</c>).
+    /// </summary>
+    /// <param name="base">The normalized base.</param>
+    /// <param name="location">The base-stripped location.</param>
+    internal static string CreateHref(string @base, string location)
+    {
+        // BEFORE_HASH_RE requires >= 1 non-'#' char before the first '#'; only then is everything up
+        // to and including that '#' collapsed to a single '#'. A leading '#' (index 0) or no '#'
+        // leaves the base verbatim.
+        var hashIndex = @base.IndexOf('#');
+        var prefix = hashIndex > 0 ? "#" : @base;
+        return prefix + location;
+    }
+
+    /// <summary>
+    /// Computes the hash-mode base from the current URL: the provided base (or
+    /// <c>pathname + search</c>) when a host is present, or empty for a hostless <c>file://</c> URL,
+    /// with a <c>#</c> appended if absent. The C# port of the base computation in
+    /// <c>createWebHashHistory</c> (<c>packages/router/src/history/hash.ts</c>); the result is then
+    /// passed through <see cref="NormalizeBase"/> exactly as upstream forwards it to
+    /// <c>createWebHistory</c>.
+    /// </summary>
+    /// <param name="providedBase">The caller-supplied base, or <see langword="null"/>.</param>
+    /// <param name="host">The raw <c>location.host</c> (empty for <c>file://</c>).</param>
+    /// <param name="pathname">The raw <c>location.pathname</c>.</param>
+    /// <param name="search">The raw <c>location.search</c>.</param>
+    internal static string ComputeHashBase(string? providedBase, string host, string pathname, string search)
+    {
+        string result;
+        if (!string.IsNullOrEmpty(host))
+        {
+            result = string.IsNullOrEmpty(providedBase) ? pathname + search : providedBase;
+        }
+        else
+        {
+            result = string.Empty;
+        }
+        if (!result.Contains('#', StringComparison.Ordinal))
+        {
+            result += "#";
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Derives the current base-stripped location from raw URL components. In hash mode (base carries
+    /// a <c>#</c>) the location is the portion of the fragment after the hash-base, forced to a
+    /// leading <c>/</c>; otherwise it is <c>stripBase(pathname) + search + hash</c>. The C# port of
+    /// <c>createCurrentLocation</c> (<c>packages/router/src/history/html5.ts</c>).
+    /// </summary>
+    /// <param name="base">The normalized base.</param>
+    /// <param name="pathname">The raw <c>location.pathname</c>.</param>
+    /// <param name="search">The raw <c>location.search</c> (including a leading <c>?</c> when present).</param>
+    /// <param name="hash">The raw <c>location.hash</c> (including a leading <c>#</c> when present).</param>
+    internal static string CreateCurrentLocation(string @base, string pathname, string search, string hash)
+    {
+        var hashPosition = @base.IndexOf('#');
+        if (hashPosition >= 0)
+        {
+            var hashBase = @base[hashPosition..];
+            var slicePosition = hash.Contains(hashBase, StringComparison.Ordinal) ? hashBase.Length : 1;
+            var pathFromHash = hash.Length > slicePosition ? hash[slicePosition..] : string.Empty;
+            if (pathFromHash.Length == 0 || pathFromHash[0] != '/')
+            {
+                pathFromHash = "/" + pathFromHash;
+            }
+            // Upstream returns stripBase(pathFromHash, '') — an empty base strips nothing.
+            return pathFromHash;
+        }
+        return StripBase(pathname, @base) + search + hash;
+    }
+
+    private static bool IsScheme(ReadOnlySpan<char> value)
+    {
+        foreach (var character in value)
+        {
+            if (!char.IsLetterOrDigit(character))
+            {
+                return false;
+            }
+        }
+        return value.Length > 0;
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/IBrowserHistoryInterop.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/IBrowserHistoryInterop.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The thin interop edge the web/hash history policy drives — the only surface that ever touches the
+/// browser. Each method is a single interop crossing carrying flat primitives; the DOM-free policy
+/// (<see cref="BrowserRouterHistory"/>) computes every URL and <see cref="RouterHistoryState"/> and
+/// hands them here to apply. Modeling the edge as an injected seam (mirroring
+/// <c>BrowserEventInvokerRegistry</c>'s recorded bridge delegates) lets the policy — base handling,
+/// state round-trip, listener bookkeeping, interop-call counting — be unit-tested with a fake
+/// implementation and no browser; the real implementation is
+/// <see cref="JavaScriptBrowserHistoryInterop"/>.
+/// </summary>
+internal interface IBrowserHistoryInterop
+{
+    /// <summary>
+    /// Reads the raw <c>location</c> components and the current entry's state in one interop crossing
+    /// (the batched read). Ports the reads <c>createCurrentLocation</c> and the state bootstrap make.
+    /// </summary>
+    BrowserHistorySnapshot ReadSnapshot();
+
+    /// <summary>
+    /// Reads the document <c>&lt;base&gt;</c> element's href (origin already stripped), or
+    /// <see langword="null"/> when there is none — the web-mode default when no base is configured.
+    /// Called at most once, at construction. Ports the <c>&lt;base&gt;</c> read in <c>normalizeBase</c>.
+    /// </summary>
+    string? ReadBaseHref();
+
+    /// <summary>
+    /// Applies a push in one interop crossing: <c>replaceState(amendedCurrentState)</c> on
+    /// <paramref name="currentUrl"/> (recording the leaving entry's live <c>window.scrollX/Y</c> as
+    /// its scroll anchor) followed by <c>pushState(newState)</c> on <paramref name="toUrl"/>. Ports
+    /// the two <c>changeLocation</c> calls of <c>useHistoryStateNavigation.push</c>.
+    /// </summary>
+    /// <param name="currentUrl">The absolute URL of the leaving entry (base already prepended).</param>
+    /// <param name="amendedCurrentState">The leaving entry's rewritten state (its scroll is filled from the live scroll).</param>
+    /// <param name="toUrl">The absolute URL of the new entry.</param>
+    /// <param name="newState">The new entry's state.</param>
+    void Push(string currentUrl, RouterHistoryState amendedCurrentState, string toUrl, RouterHistoryState newState);
+
+    /// <summary>
+    /// Applies a replace in one interop crossing: <c>replaceState(newState)</c> on
+    /// <paramref name="toUrl"/>. Ports the single <c>changeLocation</c> of
+    /// <c>useHistoryStateNavigation.replace</c>.
+    /// </summary>
+    /// <param name="toUrl">The absolute URL of the entry (base already prepended).</param>
+    /// <param name="newState">The entry's state.</param>
+    void Replace(string toUrl, RouterHistoryState newState);
+
+    /// <summary>Moves through browser history by <paramref name="delta"/> entries (<c>history.go</c>).</summary>
+    /// <param name="delta">The signed number of entries to move.</param>
+    void Go(int delta);
+
+    /// <summary>
+    /// Subscribes <paramref name="onPopState"/> to the browser <c>popstate</c> event, attaching
+    /// exactly one JS listener. The listener reconstructs a <see cref="BrowserHistorySnapshot"/> for
+    /// the arrived entry and invokes the callback. Called once per history instance.
+    /// </summary>
+    /// <param name="onPopState">The policy's popstate handler.</param>
+    void Subscribe(Action<BrowserHistorySnapshot> onPopState);
+
+    /// <summary>
+    /// Removes the <c>popstate</c> listener attached by <see cref="Subscribe"/>. Must be called on
+    /// teardown so no interop listener leaks across history instances (test hosts create many).
+    /// </summary>
+    void Unsubscribe();
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/JavaScriptBrowserHistoryInterop.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/JavaScriptBrowserHistoryInterop.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The real browser edge of the history: the <c>[JSImport]</c> bindings to this package's
+/// <c>viu-history.js</c> module. It is a thin flattener — the DOM-free policy
+/// (<see cref="BrowserRouterHistory"/>) computes every URL and <see cref="RouterHistoryState"/>, and
+/// this class marshals them into flat, primitives-only interop crossings (no object-graph
+/// marshaling): a null <c>back</c>/<c>forward</c> link and an absent scroll are encoded as an empty
+/// string / <see langword="false"/> flag rather than a null. Mirrors the
+/// <c>BrowserDomBridge</c>/<c>viu-dom.js</c> pattern of <c>Assimalign.Viu.RuntimeDom</c>.
+/// Single-threaded by design — never call off the main WASM thread.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal sealed partial class JavaScriptBrowserHistoryInterop : IBrowserHistoryInterop
+{
+    /// <summary>The JS module name; doubles as the assembly key for <c>getAssemblyExports</c>.</summary>
+    internal const string ModuleName = "Assimalign.Viu.Router";
+
+    // 0 is the "not subscribed" sentinel (dispatch ids start at 1).
+    private int subscriptionId;
+
+    internal static Task InitializeModuleAsync()
+        => Imports.Initialize();
+
+    /// <inheritdoc/>
+    public BrowserHistorySnapshot ReadSnapshot()
+        => BrowserHistorySnapshotMarshaller.Decode(Imports.ReadSnapshot());
+
+    /// <inheritdoc/>
+    public string? ReadBaseHref()
+    {
+        var href = Imports.ReadBaseHref();
+        return string.IsNullOrEmpty(href) ? null : href;
+    }
+
+    /// <inheritdoc/>
+    public void Push(string currentUrl, RouterHistoryState amendedCurrentState, string toUrl, RouterHistoryState newState)
+        => Imports.Push(
+            currentUrl,
+            amendedCurrentState.Back ?? string.Empty,
+            amendedCurrentState.Current,
+            amendedCurrentState.Forward ?? string.Empty,
+            amendedCurrentState.Replaced,
+            amendedCurrentState.Position,
+            toUrl,
+            newState.Back ?? string.Empty,
+            newState.Current,
+            newState.Forward ?? string.Empty,
+            newState.Replaced,
+            newState.Position,
+            newState.Scroll.HasValue,
+            newState.Scroll?.Left ?? 0d,
+            newState.Scroll?.Top ?? 0d);
+
+    /// <inheritdoc/>
+    public void Replace(string toUrl, RouterHistoryState newState)
+        => Imports.Replace(
+            toUrl,
+            newState.Back ?? string.Empty,
+            newState.Current,
+            newState.Forward ?? string.Empty,
+            newState.Replaced,
+            newState.Position,
+            newState.Scroll.HasValue,
+            newState.Scroll?.Left ?? 0d,
+            newState.Scroll?.Top ?? 0d);
+
+    /// <inheritdoc/>
+    public void Go(int delta)
+        => Imports.Go(delta);
+
+    /// <inheritdoc/>
+    public void Subscribe(Action<BrowserHistorySnapshot> onPopState)
+    {
+        subscriptionId = BrowserHistoryInteropDispatch.Register(onPopState);
+        Imports.Subscribe(subscriptionId);
+    }
+
+    /// <inheritdoc/>
+    public void Unsubscribe()
+    {
+        if (subscriptionId == 0)
+        {
+            return;
+        }
+        Imports.Unsubscribe(subscriptionId);
+        BrowserHistoryInteropDispatch.Unregister(subscriptionId);
+        subscriptionId = 0;
+    }
+
+    // --- raw imports (module: Assimalign.Viu.Router -> wwwroot/viu-history.js) --------------------
+
+    private static partial class Imports
+    {
+        [JSImport("history.readSnapshot", ModuleName)]
+        [return: JSMarshalAs<JSType.Array<JSType.String>>]
+        internal static partial string[] ReadSnapshot();
+
+        [JSImport("history.readBaseHref", ModuleName)]
+        internal static partial string? ReadBaseHref();
+
+        [JSImport("history.push", ModuleName)]
+        internal static partial void Push(
+            string currentUrl,
+            string amendedBack,
+            string amendedCurrent,
+            string amendedForward,
+            bool amendedReplaced,
+            int amendedPosition,
+            string toUrl,
+            string newBack,
+            string newCurrent,
+            string newForward,
+            bool newReplaced,
+            int newPosition,
+            bool newHasScroll,
+            double newScrollLeft,
+            double newScrollTop);
+
+        [JSImport("history.replace", ModuleName)]
+        internal static partial void Replace(
+            string url,
+            string back,
+            string current,
+            string forward,
+            bool replaced,
+            int position,
+            bool hasScroll,
+            double scrollLeft,
+            double scrollTop);
+
+        [JSImport("history.go", ModuleName)]
+        internal static partial void Go(int delta);
+
+        [JSImport("history.subscribe", ModuleName)]
+        internal static partial void Subscribe(int subscriptionId);
+
+        [JSImport("history.unsubscribe", ModuleName)]
+        internal static partial void Unsubscribe(int subscriptionId);
+
+        [JSImport("initialize", ModuleName)]
+        [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
+        internal static partial Task Initialize();
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/MemoryRouterHistory.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/MemoryRouterHistory.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The in-memory history: a queue of entries with a movable position and no browser coupling at all.
+/// The C# port of vue-router's <c>createMemoryHistory</c>
+/// (<c>packages/router/src/history/memory.ts</c>) — the mode used for tests and non-browser hosts,
+/// and the reference model for the push/replace/go and position semantics the web history reproduces
+/// over interop.
+/// </summary>
+/// <remarks>
+/// References no interop assembly and touches no DOM. Each entry carries a full
+/// <see cref="RouterHistoryState"/> (a deliberate enrichment over upstream's empty <c>{}</c> memory
+/// state) so the monotonic position counter round-trips exactly as it does in the browser — the
+/// [V01.01.08.02] requirement that memory reproduce the same state semantics. Not thread-safe.
+/// </remarks>
+internal sealed class MemoryRouterHistory : IRouterHistory
+{
+    private const string Start = "/";
+
+    private readonly List<(string Location, RouterHistoryState State)> queue = [];
+    private readonly List<NavigationCallback> listeners = [];
+    private int position;
+
+    internal MemoryRouterHistory(string? @base)
+    {
+        Base = HistoryPathNormalization.NormalizeBase(@base);
+        Reset();
+    }
+
+    /// <inheritdoc/>
+    public string Base { get; }
+
+    /// <inheritdoc/>
+    public string Location => queue[position].Location;
+
+    /// <inheritdoc/>
+    public RouterHistoryState State => queue[position].State;
+
+    /// <inheritdoc/>
+    public void Push(string location, RouterHistoryState? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        var newState = RouterHistoryStateBuilder.BuildForPush(State, location, data?.Scroll);
+        SetLocation(location, newState);
+    }
+
+    /// <inheritdoc/>
+    public void Replace(string location, RouterHistoryState? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        // Upstream: queue.splice(position--, 1); setLocation(to) — drop the current entry and
+        // decrement, then setLocation re-adds at the same index (truncating any forward entries).
+        var newState = RouterHistoryStateBuilder.BuildForReplace(State, location, data?.Scroll);
+        queue.RemoveAt(position);
+        position--;
+        SetLocation(location, newState);
+    }
+
+    /// <inheritdoc/>
+    public void Go(int delta, bool triggerListeners = true)
+    {
+        var from = Location;
+        // Upstream treats delta === 0 as forward in abstract mode (0 does not reload as it would in
+        // the browser), so only a strictly negative delta is "back".
+        var direction = delta < 0 ? NavigationDirection.Back : NavigationDirection.Forward;
+        position = Math.Max(0, Math.Min(position + delta, queue.Count - 1));
+        if (triggerListeners)
+        {
+            NotifyListeners(Location, from, direction, delta);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Action Listen(NavigationCallback callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        listeners.Add(callback);
+        return () => listeners.Remove(callback);
+    }
+
+    /// <inheritdoc/>
+    public string CreateHref(string location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        return HistoryPathNormalization.CreateHref(Base, location);
+    }
+
+    /// <inheritdoc/>
+    public void Destroy()
+    {
+        listeners.Clear();
+        Reset();
+    }
+
+    // Upstream setLocation: position++, then append at the tip or truncate-from-here and append.
+    private void SetLocation(string location, RouterHistoryState state)
+    {
+        position++;
+        if (position < queue.Count)
+        {
+            queue.RemoveRange(position, queue.Count - position);
+        }
+        queue.Add((location, state));
+    }
+
+    private void NotifyListeners(string to, string from, NavigationDirection direction, int delta)
+    {
+        var information = new NavigationInformation(NavigationType.Pop, direction, delta);
+        // Snapshot so a listener that unsubscribes mid-notification does not disturb iteration.
+        foreach (var callback in listeners.ToArray())
+        {
+            callback(to, from, information);
+        }
+    }
+
+    private void Reset()
+    {
+        queue.Clear();
+        position = 0;
+        queue.Add((Start, RouterHistoryStateBuilder.BuildInitial(Start, position: 0)));
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/Internal/RouterHistoryStateBuilder.cs
+++ b/libraries/Assimalign.Viu.Router/src/Internal/RouterHistoryStateBuilder.cs
@@ -1,0 +1,73 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The pure state-machine arithmetic for a push/replace/bootstrap, shared by the memory and web
+/// histories: it produces the <see cref="RouterHistoryState"/> objects a navigation writes without
+/// touching the DOM or interop, so the linked-list/position semantics are unit-testable. The C# port
+/// of vue-router's <c>buildState</c> and the state assembly inside <c>useHistoryStateNavigation</c>'s
+/// <c>push</c>/<c>replace</c> (<c>packages/router/src/history/html5.ts</c>).
+/// </summary>
+/// <remarks>
+/// Position is assigned here (monotonic, +1 per push, preserved across a replace) rather than read
+/// from <c>window.history.length</c>, so the same arithmetic runs identically in memory and in the
+/// browser. The one field this layer cannot compute is the leaving entry's live scroll anchor: a
+/// browser push captures <c>window.scrollX/Y</c> at apply time (the interop edge injects it), while
+/// memory has no scroll and leaves it <see langword="null"/>.
+/// </remarks>
+internal static class RouterHistoryStateBuilder
+{
+    /// <summary>
+    /// Builds the initial state for a fresh entry that has no prior state — the C# port of the
+    /// <c>buildState(null, current, null, replaced: true, position: history.length - 1)</c> bootstrap
+    /// upstream writes when <c>history.state</c> is empty.
+    /// </summary>
+    /// <param name="current">The current location.</param>
+    /// <param name="position">The seed position (upstream: <c>history.length - 1</c>; memory: <c>0</c>).</param>
+    internal static RouterHistoryState BuildInitial(string current, int position)
+        => new(Back: null, Current: current, Forward: null, Replaced: true, Position: position, Scroll: null);
+
+    /// <summary>
+    /// Rewrites the leaving entry during a push so its <see cref="RouterHistoryState.Forward"/> points
+    /// at the pushed location (upstream amends the current entry with <c>forward: to</c> and the live
+    /// scroll before pushing the new one). The scroll anchor stays <see langword="null"/> here; the
+    /// browser interop injects <c>window.scrollX/Y</c> when it applies the replace.
+    /// </summary>
+    /// <param name="current">The state of the entry being left.</param>
+    /// <param name="to">The location being pushed.</param>
+    internal static RouterHistoryState AmendCurrentForPush(RouterHistoryState current, string to)
+        => current with { Forward = to };
+
+    /// <summary>
+    /// Builds the new entry for a push: its predecessor is the leaving location, it has no successor
+    /// yet, and its position is one past the leaving entry's. The C# port of
+    /// <c>buildState(currentLocation, to, null)</c> with <c>position: currentState.position + 1</c>.
+    /// </summary>
+    /// <param name="current">The state of the entry being left.</param>
+    /// <param name="to">The location being pushed.</param>
+    /// <param name="scrollSeed">An optional scroll anchor to seed on the new entry (from push data).</param>
+    internal static RouterHistoryState BuildForPush(RouterHistoryState current, string to, ScrollPosition? scrollSeed)
+        => new(
+            Back: current.Current,
+            Current: to,
+            Forward: null,
+            Replaced: false,
+            Position: current.Position + 1,
+            Scroll: scrollSeed);
+
+    /// <summary>
+    /// Builds the entry for a replace: it keeps the leaving entry's neighbours and position but marks
+    /// itself replaced. The C# port of <c>buildState(currentState.back, to, currentState.forward,
+    /// true)</c> pinned to <c>position: currentState.position</c>.
+    /// </summary>
+    /// <param name="current">The state of the entry being replaced.</param>
+    /// <param name="to">The replacement location.</param>
+    /// <param name="scrollSeed">An optional scroll anchor to seed on the entry (from replace data).</param>
+    internal static RouterHistoryState BuildForReplace(RouterHistoryState current, string to, ScrollPosition? scrollSeed)
+        => new(
+            Back: current.Back,
+            Current: to,
+            Forward: current.Forward,
+            Replaced: true,
+            Position: current.Position,
+            Scroll: scrollSeed);
+}

--- a/libraries/Assimalign.Viu.Router/src/NavigationDirection.cs
+++ b/libraries/Assimalign.Viu.Router/src/NavigationDirection.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The direction of a <c>popstate</c>/<c>go</c> navigation relative to the current entry, derived
+/// from the signed distance between the leaving and arriving history positions. The C# port of
+/// vue-router's <c>NavigationDirection</c> (<c>packages/router/src/history/common.ts</c>), whose
+/// string values are <c>"back"</c>, <c>"forward"</c>, and <c>""</c> (unknown).
+/// </summary>
+public enum NavigationDirection
+{
+    /// <summary>The distance could not be determined (upstream <c>NavigationDirection.unknown</c>, value <c>""</c>).</summary>
+    Unknown,
+
+    /// <summary>The navigation moved backward in history (upstream <c>NavigationDirection.back</c>).</summary>
+    Back,
+
+    /// <summary>The navigation moved forward in history (upstream <c>NavigationDirection.forward</c>).</summary>
+    Forward,
+}

--- a/libraries/Assimalign.Viu.Router/src/NavigationInformation.cs
+++ b/libraries/Assimalign.Viu.Router/src/NavigationInformation.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The metadata a history reports to its listeners for a single navigation: the initiating
+/// <see cref="Type"/>, the <see cref="Direction"/> relative to the current entry, and the signed
+/// <see cref="Delta"/> (the distance between the leaving and arriving history positions). The C#
+/// port of vue-router's <c>NavigationInformation</c>
+/// (<c>packages/router/src/history/common.ts</c>).
+/// </summary>
+/// <param name="Type">Whether the navigation was a browser pop or an application push.</param>
+/// <param name="Direction">The direction relative to the current entry.</param>
+/// <param name="Delta">
+/// The signed distance between positions (negative for backward, positive for forward, zero when
+/// unknown) — the basis for back/forward detection and scroll restoration.
+/// </param>
+public readonly record struct NavigationInformation(
+    NavigationType Type,
+    NavigationDirection Direction,
+    int Delta);

--- a/libraries/Assimalign.Viu.Router/src/NavigationType.cs
+++ b/libraries/Assimalign.Viu.Router/src/NavigationType.cs
@@ -1,0 +1,16 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// How a history navigation was initiated. The C# port of vue-router's <c>NavigationType</c>
+/// (<c>packages/router/src/history/common.ts</c>): a <see cref="Push"/> is an application-initiated
+/// <c>push</c>/<c>replace</c>, while a <see cref="Pop"/> is a browser-initiated back/forward
+/// (a <c>popstate</c>) or the memory equivalent driven by <see cref="IRouterHistory.Go"/>.
+/// </summary>
+public enum NavigationType
+{
+    /// <summary>A browser back/forward or memory <c>go</c> (upstream <c>NavigationType.pop</c>, value <c>"pop"</c>).</summary>
+    Pop,
+
+    /// <summary>An application-initiated push/replace (upstream <c>NavigationType.push</c>, value <c>"push"</c>).</summary>
+    Push,
+}

--- a/libraries/Assimalign.Viu.Router/src/RouterHistory.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouterHistory.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The factory facade for the router's history modes — the C# port of vue-router's
+/// <c>createMemoryHistory</c>, <c>createWebHistory</c>, and <c>createWebHashHistory</c>
+/// (<c>packages/router/src/history/</c>). Each returns an <see cref="IRouterHistory"/>; the memory
+/// mode is pure and needs no browser, while the web and hash modes drive the History API over
+/// interop and require <see cref="InitializeAsync"/> to have completed first.
+/// </summary>
+public static class RouterHistory
+{
+    private static Task? initialization;
+
+    /// <summary>
+    /// Loads this package's <c>viu-history.js</c> bridge module and binds the <c>popstate</c>
+    /// dispatch. Idempotent — later calls await the same initialization. Must complete before
+    /// <see cref="CreateWeb"/> or <see cref="CreateWebHash"/>. The memory mode does not need it.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the module download.</param>
+    [SupportedOSPlatform("browser")]
+    public static Task InitializeAsync(CancellationToken cancellationToken = default)
+        => initialization ??= InitializeCoreAsync(cancellationToken);
+
+    /// <summary>
+    /// Creates an in-memory history (upstream <c>createMemoryHistory</c>) — pure, interop-free, and
+    /// the mode used for tests and non-browser hosts.
+    /// </summary>
+    /// <param name="basePath">The base path, or <see langword="null"/> for none.</param>
+    public static IRouterHistory CreateMemory(string? basePath = null)
+        => new MemoryRouterHistory(basePath);
+
+    /// <summary>
+    /// Creates an HTML5 History API history (upstream <c>createWebHistory</c>): clean URLs driven by
+    /// <c>pushState</c>/<c>replaceState</c> with a <c>popstate</c> listener. When no
+    /// <paramref name="basePath"/> is given, the document <c>&lt;base&gt;</c> href (origin stripped)
+    /// or <c>"/"</c> is used.
+    /// </summary>
+    /// <param name="basePath">The base path (e.g. <c>"/app/"</c>), or <see langword="null"/> to auto-detect.</param>
+    /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
+    [SupportedOSPlatform("browser")]
+    public static IRouterHistory CreateWeb(string? basePath = null)
+    {
+        EnsureInitialized();
+        var interop = new JavaScriptBrowserHistoryInterop();
+        return new BrowserRouterHistory(interop, ResolveWebBase(interop, basePath));
+    }
+
+    /// <summary>
+    /// Creates a hash-mode history (upstream <c>createWebHashHistory</c>): the whole route lives in
+    /// <c>location.hash</c>, so navigation never triggers a server request. The base defaults from
+    /// the current <c>location.pathname</c>/<c>search</c>, with a <c>#</c> ensured.
+    /// </summary>
+    /// <param name="basePath">The base (e.g. <c>"/folder/#/app/"</c>), or <see langword="null"/> to auto-detect.</param>
+    /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
+    [SupportedOSPlatform("browser")]
+    public static IRouterHistory CreateWebHash(string? basePath = null)
+    {
+        EnsureInitialized();
+        var interop = new JavaScriptBrowserHistoryInterop();
+        return new BrowserRouterHistory(interop, ResolveHashBase(interop, basePath));
+    }
+
+    // Web base: a configured base wins; otherwise the <base> href (origin stripped) or "/".
+    // Mirrors normalizeBase's <base>-element branch. Interop-agnostic, so unit-testable with a fake.
+    internal static string ResolveWebBase(IBrowserHistoryInterop interop, string? basePath)
+    {
+        string raw;
+        if (!string.IsNullOrEmpty(basePath))
+        {
+            raw = basePath;
+        }
+        else
+        {
+            var href = interop.ReadBaseHref();
+            raw = href is null ? "/" : HistoryPathNormalization.StripBaseHrefOrigin(href);
+        }
+        return HistoryPathNormalization.NormalizeBase(raw);
+    }
+
+    // Hash base: computed from the current URL then normalized, exactly as createWebHashHistory
+    // forwards its computed base to createWebHistory. Interop-agnostic, so unit-testable with a fake.
+    internal static string ResolveHashBase(IBrowserHistoryInterop interop, string? basePath)
+    {
+        var snapshot = interop.ReadSnapshot();
+        var hashBase = HistoryPathNormalization.ComputeHashBase(
+            basePath, snapshot.Host, snapshot.Pathname, snapshot.Search);
+        return HistoryPathNormalization.NormalizeBase(hashBase);
+    }
+
+    [SupportedOSPlatform("browser")]
+    private static async Task InitializeCoreAsync(CancellationToken cancellationToken)
+    {
+        // The module ships with this package as a static web asset; consumers get it under
+        // /_content/<package id>/ (the module name doubles as the [JSImport] module key).
+        await JSHost.ImportAsync(
+            JavaScriptBrowserHistoryInterop.ModuleName,
+            "/_content/Assimalign.Viu.Router/viu-history.js",
+            cancellationToken);
+        await JavaScriptBrowserHistoryInterop.InitializeModuleAsync();
+    }
+
+    [SupportedOSPlatform("browser")]
+    private static void EnsureInitialized()
+    {
+        if (initialization is not { IsCompletedSuccessfully: true })
+        {
+            throw new InvalidOperationException(
+                "RouterHistory.InitializeAsync() must complete before creating a web or hash history.");
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Router/src/RouterHistoryState.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouterHistoryState.cs
@@ -1,0 +1,38 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// The state carried on a single history entry — a flat, primitives-only payload with no nested
+/// object graph so it round-trips cheaply across the JS-interop boundary and through the browser
+/// History API's structured-clone serialization. The C# port of vue-router's <c>StateEntry</c>
+/// (the object <c>useHistoryStateNavigation</c> writes with <c>history.pushState</c>/
+/// <c>replaceState</c>, <c>packages/router/src/history/html5.ts</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The linked-list fields (<see cref="Back"/>/<see cref="Current"/>/<see cref="Forward"/>) let the
+/// history reconstruct adjacency after a <c>popstate</c> that the application never observed, and
+/// <see cref="Position"/> is a monotonically assigned counter: comparing the arriving entry's
+/// position to the leaving entry's yields the signed navigation distance
+/// (<see cref="NavigationInformation.Delta"/>) that drives back/forward detection. Value equality
+/// (a record) so a navigation pipeline can compare and snapshot state cheaply.
+/// </para>
+/// </remarks>
+/// <param name="Back">The location of the previous entry, or <see langword="null"/> at the start of history.</param>
+/// <param name="Current">The location of this entry.</param>
+/// <param name="Forward">The location of the next entry, or <see langword="null"/> at the tip of history.</param>
+/// <param name="Replaced">Whether this entry replaced its predecessor rather than being pushed onto it.</param>
+/// <param name="Position">
+/// The entry's monotonic position counter (the basis for back/forward distance detection and scroll
+/// restoration). Mirrors the <c>position</c> field upstream seeds from <c>window.history.length</c>.
+/// </param>
+/// <param name="Scroll">
+/// The saved scroll anchor for this entry, or <see langword="null"/> when none was captured (a fresh
+/// push captures the leaving entry's scroll and seeds the arriving entry's as <see langword="null"/>).
+/// </param>
+public sealed record RouterHistoryState(
+    string? Back,
+    string Current,
+    string? Forward,
+    bool Replaced,
+    int Position,
+    ScrollPosition? Scroll);

--- a/libraries/Assimalign.Viu.Router/src/ScrollPosition.cs
+++ b/libraries/Assimalign.Viu.Router/src/ScrollPosition.cs
@@ -1,0 +1,13 @@
+namespace Assimalign.Viu.Router;
+
+/// <summary>
+/// A saved scroll anchor (document scroll offset) carried on a history entry's state so a later
+/// back/forward navigation can restore it. The C# port of the <c>scroll</c> field vue-router stores
+/// on its history state (<c>_ScrollPositionNormalized</c> in
+/// <c>packages/router/src/scrollBehavior.ts</c>, produced by <c>computeScrollPosition()</c> over
+/// <c>window.scrollX</c>/<c>window.scrollY</c>). Scroll <em>restoration</em> itself is a later
+/// Router feature ([V01.01.08.05]); this history layer only round-trips the anchor.
+/// </summary>
+/// <param name="Left">The horizontal scroll offset in CSS pixels (<c>window.scrollX</c>).</param>
+/// <param name="Top">The vertical scroll offset in CSS pixels (<c>window.scrollY</c>).</param>
+public readonly record struct ScrollPosition(double Left, double Top);

--- a/libraries/Assimalign.Viu.Router/src/wwwroot/viu-history.js
+++ b/libraries/Assimalign.Viu.Router/src/wwwroot/viu-history.js
@@ -1,0 +1,140 @@
+// The JS half of the Assimalign.Viu.Router history interop — the browser edge of vue-router's
+// HTML5/hash history (createWebHistory / useHistoryStateNavigation / useHistoryListeners:
+// https://github.com/vuejs/router/blob/main/packages/router/src/history/html5.ts).
+//
+// Contract notes:
+// - The .NET policy (BrowserRouterHistory) owns every URL and every state object; these functions
+//   are dumb appliers. The one thing the DOM owns is the live window scroll saved on the leaving
+//   entry during a push (upstream computeScrollPosition()).
+// - Reads are batched: readSnapshot() returns the whole location + state in ONE call, so .NET never
+//   issues chatty per-property getters ([V01.01.08.02]).
+// - State crosses as a flat, primitives-only payload: back/current/forward strings ('' encodes
+//   null), a replaced flag and position counter, and an optional { left, top } scroll. No object
+//   graph is marshaled.
+// - popstate is delivered through the single [JSExport] dispatch, routed by subscription id so
+//   teardown (unsubscribe) never leaks a listener across history instances.
+
+let dispatchPopState = null            // the single [JSExport] popstate dispatch
+const popstateListeners = new Map()    // subscription id -> popstate handler
+
+// Upstream computeScrollPosition(): the document scroll offset recorded on the leaving entry.
+function computeScroll() {
+    return { left: window.scrollX, top: window.scrollY }
+}
+
+// Reconstruct the flat primitives into the object the History API stores. '' decodes back to null
+// so the round-tripped state matches the .NET RouterHistoryState exactly.
+function buildStateObject(back, current, forward, replaced, position, scroll) {
+    return {
+        back: back.length ? back : null,
+        current: current,
+        forward: forward.length ? forward : null,
+        replaced: replaced,
+        position: position,
+        scroll: scroll
+    }
+}
+
+export async function initialize() {
+    // Bind the single .NET popstate dispatch ([V01.01.08.02]): one JSExport carries the arrived
+    // entry's location + state as primitives and routes by subscription id.
+    const { getAssemblyExports } = await globalThis.getDotnetRuntime(0)
+    const exports = await getAssemblyExports('Assimalign.Viu.Router')
+    dispatchPopState = exports.Assimalign.Viu.Router.BrowserHistoryInteropDispatch.DispatchPopState
+}
+
+export const history = {
+    // Batched read: raw location components + the current entry's state in a single crossing.
+    readSnapshot: () => {
+        const state = window.history.state
+        const hasState = !!(state && typeof state.position === 'number')
+        const scroll = hasState && state.scroll ? state.scroll : null
+        return [
+            window.location.pathname,
+            window.location.search,
+            window.location.hash,
+            window.location.host,
+            String(window.history.length),
+            hasState ? '1' : '0',
+            hasState && state.back ? state.back : '',
+            hasState && state.current ? state.current : '',
+            hasState && state.forward ? state.forward : '',
+            hasState && state.replaced ? '1' : '0',
+            hasState ? String(state.position | 0) : '0',
+            scroll ? '1' : '0',
+            scroll ? String(scroll.left) : '0',
+            scroll ? String(scroll.top) : '0'
+        ]
+    },
+
+    // The document <base> href, or null — the web-mode default when no base is configured.
+    readBaseHref: () => {
+        const element = document.querySelector('base')
+        return element ? element.getAttribute('href') : null
+    },
+
+    // Push: rewrite the leaving entry (recording its live scroll) then push the new one — the two
+    // changeLocation calls of useHistoryStateNavigation.push, collapsed into one interop crossing.
+    push: (currentUrl, amendedBack, amendedCurrent, amendedForward, amendedReplaced, amendedPosition,
+           toUrl, newBack, newCurrent, newForward, newReplaced, newPosition,
+           newHasScroll, newScrollLeft, newScrollTop) => {
+        const amended = buildStateObject(
+            amendedBack, amendedCurrent, amendedForward, amendedReplaced, amendedPosition, computeScroll())
+        window.history.replaceState(amended, '', currentUrl)
+        const created = buildStateObject(
+            newBack, newCurrent, newForward, newReplaced, newPosition,
+            newHasScroll ? { left: newScrollLeft, top: newScrollTop } : null)
+        window.history.pushState(created, '', toUrl)
+    },
+
+    // Replace: a single replaceState — the one changeLocation of useHistoryStateNavigation.replace.
+    replace: (url, back, current, forward, replaced, position, hasScroll, scrollLeft, scrollTop) => {
+        const state = buildStateObject(
+            back, current, forward, replaced, position,
+            hasScroll ? { left: scrollLeft, top: scrollTop } : null)
+        window.history.replaceState(state, '', url)
+    },
+
+    go: (delta) => window.history.go(delta),
+
+    // Attach exactly one popstate listener for this history instance. The listener forwards the
+    // arrived entry's location + state to the .NET dispatch as primitives, then .NET computes the
+    // signed delta/direction against its cached state.
+    subscribe: (subscriptionId) => {
+        const handler = (event) => {
+            if (!dispatchPopState) {
+                return
+            }
+            const state = event.state
+            const hasState = !!(state && typeof state.position === 'number')
+            const scroll = hasState && state.scroll ? state.scroll : null
+            dispatchPopState(
+                subscriptionId,
+                window.location.pathname,
+                window.location.search,
+                window.location.hash,
+                window.location.host,
+                window.history.length,
+                hasState,
+                hasState ? (state.back ?? null) : null,
+                hasState ? (state.current ?? '') : '',
+                hasState ? (state.forward ?? null) : null,
+                hasState ? !!state.replaced : false,
+                hasState ? (state.position | 0) : 0,
+                scroll ? true : false,
+                scroll ? scroll.left : 0,
+                scroll ? scroll.top : 0)
+        }
+        popstateListeners.set(subscriptionId, handler)
+        window.addEventListener('popstate', handler)
+    },
+
+    // Deterministic teardown: remove this instance's popstate listener so nothing leaks.
+    unsubscribe: (subscriptionId) => {
+        const handler = popstateListeners.get(subscriptionId)
+        if (handler) {
+            window.removeEventListener('popstate', handler)
+            popstateListeners.delete(subscriptionId)
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/BrowserHistorySnapshotMarshallerTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/BrowserHistorySnapshotMarshallerTests.cs
@@ -1,0 +1,79 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the flat, primitives-only wire format the single batched read returns from the JS edge — the
+// state round-trip (position + scroll anchor) the [V01.01.08.02] criterion requires, verified without
+// a browser by decoding a hand-built payload.
+public class BrowserHistorySnapshotMarshallerTests
+{
+    [Fact]
+    public void Decode_FullStateWithScroll_RoundTripsEveryField()
+    {
+        var raw = new[]
+        {
+            "/app/users", "?q=1", "#section", "example.com", "10",
+            "1",                 // hasState
+            "/app",              // back
+            "/app/users",        // current
+            "",                  // forward (empty -> null)
+            "1",                 // replaced
+            "7",                 // position
+            "1",                 // hasScroll
+            "12.5", "34",        // scroll left/top
+        };
+
+        var snapshot = BrowserHistorySnapshotMarshaller.Decode(raw);
+
+        snapshot.Pathname.ShouldBe("/app/users");
+        snapshot.Search.ShouldBe("?q=1");
+        snapshot.Hash.ShouldBe("#section");
+        snapshot.Host.ShouldBe("example.com");
+        snapshot.HistoryLength.ShouldBe(10);
+
+        var state = snapshot.State.ShouldNotBeNull();
+        state.Back.ShouldBe("/app");
+        state.Current.ShouldBe("/app/users");
+        state.Forward.ShouldBeNull();          // "" decodes to null
+        state.Replaced.ShouldBeTrue();
+        state.Position.ShouldBe(7);
+        state.Scroll.ShouldBe(new ScrollPosition(12.5, 34));
+    }
+
+    [Fact]
+    public void Decode_StateWithoutScroll_LeavesScrollNullAndKeepsForwardLink()
+    {
+        var raw = new[]
+        {
+            "/", "", "", "example.com", "3",
+            "1", "", "/", "/next", "0", "2", "0", "0", "0",
+        };
+
+        var state = BrowserHistorySnapshotMarshaller.Decode(raw).State.ShouldNotBeNull();
+
+        state.Back.ShouldBeNull();             // "" -> null
+        state.Forward.ShouldBe("/next");
+        state.Replaced.ShouldBeFalse();
+        state.Position.ShouldBe(2);
+        state.Scroll.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Decode_NoState_YieldsNullState()
+    {
+        var raw = new[]
+        {
+            "/", "", "", "example.com", "1",
+            "0", "", "", "", "0", "0", "0", "0", "0",
+        };
+
+        BrowserHistorySnapshotMarshaller.Decode(raw).State.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Decode_WrongLength_Throws()
+        => Should.Throw<ArgumentException>(() => BrowserHistorySnapshotMarshaller.Decode(["too", "short"]));
+}

--- a/libraries/Assimalign.Viu.Router/test/BrowserRouterHistoryTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/BrowserRouterHistoryTests.cs
@@ -1,0 +1,250 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the browser history policy (BrowserRouterHistory) — the C# port of vue-router's
+// useHistoryStateNavigation + useHistoryListeners (packages/router/src/history/html5.ts) — exercised
+// against the instrumented interop seam with no browser. Covers base prepend-on-write /
+// strip-on-read, the position-counter state round-trip, popstate delta/direction, the batched-read
+// call count, silent go, and listener teardown. [V01.01.08.02] browser-mode ACs.
+public class BrowserRouterHistoryTests
+{
+    private static BrowserHistorySnapshot Snapshot(
+        string pathname,
+        RouterHistoryState? state,
+        int historyLength = 1,
+        string search = "",
+        string hash = "",
+        string host = "example.com")
+        => new(pathname, search, hash, host, historyLength, state);
+
+    private static RouterHistoryState StateAt(
+        string current,
+        int position,
+        string? back = null,
+        string? forward = null,
+        bool replaced = false)
+        => new(back, current, forward, replaced, position, null);
+
+    private static (BrowserRouterHistory History, FakeBrowserHistoryInterop Interop) CreateWeb(
+        string normalizedBase,
+        BrowserHistorySnapshot initialSnapshot)
+    {
+        var interop = new FakeBrowserHistoryInterop(initialSnapshot);
+        var history = new BrowserRouterHistory(interop, normalizedBase);
+        return (history, interop);
+    }
+
+    [Fact]
+    public void Construction_WithNoExistingState_SeedsInitialStateAndSubscribes()
+    {
+        // A fresh navigation to /app/users with no prior Viu state, base "/app".
+        var (history, interop) = CreateWeb("/app", Snapshot("/app/users", state: null, historyLength: 6));
+
+        history.Location.ShouldBe("/users");             // base stripped on read
+        history.State.Position.ShouldBe(5);              // seeded from historyLength - 1
+        history.State.Replaced.ShouldBeTrue();
+        interop.ReplaceCalls.Count.ShouldBe(1);          // the bootstrap replaceState
+        interop.ReplaceCalls[0].ToUrl.ShouldBe("/app/users");  // written with the base prepended
+        interop.IsSubscribed.ShouldBeTrue();
+        interop.SubscribeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Construction_WithExistingState_AdoptsItWithoutBootstrapping()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/users", StateAt("/users", position: 3)));
+
+        history.State.Position.ShouldBe(3);
+        interop.ReplaceCalls.ShouldBeEmpty();   // no bootstrap when state already exists
+    }
+
+    [Fact]
+    public void Push_WritesBasePrefixedUrlsAndAdvancesPosition()
+    {
+        var (history, interop) = CreateWeb("/app", Snapshot("/", StateAt("/", position: 0), historyLength: 1));
+
+        history.Push("/users");
+
+        var push = interop.PushCalls.ShouldHaveSingleItem();
+        push.CurrentUrl.ShouldBe("/app/");          // the leaving entry's URL (base + "/")
+        push.ToUrl.ShouldBe("/app/users");          // the pushed URL (base prepended)
+        push.AmendedCurrent.Forward.ShouldBe("/users");  // leaving entry repointed forward
+        push.NewState.Position.ShouldBe(1);         // monotonic advance
+        history.Location.ShouldBe("/users");        // base stripped in the exposed location
+        history.State.Position.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Push_InHashMode_WritesHashFragmentUrls()
+    {
+        // Hash base "#": BuildUrl uses the "#…" slice, so navigation only touches the fragment.
+        var (history, interop) = CreateWeb("#", Snapshot("/", StateAt("/", position: 0)));
+
+        history.Push("/users");
+
+        interop.PushCalls[0].ToUrl.ShouldBe("#/users");   // never a server-request path
+    }
+
+    [Fact]
+    public void Replace_WritesBasePrefixedUrlAndPreservesPosition()
+    {
+        var (history, interop) = CreateWeb("/app", Snapshot("/users", StateAt("/users", position: 4)));
+
+        history.Replace("/profile");
+
+        var replace = interop.ReplaceCalls.ShouldHaveSingleItem();
+        replace.ToUrl.ShouldBe("/app/profile");
+        replace.NewState.Position.ShouldBe(4);        // position preserved
+        replace.NewState.Replaced.ShouldBeTrue();
+        history.Location.ShouldBe("/profile");
+    }
+
+    [Fact]
+    public void PopState_Backward_StripsBaseAndReportsBackWithSignedDelta()
+    {
+        var (history, interop) = CreateWeb("/app", Snapshot("/b", StateAt("/b", position: 7)));
+        var seen = new List<(string To, string From, NavigationInformation Information)>();
+        history.Listen((to, from, information) => seen.Add((to, from, information)));
+
+        // Browser back to /app/a whose stored state is at position 6.
+        interop.FirePopState(Snapshot("/app/a", StateAt("/a", position: 6)));
+
+        history.Location.ShouldBe("/a");         // base stripped on read
+        history.State.Position.ShouldBe(6);
+        var (to, from, information) = seen.ShouldHaveSingleItem();
+        to.ShouldBe("/a");
+        from.ShouldBe("/b");
+        information.Type.ShouldBe(NavigationType.Pop);
+        information.Direction.ShouldBe(NavigationDirection.Back);
+        information.Delta.ShouldBe(-1);          // 6 - 7
+    }
+
+    [Fact]
+    public void PopState_Forward_ReportsForwardDirection()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/a", StateAt("/a", position: 3)));
+        var seen = new List<NavigationInformation>();
+        history.Listen((to, from, information) => seen.Add(information));
+
+        interop.FirePopState(Snapshot("/b", StateAt("/b", position: 5)));
+
+        seen[0].Direction.ShouldBe(NavigationDirection.Forward);
+        seen[0].Delta.ShouldBe(2);   // 5 - 3
+    }
+
+    [Fact]
+    public void PopState_SamePosition_ReportsUnknownDirection()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/a", StateAt("/a", position: 3)));
+        var seen = new List<NavigationInformation>();
+        history.Listen((to, from, information) => seen.Add(information));
+
+        interop.FirePopState(Snapshot("/a", StateAt("/a", position: 3)));
+
+        seen[0].Direction.ShouldBe(NavigationDirection.Unknown);
+        seen[0].Delta.ShouldBe(0);
+    }
+
+    [Fact]
+    public void PopState_WithNoState_SynthesizesByReplacing()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/a", StateAt("/a", position: 2)));
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        // An entry created before this history (no Viu state) arrives via popstate.
+        interop.FirePopState(Snapshot("/legacy", state: null));
+
+        interop.ReplaceCalls.ShouldHaveSingleItem();   // synthesized a state in place
+        history.Location.ShouldBe("/legacy");
+        notifications.ShouldBe(1);
+    }
+
+    [Fact]
+    public void SilentGo_SwallowsTheResultingPopStateButStillUpdatesState()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/b", StateAt("/b", position: 2)));
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Go(-1, triggerListeners: false);
+        interop.GoCalls.ShouldBe([-1]);
+        // The browser now fires popstate for the arrived entry; the policy must swallow it.
+        interop.FirePopState(Snapshot("/a", StateAt("/a", position: 1)));
+
+        notifications.ShouldBe(0);            // swallowed
+        history.Location.ShouldBe("/a");      // but state is reconciled
+        history.State.Position.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Go_WithTriggerListeners_DoesNotSwallowTheNextPopState()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/b", StateAt("/b", position: 2)));
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Go(-1);
+        interop.FirePopState(Snapshot("/a", StateAt("/a", position: 1)));
+
+        notifications.ShouldBe(1);
+    }
+
+    [Fact]
+    public void LocationAndStateReads_AreBatchedIntoASingleInteropCall()
+    {
+        // The whole batched-read criterion: the policy reads the environment ONCE at construction and
+        // never issues a per-property / per-navigation getter afterward.
+        var (history, interop) = CreateWeb("/app", Snapshot("/", StateAt("/", position: 0)));
+
+        history.Push("/a");
+        history.Replace("/b");
+        history.Go(-1);
+        interop.FirePopState(Snapshot("/app/c", StateAt("/c", position: 1)));
+        _ = history.Location;
+        _ = history.State;
+
+        interop.ReadSnapshotCount.ShouldBe(1);   // exactly the one bootstrap read
+    }
+
+    [Fact]
+    public void Listen_ReturnedUnsubscribe_StopsNotifications()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/a", StateAt("/a", position: 1)));
+        var notifications = 0;
+        var unsubscribe = history.Listen((to, from, information) => notifications++);
+
+        interop.FirePopState(Snapshot("/b", StateAt("/b", position: 2)));
+        unsubscribe();
+        interop.FirePopState(Snapshot("/c", StateAt("/c", position: 3)));
+
+        notifications.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Destroy_UnsubscribesTheInteropListenerAndClearsListeners()
+    {
+        var (history, interop) = CreateWeb("", Snapshot("/a", StateAt("/a", position: 1)));
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Destroy();
+
+        interop.UnsubscribeCount.ShouldBe(1);   // the JS popstate listener is torn down (no leak)
+        interop.IsSubscribed.ShouldBeFalse();
+        interop.FirePopState(Snapshot("/b", StateAt("/b", position: 2)));
+        notifications.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CreateHref_UsesTheConfiguredBase()
+    {
+        var (history, _) = CreateWeb("/app", Snapshot("/", StateAt("/", position: 0)));
+
+        history.CreateHref("/users").ShouldBe("/app/users");
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/FakeBrowserHistoryInterop.cs
+++ b/libraries/Assimalign.Viu.Router/test/FakeBrowserHistoryInterop.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// An instrumented stand-in for the browser edge (the same seam the real
+// JavaScriptBrowserHistoryInterop implements): it records every crossing and lets a test drive a
+// popstate, so the whole BrowserRouterHistory policy — base handling, state round-trip, listener
+// bookkeeping, and interop-call counting — is exercised with no browser. Mirrors the recorded-bridge
+// approach of RuntimeDom's BrowserEventInvokerRegistryTests.
+internal sealed class FakeBrowserHistoryInterop : IBrowserHistoryInterop
+{
+    private Action<BrowserHistorySnapshot>? popStateHandler;
+
+    internal FakeBrowserHistoryInterop(BrowserHistorySnapshot initialSnapshot)
+        => InitialSnapshot = initialSnapshot;
+
+    // The snapshot returned by ReadSnapshot (the environment the policy bootstraps from).
+    internal BrowserHistorySnapshot InitialSnapshot { get; set; }
+
+    internal string? BaseHref { get; set; }
+
+    internal int ReadSnapshotCount { get; private set; }
+
+    internal int SubscribeCount { get; private set; }
+
+    internal int UnsubscribeCount { get; private set; }
+
+    internal bool IsSubscribed => popStateHandler is not null;
+
+    internal List<(string CurrentUrl, RouterHistoryState AmendedCurrent, string ToUrl, RouterHistoryState NewState)> PushCalls { get; } = [];
+
+    internal List<(string ToUrl, RouterHistoryState NewState)> ReplaceCalls { get; } = [];
+
+    internal List<int> GoCalls { get; } = [];
+
+    public BrowserHistorySnapshot ReadSnapshot()
+    {
+        ReadSnapshotCount++;
+        return InitialSnapshot;
+    }
+
+    public string? ReadBaseHref()
+        => BaseHref;
+
+    public void Push(string currentUrl, RouterHistoryState amendedCurrentState, string toUrl, RouterHistoryState newState)
+        => PushCalls.Add((currentUrl, amendedCurrentState, toUrl, newState));
+
+    public void Replace(string toUrl, RouterHistoryState newState)
+        => ReplaceCalls.Add((toUrl, newState));
+
+    public void Go(int delta)
+        => GoCalls.Add(delta);
+
+    public void Subscribe(Action<BrowserHistorySnapshot> onPopState)
+    {
+        popStateHandler = onPopState;
+        SubscribeCount++;
+    }
+
+    public void Unsubscribe()
+    {
+        popStateHandler = null;
+        UnsubscribeCount++;
+    }
+
+    // Simulate the browser firing popstate for an arrived entry (what the JS listener would forward
+    // through the [JSExport] dispatch).
+    internal void FirePopState(BrowserHistorySnapshot arrived)
+        => popStateHandler?.Invoke(arrived);
+}

--- a/libraries/Assimalign.Viu.Router/test/HistoryPathNormalizationTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/HistoryPathNormalizationTests.cs
@@ -1,0 +1,67 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the base-path arithmetic of vue-router's history layer: normalizeBase / stripBase / createHref
+// (packages/router/src/history/common.ts, location.ts) and the createCurrentLocation / hash-base
+// logic (html5.ts, hash.ts). [V01.01.08.02] base handling AC.
+public class HistoryPathNormalizationTests
+{
+    [Theory]
+    [InlineData(null, "")]      // no base -> "/" default -> trailing slash trimmed -> "" (no base)
+    [InlineData("", "")]
+    [InlineData("/", "")]
+    [InlineData("/app", "/app")]
+    [InlineData("/app/", "/app")]
+    [InlineData("app", "/app")] // forced leading slash
+    [InlineData("#", "#")]      // a hash base keeps its leading '#'
+    [InlineData("#/", "#")]
+    [InlineData("/folder/#", "/folder/#")]
+    public void NormalizeBase_MatchesUpstream(string? input, string expected)
+        => HistoryPathNormalization.NormalizeBase(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("/app/users", "/app", "/users")]
+    [InlineData("/app", "/app", "/")]              // exact match collapses to "/"
+    [InlineData("/other", "/app", "/other")]       // no prefix -> unchanged
+    [InlineData("/APP/users", "/app", "/users")]   // case-insensitive prefix match
+    [InlineData("/users", "", "/users")]           // empty base strips nothing
+    public void StripBase_MatchesUpstream(string pathname, string @base, string expected)
+        => HistoryPathNormalization.StripBase(pathname, @base).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("/app", "/users", "/app/users")]   // plain base is prefixed
+    [InlineData("", "/users", "/users")]
+    [InlineData("#", "/users", "#/users")]         // leading '#' base kept verbatim
+    [InlineData("/folder/#", "/users", "#/users")] // "<path>#" collapses to '#'
+    public void CreateHref_MatchesUpstreamBeforeHashReplacement(string @base, string location, string expected)
+        => HistoryPathNormalization.CreateHref(@base, location).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(null, "example.com", "/folder/", "", "/folder/#")]  // default base from pathname + '#'
+    [InlineData(null, "", "/folder/", "", "#")]                     // hostless file:// ignores the path
+    [InlineData("/app/", "example.com", "/folder/", "", "/app/#")]  // provided base gets a '#'
+    [InlineData("/folder/#/app/", "example.com", "/x", "", "/folder/#/app/")] // already hashed -> untouched
+    public void ComputeHashBase_MatchesUpstream(string? providedBase, string host, string pathname, string search, string expected)
+        => HistoryPathNormalization.ComputeHashBase(providedBase, host, pathname, search).ShouldBe(expected);
+
+    [Theory]
+    // Web mode (no '#' in base): stripBase(pathname) + search + hash.
+    [InlineData("/app", "/app/users", "?q=1", "#sec", "/users?q=1#sec")]
+    [InlineData("", "/users", "", "", "/users")]
+    // Hash mode (base carries '#'): the fragment after the hash-base, forced to a leading '/'.
+    [InlineData("#", "/anything", "", "#/users", "/users")]
+    [InlineData("/folder/#", "/folder/", "", "#/users", "/users")]
+    [InlineData("#", "/x", "", "", "/")]            // empty hash -> root
+    [InlineData("#!/", "/x", "", "#!/users", "/users")]
+    public void CreateCurrentLocation_MatchesUpstream(string @base, string pathname, string search, string hash, string expected)
+        => HistoryPathNormalization.CreateCurrentLocation(@base, pathname, search, hash).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("https://example.com/app/", "/app/")] // scheme://host stripped
+    [InlineData("/app/", "/app/")]                    // relative href untouched
+    [InlineData("https://example.com", "")]           // host with no path -> empty
+    public void StripBaseHrefOrigin_MatchesUpstream(string href, string expected)
+        => HistoryPathNormalization.StripBaseHrefOrigin(href).ShouldBe(expected);
+}

--- a/libraries/Assimalign.Viu.Router/test/MemoryRouterHistoryTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/MemoryRouterHistoryTests.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the memory history — the C# port of vue-router's createMemoryHistory
+// (packages/router/src/history/memory.ts). It is the interop-free reference model for the
+// push/replace/go and position semantics the web history reproduces. [V01.01.08.02] memory-mode AC.
+public class MemoryRouterHistoryTests
+{
+    private static IRouterHistory CreateHistory(string? basePath = null)
+        => RouterHistory.CreateMemory(basePath);
+
+    [Fact]
+    public void InitialEntry_IsRootAtPositionZero()
+    {
+        var history = CreateHistory();
+
+        history.Location.ShouldBe("/");
+        history.State.Current.ShouldBe("/");
+        history.State.Position.ShouldBe(0);
+        history.State.Replaced.ShouldBeTrue();
+        history.Base.ShouldBe("");
+    }
+
+    [Fact]
+    public void Push_AdvancesLocationAndPositionAndLinksBack()
+    {
+        var history = CreateHistory();
+
+        history.Push("/a");
+        history.Push("/b");
+
+        history.Location.ShouldBe("/b");
+        history.State.Position.ShouldBe(2);   // monotonic +1 per push
+        history.State.Back.ShouldBe("/a");    // linked to the entry left behind
+    }
+
+    [Fact]
+    public void Push_DoesNotNotifyListeners()
+    {
+        var history = CreateHistory();
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Push("/a");
+
+        // Only pop navigations (go/back/forward) notify — pushes do not.
+        notifications.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GoBack_MovesToPreviousEntryAndNotifiesWithBackDirection()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        history.Push("/b");
+        var seen = new List<NavigationInformation>();
+        var toFrom = new List<(string To, string From)>();
+        history.Listen((to, from, information) =>
+        {
+            seen.Add(information);
+            toFrom.Add((to, from));
+        });
+
+        history.Go(-1);
+
+        history.Location.ShouldBe("/a");
+        history.State.Position.ShouldBe(1);
+        seen.Count.ShouldBe(1);
+        seen[0].Type.ShouldBe(NavigationType.Pop);
+        seen[0].Direction.ShouldBe(NavigationDirection.Back);
+        seen[0].Delta.ShouldBe(-1);
+        toFrom[0].ShouldBe(("/a", "/b"));
+    }
+
+    [Fact]
+    public void GoForward_AfterGoingBack_MovesForwardWithForwardDirection()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        history.Push("/b");
+        history.Go(-2);   // back to "/"
+        var seen = new List<NavigationInformation>();
+        history.Listen((to, from, information) => seen.Add(information));
+
+        history.Go(1);
+
+        history.Location.ShouldBe("/a");
+        seen[0].Direction.ShouldBe(NavigationDirection.Forward);
+        seen[0].Delta.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Go_ClampsWithinBoundsButStillNotifiesWithRawDelta()
+    {
+        var history = CreateHistory();
+        history.Push("/a");   // position 1, at the tip
+        var seen = new List<NavigationInformation>();
+        history.Listen((to, from, information) => seen.Add(information));
+
+        history.Go(5);        // clamps: cannot move past the tip
+
+        history.Location.ShouldBe("/a");     // unchanged
+        seen[0].Delta.ShouldBe(5);           // raw requested delta, upstream-faithful
+        seen[0].Direction.ShouldBe(NavigationDirection.Forward);
+    }
+
+    [Fact]
+    public void Go_ZeroDelta_IsForwardInAbstractMode()
+    {
+        var history = CreateHistory();
+        var seen = new List<NavigationInformation>();
+        history.Listen((to, from, information) => seen.Add(information));
+
+        history.Go(0);
+
+        // Upstream treats delta === 0 as forward in abstract mode (memory has no page reload).
+        seen[0].Direction.ShouldBe(NavigationDirection.Forward);
+    }
+
+    [Fact]
+    public void Go_WithTriggerListenersFalse_DoesNotNotify()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Go(-1, triggerListeners: false);
+
+        history.Location.ShouldBe("/");   // still moved
+        notifications.ShouldBe(0);        // but silently
+    }
+
+    [Fact]
+    public void PushAfterGoingBack_TruncatesForwardEntries()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        history.Push("/b");
+        history.Go(-1);       // back to "/a"; "/b" is now a forward entry
+
+        history.Push("/c");   // replaces the forward branch
+
+        history.Location.ShouldBe("/c");
+        history.State.Position.ShouldBe(2);
+        history.Go(1);        // there is nothing forward of "/c"
+        history.Location.ShouldBe("/c");
+    }
+
+    [Fact]
+    public void Replace_KeepsPositionAndTruncatesForward()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        history.Push("/b");
+        history.Go(-1);       // at "/a", position 1, "/b" forward
+
+        history.Replace("/x");
+
+        history.Location.ShouldBe("/x");
+        history.State.Position.ShouldBe(1);   // replace preserves the position counter
+        history.State.Replaced.ShouldBeTrue();
+        history.Go(1);
+        history.Location.ShouldBe("/x");      // "/b" was truncated by the replace
+    }
+
+    [Fact]
+    public void Listen_ReturnedUnsubscribe_StopsFurtherNotifications()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        var notifications = 0;
+        var unsubscribe = history.Listen((to, from, information) => notifications++);
+
+        history.Go(-1);
+        unsubscribe();
+        history.Go(1);
+
+        notifications.ShouldBe(1);   // only the first go was observed
+    }
+
+    [Fact]
+    public void Destroy_ResetsToRootAndClearsListeners()
+    {
+        var history = CreateHistory();
+        history.Push("/a");
+        var notifications = 0;
+        history.Listen((to, from, information) => notifications++);
+
+        history.Destroy();
+
+        history.Location.ShouldBe("/");
+        history.State.Position.ShouldBe(0);
+        history.Push("/b");
+        history.Go(-1);
+        notifications.ShouldBe(0);   // the pre-destroy listener is gone
+    }
+
+    [Theory]
+    [InlineData(null, "/users", "/users")]     // no base
+    [InlineData("/app/", "/users", "/app/users")]
+    public void CreateHref_PrefixesTheBase(string? basePath, string location, string expected)
+        => CreateHistory(basePath).CreateHref(location).ShouldBe(expected);
+
+    [Fact]
+    public void CreateMemory_NormalizesTheBase()
+        => CreateHistory("/app/").Base.ShouldBe("/app");
+}

--- a/libraries/Assimalign.Viu.Router/test/RouteMatcherResolveTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouteMatcherResolveTests.cs
@@ -103,18 +103,19 @@ public class RouteMatcherResolveTests
         "Trimming",
         "IL2026:RequiresUnreferencedCode",
         Justification = "Test-only reflection over assembly references to assert the matcher's dependency boundary; the test project is never trimmed or AOT-published.")]
-    public void MatcherAssembly_HasNoDomInteropOrRendererDependency()
+    public void RouterAssembly_DependsOnNoOtherViuLibrary()
     {
-        // Acceptance criterion: the matcher assembly depends on no other Viu library and on no
-        // JavaScript-interop assembly, so it stays unit-testable in a plain .NET host.
+        // Acceptance criterion (matcher + memory history stay runnable in a plain .NET host): this
+        // assembly references no other Viu library and no Viu renderer/interop assembly. [V01.01.08.02]
+        // added a browser history edge over the framework's System.Runtime.InteropServices.JavaScript
+        // primitive (gated by [SupportedOSPlatform("browser")], exercised only through the injected
+        // seam off-browser); that framework reference is allowed — the forbidden coupling is to
+        // another Viu package, which would drag the DOM bridge / renderer in and break the pure host.
         var referenced = typeof(RouteMatcher).Assembly
             .GetReferencedAssemblies()
             .Select(assembly => assembly.Name ?? string.Empty)
             .ToArray();
 
         referenced.ShouldNotContain(name => name.StartsWith("Assimalign.", StringComparison.Ordinal));
-        referenced.ShouldNotContain(name => name.Contains("JavaScript", StringComparison.Ordinal));
-        referenced.ShouldNotContain(name => name.Contains("Runtime", StringComparison.Ordinal)
-            && name.Contains("Viu", StringComparison.Ordinal));
     }
 }

--- a/libraries/Assimalign.Viu.Router/test/RouterHistoryFactoryTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouterHistoryFactoryTests.cs
@@ -1,0 +1,81 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the factory base-resolution helpers of RouterHistory — the C# port of how createWebHistory
+// defaults its base from <base href> and how createWebHashHistory computes a hash base
+// (packages/router/src/history/html5.ts, hash.ts) — plus the memory mode's no-browser guarantee.
+public class RouterHistoryFactoryTests
+{
+    private static FakeBrowserHistoryInterop Interop(
+        string host = "example.com",
+        string pathname = "/",
+        string search = "")
+        => new(new BrowserHistorySnapshot(pathname, search, string.Empty, host, 1, null));
+
+    [Fact]
+    public void ResolveWebBase_ConfiguredBase_Normalized()
+    {
+        var resolved = RouterHistory.ResolveWebBase(Interop(), "/app/");
+
+        resolved.ShouldBe("/app");
+    }
+
+    [Fact]
+    public void ResolveWebBase_NoBase_UsesBaseHrefWithOriginStripped()
+    {
+        var interop = Interop();
+        interop.BaseHref = "https://example.com/base/";
+
+        var resolved = RouterHistory.ResolveWebBase(interop, basePath: null);
+
+        resolved.ShouldBe("/base");
+    }
+
+    [Fact]
+    public void ResolveWebBase_NoBaseAndNoBaseElement_DefaultsToEmpty()
+    {
+        var interop = Interop();
+        interop.BaseHref = null;
+
+        var resolved = RouterHistory.ResolveWebBase(interop, basePath: null);
+
+        resolved.ShouldBe("");   // "/" default -> trailing slash trimmed
+    }
+
+    [Fact]
+    public void ResolveHashBase_NoBase_DerivesFromLocationWithHash()
+    {
+        var resolved = RouterHistory.ResolveHashBase(Interop(pathname: "/folder/"), basePath: null);
+
+        resolved.ShouldBe("/folder/#");
+    }
+
+    [Fact]
+    public void ResolveHashBase_ConfiguredBase_GetsAHash()
+    {
+        var resolved = RouterHistory.ResolveHashBase(Interop(), "/app/");
+
+        resolved.ShouldBe("/app/#");
+    }
+
+    [Fact]
+    public void ResolveHashBase_HostlessFileUrl_YieldsBareHash()
+    {
+        var resolved = RouterHistory.ResolveHashBase(Interop(host: string.Empty, pathname: "/folder/"), basePath: null);
+
+        resolved.ShouldBe("#");
+    }
+
+    [Fact]
+    public void CreateMemory_NeedsNoInitializationAndIsInteropFree()
+    {
+        // The memory mode works with no InitializeAsync and no browser at all — the proof it carries
+        // zero interop dependency (it is exercised here on a plain .NET host).
+        var history = RouterHistory.CreateMemory();
+
+        history.Push("/a");
+        history.Location.ShouldBe("/a");
+    }
+}

--- a/libraries/Assimalign.Viu.Router/test/RouterHistoryStateBuilderTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/RouterHistoryStateBuilderTests.cs
@@ -1,0 +1,77 @@
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the push/replace/bootstrap state arithmetic — the C# port of vue-router's buildState and the
+// state assembly in useHistoryStateNavigation (packages/router/src/history/html5.ts). [V01.01.08.02]
+// position-counter round-trip AC.
+public class RouterHistoryStateBuilderTests
+{
+    [Fact]
+    public void BuildInitial_SeedsAReplacedRootedEntry()
+    {
+        var state = RouterHistoryStateBuilder.BuildInitial("/start", position: 5);
+
+        state.Back.ShouldBeNull();
+        state.Current.ShouldBe("/start");
+        state.Forward.ShouldBeNull();
+        state.Replaced.ShouldBeTrue();
+        state.Position.ShouldBe(5);
+        state.Scroll.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AmendCurrentForPush_OnlyRepointsForward()
+    {
+        var current = new RouterHistoryState("/back", "/current", null, Replaced: false, Position: 2, Scroll: null);
+
+        var amended = RouterHistoryStateBuilder.AmendCurrentForPush(current, "/next");
+
+        // Forward now points at the pushed location; every other field is preserved (scroll is filled
+        // in by the interop at apply time, not here).
+        amended.Forward.ShouldBe("/next");
+        amended.Back.ShouldBe("/back");
+        amended.Current.ShouldBe("/current");
+        amended.Position.ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildForPush_LinksBackAndAdvancesPositionByOne()
+    {
+        var current = new RouterHistoryState("/older", "/current", null, Replaced: false, Position: 3, Scroll: null);
+
+        var pushed = RouterHistoryStateBuilder.BuildForPush(current, "/next", scrollSeed: null);
+
+        pushed.Back.ShouldBe("/current");   // the entry we are leaving
+        pushed.Current.ShouldBe("/next");
+        pushed.Forward.ShouldBeNull();
+        pushed.Replaced.ShouldBeFalse();
+        pushed.Position.ShouldBe(4);         // +1, the monotonic advance
+        pushed.Scroll.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildForPush_SeedsScrollWhenProvided()
+    {
+        var current = new RouterHistoryState(null, "/current", null, Replaced: true, Position: 0, Scroll: null);
+
+        var pushed = RouterHistoryStateBuilder.BuildForPush(current, "/next", new ScrollPosition(10, 20));
+
+        pushed.Scroll.ShouldBe(new ScrollPosition(10, 20));
+    }
+
+    [Fact]
+    public void BuildForReplace_KeepsNeighboursAndPosition()
+    {
+        var current = new RouterHistoryState("/back", "/current", "/forward", Replaced: false, Position: 7, Scroll: null);
+
+        var replaced = RouterHistoryStateBuilder.BuildForReplace(current, "/swap", scrollSeed: null);
+
+        replaced.Back.ShouldBe("/back");        // neighbours preserved
+        replaced.Forward.ShouldBe("/forward");
+        replaced.Current.ShouldBe("/swap");
+        replaced.Replaced.ShouldBeTrue();
+        replaced.Position.ShouldBe(7);          // position preserved, not advanced
+    }
+}


### PR DESCRIPTION
## Summary
- Ports vue-router v4's `packages/router/src/history/` to `Assimalign.Viu.Router`: the `IRouterHistory` contract (`Base`/`Location`/`State`, `Push`/`Replace`/`Go`, `Listen`, `CreateHref`, `Destroy`), a `RouterHistoryState` flat state record, and the `RouterHistory` factory facade (`CreateMemory`/`CreateWeb`/`CreateWebHash` + browser-only `InitializeAsync`).
- **DOM-free policy, thin interop edge** (the issue's binding boundary): memory mode is pure; the web/hash push/replace/popstate state machine, base prepend/strip, and listener bookkeeping live in a DOM-free `BrowserRouterHistory` driving an injected `IBrowserHistoryInterop` seam. The real edge is `[JSImport]` bindings to a new `viu-history.js` (loaded from `/_content/Assimalign.Viu.Router/`, mirroring RuntimeDom's module pattern) plus one `[JSExport]` popstate dispatch routed by subscription id so teardown never leaks a listener.
- **Batched interop**: snapshot reads return the whole location + state in one crossing (pinned by an interop-call-count test); push collapses upstream's two `changeLocation` calls into one crossing; state marshals as flat primitives only.
- Divergences documented in `docs/DESIGN.md`: memory mode carries full state per entry (position round-trip requirement), root-relative write URLs keep the write path DOM-free, and live scroll is the single JS-owned field.
- The matcher's dependency-boundary test is narrowed with rationale: it still forbids referencing any other `Assimalign.*` assembly (the coupling that would break the pure test host), while the BCL `System.Runtime.InteropServices.JavaScript` reference this issue's boundary sanctions is allowed, gated by `[SupportedOSPlatform("browser")]`. `AllowUnsafeBlocks` added to the csproj for the interop generator (SYSLIB1074), documented in place — same as RuntimeDom.
- Scope creep filed, not absorbed: [#187 [V01.01.12.20]](https://github.com/assimalign/viu/issues/187) — the SDK/framework packs hardcode RuntimeDom's `wwwroot`, so `viu-history.js` needs framework-membership wiring to reach external SDK consumers (in-repo static-web-asset flow already delivers it).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · Router tests **147/147** (78 new: base prepend/strip across web+hash, monotonic position round-trip, popstate delta→direction, single-crossing snapshot reads, silent-go listener suppression, leak-free teardown — browser policy fully exercised through the recording fake). The `[JSImport]`/`[JSExport]` edge is compile-verified and signature-matched to `viu-history.js`; real-browser validation belongs to the e2e harness ([V01.01.11.03], #87) per the repo testing rule.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)