### PR TITLE
feat(runtime-dom): implement TransitionGroup move (FLIP) transitions [V01.01.04.07.03]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
@@ -117,9 +117,11 @@ buffered is opt-in for this delivery.
 - **Differential proof**: the full renderer scenario battery runs through direct and buffered modes
   and asserts byte-identical serialized DOM; an instrumented apply counter proves one boundary
   crossing per flush over hundreds of mutations. Full 10k-row benchmarks belong to [V01.01.11.04].
-- **Transition sequencing barrier**: three opcodes (`AddTransitionClass`, `RemoveTransitionClass`,
+- **Transition sequencing barrier**: opcodes 21/22/23 (`AddTransitionClass`, `RemoveTransitionClass`,
   `ForceReflow`) let the CSS-transition choreography ride the buffer without coalescing away the
-  browser's transition trigger — see the next section ([V01.01.04.07.02]).
+  browser's transition trigger ([V01.01.04.07.02]); opcodes 24/25 (`SetMoveTransform`,
+  `ClearMoveStyles`) extend the same model to the FLIP move write frame, and add the wire format's first
+  `float64` operands ([V01.01.04.07.03]) — see the next two sections.
 
 ## Transition class sequencing under batching ([V01.01.04.07.02])
 
@@ -140,14 +142,52 @@ batching everywhere else (one interop crossing per flush is unchanged):
 - **Frame boundary — the `nextFrame` continuation.** The `*-to` swap is scheduled through the real
   double-`requestAnimationFrame`; the buffered adaptor applies the continuation's writes when it runs,
   two frames after the from/active frame committed, so the two class states land in distinct browser
-  frames and can never coalesce. `whenTransitionEnds`/`measurePosition`/`hasCssTransform` and the FLIP
-  ops force a flush and hit the live bridge (so `getComputedStyle`/`getBoundingClientRect` observe the
+  frames and can never coalesce. `whenTransitionEnds`/`measurePositions`/`hasCssTransform`/`whenMoveEnds`
+  force a flush and hit the live bridge (so `getComputedStyle`/`getBoundingClientRect` observe the
   committed classes/layout); their resolve callbacks flush the finishing class removals.
 - **Proof.** `BufferedTransitionSequencingTests` drives the real renderer + real `<Transition>` through
   the buffered applier and asserts, per flush, that from/active land in one frame, the to-swap in a
   distinct later frame, and the leave reflow op lands *between* the from- and active-class writes.
-- FLIP *move* batching (one read pass, one reflow for N elements) is the separate #163; buffered FLIP
-  reads are correct here (forced flush) but not yet batched. `v-show` transition coalescing is #161.
+- FLIP *move* batching (the `<TransitionGroup>` reorder pass) is the next section ([V01.01.04.07.03]);
+  `v-show` transition coalescing is #161.
+
+## Transition FLIP move batching ([V01.01.04.07.03])
+
+`<TransitionGroup>` animates keyed reorders with a FLIP (First-Last-Invert-Play): snapshot each child's
+position before the patch, read it again after, apply an inverting `transform` to every child that
+moved, force one reflow, then add the resolved `*-move` class and clear the transform so each child
+animates from its old spot to its new one — cleaning up on `transitionend` (upstream
+`TransitionGroup.ts` `recordPosition`/`applyTranslation`/`forceReflow`, gated by the `hasCSSTransform`
+clone probe). Upstream reads `getBoundingClientRect` per child inside a same-process JS loop; on a
+handle platform every read is a boundary crossing, so a naive port costs N crossings per pass. Two
+design choices keep policy in .NET (the "decision logic lives in .NET; JS stays a dumb applier" split)
+while collapsing the FLIP to a constant number of crossings:
+
+- **Batched read pass — one crossing per snapshot.** `DomTransitionOperations.MeasurePositions` takes an
+  array of handles and returns the flat `[left, top, …]` rectangles in a single crossing (the
+  `dom.measurePositions` read op, mirroring the history bridge's `readSnapshot` flat-primitives pattern).
+  Which children moved and their inverting deltas are computed .NET-side; JS only reads rectangles. A
+  reorder of N children costs exactly two read crossings — the pre-patch snapshot and the post-patch
+  read — regardless of N. In buffered mode the read forces the pending patch to commit first, so
+  `getBoundingClientRect` observes the settled post-reorder layout, then reads all N in one call.
+- **Batched write frame — one crossing for the move.** The FLIP transform writes join the command
+  buffer: `SetMoveTransform` (opcode 24, carrying `float64` deltas) and `ClearMoveStyles` (opcode 25)
+  sit alongside `AddTransitionClass` (21) and the `ForceReflow` barrier (23). `TransitionGroup` emits
+  the whole write pass — every child's transform, then the reflow barrier, then each child's move class
+  and transform clear — before registering any `whenMoveEnds` listener, so the buffered adaptor commits
+  the entire frame in one crossing in exact upstream order. (`whenMoveEnds` stays a direct per-element
+  `transitionend` registration, like `addEventListener`; it is a listener attach, not a read, and its
+  resolve flushes the finishing move-class removal.) An interrupted reorder force-finishes the in-flight
+  move first (upstream `callPendingCbs`) so the re-measure sees settled positions.
+- **Wire version.** These opcodes and the `float64` operand bumped the frame version `0x02` → `0x03`
+  on both `DomCommandBuffer.cs` and `viu-dom.js`; the test-side `CommandBufferDecoder` (the DOM-free
+  oracle for the JS applier) decodes them identically.
+- **Proof.** `TransitionGroupTests` pins, through the recording adapter, the move class + inverting
+  transform applied only to moved children and removed on `transitionend`, the `hasCSSTransform` gate,
+  an interrupted reorder converging with no residue, cleanup leaving none — and, run-count-pinned, that
+  each position pass is exactly one batched read crossing carrying the full child batch regardless of
+  child count. `DomCommandBufferTests` round-trips the FLIP opcodes through the buffer and decoder,
+  asserting the `float64` deltas survive and the transform/reflow/class/clear order is preserved.
 
 ## Non-goals (sequenced work)
 

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserDomBridge.cs
@@ -400,15 +400,15 @@ internal static partial class BrowserDomBridge
         }
     }
 
-    internal static double[] MeasurePosition(int nodeHandle)
+    internal static double[] MeasurePositions(int[] nodeHandles)
     {
         try
         {
-            return Imports.MeasurePosition(nodeHandle);
+            return Imports.MeasurePositions(nodeHandles);
         }
         catch (JSException exception)
         {
-            throw Translate("measurePosition", nodeHandle, exception);
+            throw Translate("measurePositions", nodeHandles.Length > 0 ? nodeHandles[0] : 0, exception);
         }
     }
 
@@ -601,9 +601,13 @@ internal static partial class BrowserDomBridge
             int explicitTimeout,
             [JSMarshalAs<JSType.Function>] Action resolve);
 
-        [JSImport("dom.measurePosition", ModuleName)]
+        // Batched FLIP snapshot read ([V01.01.04.07.03]): the handle array crosses in one call and the
+        // flat [left, top, ...] result returns in one call, mirroring the history bridge's readSnapshot
+        // flat-primitives pattern — N children cost one crossing, not N.
+        [JSImport("dom.measurePositions", ModuleName)]
         [return: JSMarshalAs<JSType.Array<JSType.Number>>]
-        internal static partial double[] MeasurePosition(int nodeHandle);
+        internal static partial double[] MeasurePositions(
+            [JSMarshalAs<JSType.Array<JSType.Number>>] int[] nodeHandles);
 
         [JSImport("dom.setMoveTransform", ModuleName)]
         internal static partial void SetMoveTransform(int nodeHandle, double deltaX, double deltaY);

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -74,10 +74,16 @@ internal static class BrowserNodeOperations
             ForceReflow = static () => BrowserDomBridge.ForceReflow(),
             WhenTransitionEnds = static (element, expectedType, explicitTimeout, resolve) =>
                 BrowserDomBridge.WhenTransitionEnds(element, expectedType, explicitTimeout, resolve),
-            MeasurePosition = static element =>
+            MeasurePositions = static handles =>
             {
-                var position = BrowserDomBridge.MeasurePosition(element);
-                return new TransitionRectangle(position[0], position[1]);
+                // One crossing reads all rectangles; decode the flat [left, top, ...] pairs .NET-side.
+                var flat = BrowserDomBridge.MeasurePositions(handles);
+                var rectangles = new TransitionRectangle[handles.Length];
+                for (var index = 0; index < handles.Length; index++)
+                {
+                    rectangles[index] = new TransitionRectangle(flat[index * 2], flat[index * 2 + 1]);
+                }
+                return rectangles;
             },
             SetMoveTransform = static (element, deltaX, deltaY) => BrowserDomBridge.SetMoveTransform(element, deltaX, deltaY),
             ClearMoveStyles = static element => BrowserDomBridge.ClearMoveStyles(element),

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
@@ -47,10 +47,12 @@ namespace Assimalign.Viu.RuntimeDom;
 /// frames and can never coalesce.</item>
 /// </list>
 /// Transition reads and listener registrations (<c>NextFrame</c>'s scheduling, <c>WhenTransitionEnds</c>,
-/// <c>MeasurePosition</c>, <c>HasCssTransform</c>, the FLIP ops) force a flush and then hit the live
+/// <c>MeasurePositions</c>, <c>HasCssTransform</c>, <c>WhenMoveEnds</c>) force a flush and then hit the live
 /// bridge, so <c>getComputedStyle</c>/<c>getBoundingClientRect</c> observe the committed classes/layout;
-/// their resolve callbacks flush the finishing class removals. (FLIP <em>move</em> batching — reading all
-/// positions in one pass — is the separate #163.)
+/// their resolve callbacks flush the finishing class removals. The FLIP <em>move</em> pass is batched
+/// ([V01.01.04.07.03]): <c>MeasurePositions</c> reads every child's rectangle in one crossing, and the
+/// FLIP transform writes (<c>SetMoveTransform</c>/<c>ClearMoveStyles</c>, opcodes 24/25) ride the command
+/// buffer with the reflow barrier so the whole move write frame commits in one crossing.
 /// </para>
 /// Ambient by activation: <see cref="Activate"/> points the flush seam, the event dispatcher, the
 /// directive operations, and the transition operations at this instance; <see cref="Deactivate"/>
@@ -274,23 +276,19 @@ internal sealed class BufferedBrowserNodeOperations
                 ApplyPending();
             });
         },
-        // FLIP reads/writes force a flush so getBoundingClientRect and the clone read see committed DOM;
-        // batching the FLIP position pass into one read/write phase is the separate #163.
-        MeasurePosition = element =>
+        // FLIP move batching ([V01.01.04.07.03]). The read pass is one crossing: flush the pending patch
+        // so getBoundingClientRect sees the committed post-reorder layout, then read every child's rect in
+        // one batched call. The write pass (per-element transform, the reflow barrier, the move class, and
+        // the transform clear) rides the command buffer — opcodes 24/25 join 21/23 — so the whole FLIP
+        // frame commits in one crossing in upstream order, never one per moved child.
+        MeasurePositions = handles =>
         {
             FlushPending();
-            return direct.MeasurePosition(element);
+            return direct.MeasurePositions(handles);
         },
-        SetMoveTransform = (element, deltaX, deltaY) =>
-        {
-            FlushPending();
-            direct.SetMoveTransform(element, deltaX, deltaY);
-        },
-        ClearMoveStyles = element =>
-        {
-            FlushPending();
-            direct.ClearMoveStyles(element);
-        },
+        SetMoveTransform = (element, deltaX, deltaY) => _buffer.WriteSetMoveTransform(element, deltaX, deltaY),
+        ClearMoveStyles = element => _buffer.WriteClearMoveStyles(element),
+        // The clone read must see committed classes/layout: flush the pending frame, then read directly.
         HasCssTransform = (element, root, moveClass) =>
         {
             FlushPending();

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandBuffer.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandBuffer.cs
@@ -28,7 +28,7 @@ namespace Assimalign.Viu.RuntimeDom;
 /// [2..6)     opCount           (int32)
 /// [6..10)    nextHandle        (int32)  -- the .NET counter after this batch; JS adopts max(its, this)
 /// [10..14)   stringTableOffset (int32)  -- absolute byte offset where the string table begins
-/// [14..)     ops: each = [opcode:byte] then operands (int32 handles/indices, 1-byte bools)
+/// [14..)     ops: each = [opcode:byte] then operands (int32 handles/indices, 1-byte bools, float64 FLIP deltas)
 /// [offset]   stringCount(int32), then per string: [utf8ByteLength:int32][utf8 bytes]
 /// </code>
 /// Strings (tags, prop/event names, values) are interned per flush and referenced by int32 index; a
@@ -46,9 +46,11 @@ internal sealed class DomCommandBuffer
 
     /// <summary>
     /// The frame format version — bump on any layout or opcode change so drift fails loudly. 0x02 added
-    /// the transition class/reflow-barrier opcodes ([V01.01.04.07.02]).
+    /// the transition class/reflow-barrier opcodes ([V01.01.04.07.02]); 0x03 added the FLIP move
+    /// opcodes (<see cref="DomCommandOpcode.SetMoveTransform"/>/<see cref="DomCommandOpcode.ClearMoveStyles"/>)
+    /// and, with the move deltas, the first <c>float64</c> operands ([V01.01.04.07.03]).
     /// </summary>
-    internal const byte Version = 0x02;
+    internal const byte Version = 0x03;
 
     /// <summary>Header size: magic + version + opCount + nextHandle + stringTableOffset.</summary>
     internal const int HeaderSize = 2 + 4 + 4 + 4;
@@ -285,6 +287,28 @@ internal sealed class DomCommandBuffer
     /// </summary>
     internal void WriteForceReflow() => WriteOpcode(DomCommandOpcode.ForceReflow);
 
+    /// <summary>
+    /// Writes a FLIP inverting transform op (<see cref="DomCommandOpcode.SetMoveTransform"/>): the whole
+    /// move write pass rides one frame so N reordered children cost one interop crossing ([V01.01.04.07.03]).
+    /// </summary>
+    internal void WriteSetMoveTransform(int handle, double deltaX, double deltaY)
+    {
+        WriteOpcode(DomCommandOpcode.SetMoveTransform);
+        WriteInt32(handle);
+        WriteDouble(deltaX);
+        WriteDouble(deltaY);
+    }
+
+    /// <summary>
+    /// Writes a FLIP transform-clear op (<see cref="DomCommandOpcode.ClearMoveStyles"/>) so the move
+    /// class animates the element back to its settled position ([V01.01.04.07.03]).
+    /// </summary>
+    internal void WriteClearMoveStyles(int handle)
+    {
+        WriteOpcode(DomCommandOpcode.ClearMoveStyles);
+        WriteInt32(handle);
+    }
+
     // --- primitives ------------------------------------------------------------------------------
 
     private void WriteHandleName(DomCommandOpcode opcode, int handle, string name)
@@ -319,6 +343,13 @@ internal sealed class DomCommandBuffer
     {
         BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(_position, 4), value);
         _position += 4;
+    }
+
+    private void WriteDouble(double value)
+    {
+        EnsureCapacity(8);
+        BinaryPrimitives.WriteDoubleLittleEndian(_buffer.AsSpan(_position, 8), value);
+        _position += 8;
     }
 
     private void WriteBoolean(bool value)

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandOpcode.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomCommandOpcode.cs
@@ -95,4 +95,21 @@ internal enum DomCommandOpcode : byte
     /// the interop boundary exactly once ([V01.01.04.07.02]).
     /// </summary>
     ForceReflow = 23,
+
+    /// <summary>
+    /// Apply a FLIP inverting transform: <c>[handle][deltaX:float64][deltaY:float64]</c> (upstream
+    /// <c>applyTranslation</c>'s <c>style.transform = translate(dx,dy); style.transitionDuration = '0s'</c>
+    /// — <c>packages/runtime-dom/src/components/TransitionGroup.ts</c>). Buffered so the whole FLIP write
+    /// pass — every element's transform, the <see cref="ForceReflow"/> barrier, then the move class and
+    /// the transform clear — rides one frame in upstream order, one interop crossing ([V01.01.04.07.03]).
+    /// The <c>float64</c> deltas are the first non-int32/bool operands in the wire format.
+    /// </summary>
+    SetMoveTransform = 24,
+
+    /// <summary>
+    /// Clear the FLIP transform and zero transition-duration so the move class animates the element back
+    /// to its settled spot: <c>[handle]</c> (upstream <c>style.transform = style.transitionDuration = ''</c>).
+    /// Buffered after the reflow barrier and the move class in the same FLIP write frame ([V01.01.04.07.03]).
+    /// </summary>
+    ClearMoveStyles = 25,
 }

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomTransitionOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/DomTransitionOperations.cs
@@ -53,8 +53,16 @@ internal sealed class DomTransitionOperations
     /// </summary>
     public required Action<int, string?, int, Action> WhenTransitionEnds { get; init; }
 
-    /// <summary>Reads an element's top-left position for a FLIP snapshot (upstream: <c>getBoundingClientRect</c>).</summary>
-    public required Func<int, TransitionRectangle> MeasurePosition { get; init; }
+    /// <summary>
+    /// Reads the top-left positions of a whole batch of elements for a FLIP snapshot in <b>one</b>
+    /// interop crossing (upstream reads <c>getBoundingClientRect</c> per child inside a same-process JS
+    /// loop; a handle platform pays a boundary crossing per read, so the FLIP pass is batched — N
+    /// children cost one crossing, not N — [V01.01.04.07.03]). Returns one
+    /// <see cref="TransitionRectangle"/> per handle, index-aligned with <paramref name="handles"/>.
+    /// Decision logic (which children moved, the inverting delta) stays in .NET; the applier only reads
+    /// rectangles, preserving the "policy in C#, dumb applier in JS" split the bridge documents.
+    /// </summary>
+    public required Func<int[], TransitionRectangle[]> MeasurePositions { get; init; }
 
     /// <summary>
     /// Applies a FLIP inverting transform and a zero transition-duration to an element (upstream:

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Transitions/TransitionGroup.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Transitions/TransitionGroup.cs
@@ -16,9 +16,12 @@ namespace Assimalign.Viu.RuntimeDom;
 /// on <c>transitionend</c>.
 /// <para>
 /// The position snapshots and the transform writes go through <see cref="DomTransitionOperations"/> in
-/// the exact three-phase order upstream uses (finish pending callbacks, read all positions, then write
-/// all transforms) so the read pass and the write pass never interleave — the documented synchronous
-/// layout seam the bridge-backed implementation fulfils. Referenced by the compiled render through
+/// the exact order upstream uses (finish pending callbacks, read all positions, then write all
+/// transforms) so the read pass and the write pass never interleave — the documented synchronous layout
+/// seam the bridge-backed implementation fulfils. Because a handle platform crosses the interop boundary
+/// per read, the read pass is <b>batched</b>: <see cref="DomTransitionOperations.MeasurePositions"/> reads
+/// every child's rectangle in one crossing, so a reorder of N children costs one crossing per pass, not N
+/// ([V01.01.04.07.03]). Referenced by the compiled render through
 /// <see cref="DomRenderHelpers._TransitionGroup"/>. Not thread-safe (single-threaded JS event-loop model).
 /// </para>
 /// </summary>
@@ -73,19 +76,29 @@ public sealed class TransitionGroup : IComponentDefinition
             }
 
             // Snapshot the outgoing children's pre-patch positions and refresh their hooks (upstream:
-            // the prevChildren loop recording positionMap). The FLIP delta reads these in onUpdated.
+            // the prevChildren loop recording positionMap). The FLIP delta reads these in onUpdated. The
+            // whole snapshot is one batched read crossing rather than one per child ([V01.01.04.07.03]).
             if (previousChildren is not null)
             {
                 positionMap.Clear();
                 var operations = DomTransitionOperations.Current;
+                var measured = new List<VirtualNode>(previousChildren.Count);
                 foreach (var child in previousChildren)
                 {
                     BaseTransition.SetTransitionHooks(
                         child,
                         BaseTransition.ResolveTransitionHooks(child, resolved, state, instance, null));
-                    if (operations is not null && child.El is { } element)
+                    if (operations is not null && child.El is not null)
                     {
-                        positionMap[child] = operations.MeasurePosition((int)element);
+                        measured.Add(child);
+                    }
+                }
+                if (operations is not null && measured.Count > 0)
+                {
+                    var rectangles = operations.MeasurePositions(HandlesOf(measured));
+                    for (var index = 0; index < measured.Count; index++)
+                    {
+                        positionMap[measured[index]] = rectangles[index];
                     }
                 }
             }
@@ -125,27 +138,32 @@ public sealed class TransitionGroup : IComponentDefinition
             return;
         }
 
-        // Three passes, no interleaving of reads and writes (upstream comment: prevent layout thrashing).
+        // No interleaving of reads and writes (upstream comment: prevent layout thrashing), and the reads
+        // and the whole write frame are each one interop crossing ([V01.01.04.07.03]).
         // 1. finish any pending move/enter callbacks so a re-triggered FLIP measures settled positions.
         foreach (var child in previousChildren)
         {
             CallPendingCallbacks(state, moveCallbacks, child);
         }
-        // 2. read every new position.
-        var newPositions = new TransitionRectangle[previousChildren.Count];
-        for (var index = 0; index < previousChildren.Count; index++)
+        // 2. read every new position in ONE batched crossing (upstream: recordPosition per child, in a
+        //    same-process JS loop; here the whole pass is a single boundary crossing).
+        var measured = new List<VirtualNode>(previousChildren.Count);
+        foreach (var child in previousChildren)
         {
-            if (previousChildren[index].El is { } element)
+            if (child.El is not null)
             {
-                newPositions[index] = operations.MeasurePosition((int)element);
+                measured.Add(child);
             }
         }
-        // 3. write the inverting transforms for the children that moved.
+        var newPositions = measured.Count > 0
+            ? operations.MeasurePositions(HandlesOf(measured))
+            : [];
+        // 3. write the inverting transforms for the children that moved (upstream applyTranslation).
         var moved = new List<VirtualNode>();
-        for (var index = 0; index < previousChildren.Count; index++)
+        for (var index = 0; index < measured.Count; index++)
         {
-            var child = previousChildren[index];
-            if (child.El is not { } element || !positionMap.TryGetValue(child, out var oldPosition))
+            var child = measured[index];
+            if (!positionMap.TryGetValue(child, out var oldPosition))
             {
                 continue;
             }
@@ -154,18 +172,26 @@ public sealed class TransitionGroup : IComponentDefinition
             var deltaY = oldPosition.Top - newPosition.Top;
             if (deltaX != 0 || deltaY != 0)
             {
-                operations.SetMoveTransform((int)element, deltaX, deltaY);
+                operations.SetMoveTransform((int)child.El!, deltaX, deltaY);
                 moved.Add(child);
             }
         }
 
-        // Force everything into position, then run the move class with the inverse transform cleared.
+        // 4. force everything into position (upstream forceReflow, once), then add the move class and clear
+        //    the inverse transform so each moved child animates home. In buffered mode steps 3-4 are one
+        //    command-buffer frame: transforms, the reflow barrier, then move class + clear, in this order.
         operations.ForceReflow();
         foreach (var child in moved)
         {
             var element = (int)child.El!;
             operations.AddTransitionClass(element, moveClass);
             operations.ClearMoveStyles(element);
+        }
+        // 5. register the move-end cleanup AFTER the write frame — the buffered WhenMoveEnds flushes the
+        //    frame committed in steps 3-4 as one crossing, then attaches the transitionend listener.
+        foreach (var child in moved)
+        {
+            var element = (int)child.El!;
             void MoveDone()
             {
                 if (!moveCallbacks.Remove(element))
@@ -177,6 +203,17 @@ public sealed class TransitionGroup : IComponentDefinition
             moveCallbacks[element] = MoveDone;
             operations.WhenMoveEnds(element, MoveDone);
         }
+    }
+
+    // Projects a child list to the int element handles the batched read/FLIP ops address them by.
+    private static int[] HandlesOf(List<VirtualNode> children)
+    {
+        var handles = new int[children.Count];
+        for (var index = 0; index < children.Count; index++)
+        {
+            handles[index] = (int)children[index].El!;
+        }
+        return handles;
     }
 
     // Upstream callPendingCbs: force-finish an in-flight move (moveCbKey) and enter (enterCbKey) so the

--- a/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
@@ -117,7 +117,9 @@ function applyRemove(childHandle, released) {
 // (the void ops below reuse the exact same dom.* leaves).
 
 const COMMAND_MAGIC = 0xB6
-const COMMAND_VERSION = 0x02 // 0x02 added the transition class / reflow-barrier opcodes ([V01.01.04.07.02])
+// 0x02 added the transition class / reflow-barrier opcodes ([V01.01.04.07.02]); 0x03 added the FLIP move
+// opcodes (24/25) and, with the move deltas, the first float64 operands ([V01.01.04.07.03]).
+const COMMAND_VERSION = 0x03
 const textDecoder = new TextDecoder()
 
 // Register a node AS a handle the .NET side pre-allocated (a one-way buffered create cannot return
@@ -499,11 +501,13 @@ export const dom = {
     // The DOM-side contract of DomTransitionOperations: classList add/remove tracked in el.__vtc,
     // the double-rAF next frame, the forced reflow, transitionend/animationend end-detection, and
     // the FLIP getBoundingClientRect/transform ops. In direct mode these are called one op per crossing;
-    // in buffered mode ([V01.01.04.07.02]) addTransitionClass/removeTransitionClass/forceReflow are also
-    // reached through the command-buffer opcodes (21/22/23) so the class sequence stays ordered with the
-    // node ops and the reflow barrier lands between the from- and to-class writes. rAF timing and the
-    // read/listener ops (nextFrame, whenTransitionEnds, measurePosition, the FLIP ops) stay direct — the
-    // buffered adaptor forces a flush before each so they observe committed classes/layout.
+    // in buffered mode addTransitionClass/removeTransitionClass/forceReflow ([V01.01.04.07.02], opcodes
+    // 21/22/23) and setMoveTransform/clearMoveStyles ([V01.01.04.07.03], opcodes 24/25) are reached
+    // through the command buffer so the class + FLIP-transform sequence stays ordered with the node ops
+    // and the reflow barrier lands between them. The batched FLIP read (measurePositions) and the rAF/
+    // listener ops (nextFrame, whenTransitionEnds, whenMoveEnds, hasCssTransform) stay direct — the
+    // buffered adaptor forces a flush before each so they observe committed classes/layout, and
+    // measurePositions reads every child's rect in one crossing rather than one per child.
 
     addTransitionClass: (nodeHandle, cssClass) => {
         const el = getNode('addTransitionClass', nodeHandle)
@@ -548,9 +552,17 @@ export const dom = {
         el.addEventListener(endEvent, onEnd)
     },
 
-    measurePosition: nodeHandle => {
-        const rect = getNode('measurePosition', nodeHandle).getBoundingClientRect()
-        return [rect.left, rect.top]
+    // Batched FLIP snapshot read ([V01.01.04.07.03]): N element handles cross the boundary once and the
+    // flat [left0, top0, left1, top1, ...] result returns once, so reordering N children costs a single
+    // interop crossing per pass rather than one per child. Decision logic (deltas, who moved) stays .NET-side.
+    measurePositions: handles => {
+        const result = new Array(handles.length * 2)
+        for (let index = 0; index < handles.length; index++) {
+            const rect = getNode('measurePositions', handles[index]).getBoundingClientRect()
+            result[index * 2] = rect.left
+            result[index * 2 + 1] = rect.top
+        }
+        return result
     },
 
     setMoveTransform: (nodeHandle, deltaX, deltaY) => {
@@ -620,6 +632,11 @@ export const dom = {
             return value
         }
         const flag = () => bytes[cursor++] !== 0
+        const num = () => {
+            const value = view.getFloat64(cursor, true)
+            cursor += 8
+            return value
+        }
         const str = () => {
             const index = int()
             return index < 0 ? null : strings[index]
@@ -653,6 +670,11 @@ export const dom = {
                 case 21: dom.addTransitionClass(int(), str()); break
                 case 22: dom.removeTransitionClass(int(), str()); break
                 case 23: dom.forceReflow(); break
+                // FLIP move write pass ([V01.01.04.07.03]): every reordered child's inverting transform,
+                // then the reflow barrier (23), then the move class (21) + transform clear (25) ride one
+                // frame in upstream order, so N moved children commit in a single interop crossing.
+                case 24: dom.setMoveTransform(int(), num(), num()); break
+                case 25: dom.clearMoveStyles(int()); break
                 default: fail('applyCommandBuffer', 0, `unknown opcode ${opcode}`)
             }
         }

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
@@ -239,8 +239,9 @@ public sealed class BufferedTransitionSequencingTests
             // The rAF scheduling and end-detection stay direct (the buffered wrapper flushes around them).
             NextFrame = _nextFrameQueue.Add,
             WhenTransitionEnds = (element, _, _, resolve) => _endResolvers[element] = resolve,
-            // FLIP ops are unused by <Transition>; stub them (their batching is #163).
-            MeasurePosition = _ => default,
+            // FLIP ops are unused by <Transition>; stub them (their own batched coverage is in the
+            // TransitionGroup adapter and command-buffer tests, [V01.01.04.07.03]).
+            MeasurePositions = handles => new TransitionRectangle[handles.Length],
             SetMoveTransform = (_, _, _) => { },
             ClearMoveStyles = _ => { },
             HasCssTransform = (_, _, _) => false,

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/CommandBufferDecoder.cs
@@ -107,6 +107,13 @@ internal static class CommandBufferDecoder
                     // The reflow barrier carries no operands; the real applier reads document.body.offsetHeight.
                     dom.ForceReflow();
                     break;
+                case DomCommandOpcode.SetMoveTransform:
+                    // The first float64 operands in the wire format: the FLIP inverting delta ([V01.01.04.07.03]).
+                    dom.SetMoveTransform(ReadInt(span, ref cursor), ReadDouble(span, ref cursor), ReadDouble(span, ref cursor));
+                    break;
+                case DomCommandOpcode.ClearMoveStyles:
+                    dom.ClearMoveStyles(ReadInt(span, ref cursor));
+                    break;
                 default:
                     throw new InvalidOperationException($"Unknown command-buffer opcode {(byte)opcode}.");
             }
@@ -139,4 +146,11 @@ internal static class CommandBufferDecoder
     }
 
     private static bool ReadBool(ReadOnlySpan<byte> span, ref int cursor) => span[cursor++] != 0;
+
+    private static double ReadDouble(ReadOnlySpan<byte> span, ref int cursor)
+    {
+        var value = BinaryPrimitives.ReadDoubleLittleEndian(span[cursor..]);
+        cursor += 8;
+        return value;
+    }
 }

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/DomCommandBufferTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/DomCommandBufferTests.cs
@@ -179,6 +179,46 @@ public sealed class DomCommandBufferTests
     }
 
     [Fact]
+    public void FlipMoveOpcodes_RoundTripAsFloat64_InUpstreamWriteOrder()
+    {
+        var dom = new InMemoryHandleDom();
+        var buffer = new DomCommandBuffer();
+        var one = buffer.AllocateHandle();
+        var two = buffer.AllocateHandle();
+        buffer.WriteCreateElement(one, "li", null);
+        buffer.WriteCreateElement(two, "li", null);
+
+        // The FLIP write frame ([V01.01.04.07.03]): invert every moved child, one reflow barrier, then the
+        // move class + transform clear — the exact upstream applyTranslation/forceReflow/moveClass order.
+        buffer.WriteSetMoveTransform(one, 12.5, -7.25); // fractional deltas prove the float64 operand fidelity
+        buffer.WriteSetMoveTransform(two, 0, 40);
+        buffer.WriteForceReflow();
+        buffer.WriteAddTransitionClass(one, "v-move");
+        buffer.WriteClearMoveStyles(one);
+        buffer.WriteAddTransitionClass(two, "v-move");
+        buffer.WriteClearMoveStyles(two);
+
+        CommandBufferDecoder.Apply(buffer.BackingArray, buffer.FinalizeFrame(), dom);
+
+        // The single frame replays in order: transforms (float64 deltas intact), the reflow, then per child
+        // the move class and the transform clear.
+        dom.TransitionLog.ShouldBe(
+        [
+            $"transform:{one}:12.5,-7.25",
+            $"transform:{two}:0,40",
+            "reflow",
+            "add:v-move",
+            $"clear:{one}",
+            "add:v-move",
+            $"clear:{two}",
+        ]);
+        dom.ReflowCount.ShouldBe(1);
+        // The move class stuck and the inverting transform was cleared so the element animates home.
+        dom.TransitionClasses(one).ShouldContain("v-move");
+        dom.MoveTransform(one).ShouldBeNull();
+    }
+
+    [Fact]
     public void Decoder_RejectsAFrameWithAMismatchedVersion()
     {
         var buffer = new DomCommandBuffer();

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/InMemoryHandleDom.cs
@@ -192,6 +192,27 @@ internal sealed class InMemoryHandleDom
         ReflowCount++;
     }
 
+    // FLIP move ops ([V01.01.04.07.03]): mirror viu-dom.js setMoveTransform (inline transform +
+    // transitionDuration:0s) and clearMoveStyles. Kept out of the structural Serialize() fingerprint like
+    // the transition classes; the ordered log lets a sequencing test pin transforms -> reflow -> class -> clear.
+
+    /// <summary>Records the FLIP inverting transform for an element (upstream <c>applyTranslation</c>).</summary>
+    internal void SetMoveTransform(int handle, double deltaX, double deltaY)
+    {
+        TransitionLog.Add(string.Create(CultureInfo.InvariantCulture, $"transform:{handle}:{deltaX},{deltaY}"));
+        Get(handle).MoveTransform = (deltaX, deltaY);
+    }
+
+    /// <summary>Clears the FLIP transform so the move class animates the element home (upstream <c>clearMoveStyles</c>).</summary>
+    internal void ClearMoveStyles(int handle)
+    {
+        TransitionLog.Add(string.Create(CultureInfo.InvariantCulture, $"clear:{handle}"));
+        Get(handle).MoveTransform = null;
+    }
+
+    /// <summary>The FLIP inverting transform currently applied to an element, or null once cleared.</summary>
+    internal (double DeltaX, double DeltaY)? MoveTransform(int handle) => Get(handle).MoveTransform;
+
     /// <summary>The transition classes currently on an element (upstream <c>el.__vtc</c>/<c>classList</c>).</summary>
     internal IReadOnlyCollection<string> TransitionClasses(int handle) => Get(handle).TransitionClasses;
 
@@ -355,5 +376,8 @@ internal sealed class InMemoryHandleDom
         // Transition classes are tracked apart from the bound `class` attribute (upstream el.__vtc), so
         // they stay out of the structural Serialize() fingerprint the differential test compares.
         internal HashSet<string> TransitionClasses { get; } = new(StringComparer.Ordinal);
+
+        // The FLIP inverting transform (upstream el.style.transform), likewise out of the fingerprint.
+        internal (double DeltaX, double DeltaY)? MoveTransform { get; set; }
     }
 }

--- a/libraries/Assimalign.Viu.RuntimeDom/test/TransitionGroupTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/TransitionGroupTests.cs
@@ -82,6 +82,130 @@ public sealed class TransitionGroupTests : IDisposable
         _harness.Classes(spans[0]).ShouldNotContain("v-move");
     }
 
+    [Theory]
+    [InlineData(3)]
+    [InlineData(9)]
+    public void Reorder_BatchesEachPositionPass_IntoOneReadCrossing_RegardlessOfChildCount(int itemCount)
+    {
+        var initial = new string[itemCount];
+        for (var index = 0; index < itemCount; index++)
+        {
+            initial[index] = $"{index + 1}";
+        }
+        var list = Reactive.Reference(initial);
+        _harness.Render(Group(list));
+        var spans = _harness.FindElements("span");
+
+        // Old then new position per child — reversed layout so the ends move (the pre-patch snapshot dequeues
+        // the old, the post-patch read the new).
+        for (var index = 0; index < itemCount; index++)
+        {
+            _harness.EnqueuePosition(spans[index], 0, index * 10);
+            _harness.EnqueuePosition(spans[index], 0, (itemCount - 1 - index) * 10);
+        }
+
+        var reversed = new string[itemCount];
+        for (var index = 0; index < itemCount; index++)
+        {
+            reversed[index] = initial[itemCount - 1 - index];
+        }
+        list.Value = reversed;
+        _harness.RunUntilIdle();
+
+        // The batched-read acceptance criterion: exactly TWO read crossings for the whole reorder — one
+        // pre-patch snapshot, one post-patch read — no matter how many children, and each crossing carries
+        // the full child batch. Upstream reads getBoundingClientRect per child inside a same-process JS loop;
+        // a handle platform batches the pass so N children cost one crossing, not N ([V01.01.04.07.03]).
+        _harness.MeasurePositionsCallCount.ShouldBe(2);
+        _harness.MeasuredBatchSizes.ShouldBe([itemCount, itemCount]);
+        // Sanity: the FLIP actually ran (the first item moved to the far end).
+        _harness.Classes(spans[0]).ShouldContain("v-move");
+    }
+
+    [Fact]
+    public void InterruptedReorder_ForceFinishesTheInFlightMove_ThenConverges()
+    {
+        var list = Reactive.Reference<string[]>(["1", "2", "3"]);
+        _harness.Render(Group(list));
+        var spans = _harness.FindElements("span");
+        int one = spans[0], two = spans[1], three = spans[2];
+
+        // Two reorders' worth of positions per element (old, new, old, new): 2 stays put, 1 and 3 move both times.
+        _harness.EnqueuePosition(one, 0, 0);
+        _harness.EnqueuePosition(one, 0, 100);
+        _harness.EnqueuePosition(one, 0, 100);
+        _harness.EnqueuePosition(one, 0, 0);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(three, 0, 100);
+        _harness.EnqueuePosition(three, 0, 0);
+        _harness.EnqueuePosition(three, 0, 0);
+        _harness.EnqueuePosition(three, 0, 100);
+
+        // Reorder 1: 1 and 3 swap; both gain the move class and a pending move-end.
+        list.Value = ["3", "2", "1"];
+        _harness.RunUntilIdle();
+        _harness.Classes(one).ShouldContain("v-move");
+        _harness.HasPendingMove(one).ShouldBeTrue();
+
+        // Reorder 2 BEFORE the first move ends: upstream callPendingCbs force-finishes the in-flight move
+        // (the interrupted move class is removed) and the FLIP re-runs from the settled position — a fresh
+        // pending move replaces the stale one rather than stacking a second transitionend listener.
+        list.Value = ["1", "2", "3"];
+        _harness.RunUntilIdle();
+        _harness.Classes(one).ShouldContain("v-move");
+        _harness.HasPendingMove(one).ShouldBeTrue();
+        // The inverting transform is written then cleared within each FLIP, so nothing lingers inline.
+        _harness.MoveTransforms.ShouldBeEmpty();
+
+        // The final move end converges: no move class, no pending callback anywhere.
+        _harness.FireMoveEnd(one);
+        _harness.FireMoveEnd(three);
+        _harness.Classes(one).ShouldNotContain("v-move");
+        _harness.Classes(three).ShouldNotContain("v-move");
+        _harness.HasPendingMove(one).ShouldBeFalse();
+        _harness.HasPendingMove(three).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CompletedReorder_LeavesNoResidue_OnceEveryMoveEnds()
+    {
+        var list = Reactive.Reference<string[]>(["1", "2", "3"]);
+        _harness.Render(Group(list));
+        var spans = _harness.FindElements("span");
+        int one = spans[0], two = spans[1], three = spans[2];
+
+        _harness.EnqueuePosition(one, 0, 0);
+        _harness.EnqueuePosition(one, 0, 100);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(two, 0, 50);
+        _harness.EnqueuePosition(three, 0, 100);
+        _harness.EnqueuePosition(three, 0, 0);
+
+        list.Value = ["3", "1", "2"];
+        _harness.RunUntilIdle();
+
+        // The FLIP wrote and then cleared the inverting transform for each moved child (upstream
+        // applyTranslation then style.transform = ''), so no inline transform lingers even mid-animation.
+        _harness.MoveTransforms.ShouldBeEmpty();
+        _harness.HasPendingMove(one).ShouldBeTrue();
+        _harness.HasPendingMove(three).ShouldBeTrue();
+        // The static item never entered the move pipeline.
+        _harness.Classes(two).ShouldNotContain("v-move");
+        _harness.HasPendingMove(two).ShouldBeFalse();
+
+        // Firing every move end removes the move class and drops the pending callback — the group is clean.
+        _harness.FireMoveEnd(one);
+        _harness.FireMoveEnd(three);
+        _harness.Classes(one).ShouldNotContain("v-move");
+        _harness.Classes(three).ShouldNotContain("v-move");
+        _harness.HasPendingMove(one).ShouldBeFalse();
+        _harness.HasPendingMove(three).ShouldBeFalse();
+        _harness.MoveTransforms.ShouldBeEmpty();
+    }
+
     // A component rendering <TransitionGroup tag="div"> over a keyed list of <span>s.
     private static RenderComponent Group(Reference<string[]> list)
         => new((_, _) => () =>

--- a/libraries/Assimalign.Viu.RuntimeDom/test/TransitionTestHarness.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/TransitionTestHarness.cs
@@ -45,12 +45,22 @@ internal sealed class TransitionTestHarness : IDisposable
             NextFrame = callback => _nextFrameQueue.Add(callback),
             ForceReflow = () => ReflowCount++,
             WhenTransitionEnds = (element, _, _, resolve) => _endResolvers[element] = resolve,
-            MeasurePosition = element =>
+            MeasurePositions = handles =>
             {
-                MeasureLog.Add(element);
-                return _positions.TryGetValue(element, out var queue) && queue.Count > 0
-                    ? (queue.Count > 1 ? queue.Dequeue() : queue.Peek())
-                    : default;
+                // One batched read crossing per FLIP pass ([V01.01.04.07.03]); the interop-call-count
+                // criterion counts these — a reorder of N children must not cost N crossings.
+                MeasurePositionsCallCount++;
+                MeasuredBatchSizes.Add(handles.Length);
+                var result = new TransitionRectangle[handles.Length];
+                for (var index = 0; index < handles.Length; index++)
+                {
+                    var element = handles[index];
+                    MeasureLog.Add(element);
+                    result[index] = _positions.TryGetValue(element, out var queue) && queue.Count > 0
+                        ? (queue.Count > 1 ? queue.Dequeue() : queue.Peek())
+                        : default;
+                }
+                return result;
             },
             SetMoveTransform = (element, deltaX, deltaY) =>
             {
@@ -103,6 +113,15 @@ internal sealed class TransitionTestHarness : IDisposable
 
     /// <summary>The element handles measured, in order (diagnostics).</summary>
     public List<int> MeasureLog { get; } = [];
+
+    /// <summary>
+    /// The number of batched <see cref="DomTransitionOperations.MeasurePositions"/> crossings — one per
+    /// FLIP pass (pre-patch snapshot + post-patch read), independent of child count ([V01.01.04.07.03]).
+    /// </summary>
+    public int MeasurePositionsCallCount { get; private set; }
+
+    /// <summary>The child count of each batched read crossing, in order — proves the whole pass rode one call.</summary>
+    public List<int> MeasuredBatchSizes { get; } = [];
 
     /// <summary>Whether the fake reports that the move class adds a CSS transform (drives the FLIP gate).</summary>
     public bool HasCssTransform { get; set; } = true;


### PR DESCRIPTION
## Summary
- Implements the FLIP move pipeline mirroring vuejs/core `TransitionGroup.ts`: pre-patch position snapshot, post-patch compare, inverted transform, one forced reflow, move class + transform clear animating children to their final spots, `transitionend` cleanup guarded to the move transition, and the `hasCSSTransform` clone probe gating the path.
- **Batched read pass**: `MeasurePositions(int[]) → TransitionRectangle[]` reads every child's rectangle in ONE interop crossing (flat `[left, top, …]` primitives, the history-bridge snapshot pattern) — a reorder of N children costs exactly two read crossings regardless of N, pinned by an interop-call-count Theory at N=3 and N=9. Delta computation and moved-child policy stay .NET-side per the DESIGN.md applier split.
- **Batched write pass**: `SetMoveTransform`/`ClearMoveStyles` become command-buffer opcodes 24/25 — the whole move sequence (every transform → reflow barrier → move classes + clears) commits in one crossing in upstream order. Frame version bumped `0x02`→`0x03` on the C# writer, `viu-dom.js` applier (with the drift-rejecting version check), and the test-side decoder oracle; opcode 24 carries the wire format's first float64 operands (`WriteDoubleLittleEndian` ↔ `getFloat64(…, true)`, round-trip-pinned including fractional deltas).
- Interrupted reorders run upstream's `callPendingCbs` semantics (in-flight move force-finished, group converges, no residue); the one-crossing-per-flush batching pin and all prior sequencing tests stay green; the event-dispatch side of `viu-dom.js` is untouched (kept clean for the stacked #191 click bridge).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings (WASM example included) · RuntimeDom tests **165/165** (+5: batched-read call counts, interrupted-reorder convergence, no-residue cleanup, float64 wire round-trip in upstream write order; existing moved-only/gate tests green).

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)