### PR TITLE
feat(runtime-core): implement KeepAlive [V01.01.03.18]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -44,6 +44,38 @@ typed; cross-cutting values flow through typed provide/inject (`InjectionKey<T>`
 (`IPlugin<TNode>`). `Application<TNode>` and `ApplicationConfiguration` deliberately omit an
 `app.config.globalProperties` bag.
 
+## Teleport is a special vnode type, not a component
+
+`Teleport` ([V01.01.03.17], upstream `components/Teleport.ts`) mirrors upstream by being a distinct
+`VirtualNodeType.Teleport` (carrying `ShapeFlags.Teleport`) that the renderer branches on in
+*patch / move / unmount* — **not** an `IComponentDefinition` like `BaseTransition`. It cannot be an
+ordinary component: it frames its own tree position with a main-tree anchor pair (reusing the vnode's
+`El`/`Anchor`) while mounting its children into a *different* container, and it moves those children
+between containers when `disabled`/`to` change — behavior with no place in the component render model.
+Target-side state (the resolved target and its anchor pair, plus the deferred-mount job) hangs off a
+single internal `TeleportState` reference so a non-Teleport vnode pays only one null field.
+
+Target lookup is the one new platform seam: the `to` prop is either a direct platform-node target or a
+selector resolved through `RendererOptions<TNode>.QuerySelector` — the browser adapter's DOM
+`querySelector`, the test adapter's registered-root search. The renderer never touches a node except
+through node-ops, so no DOM/JS access leaks in. `defer` resolves the target in a post-flush job
+(so a Teleport can target an element rendered later in the same tree); toggling `disabled` and changing
+`to` relocate the existing nodes with `insert` (no unmount), preserving subtree state.
+
+Deliberate divergences from upstream `Teleport.ts`, each documented at its call site:
+
+- **No SVG/MathML target-namespace sniff.** Upstream inspects the resolved target's `namespaceURI` to
+  switch the children's namespace; Viu's node-ops expose no element-namespace query, so the ambient
+  compiled namespace is threaded through instead.
+- **Target anchors are created only when the target resolves.** Upstream's `prepareAnchor` always
+  creates the `targetStart`/`targetAnchor` pair (for its hydration path) and inserts them only when a
+  target exists; Viu creates none for an unresolved target, so a missing/disabled Teleport never leaks
+  two never-inserted platform-node handles. The `TeleportEndKey` sibling-skip property is likewise
+  hydration-only and omitted.
+- **`default(TNode)` is honored as the "no node" sentinel** when resolving a string target: a value-type
+  handle renderer (the browser's `0`) returning it means "not found", exactly as a null reference-type
+  handle does — so a missing selector never teleports into node `0`.
+
 ## Deltas from Vue 3
 
 - **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -76,6 +76,48 @@ Deliberate divergences from upstream `Teleport.ts`, each documented at its call 
   handle renderer (the browser's `0`) returning it means "not found", exactly as a null reference-type
   handle does — so a missing selector never teleports into node `0`.
 
+## KeepAlive is a component with renderer-internal reach
+
+`KeepAlive` ([V01.01.03.18], upstream `components/KeepAlive.ts`) is — unlike Teleport — a real
+`IComponentDefinition` (`KeepAlive.Instance`, the singleton `RenderHelpers._KeepAlive` resolves to). It
+wraps one dynamic child and, when the view switches, has the renderer **move the outgoing child's subtree
+into a hidden storage container instead of unmounting it** (`deactivate`) and move it home on return
+(`activate`), so the child's `Setup` runs once and all its state survives. The two paths are driven by
+`ShapeFlags.ComponentShouldKeepAlive` / `ComponentKeptAlive` (bit-for-bit with `@vue/shared`): the
+renderer's `processComponent` short-circuits a kept-alive vnode into `ActivateComponent` instead of a
+fresh mount, and its `unmount` short-circuits a should-keep-alive vnode into `DeactivateComponent`
+(move-to-storage) instead of teardown.
+
+Upstream injects the renderer internals onto `instance.ctx.renderer` in `mountComponent`; Viu mirrors the
+split without leaking `TNode` into the component. The renderer owns activate/deactivate and, at mount,
+attaches an internal `KeepAliveContext` (a node-op-created storage container plus a real-unmount delegate)
+to the KeepAlive instance **before** `Setup` runs. `KeepAlive` itself owns the cache and the render/prune
+logic: because `KeepAlive.Instance` is a shared singleton, every per-mount value (the cache, the
+least-recently-used key order, the current/pending keys) is **closure** state created fresh per `Setup`,
+never an instance field. The cache key is the child's vnode key when present, else the component
+definition reference — a typed key, never a reflected type name (AOT/trimming). `Max` caps the cache with
+LRU eviction (a `LinkedList<object>` orders keys oldest-first); `Include`/`Exclude` match the child's
+declared `IComponentDefinition.Name`, and a `flush: 'post'` watch prunes newly excluded entries when the
+props change.
+
+`Activated`/`Deactivated` hooks mirror upstream's `registerKeepAliveHook`: a KeepAlive activates only its
+*direct* child, so a nested descendant's hook is prepended onto every ancestor KeepAlive-root instance's
+hook list, and one `InvokeHooks` on that root fires the whole subtree child-before-parent. A
+deactivation-branch check (upstream's `__wdc`) skips a hook whose owning branch is already deactivated so
+nested KeepAlives do not double-fire.
+
+Deliberate divergences from upstream `KeepAlive.ts`, each documented at its call site:
+
+- **No Suspense unwrapping.** Upstream's `getInnerChild` unwraps a Suspense child; Viu treats the child as
+  its own inner child until Suspense lands ([V01.01.03.20]).
+- **No mount-invalidation of a pending activated/mounted hook.** Upstream 3.5 calls `invalidateMount` when
+  deactivating so a queued-but-unrun mounted/activated hook is cancelled; Viu's synchronous per-render
+  flush drains a newly-mounted subtree's post-flush hooks before any later render can deactivate it, so
+  `mounted` still fires exactly once and the guard is unnecessary for discrete render cycles.
+- **Aggregated hooks fire with the KeepAlive-root as the ambient instance.** Upstream's `invokeArrayFns`
+  sets no current instance; Viu fires the aggregated list through the root's `InvokeHooks`, so a
+  descendant hook that reads `ComponentInstance.Current` sees the root — a minor divergence pinned by test.
+
 ## Deltas from Vue 3
 
 - **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
@@ -14,16 +14,18 @@ a platform package supplies the node-ops (the browser's `Assimalign.Viu.RuntimeD
   `VirtualNodeFactory` (including `Teleport`/`TeleportBlock`), `VirtualNodeProperties`.
 - **Renderer** (`Rendering/`) — `RendererFactory.CreateRenderer(options)` (Vue's `createRenderer`),
   `Renderer<TNode>` (the mount/patch/unmount pipeline, including the `Teleport` built-in as a special
-  vnode type in the patch/move/unmount paths — [V01.01.03.17]), `RendererOptions<TNode>` (the
-  injected platform node-ops, whose optional `QuerySelector` resolves a Teleport string target),
-  `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
+  vnode type in the patch/move/unmount paths — [V01.01.03.17], and the `KeepAlive` activate/deactivate
+  operations its `processComponent`/`unmount` shape-flag branches short-circuit into — [V01.01.03.18]),
+  `RendererOptions<TNode>` (the injected platform node-ops, whose optional `QuerySelector` resolves a
+  Teleport string target), `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
 - **Scheduler** (`Scheduling/`) — `Scheduler` (batched flush phases and `NextTick`) and
   `SchedulerJob`.
 - **Component model** (`Components/`) — `ComponentInstance`, `ComponentSetupContext`,
   `ComponentProperties` / `ComponentPropertyDefinition` (props declaration and validation),
   `ComponentAttributes` (attrs fallthrough), `ComponentEmitDefinition` (emits), `ComponentSlots`,
-  `Lifecycle` (the hook registration facade), `DynamicComponents`, and the transition scaffolding
-  (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
+  `Lifecycle` (the hook registration facade, including `OnActivated`/`OnDeactivated`),
+  `DynamicComponents`, the `KeepAlive` caching built-in ([V01.01.03.18]), and the transition
+  scaffolding (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
 - **Application / plugins** — `Application<TNode>` (Vue's `createApp` shell: one root mounted into
   one container), `ApplicationConfiguration` (error/warn handlers, performance flag),
   `IComponentDefinition`, `IPlugin<TNode>`.

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
@@ -10,11 +10,13 @@ a platform package supplies the node-ops (the browser's `Assimalign.Viu.RuntimeD
 ## Public surface
 
 - **Virtual DOM model** (`src/` root) — `VirtualNode` (the unified vnode: element / component /
-  text / comment / static / fragment via `VirtualNodeType` + a shape-flag bitmask),
-  `VirtualNodeFactory`, `VirtualNodeProperties`.
+  text / comment / static / fragment / teleport via `VirtualNodeType` + a shape-flag bitmask),
+  `VirtualNodeFactory` (including `Teleport`/`TeleportBlock`), `VirtualNodeProperties`.
 - **Renderer** (`Rendering/`) — `RendererFactory.CreateRenderer(options)` (Vue's `createRenderer`),
-  `Renderer<TNode>` (the mount/patch/unmount pipeline), `RendererOptions<TNode>` (the injected
-  platform node-ops), `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
+  `Renderer<TNode>` (the mount/patch/unmount pipeline, including the `Teleport` built-in as a special
+  vnode type in the patch/move/unmount paths — [V01.01.03.17]), `RendererOptions<TNode>` (the
+  injected platform node-ops, whose optional `QuerySelector` resolves a Teleport string target),
+  `RenderEffect<TNode>` (reactive re-render integration), and `BlockToken`.
 - **Scheduler** (`Scheduling/`) — `Scheduler` (batched flush phases and `NextTick`) and
   `SchedulerJob`.
 - **Component model** (`Components/`) — `ComponentInstance`, `ComponentSetupContext`,

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/ComponentInstance.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/ComponentInstance.cs
@@ -82,6 +82,29 @@ public sealed class ComponentInstance
     internal HashSet<string>? LastProvidedNames { get; set; }
 
     /// <summary>
+    /// Whether this instance runs the <see cref="KeepAlive"/> built-in (upstream: <c>isKeepAlive</c>,
+    /// the <c>__isKeepAlive</c> component flag). Read when registering
+    /// <see cref="Lifecycle.OnActivated"/>/<see cref="Lifecycle.OnDeactivated"/> so a descendant hook is
+    /// injected onto every ancestor KeepAlive-root instance ([V01.01.03.18]).
+    /// </summary>
+    internal bool IsKeepAlive => Definition is KeepAlive;
+
+    /// <summary>
+    /// Whether this instance's subtree currently lives in a <see cref="KeepAlive"/> storage container —
+    /// upstream's <c>instance.isDeactivated</c>. Set by the renderer's activate/deactivate operations
+    /// (only ever on a KeepAlive's direct child), and read by the activated/deactivated hook wrapper to
+    /// skip firing a hook whose owning branch is deactivated ([V01.01.03.18]).
+    /// </summary>
+    internal bool IsDeactivated { get; set; }
+
+    /// <summary>
+    /// The renderer internals for a mounted <see cref="KeepAlive"/> (upstream: <c>instance.ctx.renderer</c>
+    /// for a KeepAlive) — a storage container plus a real-unmount operation. The renderer sets it before
+    /// <c>Setup</c> runs; null on every non-KeepAlive instance ([V01.01.03.18]).
+    /// </summary>
+    internal KeepAliveContext? KeepAliveContext { get; set; }
+
+    /// <summary>
     /// The instance whose <c>Setup</c>, render, or lifecycle hook is executing — upstream's
     /// <c>getCurrentInstance()</c>. Null outside those windows.
     /// </summary>
@@ -179,6 +202,19 @@ public sealed class ComponentInstance
 
     internal void RegisterHook(LifecycleHookKind kind, Delegate hook)
         => (_hooks[(int)kind] ??= []).Add(hook);
+
+    /// <summary>
+    /// Prepends a hook so it runs before hooks already registered for the same kind — the C# port of
+    /// <c>injectHook(type, hook, target, /*prepend*/ true)</c>. KeepAlive uses this to aggregate a
+    /// descendant's activated/deactivated hook onto the KeepAlive-root instance ahead of the root's own,
+    /// yielding child-before-parent firing ([V01.01.03.18]).
+    /// </summary>
+    internal void PrependHook(LifecycleHookKind kind, Delegate hook)
+        => (_hooks[(int)kind] ??= []).Insert(0, hook);
+
+    /// <summary>Removes a previously registered hook (upstream: <c>remove(instance[type], hook)</c>).</summary>
+    internal void RemoveHook(LifecycleHookKind kind, Delegate hook)
+        => _hooks[(int)kind]?.Remove(hook);
 
     internal bool HasHooks(LifecycleHookKind kind) => _hooks[(int)kind] is { Count: > 0 };
 

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/KeepAlive.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/KeepAlive.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Shared;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The <c>&lt;KeepAlive&gt;</c> built-in — the C# port of upstream's <c>KeepAlive</c> component
+/// (<c>packages/runtime-core/src/components/KeepAlive.ts</c>,
+/// https://vuejs.org/guide/built-ins/keep-alive.html). Unlike <see cref="BaseTransition"/> (which only
+/// stamps hooks) and unlike <c>Teleport</c> (a special vnode type), KeepAlive is a real
+/// <see cref="IComponentDefinition"/> with renderer-internal reach: it wraps a single dynamic child and,
+/// instead of unmounting the outgoing child when the view switches, has the renderer move its subtree
+/// into a hidden storage container (<c>deactivate</c>) and move it back on return (<c>activate</c>), so
+/// the child's <c>Setup</c> runs once and all internal state is preserved across switches.
+/// <para>
+/// The cache is keyed by the child's vnode key when present, else by the component definition reference
+/// (a typed key — never a reflected type name). <c>Include</c>/<c>Exclude</c> match on the component's
+/// declared <see cref="IComponentDefinition.Name"/> (a comma-separated string, a string list, or a
+/// predicate — the C# analogue of upstream's string / array / RegExp); a non-matching child mounts and
+/// unmounts normally. <c>Max</c> caps the cache with least-recently-used eviction: the least-recently
+/// accessed cached instance is fully unmounted when the cache would overflow. Changing
+/// <c>Include</c>/<c>Exclude</c> prunes newly excluded entries; unmounting the KeepAlive unmounts every
+/// cached instance. <c>Activated</c>/<c>Deactivated</c> lifecycle hooks
+/// (<see cref="Lifecycle.OnActivated"/>/<see cref="Lifecycle.OnDeactivated"/>) fire on the direct child
+/// and, aggregated child-before-parent, on its nested descendants.
+/// </para>
+/// <para>
+/// The renderer wires its internals (a storage container and a real-unmount operation) onto the instance
+/// before <c>Setup</c> runs (<see cref="ComponentInstance.KeepAliveContext"/>). Because
+/// <see cref="Instance"/> is a shared singleton, all per-mount state (the cache, the LRU key order, the
+/// current and pending keys) is <b>closure</b> state created fresh per <c>Setup</c> — never instance
+/// fields. Suspense unwrapping is deferred to <c>Suspense</c> ([V01.01.03.20]). Not thread-safe
+/// (single-threaded JS event-loop model).
+/// </para>
+/// </summary>
+public sealed class KeepAlive : IComponentDefinition
+{
+    /// <summary>The shared component instance the compiled render references via <see cref="RenderHelpers._KeepAlive"/>.</summary>
+    public static readonly KeepAlive Instance = new();
+
+    // include / exclude / max are declared props so their values flow through the instance's
+    // shallow-reactive props (upstream: props: { include, exclude, max }); the include/exclude watch
+    // and the render read them reactively.
+    private static readonly IReadOnlyList<ComponentPropertyDefinition> KeepAliveProperties =
+    [
+        new ComponentPropertyDefinition("include"),
+        new ComponentPropertyDefinition("exclude"),
+        new ComponentPropertyDefinition("max"),
+    ];
+
+    private KeepAlive()
+    {
+    }
+
+    /// <inheritdoc/>
+    public string? Name => "KeepAlive";
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties => KeepAliveProperties;
+
+    /// <inheritdoc/>
+    // KeepAlive owns no element of its own; it renders its cached child, so attribute fallthrough is off.
+    public bool InheritAttributes => false;
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var instance = ComponentInstance.Current!;
+        // The renderer injects its internals (storage container + real unmount) before Setup runs
+        // (upstream mountComponent: instance.ctx.renderer = internals).
+        var unmountCached = (instance.KeepAliveContext
+            ?? throw new InvalidOperationException(
+                "KeepAlive can only be set up by the Viu renderer, which injects its internals before Setup runs."))
+            .Unmount;
+
+        // Per-mount cache state. Instance is a shared singleton, so this MUST be closure state, never
+        // instance fields (upstream: cache/keys are createComponent-local). `keys` orders the cache
+        // least-recently-used: First is the oldest (eviction candidate), Last the freshest.
+        var cache = new Dictionary<object, VirtualNode>();
+        var keys = new LinkedList<object>();
+        var keyNodes = new Dictionary<object, LinkedListNode<object>>();
+        VirtualNode? current = null;
+        object? pendingCacheKey = null;
+
+        void AddKey(object key) => keyNodes[key] = keys.AddLast(key);
+
+        void TouchKey(object key)
+        {
+            if (keyNodes.TryGetValue(key, out var node))
+            {
+                keys.Remove(node);
+                keys.AddLast(node);
+            }
+        }
+
+        void RemoveKey(object key)
+        {
+            if (keyNodes.Remove(key, out var node))
+            {
+                keys.Remove(node);
+            }
+        }
+
+        void PruneCacheEntry(object key)
+        {
+            // Upstream pruneCacheEntry: unmount the cached instance, unless it is the current active
+            // child — which cannot be unmounted now, so only reset its shape flags so a later
+            // switch-away tears it down normally.
+            if (cache.TryGetValue(key, out var cached))
+            {
+                if (current is null || !IsSameCacheType(cached, current))
+                {
+                    unmountCached(cached);
+                }
+                else
+                {
+                    ResetKeepAliveFlags(current);
+                }
+            }
+            cache.Remove(key);
+            RemoveKey(key);
+        }
+
+        void PruneCache(Func<string, bool> filter)
+        {
+            // Upstream pruneCache: prune every entry whose component name fails the filter. Snapshot the
+            // keys because PruneCacheEntry mutates the cache during iteration.
+            foreach (var key in new List<object>(keyNodes.Keys))
+            {
+                if (cache.TryGetValue(key, out var cached)
+                    && ComponentName(cached) is { } name
+                    && !filter(name))
+                {
+                    PruneCacheEntry(key);
+                }
+            }
+        }
+
+        // Prune newly excluded entries when include/exclude change, after the render commits current
+        // (upstream: watch(() => [props.include, props.exclude], ..., { flush: 'post' })).
+        ViuWatch.Watch(
+            new Func<object?>[] { () => properties["include"], () => properties["exclude"] },
+            (_, _, _) =>
+            {
+                var include = properties["include"];
+                var exclude = properties["exclude"];
+                if (include is not null)
+                {
+                    PruneCache(name => Matches(include, name));
+                }
+                if (exclude is not null)
+                {
+                    PruneCache(name => !Matches(exclude, name));
+                }
+            },
+            new WatchOptions { Flush = WatchFlushMode.Post });
+
+        // Cache the current subtree once it is mounted / updated (upstream: onMounted/onUpdated
+        // cacheSubtree). instance.Subtree is KeepAlive's rendered child, now carrying its host el.
+        void CacheSubtree()
+        {
+            if (pendingCacheKey is not null && instance.Subtree is not null)
+            {
+                cache[pendingCacheKey] = instance.Subtree;
+            }
+        }
+
+        Lifecycle.OnMounted(CacheSubtree);
+        Lifecycle.OnUpdated(CacheSubtree);
+
+        // On KeepAlive teardown, unmount every cached instance. The current active child unmounts as
+        // part of KeepAlive's own subtree unmount, so only reset its flags and fire its deactivated
+        // hook here (upstream: onBeforeUnmount).
+        Lifecycle.OnBeforeUnmount(() =>
+        {
+            var currentChild = instance.Subtree;
+            foreach (var cached in new List<VirtualNode>(cache.Values))
+            {
+                if (currentChild is not null && IsSameCacheType(cached, currentChild))
+                {
+                    ResetKeepAliveFlags(currentChild);
+                    if (currentChild.Component is ComponentInstance childInstance
+                        && childInstance.HasHooks(LifecycleHookKind.Deactivated))
+                    {
+                        Scheduler.QueuePostFlushCallback(
+                            new SchedulerJob(() => childInstance.InvokeHooks(LifecycleHookKind.Deactivated)));
+                    }
+                }
+                else
+                {
+                    unmountCached(cached);
+                }
+            }
+        });
+
+        VirtualNode? Render()
+        {
+            pendingCacheKey = null;
+            var slots = context.Slots;
+            if (slots is null || !slots.TryGetSlot("default", out var slot))
+            {
+                current = null;
+                return null;
+            }
+            var children = slot(null);
+            if (children is null || children.Length == 0)
+            {
+                current = null;
+                return null;
+            }
+            var rawChild = children[0];
+            if (children.Length > 1)
+            {
+                // KeepAlive wraps exactly one child; render them all uncached (upstream dev warning).
+                RuntimeWarnings.Warn("KeepAlive should contain exactly one component child.");
+                current = null;
+                return VirtualNodeFactory.Fragment(children);
+            }
+            // Only a stateful component can be kept alive (upstream: else current = null; return rawVNode).
+            if (rawChild is null
+                || (rawChild.ShapeFlag & ShapeFlags.StatefulComponent) == 0
+                || rawChild.ComponentType is not IComponentDefinition componentDefinition)
+            {
+                current = rawChild;
+                return rawChild;
+            }
+
+            var name = componentDefinition.Name;
+            var include = properties["include"];
+            var exclude = properties["exclude"];
+            var maxValue = properties["max"];
+            if ((include is not null && (name is null || !Matches(include, name)))
+                || (exclude is not null && name is not null && Matches(exclude, name)))
+            {
+                // Filtered out: this child mounts and unmounts normally, uncached.
+                current = rawChild;
+                return rawChild;
+            }
+
+            var child = rawChild;
+            var key = child.Key ?? componentDefinition;
+            var hasCached = cache.TryGetValue(key, out var cached);
+            // Clone a reused (already-mounted) child before mutating its el/component/shapeFlag
+            // (upstream: if (vnode.el) vnode = cloneVNode(vnode)). A fresh render slot vnode has no el.
+            if (child.El is not null)
+            {
+                child = VirtualNodeFactory.Clone(child);
+            }
+            pendingCacheKey = key;
+            if (hasCached)
+            {
+                // Copy the cached mounted state so the renderer reactivates instead of remounting.
+                child.El = cached!.El;
+                child.Component = cached.Component;
+                if (child.Transition is not null)
+                {
+                    BaseTransition.SetTransitionHooks(child, child.Transition);
+                }
+                child.ShapeFlag |= ShapeFlags.ComponentKeptAlive;
+                TouchKey(key);
+            }
+            else
+            {
+                AddKey(key);
+                var max = ParseMax(maxValue);
+                if (max > 0 && keys.Count > max)
+                {
+                    // Evict the least-recently-used entry (upstream: keys.values().next().value).
+                    PruneCacheEntry(keys.First!.Value);
+                }
+            }
+            // Prevent the renderer from unmounting this child: it deactivates instead.
+            child.ShapeFlag |= ShapeFlags.ComponentShouldKeepAlive;
+            current = child;
+            return child;
+        }
+
+        return Render;
+    }
+
+    // --- name matching / helpers (upstream KeepAlive.ts module functions) ------------------------
+
+    /// <summary>
+    /// Whether <paramref name="name"/> matches an include/exclude pattern (upstream: <c>matches</c>) —
+    /// a comma-separated string (segment membership, no trimming, upstream parity), a string list (any
+    /// segment matches), or a predicate (the C# analogue of upstream's RegExp arm).
+    /// </summary>
+    private static bool Matches(object? pattern, string name) => pattern switch
+    {
+        string text => SplitContains(text, name),
+        Func<string, bool> predicate => predicate(name),
+        IEnumerable<string> list => AnyMatch(list, name),
+        _ => false,
+    };
+
+    private static bool SplitContains(string pattern, string name)
+    {
+        // Upstream: pattern.split(',').includes(name) — exact segment equality, whitespace preserved.
+        foreach (var segment in pattern.Split(','))
+        {
+            if (string.Equals(segment, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool AnyMatch(IEnumerable<string> patterns, string name)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (pattern is not null && SplitContains(pattern, name))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int ParseMax(object? max) => max switch
+    {
+        // Upstream: parseInt(max, 10); a non-positive / unparseable value means "unbounded".
+        int value => value,
+        long value => (int)value,
+        string text when int.TryParse(text, out var parsed) => parsed,
+        _ => 0,
+    };
+
+    private static string? ComponentName(VirtualNode vnode)
+        => (vnode.ComponentType as IComponentDefinition)?.Name;
+
+    private static bool IsSameCacheType(VirtualNode left, VirtualNode right)
+        => left.Type == right.Type
+            && Equals(left.Key, right.Key)
+            && ReferenceEquals(left.ComponentType, right.ComponentType);
+
+    private static void ResetKeepAliveFlags(VirtualNode vnode)
+        // Upstream resetShapeFlag: clear both keep-alive bits so the vnode unmounts/mounts normally.
+        => vnode.ShapeFlag &= ~(ShapeFlags.ComponentShouldKeepAlive | ShapeFlags.ComponentKeptAlive);
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/Lifecycle.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/Lifecycle.cs
@@ -53,13 +53,25 @@ public static class Lifecycle
     /// <param name="hook">The prefetch task factory.</param>
     public static void OnServerPrefetch(Func<Task> hook) => Register(LifecycleHookKind.ServerPrefetch, hook, nameof(OnServerPrefetch));
 
-    /// <summary>Stored for KeepAlive activation ([V01.01.03.18]); a no-op without a KeepAlive parent.</summary>
+    /// <summary>
+    /// Registers a hook that fires when a <c>&lt;KeepAlive&gt;</c> re-activates this component's cached
+    /// subtree (and on its initial mount inside a KeepAlive) — the C# port of <c>onActivated</c>
+    /// (<c>packages/runtime-core/src/components/KeepAlive.ts</c>,
+    /// https://vuejs.org/api/composition-api-lifecycle.html#onactivated). A no-op for a component with no
+    /// KeepAlive ancestor. Nested descendants' activated hooks fire child-before-parent (see
+    /// <see cref="OnDeactivated"/> for the mechanism).
+    /// </summary>
     /// <param name="hook">The hook.</param>
-    public static void OnActivated(Action hook) => Register(LifecycleHookKind.Activated, hook, nameof(OnActivated));
+    public static void OnActivated(Action hook) => RegisterKeepAliveHook(LifecycleHookKind.Activated, hook, nameof(OnActivated));
 
-    /// <summary>Stored for KeepAlive deactivation ([V01.01.03.18]); a no-op without a KeepAlive parent.</summary>
+    /// <summary>
+    /// Registers a hook that fires when a <c>&lt;KeepAlive&gt;</c> deactivates this component's subtree
+    /// (moves it to storage) — the C# port of <c>onDeactivated</c>
+    /// (https://vuejs.org/api/composition-api-lifecycle.html#ondeactivated). A no-op for a component with
+    /// no KeepAlive ancestor.
+    /// </summary>
     /// <param name="hook">The hook.</param>
-    public static void OnDeactivated(Action hook) => Register(LifecycleHookKind.Deactivated, hook, nameof(OnDeactivated));
+    public static void OnDeactivated(Action hook) => RegisterKeepAliveHook(LifecycleHookKind.Deactivated, hook, nameof(OnDeactivated));
 
     private static void Register(LifecycleHookKind kind, Delegate hook, string apiName)
     {
@@ -73,5 +85,52 @@ public static class Lifecycle
             return;
         }
         instance.RegisterHook(kind, hook);
+    }
+
+    private static void RegisterKeepAliveHook(LifecycleHookKind kind, Action hook, string apiName)
+    {
+        // The C# port of registerKeepAliveHook (KeepAlive.ts). A KeepAlive activates/deactivates only its
+        // direct child, so a nested descendant's hook is aggregated onto every ancestor KeepAlive-root
+        // instance; a single InvokeHooks on that root then fires the whole subtree child-before-parent.
+        ArgumentNullException.ThrowIfNull(hook);
+        var target = ComponentInstance.Current;
+        if (target is null)
+        {
+            RuntimeWarnings.Warn(
+                $"{apiName}() is called when there is no active component instance to be associated with. "
+                + "Lifecycle hooks can only be registered during Setup().");
+            return;
+        }
+        // Wrap with the deactivation-branch check (upstream __wdc): skip firing when the target or any
+        // ancestor is currently in a deactivated (stored) branch, so a nested KeepAlive does not
+        // double-fire an already-deactivated descendant.
+        Action wrapped = () =>
+        {
+            for (var node = target; node is not null; node = node.Parent)
+            {
+                if (node.IsDeactivated)
+                {
+                    return;
+                }
+            }
+            hook();
+        };
+        target.RegisterHook(kind, wrapped);
+        // Walk up and inject the wrapped hook onto every ancestor that is a KeepAlive-root direct child
+        // (its parent is a KeepAlive), prepending so deeper descendants fire before shallower ones.
+        var current = target.Parent;
+        while (current?.Parent is not null)
+        {
+            if (current.Parent.IsKeepAlive)
+            {
+                var keepAliveRoot = current;
+                keepAliveRoot.PrependHook(kind, wrapped);
+                // Remove the injected copy when the target unmounts (upstream: onUnmounted(remove, target)).
+                target.RegisterHook(
+                    LifecycleHookKind.Unmounted,
+                    (Action)(() => keepAliveRoot.RemoveHook(kind, wrapped)));
+            }
+            current = current.Parent;
+        }
     }
 }

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/BuiltInVirtualNodeType.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/BuiltInVirtualNodeType.cs
@@ -5,11 +5,12 @@ namespace Assimalign.Viu.RuntimeCore;
 /// <c>Suspense</c>/<c>KeepAlive</c>/<c>BaseTransition</c> symbols from <c>@vue/runtime-core</c>
 /// (<c>packages/runtime-core/src/vnode.ts</c> / <c>components/*</c>). The compiled render passes one of
 /// these as the <c>tag</c> argument to the vnode factories (e.g. <see cref="RenderHelpers._Fragment"/>);
-/// <see cref="RenderHelpers"/> dispatches on the marker identity. <see cref="IsFragment"/> markers are fully
-/// realized, and <c>BaseTransition</c> is now a real component (<see cref="RenderHelpers._BaseTransition"/>
-/// resolves to <see cref="BaseTransition"/>, [V01.01.04.07]) rather than a marker of this type. The
-/// remaining component-like built-ins (Teleport, Suspense, KeepAlive) are still surface markers whose
-/// renderer support is delivered by their own work items, so rendering one throws a clear
+/// <see cref="RenderHelpers"/> dispatches on the marker identity. <see cref="IsFragment"/> and
+/// <see cref="IsTeleport"/> markers are fully realized ([V01.01.03.17] delivered Teleport), and
+/// <c>BaseTransition</c> is now a real component (<see cref="RenderHelpers._BaseTransition"/> resolves to
+/// <see cref="BaseTransition"/>, [V01.01.04.07]) rather than a marker of this type. The remaining
+/// component-like built-ins (Suspense, KeepAlive) are still surface markers whose renderer support is
+/// delivered by their own work items, so rendering one throws a clear
 /// <see cref="System.NotSupportedException"/> rather than silently mis-rendering.
 /// </summary>
 internal sealed class BuiltInVirtualNodeType
@@ -17,10 +18,12 @@ internal sealed class BuiltInVirtualNodeType
     /// <summary>Creates a built-in marker.</summary>
     /// <param name="name">The upstream built-in name (for diagnostics).</param>
     /// <param name="isFragment">Whether this marker is the fully-realized <c>Fragment</c> type.</param>
-    internal BuiltInVirtualNodeType(string name, bool isFragment)
+    /// <param name="isTeleport">Whether this marker is the <c>Teleport</c> type.</param>
+    internal BuiltInVirtualNodeType(string name, bool isFragment, bool isTeleport = false)
     {
         Name = name;
         IsFragment = isFragment;
+        IsTeleport = isTeleport;
     }
 
     /// <summary>The upstream built-in name.</summary>
@@ -28,6 +31,9 @@ internal sealed class BuiltInVirtualNodeType
 
     /// <summary>Whether this marker is the fully-realized <c>Fragment</c> type.</summary>
     internal bool IsFragment { get; }
+
+    /// <summary>Whether this marker is the <c>Teleport</c> type (<see cref="VirtualNodeType.Teleport"/>).</summary>
+    internal bool IsTeleport { get; }
 
     /// <inheritdoc/>
     public override string ToString() => Name;

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/BuiltInVirtualNodeType.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/BuiltInVirtualNodeType.cs
@@ -6,11 +6,12 @@ namespace Assimalign.Viu.RuntimeCore;
 /// (<c>packages/runtime-core/src/vnode.ts</c> / <c>components/*</c>). The compiled render passes one of
 /// these as the <c>tag</c> argument to the vnode factories (e.g. <see cref="RenderHelpers._Fragment"/>);
 /// <see cref="RenderHelpers"/> dispatches on the marker identity. <see cref="IsFragment"/> and
-/// <see cref="IsTeleport"/> markers are fully realized ([V01.01.03.17] delivered Teleport), and
-/// <c>BaseTransition</c> is now a real component (<see cref="RenderHelpers._BaseTransition"/> resolves to
-/// <see cref="BaseTransition"/>, [V01.01.04.07]) rather than a marker of this type. The remaining
-/// component-like built-ins (Suspense, KeepAlive) are still surface markers whose renderer support is
-/// delivered by their own work items, so rendering one throws a clear
+/// <see cref="IsTeleport"/> markers are fully realized ([V01.01.03.17] delivered Teleport), and both
+/// <c>BaseTransition</c> ([V01.01.04.07]) and <c>KeepAlive</c> ([V01.01.03.18]) are now real components
+/// (<see cref="RenderHelpers._BaseTransition"/>/<see cref="RenderHelpers._KeepAlive"/> resolve to
+/// <see cref="BaseTransition"/>/<see cref="KeepAlive"/>) rather than markers of this type. The one
+/// remaining component-like built-in (Suspense) is still a surface marker whose renderer support is
+/// delivered by its own work item, so rendering it throws a clear
 /// <see cref="System.NotSupportedException"/> rather than silently mis-rendering.
 /// </summary>
 internal sealed class BuiltInVirtualNodeType

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/KeepAliveContext.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/KeepAliveContext.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The renderer internals a mounted <see cref="KeepAlive"/> instance consumes — the C# stand-in for
+/// the <c>renderer</c> slice upstream injects onto <c>instance.ctx</c> in <c>mountComponent</c>
+/// (<c>packages/runtime-core/src/renderer.ts</c>: <c>if (isKeepAlive(vnode)) instance.ctx.renderer =
+/// internals</c>). The renderer creates it on the KeepAlive instance <b>before</b> <c>Setup</c> runs so
+/// the component's cache/prune logic can reach back into the platform-generic renderer without
+/// <see cref="KeepAlive"/> knowing the <c>TNode</c> type.
+/// <para>
+/// The split mirrors upstream: <see cref="KeepAlive"/> owns the cache and the render/prune logic; the
+/// renderer owns the storage container and the <see cref="Unmount"/> operation. Activation and
+/// deactivation stay entirely on the renderer — its shape-flag branches call them directly — so they
+/// are not surfaced here. Not thread-safe (single-threaded JS event-loop model).
+/// </para>
+/// </summary>
+internal sealed class KeepAliveContext
+{
+    /// <summary>
+    /// The detached storage element the renderer moves a deactivated subtree into (upstream:
+    /// <c>storageContainer = createElement('div')</c>). Boxed <c>TNode</c> — created and read only by
+    /// the renderer's deactivate path; opaque to <see cref="KeepAlive"/>.
+    /// </summary>
+    internal required object StorageContainer { get; init; }
+
+    /// <summary>
+    /// Really unmounts a cached child vnode — the renderer resets its keep-alive shape flags and tears
+    /// it down with host removal (upstream: KeepAlive's local <c>unmount</c> wrapper around
+    /// <c>_unmount(vnode, instance, ..., /*doRemove*/ true)</c>). Consumed by <see cref="KeepAlive"/>'s
+    /// cache pruning and its own teardown.
+    /// </summary>
+    internal required Action<VirtualNode> Unmount { get; init; }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/TeleportMoveType.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/TeleportMoveType.cs
@@ -1,0 +1,29 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// Why a <see cref="VirtualNodeType.Teleport"/>'s nodes are being moved — the C# port of upstream's
+/// <c>TeleportMoveTypes</c> (<c>packages/runtime-core/src/components/Teleport.ts</c>). The value picks
+/// which anchors move and whether the children travel with them (see the renderer's
+/// <c>MoveTeleport</c>). [V01.01.03.17]
+/// </summary>
+internal enum TeleportMoveType
+{
+    /// <summary>
+    /// The <c>to</c> target changed: the target anchor is inserted into the new container and the
+    /// children follow it (upstream: <c>TARGET_CHANGE</c>).
+    /// </summary>
+    TargetChange,
+
+    /// <summary>
+    /// <c>disabled</c> toggled: the children move between the main-tree position and the target
+    /// container without unmounting, so subtree state is preserved (upstream: <c>TOGGLE</c>).
+    /// </summary>
+    Toggle,
+
+    /// <summary>
+    /// The whole Teleport is being relocated in the main tree (e.g. a keyed reorder): the main-tree
+    /// anchor pair moves, and the children move only when the Teleport is disabled (enabled children
+    /// stay in the target) (upstream: <c>REORDER</c>).
+    /// </summary>
+    Reorder,
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/TeleportState.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/TeleportState.cs
@@ -1,0 +1,47 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The renderer-owned target-side state of a <see cref="VirtualNodeType.Teleport"/> vnode — the C#
+/// stand-in for the <c>target</c>/<c>targetStart</c>/<c>targetAnchor</c> back-pointers upstream hangs
+/// directly on the Teleport vnode (<c>packages/runtime-core/src/components/Teleport.ts</c>). Kept as
+/// a single nullable reference on <see cref="VirtualNode.TeleportState"/> so a plain vnode pays only
+/// one null field on the hot path, and allocated only when a Teleport actually mounts.
+/// <para>
+/// The main-tree anchor pair framing the Teleport's original position reuses the shared
+/// <see cref="VirtualNode.El"/> (start) and <see cref="VirtualNode.Anchor"/> (end) fields; this holder
+/// carries only the target-container container/anchors and the deferred-mount job. The node handles
+/// are stored boxed as <see cref="object"/> because <see cref="VirtualNode"/> is not generic over the
+/// platform node type (matching how <see cref="VirtualNode.El"/> boxes its <c>TNode</c>). Not
+/// thread-safe (single-threaded JS event-loop model). [V01.01.03.17]
+/// </para>
+/// </summary>
+internal sealed class TeleportState
+{
+    /// <summary>
+    /// The resolved target container the children are teleported into (upstream: <c>vnode.target</c>),
+    /// or null when the <c>to</c> target could not be resolved. A boxed platform node handle.
+    /// </summary>
+    internal object? Target { get; set; }
+
+    /// <summary>
+    /// The start anchor framing the teleported content inside <see cref="Target"/> (upstream:
+    /// <c>vnode.targetStart</c>). A boxed platform node handle; null until the target anchors are
+    /// prepared.
+    /// </summary>
+    internal object? TargetStart { get; set; }
+
+    /// <summary>
+    /// The end anchor inside <see cref="Target"/> that the teleported children mount before (upstream:
+    /// <c>vnode.targetAnchor</c>). A boxed platform node handle; null until the target anchors are
+    /// prepared.
+    /// </summary>
+    internal object? TargetAnchor { get; set; }
+
+    /// <summary>
+    /// The post-flush job that resolves the target and mounts the children for a <c>defer</c>-ed
+    /// Teleport (upstream: the <c>pendingMounts</c> entry queued by <c>queuePendingMount</c>), or null
+    /// when the Teleport mounted synchronously. Superseded on update and disposed on unmount so a stale
+    /// deferred mount cannot run after the Teleport has moved or been torn down.
+    /// </summary>
+    internal SchedulerJob? PendingMount { get; set; }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/RenderHelpers.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/RenderHelpers.cs
@@ -602,8 +602,12 @@ public static class RenderHelpers
     /// <summary>The <c>Fragment</c> block type (upstream: <c>Fragment</c>).</summary>
     public static readonly object _Fragment = new BuiltInVirtualNodeType("Fragment", isFragment: true);
 
-    /// <summary>The <c>Teleport</c> built-in marker (upstream: <c>Teleport</c>); renderer support is separate work.</summary>
-    public static readonly object _Teleport = new BuiltInVirtualNodeType("Teleport", isFragment: false);
+    /// <summary>
+    /// The <c>Teleport</c> built-in (upstream: <c>Teleport</c>), realized by the renderer's Teleport
+    /// patch/move/unmount paths ([V01.01.03.17]). The compiled render passes it as a vnode <c>tag</c>;
+    /// <see cref="CreateBaseVNode"/> routes it to <see cref="VirtualNodeFactory.Teleport"/>.
+    /// </summary>
+    public static readonly object _Teleport = new BuiltInVirtualNodeType("Teleport", isFragment: false, isTeleport: true);
 
     /// <summary>The <c>Suspense</c> built-in marker (upstream: <c>Suspense</c>); renderer support is separate work.</summary>
     public static readonly object _Suspense = new BuiltInVirtualNodeType("Suspense", isFragment: false);
@@ -664,6 +668,13 @@ public static class RenderHelpers
                 return asBlock
                     ? VirtualNodeFactory.FragmentBlock(fragmentChildren, key, flag)
                     : VirtualNodeFactory.Fragment(fragmentChildren, key, flag);
+            case BuiltInVirtualNodeType { IsTeleport: true }:
+                // Teleport children are always an array (never built as slots — TransformElement excludes
+                // Teleport from the single-child collapse and the slot build), so coerce to the vnode array.
+                var teleportChildren = CoerceChildren(children);
+                return asBlock
+                    ? VirtualNodeFactory.TeleportBlock(bag, teleportChildren, flag, dynamicProperties)
+                    : VirtualNodeFactory.Teleport(bag, teleportChildren, flag, dynamicProperties);
             case IComponentDefinition definition:
                 var slots = CoerceSlots(children);
                 return asBlock

--- a/libraries/Assimalign.Viu.RuntimeCore/src/RenderHelpers.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/RenderHelpers.cs
@@ -612,8 +612,13 @@ public static class RenderHelpers
     /// <summary>The <c>Suspense</c> built-in marker (upstream: <c>Suspense</c>); renderer support is separate work.</summary>
     public static readonly object _Suspense = new BuiltInVirtualNodeType("Suspense", isFragment: false);
 
-    /// <summary>The <c>KeepAlive</c> built-in marker (upstream: <c>KeepAlive</c>); renderer support is separate work.</summary>
-    public static readonly object _KeepAlive = new BuiltInVirtualNodeType("KeepAlive", isFragment: false);
+    /// <summary>
+    /// The <c>KeepAlive</c> built-in (upstream: <c>KeepAlive</c>), resolved to the real caching component
+    /// <see cref="RuntimeCore.KeepAlive"/> ([V01.01.03.18]). The compiled render passes it as a vnode
+    /// <c>tag</c>; <see cref="CreateBaseVNode"/>'s component arm mounts it, and the renderer's
+    /// activate/deactivate paths cache its child's subtree instead of unmounting it.
+    /// </summary>
+    public static readonly object _KeepAlive = KeepAlive.Instance;
 
     /// <summary>
     /// The <c>BaseTransition</c> built-in (upstream: <c>BaseTransition</c>), resolved to the real

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
@@ -544,7 +544,16 @@ public sealed class Renderer<TNode>
     {
         if (current is null)
         {
-            MountComponent(next, container, anchor, elementNamespace, parentComponent);
+            if ((next.ShapeFlag & ShapeFlags.ComponentKeptAlive) != 0 && parentComponent is not null)
+            {
+                // A cached child re-entering a <KeepAlive>: reactivate its stored subtree instead of a
+                // fresh mount (upstream processComponent: (parentComponent.ctx).activate). [V01.01.03.18]
+                ActivateComponent(next, container, anchor, elementNamespace);
+            }
+            else
+            {
+                MountComponent(next, container, anchor, elementNamespace, parentComponent);
+            }
         }
         else
         {
@@ -563,6 +572,23 @@ public sealed class Renderer<TNode>
         }
         var instance = new ComponentInstance(definition, next, parentComponent);
         next.Component = instance;
+        // Inject the renderer internals a <KeepAlive> needs BEFORE its Setup runs (upstream
+        // mountComponent: if (isKeepAlive(vnode)) instance.ctx.renderer = internals). The storage
+        // container is created through the node-op so the mechanism works DOM-free ([V01.01.03.18]).
+        if (definition is KeepAlive)
+        {
+            instance.KeepAliveContext = new KeepAliveContext
+            {
+                StorageContainer = _options.CreateElement("div", elementNamespace),
+                Unmount = cached =>
+                {
+                    // Upstream KeepAlive.unmount: reset the keep-alive flags, then really tear it down
+                    // (host removal), routing errors through this KeepAlive instance.
+                    cached.ShapeFlag &= ~(ShapeFlags.ComponentShouldKeepAlive | ShapeFlags.ComponentKeptAlive);
+                    Unmount(cached, instance, doRemove: true);
+                },
+            };
+        }
         ComponentPropertyResolution.Resolve(instance, next);
         ResolveSlots(instance, next);
         SetupComponent(instance);
@@ -638,6 +664,14 @@ public sealed class Renderer<TNode>
             instance.VirtualNode.Anchor = subtree.Anchor;
             instance.IsMounted = true;
             QueueInstanceHooks(instance, LifecycleHookKind.Mounted);
+            // A component mounted for the first time inside a <KeepAlive> fires its activated hooks now
+            // too (upstream componentUpdateFn: instance.a && vnode.shapeFlag &
+            // COMPONENT_SHOULD_KEEP_ALIVE). The KeepAlive root's aggregated `a` list carries any nested
+            // descendants' hooks, so they fire child-before-parent ([V01.01.03.18]).
+            if ((instance.VirtualNode.ShapeFlag & ShapeFlags.ComponentShouldKeepAlive) != 0)
+            {
+                QueueInstanceHooks(instance, LifecycleHookKind.Activated);
+            }
         }
         else
         {
@@ -853,6 +887,41 @@ public sealed class Renderer<TNode>
         // Post-flush phase (upstream: queuePostRenderEffect); stable ordering keeps
         // child-before-parent for Mounted/Unmounted.
         Scheduler.QueuePostFlushCallback(new SchedulerJob(() => instance.InvokeHooks(kind)));
+    }
+
+    // --- keep-alive ([V01.01.03.18]) -----------------------------------------------------------
+
+    private void ActivateComponent(VirtualNode node, TNode container, TNode? anchor, string? elementNamespace)
+    {
+        // The C# port of KeepAlive's sharedContext.activate: move the cached subtree back into the live
+        // container, re-patch in case props changed while cached, then queue the activated hooks and the
+        // onVnodeMounted hook post-flush (upstream: queuePostRenderEffect). The child instance was never
+        // torn down, so its Setup does not re-run.
+        var instance = (ComponentInstance)node.Component!;
+        Move(node, container, anchor);
+        Patch(instance.VirtualNode, node, container, anchor, elementNamespace, instance);
+        Scheduler.QueuePostFlushCallback(new SchedulerJob(() =>
+        {
+            instance.IsDeactivated = false;
+            instance.InvokeHooks(LifecycleHookKind.Activated);
+            InvokeHook(node, null, "onVnodeMounted");
+        }));
+    }
+
+    private void DeactivateComponent(VirtualNode node, ComponentInstance keepAlive)
+    {
+        // The C# port of KeepAlive's sharedContext.deactivate: move the subtree into the KeepAlive's
+        // detached storage container (instead of unmounting it), then queue the deactivated hooks and the
+        // onVnodeUnmounted hook post-flush. The child instance and all its state are preserved.
+        var instance = (ComponentInstance)node.Component!;
+        var storageContainer = (TNode)keepAlive.KeepAliveContext!.StorageContainer;
+        Move(node, storageContainer, default);
+        Scheduler.QueuePostFlushCallback(new SchedulerJob(() =>
+        {
+            instance.InvokeHooks(LifecycleHookKind.Deactivated);
+            InvokeHook(node, null, "onVnodeUnmounted");
+            instance.IsDeactivated = true;
+        }));
     }
 
     // --- teleport ([V01.01.03.17]) -------------------------------------------------------------
@@ -1711,6 +1780,15 @@ public sealed class Renderer<TNode>
         if (node.Reference is { } reference)
         {
             SetReference(reference, oldReference: null, node, isUnmount: true, parentComponent);
+        }
+        // A <KeepAlive> child leaving the view deactivates (its subtree moves to storage) instead of
+        // unmounting, so its instance and state survive (upstream unmount:
+        // (parentComponent.ctx).deactivate(vnode); return). The KeepAlive is the owning parentComponent,
+        // so it holds the storage container ([V01.01.03.18]).
+        if ((node.ShapeFlag & ShapeFlags.ComponentShouldKeepAlive) != 0 && parentComponent?.KeepAliveContext is not null)
+        {
+            DeactivateComponent(node, parentComponent);
+            return;
         }
         // Cleanup order (upstream parity): hooks and child teardown run before node removal.
         InvokeHook(node, null, "onVnodeBeforeUnmount");

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
@@ -154,6 +154,9 @@ public sealed class Renderer<TNode>
             case VirtualNodeType.Component:
                 ProcessComponent(current, next, container, anchor, elementNamespace, parentComponent);
                 break;
+            case VirtualNodeType.Teleport:
+                ProcessTeleport(current, next, container, anchor, elementNamespace, parentComponent);
+                break;
             default:
                 throw new InvalidOperationException($"Unknown vnode type: {next.Type}.");
         }
@@ -469,8 +472,8 @@ public sealed class Renderer<TNode>
         // block collected, never the static ones — so a tree of N static nodes with K dynamic
         // bindings costs O(K) patch visits. Each pair resolves its container the way upstream does:
         // the real host parent when the child may insert or move nodes (a fragment, a replaced type,
-        // or a component), otherwise the block element itself — which the patch never reads for an
-        // in-place prop/text update, so the parentNode call is skipped.
+        // a component, or a teleport), otherwise the block element itself — which the patch never
+        // reads for an in-place prop/text update, so the parentNode call is skipped.
         for (var index = 0; index < newChildren.Count; index++)
         {
             var oldChild = oldChildren[index];
@@ -479,7 +482,8 @@ public sealed class Renderer<TNode>
                 oldChild.El is not null
                 && (oldChild.Type == VirtualNodeType.Fragment
                     || !IsSameVirtualNodeType(oldChild, newChild)
-                    || oldChild.Type == VirtualNodeType.Component)
+                    || oldChild.Type == VirtualNodeType.Component
+                    || oldChild.Type == VirtualNodeType.Teleport)
                     ? _options.ParentNode((TNode)oldChild.El)!
                     : fallbackContainer;
             Patch(oldChild, newChild, container, default, elementNamespace, parentComponent);
@@ -851,6 +855,390 @@ public sealed class Renderer<TNode>
         Scheduler.QueuePostFlushCallback(new SchedulerJob(() => instance.InvokeHooks(kind)));
     }
 
+    // --- teleport ([V01.01.03.17]) -------------------------------------------------------------
+
+    private void ProcessTeleport(
+        VirtualNode? current,
+        VirtualNode next,
+        TNode container,
+        TNode? anchor,
+        string? elementNamespace,
+        ComponentInstance? parentComponent)
+    {
+        // The C# port of TeleportImpl.process (components/Teleport.ts,
+        // https://vuejs.org/guide/built-ins/teleport.html). A Teleport is a special vnode type, not a
+        // component: it frames its original tree position with a main-tree anchor pair (El start /
+        // Anchor end) and mounts its children into a resolved target container — or in place when
+        // disabled. Target lookup goes exclusively through the injected querySelector node-op (a
+        // selector string) or a direct platform-node `to`; there is no DOM/JS access in this layer.
+        var disabled = IsTeleportDisabled(next);
+        if (current is null)
+        {
+            var mainStart = _options.CreateText(string.Empty);
+            var mainEnd = _options.CreateText(string.Empty);
+            next.El = mainStart;
+            next.Anchor = mainEnd;
+            _options.Insert(mainStart, container, anchor);
+            _options.Insert(mainEnd, container, anchor);
+            next.TeleportState = new TeleportState();
+
+            if (IsTeleportDeferred(next))
+            {
+                // defer: resolve the target and mount after the surrounding tree mounts (upstream:
+                // queuePendingMount) — this is what lets a Teleport target an element rendered later in
+                // the same tree. Both the disabled in-place mount and the target mount are deferred.
+                QueuePendingMount(next, container, elementNamespace, parentComponent);
+                return;
+            }
+            if (disabled)
+            {
+                // Disabled: render the children in place, between the main-tree anchors.
+                MountTeleportChildren(next, container, AsHostNode(next.Anchor), elementNamespace, parentComponent);
+            }
+            // Always resolve the target and frame it with the target-side anchor pair; the children
+            // mount there only when enabled (upstream: mountToTarget runs regardless of `disabled`).
+            MountTeleportToTarget(next, disabled, elementNamespace, parentComponent);
+        }
+        else
+        {
+            next.El = current.El;
+            next.Anchor = current.Anchor;
+            var state = current.TeleportState!;
+            next.TeleportState = state;
+
+            // A still-pending deferred mount from the previous vnode (the post-flush job has not run):
+            // dispose it and re-queue for the new vnode, deferring this update's work too (upstream: the
+            // pendingMount branch, which returns early).
+            if (state.PendingMount is { } stalePending)
+            {
+                stalePending.IsDisposed = true;
+                state.PendingMount = null;
+                QueuePendingMount(next, container, elementNamespace, parentComponent);
+                return;
+            }
+
+            var wasDisabled = IsTeleportDisabled(current);
+            // The children currently live in the main container (disabled) or in the resolved target
+            // (enabled); patch them where they are (upstream: currentContainer / currentAnchor).
+            TNode currentContainer;
+            TNode? currentAnchor;
+            if (!wasDisabled && state.Target is TNode resolvedTarget)
+            {
+                currentContainer = resolvedTarget;
+                currentAnchor = AsHostNode(state.TargetAnchor);
+            }
+            else
+            {
+                currentContainer = container;
+                currentAnchor = AsHostNode(next.Anchor);
+            }
+
+            if (next.DynamicChildren is not null && current.DynamicChildren is not null)
+            {
+                // Block Teleport: patch only the collected dynamic descendants, then copy the static
+                // children's host pointers forward so a later toggle/target-change move can relocate them.
+                PatchBlockChildren(current.DynamicChildren, next.DynamicChildren, currentContainer, elementNamespace, parentComponent);
+                TraverseStaticChildren(current, next);
+            }
+            else
+            {
+                PatchChildren(current, next, currentContainer, currentAnchor, elementNamespace, parentComponent);
+            }
+
+            if (disabled)
+            {
+                if (!wasDisabled)
+                {
+                    // enabled -> disabled: move the existing children back to the main-tree position
+                    // without unmounting, so their subtree state is preserved.
+                    MoveTeleport(next, container, AsHostNode(next.Anchor), TeleportMoveType.Toggle);
+                }
+            }
+            else
+            {
+                var newTarget = GetToProperty(next);
+                var oldTarget = GetToProperty(current);
+                if (!Equals(newTarget, oldTarget))
+                {
+                    // `to` changed: resolve the new target and move the children into it.
+                    var resolved = ResolveTarget(next);
+                    if (resolved is TNode nextTarget)
+                    {
+                        state.Target = resolved;
+                        MoveTeleport(next, nextTarget, default, TeleportMoveType.TargetChange);
+                    }
+                    else
+                    {
+                        RuntimeWarnings.Warn($"Invalid Teleport target on update: {newTarget}.");
+                    }
+                }
+                else if (wasDisabled && state.Target is TNode enabledTarget)
+                {
+                    // disabled -> enabled: move the children into the (unchanged) target.
+                    MoveTeleport(next, enabledTarget, AsHostNode(state.TargetAnchor), TeleportMoveType.Toggle);
+                }
+            }
+        }
+    }
+
+    private void MountTeleportChildren(VirtualNode vnode, TNode mountContainer, TNode? mountAnchor, string? elementNamespace, ComponentInstance? parentComponent)
+    {
+        // Upstream: the Teleport's local `mount` closure. A Teleport always carries array children.
+        if ((vnode.ShapeFlag & ShapeFlags.ArrayChildren) != 0)
+        {
+            MountChildren(vnode.ArrayChildren ?? [], mountContainer, mountAnchor, elementNamespace, parentComponent);
+        }
+    }
+
+    private void MountTeleportToTarget(VirtualNode vnode, bool disabled, string? elementNamespace, ComponentInstance? parentComponent)
+    {
+        // Upstream mountToTarget: resolve the target, frame it with the target-side anchor pair, and —
+        // when enabled — mount the children into it before the target end anchor. The SVG/MathML
+        // target-namespace sniff upstream performs is omitted: Viu's node-ops expose no element-namespace
+        // query, so the ambient compiled namespace is threaded through instead (documented divergence).
+        var state = vnode.TeleportState!;
+        var target = ResolveTarget(vnode);
+        state.Target = target;
+        var targetAnchor = PrepareTargetAnchors(vnode, target);
+        if (target is TNode targetContainer && !disabled)
+        {
+            MountTeleportChildren(vnode, targetContainer, targetAnchor, elementNamespace, parentComponent);
+        }
+    }
+
+    private TNode? PrepareTargetAnchors(VirtualNode vnode, object? target)
+    {
+        // Upstream prepareAnchor: create a start/end anchor pair framing the teleported content and
+        // insert both into the target. When the target is unresolved Viu creates NO anchors — a
+        // documented divergence from upstream, which always creates them for its hydration path (Viu has
+        // no hydration and would otherwise leak two never-inserted platform-node handles). The upstream
+        // TeleportEndKey sibling-skip property is likewise hydration-only and omitted.
+        if (target is not TNode targetContainer)
+        {
+            return default;
+        }
+        var state = vnode.TeleportState!;
+        var targetStart = _options.CreateText(string.Empty);
+        var targetEnd = _options.CreateText(string.Empty);
+        state.TargetStart = targetStart;
+        state.TargetAnchor = targetEnd;
+        _options.Insert(targetStart, targetContainer, default);
+        _options.Insert(targetEnd, targetContainer, default);
+        return targetEnd;
+    }
+
+    private void QueuePendingMount(VirtualNode vnode, TNode container, string? elementNamespace, ComponentInstance? parentComponent)
+    {
+        // Upstream queuePendingMount: a deferred Teleport resolves its target and mounts in a post-flush
+        // job, so a target rendered later in the same tree is available by the time it runs. The job
+        // self-guards: it no-ops if it was superseded (an update replaced it) or the Teleport unmounted.
+        var state = vnode.TeleportState!;
+        SchedulerJob job = null!;
+        job = new SchedulerJob(() =>
+        {
+            if (!ReferenceEquals(state.PendingMount, job))
+            {
+                return;
+            }
+            state.PendingMount = null;
+            var disabled = IsTeleportDisabled(vnode);
+            if (disabled)
+            {
+                // Re-read the live parent of the main start anchor (the tree may have moved since queuing).
+                var mountContainer = vnode.El is not null ? _options.ParentNode((TNode)vnode.El) ?? container : container;
+                MountTeleportChildren(vnode, mountContainer, AsHostNode(vnode.Anchor), elementNamespace, parentComponent);
+            }
+            MountTeleportToTarget(vnode, disabled, elementNamespace, parentComponent);
+        });
+        state.PendingMount = job;
+        Scheduler.QueuePostFlushCallback(job);
+    }
+
+    private void MoveTeleport(VirtualNode vnode, TNode container, TNode? parentAnchor, TeleportMoveType moveType)
+    {
+        // The C# port of moveTeleport (components/Teleport.ts).
+        var state = vnode.TeleportState!;
+        if (moveType == TeleportMoveType.TargetChange && state.TargetAnchor is TNode movingTargetAnchor)
+        {
+            // On a target change only the end anchor relocates (upstream); the start anchor is left in the
+            // old target and cleaned up on unmount.
+            _options.Insert(movingTargetAnchor, container, parentAnchor);
+        }
+        var isReorder = moveType == TeleportMoveType.Reorder;
+        if (isReorder && vnode.El is not null)
+        {
+            _options.Insert((TNode)vnode.El, container, parentAnchor);
+        }
+        // Move the children only when this is NOT a reorder, or the Teleport is disabled: an enabled
+        // Teleport's children live in the target and must stay put across a main-tree reorder. A pending
+        // (not-yet-run deferred) Teleport has no mounted children to move.
+        if (state.PendingMount is null && (!isReorder || IsTeleportDisabled(vnode)))
+        {
+            if ((vnode.ShapeFlag & ShapeFlags.ArrayChildren) != 0 && vnode.ArrayChildren is { } children)
+            {
+                for (var index = 0; index < children.Length; index++)
+                {
+                    Move(children[index], container, parentAnchor);
+                }
+            }
+        }
+        if (isReorder && vnode.Anchor is not null)
+        {
+            _options.Insert((TNode)vnode.Anchor, container, parentAnchor);
+        }
+    }
+
+    private void UnmountTeleport(VirtualNode node, ComponentInstance? parentComponent, bool doRemove)
+    {
+        // The C# port of TeleportImpl.remove: tear down the target-side anchor pair, the children (with
+        // their normal unmount lifecycles/directive hooks), and — when the whole Teleport is host-removed
+        // — the main-tree anchor pair. Upstream splits main-start removal into the generic remove(); Viu
+        // removes both main anchors here for one cohesive teardown.
+        var state = node.TeleportState;
+        var disabled = IsTeleportDisabled(node);
+        var hadPendingMount = state?.PendingMount is not null;
+        if (state?.PendingMount is { } pending)
+        {
+            pending.IsDisposed = true;
+            state.PendingMount = null;
+        }
+        if (state?.Target is not null)
+        {
+            if (state.TargetStart is not null)
+            {
+                _options.Remove((TNode)state.TargetStart);
+            }
+            if (state.TargetAnchor is not null)
+            {
+                _options.Remove((TNode)state.TargetAnchor);
+            }
+        }
+        if (doRemove)
+        {
+            if (node.El is not null)
+            {
+                _options.Remove((TNode)node.El);
+            }
+            if (node.Anchor is not null)
+            {
+                _options.Remove((TNode)node.Anchor);
+            }
+        }
+        // Children are removed when the whole Teleport is removed, or whenever they live in the target
+        // (enabled) — upstream shouldRemove = doRemove || !disabled. A never-mounted deferred Teleport,
+        // and an enabled Teleport whose target never resolved, have no children to unmount.
+        if (!hadPendingMount
+            && (disabled || state?.Target is not null)
+            && (node.ShapeFlag & ShapeFlags.ArrayChildren) != 0
+            && node.ArrayChildren is { } children)
+        {
+            var shouldRemove = doRemove || !disabled;
+            for (var index = 0; index < children.Length; index++)
+            {
+                var child = children[index];
+                Unmount(child, parentComponent, shouldRemove, optimized: child.DynamicChildren is not null);
+            }
+        }
+    }
+
+    private object? ResolveTarget(VirtualNode node)
+    {
+        // The C# port of resolveTarget: a string `to` resolves through the querySelector node-op; any
+        // other non-null `to` is a direct platform-node target used as-is. Returns the boxed target node,
+        // or null (with the upstream dev warnings) when it cannot be resolved. The renderer never touches
+        // a platform node except through node-ops, so target lookup goes only through querySelector here.
+        // A value-type TNode uses default(TNode) as its "no node" sentinel (the browser's 0 handle), so a
+        // resolved value equal to it means "not found" just as a null reference-type handle does.
+        var to = GetToProperty(node);
+        if (to is string selector)
+        {
+            if (_options.QuerySelector is null)
+            {
+                RuntimeWarnings.Warn(
+                    "Current renderer does not support string target for Teleports. "
+                    + "(missing querySelector renderer option)");
+                return null;
+            }
+            var resolved = _options.QuerySelector(selector);
+            if (resolved is TNode target && !NodeComparer.Equals(target, default!))
+            {
+                return target;
+            }
+            if (!IsTeleportDisabled(node))
+            {
+                RuntimeWarnings.Warn(
+                    $"Failed to locate Teleport target with selector \"{selector}\". "
+                    + "Note the target element must exist before the component is mounted.");
+            }
+            return null;
+        }
+        if (to is TNode directTarget && !NodeComparer.Equals(directTarget, default!))
+        {
+            return directTarget;
+        }
+        if (!IsTeleportDisabled(node))
+        {
+            RuntimeWarnings.Warn($"Invalid Teleport target: {to}.");
+        }
+        return null;
+    }
+
+    private static void TraverseStaticChildren(VirtualNode current, VirtualNode next)
+    {
+        // The C# port of traverseStaticChildren(n1, n2, shallow: true) — the production shallow form.
+        // After a block-only patch the static (non-dynamic) children are fresh vnodes without host
+        // pointers; copy the old host node forward so MoveTeleport (which relocates every child) can find
+        // them. A freshly rendered static child is not yet mounted (El null), so no clone is needed.
+        var oldChildren = current.ArrayChildren;
+        var newChildren = next.ArrayChildren;
+        if (oldChildren is null || newChildren is null)
+        {
+            return;
+        }
+        var count = Math.Min(oldChildren.Length, newChildren.Length);
+        for (var index = 0; index < count; index++)
+        {
+            var oldChild = oldChildren[index];
+            var newChild = newChildren[index];
+            if ((newChild.ShapeFlag & ShapeFlags.Element) != 0
+                && newChild.DynamicChildren is null
+                && newChild.El is null
+                && ((int)newChild.PatchFlag <= 0 || newChild.PatchFlag == PatchFlags.NeedHydration))
+            {
+                newChild.El = oldChild.El;
+            }
+            else if (newChild.Type == VirtualNodeType.Comment && newChild.El is null)
+            {
+                newChild.El = oldChild.El;
+            }
+        }
+    }
+
+    private static bool IsTeleportDisabled(VirtualNode node) => IsTeleportFlag(node, "disabled");
+
+    private static bool IsTeleportDeferred(VirtualNode node) => IsTeleportFlag(node, "defer");
+
+    private static bool IsTeleportFlag(VirtualNode node, string name)
+    {
+        // Upstream: props && (props[name] || props[name] === ''). A boolean is used directly; any string
+        // (including the empty string a bare attribute produces) is truthy; a missing/false/null prop is
+        // off.
+        if (node.Properties is null || !node.Properties.TryGetValue(name, out var value))
+        {
+            return false;
+        }
+        return value switch
+        {
+            bool flag => flag,
+            string => true,
+            null => false,
+            _ => true,
+        };
+    }
+
+    private static object? GetToProperty(VirtualNode node)
+        => node.Properties is not null && node.Properties.TryGetValue("to", out var to) ? to : null;
+
     // --- children ------------------------------------------------------------------------------
 
     private void PatchChildren(
@@ -1166,12 +1554,15 @@ public sealed class Renderer<TNode>
     {
         // The C# port of move() in renderer.ts: relocate an already-mounted vnode's host node(s)
         // before `anchor`. Components move their subtree; fragments and static nodes move their
-        // whole owned range; element/text/comment nodes move as a single host node (descendants
-        // travel with them).
+        // whole owned range; a teleport moves its own anchors (and, when disabled, its children);
+        // element/text/comment nodes move as a single host node (descendants travel with them).
         switch (node.Type)
         {
             case VirtualNodeType.Component:
                 Move(((ComponentInstance)node.Component!).Subtree!, container, anchor);
+                return;
+            case VirtualNodeType.Teleport:
+                MoveTeleport(node, container, anchor, TeleportMoveType.Reorder);
                 return;
             case VirtualNodeType.Fragment:
                 _options.Insert((TNode)node.El!, container, anchor);
@@ -1333,6 +1724,13 @@ public sealed class Renderer<TNode>
         {
             UnmountComponent(node, doRemove);
         }
+        else if (node.Type == VirtualNodeType.Teleport)
+        {
+            // Teleport is a special vnode type: its children live in the target (enabled) or in place
+            // (disabled), and it owns anchors in two containers — so its teardown is bespoke, not the
+            // generic block/array-children walk below.
+            UnmountTeleport(node, parentComponent, doRemove);
+        }
         else
         {
             var dynamicChildren = node.DynamicChildren;
@@ -1462,8 +1860,10 @@ public sealed class Renderer<TNode>
             var instance = (ComponentInstance)node.Component!;
             return instance.Subtree is null ? default : GetNextHostNode(instance.Subtree);
         }
-        if (node.Type is VirtualNodeType.Fragment or VirtualNodeType.Static)
+        if (node.Type is VirtualNodeType.Fragment or VirtualNodeType.Static or VirtualNodeType.Teleport)
         {
+            // A Teleport's main-tree footprint is [El start .. Anchor end]; its next host node follows
+            // the end anchor (its teleported children live in another container and are not siblings here).
             return node.Anchor is null ? default : _options.NextSibling((TNode)node.Anchor);
         }
         return node.El is null ? default : _options.NextSibling((TNode)node.El);

--- a/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNode.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNode.cs
@@ -159,6 +159,16 @@ public sealed class VirtualNode
     internal TransitionHooks? Transition { get; set; }
 
     /// <summary>
+    /// The target-side runtime state of a <see cref="VirtualNodeType.Teleport"/> vnode — the resolved
+    /// target container, the target-side anchor pair, and the deferred-mount job (upstream:
+    /// <c>vnode.target</c>/<c>targetStart</c>/<c>targetAnchor</c>). Null for every non-Teleport vnode —
+    /// the common case, kept to a single null check on the hot path; allocated by the renderer when a
+    /// Teleport mounts. The main-tree anchor pair reuses <see cref="El"/> and <see cref="Anchor"/>
+    /// ([V01.01.03.17]).
+    /// </summary>
+    internal TeleportState? TeleportState { get; set; }
+
+    /// <summary>
     /// Looks up a <see cref="VirtualNodeHook"/> prop (e.g. <c>"onVnodeMounted"</c>), or null.
     /// </summary>
     /// <param name="name">The hook prop name.</param>

--- a/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNodeFactory.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNodeFactory.cs
@@ -456,6 +456,69 @@ public static class VirtualNodeFactory
             PatchFlag = patchFlag,
         };
 
+    /// <summary>
+    /// Creates a <c>&lt;Teleport&gt;</c> vnode (upstream: <c>createVNode(Teleport, props, children)</c>).
+    /// A Teleport renders its children into the container named by its <c>"to"</c> prop (a selector
+    /// resolved through the renderer's <c>querySelector</c> node-op, or a direct platform-node target),
+    /// leaving an anchor pair at its own tree position; the <c>"disabled"</c> prop renders the children
+    /// in place, and <c>"defer"</c> resolves the target after the surrounding tree mounts. Teleport
+    /// children are always an array (upstream enforces this in the compiler and vnode normalization).
+    /// See <c>packages/runtime-core/src/components/Teleport.ts</c> and
+    /// https://vuejs.org/guide/built-ins/teleport.html. [V01.01.03.17]
+    /// </summary>
+    /// <param name="properties">The props — carries <c>"to"</c>, <c>"disabled"</c>, and <c>"defer"</c> — or null.</param>
+    /// <param name="children">The children to teleport; null entries become comment placeholders.</param>
+    /// <param name="patchFlag">The compiler patch hint (e.g. <see cref="PatchFlags.Props"/> when <c>to</c>/<c>disabled</c> are dynamic).</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode Teleport(
+        VirtualNodeProperties? properties,
+        VirtualNode?[]? children,
+        PatchFlags patchFlag = default,
+        string[]? dynamicProperties = null)
+    {
+        var vnode = BuildTeleport(properties, children, patchFlag, dynamicProperties);
+        // A Teleport with a dynamic patch flag is collected into the enclosing block so a parent
+        // re-render revisits it (upstream createBaseVNode tracking condition; a static Teleport is not
+        // collected, matching upstream which tracks only patchFlag > 0 / component vnodes).
+        BlockStack.TrackDynamicChild(vnode);
+        return vnode;
+    }
+
+    /// <summary>
+    /// Creates a block <c>&lt;Teleport&gt;</c> vnode whose <see cref="VirtualNode.DynamicChildren"/> are
+    /// the dynamic descendants collected since <see cref="OpenBlock"/> (upstream: <c>createBlock</c> over
+    /// the <c>Teleport</c> type). This is the block form the compiled render emits, so a Teleport update
+    /// patches only its dynamic children positionally.
+    /// </summary>
+    /// <param name="properties">The props — carries <c>"to"</c>, <c>"disabled"</c>, and <c>"defer"</c> — or null.</param>
+    /// <param name="children">The children to teleport; null entries become comment placeholders.</param>
+    /// <param name="patchFlag">The compiler patch hint.</param>
+    /// <param name="dynamicProperties">The dynamic prop names when <paramref name="patchFlag"/> has <see cref="PatchFlags.Props"/>.</param>
+    public static VirtualNode TeleportBlock(
+        VirtualNodeProperties? properties,
+        VirtualNode?[]? children,
+        PatchFlags patchFlag = default,
+        string[]? dynamicProperties = null)
+        => BlockStack.CloseBlockAndSetup(BuildTeleport(properties, children, patchFlag, dynamicProperties));
+
+    private static VirtualNode BuildTeleport(
+        VirtualNodeProperties? properties,
+        VirtualNode?[]? children,
+        PatchFlags patchFlag,
+        string[]? dynamicProperties)
+        => new(VirtualNodeType.Teleport)
+        {
+            Properties = properties,
+            Key = ExtractKey(properties),
+            Reference = ExtractReference(properties),
+            // Teleport always carries array children (upstream: normalizeChildren forces ARRAY_CHILDREN);
+            // an empty teleport keeps an empty array so the renderer's array-children paths apply.
+            ArrayChildren = NormalizeArrayChildren(children) ?? [],
+            ShapeFlag = ShapeFlags.Teleport | ShapeFlags.ArrayChildren,
+            PatchFlag = patchFlag,
+            DynamicProperties = dynamicProperties,
+        };
+
     /// <summary>Builds a property bag from name/value tuples, pre-sized exactly.</summary>
     /// <param name="entries">The property entries.</param>
     /// <exception cref="ArgumentException">An entry name is null or empty.</exception>
@@ -508,6 +571,9 @@ public static class VirtualNodeFactory
             // Carry the transition hooks across a clone (upstream cloneVNode copies vnode.transition):
             // a reused/normalized child keeps its enter/leave choreography.
             Transition = node.Transition,
+            // Carry the Teleport target-side state across a clone so a reused/normalized Teleport keeps
+            // its resolved target and anchors (parity with cloneVNode copying vnode.target/anchors).
+            TeleportState = node.TeleportState,
             AppContext = node.AppContext,
             El = node.El,
             Anchor = node.Anchor,

--- a/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNodeType.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/VirtualNodeType.cs
@@ -28,4 +28,14 @@ public enum VirtualNodeType
 
     /// <summary>A keyless wrapper for multiple root nodes (upstream: the <c>Fragment</c> symbol).</summary>
     Fragment,
+
+    /// <summary>
+    /// A <c>&lt;Teleport&gt;</c> built-in that renders its children into a different container than its
+    /// own tree position (upstream: the <c>Teleport</c> symbol; the vnode also carries
+    /// <see cref="Shared.ShapeFlags.Teleport"/>). Treated as a special vnode type in the
+    /// patch/move/unmount paths — not an ordinary component
+    /// (<c>packages/runtime-core/src/components/Teleport.ts</c>,
+    /// https://vuejs.org/guide/built-ins/teleport.html). [V01.01.03.17]
+    /// </summary>
+    Teleport,
 }

--- a/libraries/Assimalign.Viu.RuntimeCore/test/KeepAliveTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/KeepAliveTests.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.Tests;
+
+// Pins the KeepAlive built-in against the in-memory renderer, DOM-free — mirroring upstream
+// runtime-core/__tests__/components/KeepAlive.spec.ts. KeepAlive IS a component (unlike Teleport):
+// switching a child out moves its subtree to a hidden storage container (deactivate) rather than
+// unmounting, and switching back moves it home (activate), so Setup runs once and state is preserved.
+// Contract: packages/runtime-core/src/components/KeepAlive.ts and
+// https://vuejs.org/guide/built-ins/keep-alive.html. [V01.01.03.18]
+public sealed class KeepAliveTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+    private readonly List<string> _events = [];
+    private readonly Dictionary<string, int> _setupCounts = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, IReference<int>> _states = new(StringComparer.Ordinal);
+
+    public KeepAliveTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private string Serialize() => TestNodeSerializer.Serialize(_container);
+
+    private IReadOnlyList<string> EventsFor(params string[] names)
+        => _events.Where(e => names.Any(n => e.StartsWith(n + ":", StringComparison.Ordinal))).ToList();
+
+    // A stateful component that logs its lifecycle, counts its Setup runs, exposes its reactive state
+    // ref, and renders "<div>{name}{state}</div>".
+    private TestComponent Stateful(string name) => new()
+    {
+        Name = name,
+        SetupFunction = (_, _) =>
+        {
+            _setupCounts[name] = _setupCounts.GetValueOrDefault(name) + 1;
+            var state = Reactive.Reference(0);
+            _states[name] = state;
+            Lifecycle.OnMounted(() => _events.Add($"{name}:mounted"));
+            Lifecycle.OnUnmounted(() => _events.Add($"{name}:unmounted"));
+            Lifecycle.OnActivated(() => _events.Add($"{name}:activated"));
+            Lifecycle.OnDeactivated(() => _events.Add($"{name}:deactivated"));
+            return () => VirtualNodeFactory.Element("div", $"{name}{state.Value}");
+        },
+    };
+
+    // Builds a root-mounted KeepAlive whose single child is chosen by childSelector each render.
+    private void MountKeepAlive(Func<VirtualNode?> childSelector, VirtualNodeProperties? properties = null)
+    {
+        var slots = new ComponentSlots();
+        slots["default"] = _ => new[] { childSelector() };
+        _renderer.Render(VirtualNodeFactory.Component(KeepAlive.Instance, properties, slots), _container);
+    }
+
+    private static VirtualNode Child(TestComponent component) => VirtualNodeFactory.Component(component);
+
+    // --- state preservation ----------------------------------------------------------------------
+
+    [Fact]
+    public void SwitchingAway_DeactivatesInsteadOfUnmounting_PreservesStateAndSetupRunsOnce()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        MountKeepAlive(() => Child(view.Value == "a" ? componentA : componentB));
+
+        // Mutate A's internal state while it is active, then switch away and back.
+        _states["a"].Value = 5;
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>a5</div></root>");
+
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>b0</div></root>");
+
+        view.Value = "a";
+        _pump.RunUntilIdle();
+
+        // Reactivated with state intact and no Setup re-run (upstream: cached subtree moved back, not
+        // remounted).
+        Serialize().ShouldBe("<root><div>a5</div></root>");
+        _setupCounts["a"].ShouldBe(1);
+        _setupCounts["b"].ShouldBe(1);
+        _events.ShouldNotContain("a:unmounted");
+        _events.ShouldNotContain("b:unmounted");
+    }
+
+    [Fact]
+    public void ActivatedDeactivated_FireOnInitialMountAndEachSwitchCycle_WithPinnedCounts()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        MountKeepAlive(() => Child(view.Value == "a" ? componentA : componentB));
+
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        view.Value = "a";
+        _pump.RunUntilIdle();
+
+        // activated fires on initial mount inside KeepAlive AND on every reactivation; deactivated on
+        // each deactivation; mounted exactly once; unmounted never (upstream KeepAlive lifecycle).
+        _events.ShouldBe(
+        [
+            "a:mounted", "a:activated",                 // initial mount inside KeepAlive
+            "a:deactivated", "b:mounted", "b:activated", // switch to B
+            "b:deactivated", "a:activated",              // switch back to A
+        ]);
+        _events.Count(e => e == "a:mounted").ShouldBe(1);
+        _events.Count(e => e == "a:activated").ShouldBe(2);
+        _events.Count(e => e == "a:deactivated").ShouldBe(1);
+        _events.ShouldNotContain("a:unmounted");
+    }
+
+    [Fact]
+    public void NonKeptAliveComponent_NeverFiresActivatedOrDeactivated()
+    {
+        // A component with activated/deactivated hooks but no KeepAlive ancestor: the hooks register but
+        // never fire (upstream: a no-op without a KeepAlive parent).
+        var component = Stateful("solo");
+        _renderer.Render(Child(component), _container);
+        _renderer.Render(null, _container);
+
+        _events.ShouldBe(["solo:mounted", "solo:unmounted"]);
+    }
+
+    // --- include / exclude matching --------------------------------------------------------------
+
+    [Fact]
+    public void Include_OnlyCachesMatchingComponents_ExcludedOnesMountAndUnmountNormally()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        // include="a": only A is cached; B mounts/unmounts normally on every switch.
+        MountKeepAlive(
+            () => Child(view.Value == "a" ? componentA : componentB),
+            VirtualNodeFactory.Properties(("include", "a")));
+
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        view.Value = "a";
+        _pump.RunUntilIdle();
+        view.Value = "b";
+        _pump.RunUntilIdle();
+
+        // A cached across switches (Setup once, no unmount); B not cached (re-mounts, unmounts).
+        _setupCounts["a"].ShouldBe(1);
+        _events.ShouldNotContain("a:unmounted");
+        _setupCounts["b"].ShouldBe(2);
+        _events.Count(e => e == "b:unmounted").ShouldBe(1);
+        _events.ShouldNotContain("b:activated"); // B is never kept alive, so it never activates
+    }
+
+    [Fact]
+    public void Exclude_MatchingComponentsAreNotCached()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        // exclude="b": B is not cached; A is.
+        MountKeepAlive(
+            () => Child(view.Value == "a" ? componentA : componentB),
+            VirtualNodeFactory.Properties(("exclude", "b")));
+
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        view.Value = "a";
+        _pump.RunUntilIdle();
+
+        _setupCounts["a"].ShouldBe(1);          // A cached
+        _events.ShouldNotContain("a:unmounted");
+        _events.Count(e => e == "b:unmounted").ShouldBe(1); // B unmounted on switch away
+    }
+
+    [Fact]
+    public void Include_AcceptsCommaSeparatedStringAndPredicate()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var componentC = Stateful("c");
+        var view = Reactive.Reference("a");
+
+        // Comma-separated string: "a,b" caches both A and B, not C (upstream: pattern.split(',')).
+        MountKeepAlive(
+            () => Child(view.Value switch { "a" => componentA, "b" => componentB, _ => componentC }),
+            VirtualNodeFactory.Properties(("include", "a,b")));
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        view.Value = "c";
+        _pump.RunUntilIdle();
+        view.Value = "a";
+        _pump.RunUntilIdle();
+        view.Value = "b";
+        _pump.RunUntilIdle();
+
+        _setupCounts["a"].ShouldBe(1); // cached (matched)
+        _setupCounts["b"].ShouldBe(1); // cached (matched)
+        _setupCounts["c"].ShouldBe(1); // never revisited; would be 2 if it had been cached-then-evicted
+
+        // Predicate include (the C# analogue of upstream's RegExp arm): a fresh KeepAlive caching only
+        // names ending in "1".
+        _events.Clear();
+        _setupCounts.Clear();
+        var one = Stateful("one1");
+        var two = Stateful("two2");
+        var predicateView = Reactive.Reference("one1");
+        MountKeepAlive(
+            () => Child(predicateView.Value == "one1" ? one : two),
+            VirtualNodeFactory.Properties(("include", (Func<string, bool>)(name => name.EndsWith('1')))));
+        predicateView.Value = "two2";
+        _pump.RunUntilIdle();
+        predicateView.Value = "one1";
+        _pump.RunUntilIdle();
+
+        _setupCounts["one1"].ShouldBe(1);                       // matched the predicate → cached
+        _events.Count(e => e == "two2:unmounted").ShouldBe(1);  // not matched → unmounted on switch away
+    }
+
+    [Fact]
+    public void Include_AcceptsAStringList()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        // A string list caches any listed name (upstream: the array arm of matches).
+        MountKeepAlive(
+            () => Child(view.Value == "a" ? componentA : componentB),
+            VirtualNodeFactory.Properties(("include", new List<string> { "a", "b" })));
+
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        view.Value = "a";
+        _pump.RunUntilIdle();
+
+        // Both A and B are in the list → both cached (Setup once each, neither unmounted).
+        _setupCounts["a"].ShouldBe(1);
+        _setupCounts["b"].ShouldBe(1);
+        _events.ShouldNotContain("a:unmounted");
+        _events.ShouldNotContain("b:unmounted");
+    }
+
+    // --- max / LRU -------------------------------------------------------------------------------
+
+    [Fact]
+    public void Max_EnforcesLruEviction_FullyUnmountsLeastRecentlyUsed()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var componentC = Stateful("c");
+        var view = Reactive.Reference("a");
+        // max=2: caching A then B then C evicts the least-recently-used (A), fully unmounting it.
+        MountKeepAlive(
+            () => Child(view.Value switch { "a" => componentA, "b" => componentB, _ => componentC }),
+            VirtualNodeFactory.Properties(("max", 2)));
+
+        view.Value = "b";
+        _pump.RunUntilIdle(); // A cached + deactivated, B active
+        view.Value = "c";
+        _pump.RunUntilIdle(); // cache would hold A, B, C > max 2 → evict LRU (A)
+
+        // A was the least-recently-used cache entry: overflowing max fully unmounts it (a real teardown
+        // of the already-deactivated instance, distinct from the deactivation it had on the A→B switch).
+        _events.Count(e => e == "a:unmounted").ShouldBe(1);
+        _events.Count(e => e == "a:deactivated").ShouldBe(1); // once, on the A→B switch (while cached)
+
+        // B was still cached (deactivated, not unmounted) when we moved to C.
+        _events.Count(e => e == "b:unmounted").ShouldBe(0);
+
+        // Returning to A re-mounts it fresh (its cache entry was evicted): Setup runs a second time.
+        view.Value = "a";
+        _pump.RunUntilIdle();
+        _setupCounts["a"].ShouldBe(2);
+    }
+
+    // --- cache invalidation on include/exclude change --------------------------------------------
+
+    [Fact]
+    public void ChangingInclude_PrunesNewlyExcludedEntriesImmediately()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        var include = Reactive.Reference<object?>(null);
+
+        // A parent renders the KeepAlive with a reactive include prop so changing it re-resolves props.
+        var root = new TestComponent
+        {
+            SetupFunction = (_, _) => () =>
+            {
+                var slots = new ComponentSlots();
+                slots["default"] = _ => new[] { Child(view.Value == "a" ? componentA : componentB) };
+                var properties = include.Value is null
+                    ? null
+                    : VirtualNodeFactory.Properties(("include", include.Value));
+                return VirtualNodeFactory.Component(KeepAlive.Instance, properties, slots);
+            },
+        };
+        _renderer.Render(Child(root), _container);
+
+        // Cache both A and B (no filter yet); B is the current active child, A sits deactivated.
+        view.Value = "b";
+        _pump.RunUntilIdle();
+        _setupCounts["a"].ShouldBe(1);
+
+        // Narrow include to "b": A is now excluded and must be pruned from the cache immediately
+        // (upstream: watch(..., { flush: 'post' }) → pruneCache).
+        include.Value = "b";
+        _pump.RunUntilIdle();
+        _events.Count(e => e == "a:unmounted").ShouldBe(1);
+
+        // Confirm A's entry is gone: revisiting A re-mounts it fresh.
+        view.Value = "a";
+        _pump.RunUntilIdle();
+        _setupCounts["a"].ShouldBe(2);
+    }
+
+    [Fact]
+    public void UnmountingKeepAlive_UnmountsAllCachedInstances()
+    {
+        var componentA = Stateful("a");
+        var componentB = Stateful("b");
+        var view = Reactive.Reference("a");
+        MountKeepAlive(() => Child(view.Value == "a" ? componentA : componentB));
+
+        view.Value = "b";
+        _pump.RunUntilIdle(); // A deactivated (cached), B active
+        _events.Clear();
+
+        _renderer.Render(null, _container); // unmount the whole tree
+
+        // Both the active child and the deactivated cached child are fully unmounted (upstream:
+        // onBeforeUnmount tears down every cache entry).
+        _events.Count(e => e == "a:unmounted").ShouldBe(1);
+        _events.Count(e => e == "b:unmounted").ShouldBe(1);
+    }
+
+    // --- nested keep-alive-aware descendants -----------------------------------------------------
+
+    [Fact]
+    public void NestedDescendants_FireActivatedAndDeactivatedChildBeforeParent()
+    {
+        // KeepAlive > outer > inner. Both register activated/deactivated. The KeepAlive activates and
+        // deactivates its DIRECT child (outer); the nested inner's hooks are aggregated onto outer and
+        // fire child-before-parent (upstream registerKeepAliveHook parent-chain injection).
+        var inner = new TestComponent
+        {
+            Name = "inner",
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnMounted(() => _events.Add("inner:mounted"));
+                Lifecycle.OnActivated(() => _events.Add("inner:activated"));
+                Lifecycle.OnDeactivated(() => _events.Add("inner:deactivated"));
+                return () => VirtualNodeFactory.Element("span", "inner");
+            },
+        };
+        var outer = new TestComponent
+        {
+            Name = "outer",
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnMounted(() => _events.Add("outer:mounted"));
+                Lifecycle.OnActivated(() => _events.Add("outer:activated"));
+                Lifecycle.OnDeactivated(() => _events.Add("outer:deactivated"));
+                return () => VirtualNodeFactory.Element("div", VirtualNodeFactory.Component(inner));
+            },
+        };
+        var sibling = Stateful("sibling");
+        var view = Reactive.Reference("outer");
+        MountKeepAlive(() => Child(view.Value == "outer" ? outer : sibling));
+
+        view.Value = "sibling";
+        _pump.RunUntilIdle();
+        view.Value = "outer";
+        _pump.RunUntilIdle();
+
+        EventsFor("inner", "outer").ShouldBe(
+        [
+            "inner:mounted", "outer:mounted",       // mounted: child before parent
+            "inner:activated", "outer:activated",   // initial activate: child before parent
+            "inner:deactivated", "outer:deactivated", // deactivate on switch away: child before parent
+            "inner:activated", "outer:activated",   // reactivate on switch back: child before parent
+        ]);
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/test/TeleportTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/TeleportTests.cs
@@ -1,0 +1,344 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Shared;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.Tests;
+
+// Pins the platform-agnostic Teleport built-in against the in-memory renderer, DOM-free — mirroring
+// upstream runtime-core/__tests__/components/Teleport.spec.ts. Teleport is a special vnode type
+// (ShapeFlags.Teleport) handled in the patch/move/unmount paths, not an ordinary component; the
+// contract is packages/runtime-core/src/components/Teleport.ts and
+// https://vuejs.org/guide/built-ins/teleport.html. [V01.01.03.17]
+public sealed class TeleportTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+
+    public TeleportTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _pump.Dispose();
+    }
+
+    private string Serialize() => TestNodeSerializer.Serialize(_container);
+
+    private static VirtualNode ElementWithId(string tag, string id)
+        => VirtualNodeFactory.Element(tag, VirtualNodeFactory.Properties(("id", id)), (VirtualNode?[]?)null);
+
+    // --- target resolution -----------------------------------------------------------------------
+
+    [Fact]
+    public void Mount_ResolvesStringTargetThroughQuerySelector_MountsChildrenIntoTarget_AndLeavesAnchorsInPlace()
+    {
+        // Target-first ordering: a non-deferred Teleport must resolve its target at mount (upstream: the
+        // target element must exist before the teleport is mounted). #modal resolves through the test
+        // adapter's querySelector node-op (the in-memory stand-in for the DOM querySelector).
+        var tree = VirtualNodeFactory.Fragment(
+            ElementWithId("div", "modal"),
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", "#modal")),
+                [VirtualNodeFactory.Element("span", "teleported")]));
+        _renderer.Render(tree, _container);
+
+        // The teleported <span> lives inside div#modal; the Teleport leaves only its (empty) anchor pair
+        // at its own tree position.
+        Serialize().ShouldBe("<root><div id=\"modal\"><span>teleported</span></div></root>");
+    }
+
+    [Fact]
+    public void Mount_ResolvesDirectTargetNode_MountsChildrenIntoIt()
+    {
+        var target = _renderer.CreateContainer("target");
+        _renderer.Render(
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", target)),
+                [VirtualNodeFactory.Element("span", "direct")]),
+            _container);
+
+        // A direct platform-node `to` is used as-is (no querySelector); the main container keeps only the
+        // anchor pair (empty text, invisible).
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>direct</span></target>");
+        Serialize().ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void Mount_StringTargetThatDoesNotExist_Warns_AndDoesNotTeleport()
+    {
+        using var warnings = new WarningCapture();
+        _renderer.Render(
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", "#missing")),
+                [VirtualNodeFactory.Element("span", "orphan")]),
+            _container);
+
+        // Upstream resolveTarget warns when a selector target is absent and the teleport is enabled; the
+        // children are not mounted anywhere.
+        warnings.Messages.ShouldContain(message => message.Contains("Failed to locate Teleport target"));
+        Serialize().ShouldBe("<root></root>");
+    }
+
+    // --- disabled --------------------------------------------------------------------------------
+
+    [Fact]
+    public void Mount_Disabled_RendersChildrenInPlace_NotInTarget()
+    {
+        var target = _renderer.CreateContainer("target");
+        _renderer.Render(
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", target), ("disabled", true)),
+                [VirtualNodeFactory.Element("span", "inplace")]),
+            _container);
+
+        // disabled: children render between the main-tree anchors; the target only gets the (empty)
+        // framing anchors.
+        Serialize().ShouldBe("<root><span>inplace</span></root>");
+        TestNodeSerializer.Serialize(target).ShouldBe("<target></target>");
+    }
+
+    [Fact]
+    public void ToggleDisabled_MovesChildrenBetweenTargetAndInPlace_WithoutUnmounting()
+    {
+        var target = _renderer.CreateContainer("target");
+        var mountCount = 0;
+        var unmountCount = 0;
+        var child = new TestComponent
+        {
+            Name = "Child",
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnMounted(() => mountCount++);
+                Lifecycle.OnUnmounted(() => unmountCount++);
+                return () => VirtualNodeFactory.Element("span", "child");
+            },
+        };
+        VirtualNode Build(bool disabled) => VirtualNodeFactory.Teleport(
+            VirtualNodeFactory.Properties(("to", target), ("disabled", disabled)),
+            [VirtualNodeFactory.Component(child)]);
+
+        // Enabled: the child mounts into the target.
+        _renderer.Render(Build(disabled: false), _container);
+        mountCount.ShouldBe(1);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>child</span></target>");
+        Serialize().ShouldBe("<root></root>");
+
+        // enabled -> disabled: the child moves in place; the SAME instance is reused (no remount) — the
+        // acceptance criterion that subtree state is preserved, pinned by the mount/unmount run counts.
+        _renderer.Render(Build(disabled: true), _container);
+        mountCount.ShouldBe(1);
+        unmountCount.ShouldBe(0);
+        Serialize().ShouldBe("<root><span>child</span></root>");
+        TestNodeSerializer.Serialize(target).ShouldBe("<target></target>");
+
+        // disabled -> enabled: the child moves back into the target, still the same instance.
+        _renderer.Render(Build(disabled: false), _container);
+        mountCount.ShouldBe(1);
+        unmountCount.ShouldBe(0);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>child</span></target>");
+        Serialize().ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void ReactiveDisabledToggle_MovesTeleportedContent_ThroughTheScheduler()
+    {
+        var target = _renderer.CreateContainer("target");
+        var disabled = Reactive.Reference(false);
+        _renderer.Renderer.CreateRenderEffect(
+            () => VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", target), ("disabled", disabled.Value)),
+                [VirtualNodeFactory.Element("span", "x")]),
+            _container);
+
+        // Enabled: teleported into the target.
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>x</span></target>");
+        Serialize().ShouldBe("<root></root>");
+
+        // A reactive flip of `disabled` re-renders through the scheduler and moves the content in place.
+        disabled.Value = true;
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><span>x</span></root>");
+        TestNodeSerializer.Serialize(target).ShouldBe("<target></target>");
+    }
+
+    // --- target change ---------------------------------------------------------------------------
+
+    [Fact]
+    public void ChangeTarget_MovesChildrenToNewTarget()
+    {
+        var first = _renderer.CreateContainer("first");
+        var second = _renderer.CreateContainer("second");
+        VirtualNode Build(TestElement target) => VirtualNodeFactory.Teleport(
+            VirtualNodeFactory.Properties(("to", target)),
+            [VirtualNodeFactory.Element("span", "moving")]);
+
+        _renderer.Render(Build(first), _container);
+        TestNodeSerializer.Serialize(first).ShouldBe("<first><span>moving</span></first>");
+
+        // Changing `to` moves the children into the new target (upstream: moveTeleport TARGET_CHANGE).
+        _renderer.Render(Build(second), _container);
+        TestNodeSerializer.Serialize(second).ShouldBe("<second><span>moving</span></second>");
+        TestNodeSerializer.Serialize(first).ShouldBe("<first></first>");
+    }
+
+    [Fact]
+    public void MultipleTeleports_ToSameTarget_AppendInMountOrder_AndPatchIndependently()
+    {
+        var target = _renderer.CreateContainer("target");
+        VirtualNode Build(string first, string second) => VirtualNodeFactory.Fragment(
+            VirtualNodeFactory.Teleport(VirtualNodeFactory.Properties(("to", target)), [VirtualNodeFactory.Element("span", first)]),
+            VirtualNodeFactory.Teleport(VirtualNodeFactory.Properties(("to", target)), [VirtualNodeFactory.Element("span", second)]));
+
+        _renderer.Render(Build("A", "B"), _container);
+        // Two Teleports to the same target append their content in mount order.
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>A</span><span>B</span></target>");
+
+        // They patch independently: only the second Teleport's child changes.
+        _renderer.Render(Build("A", "B2"), _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>A</span><span>B2</span></target>");
+    }
+
+    [Fact]
+    public void KeyedReorderOfTeleports_MovesTheMainAnchors_ButLeavesEnabledContentInTarget()
+    {
+        var target = _renderer.CreateContainer("target");
+        VirtualNode Keyed(string key, string text) => VirtualNodeFactory.Teleport(
+            VirtualNodeFactory.Properties(("key", key), ("to", target)),
+            [VirtualNodeFactory.Element("span", text)]);
+        VirtualNode Build(string firstKey, string secondKey) => VirtualNodeFactory.Fragment(
+            [Keyed(firstKey, firstKey), Keyed(secondKey, secondKey)],
+            key: "list",
+            PatchFlags.KeyedFragment);
+
+        _renderer.Render(Build("a", "b"), _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>a</span><span>b</span></target>");
+
+        // Reordering the two keyed Teleports in the main tree moves only their (empty) main anchors; the
+        // enabled content stays put in the target in mount order (upstream: moveTeleport REORDER does not
+        // move an enabled Teleport's children).
+        _renderer.Render(Build("b", "a"), _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>a</span><span>b</span></target>");
+    }
+
+    // --- defer -----------------------------------------------------------------------------------
+
+    [Fact]
+    public void Deferred_ResolvesTargetRenderedLaterInTheSameTree_AfterMount()
+    {
+        // The target div is rendered AFTER the Teleport in the same tree, so it does not exist when the
+        // Teleport mounts. `defer` resolves the target in the post-flush phase, once the whole tree has
+        // mounted (upstream 3.5 queuePendingMount).
+        var tree = VirtualNodeFactory.Fragment(
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", "#late"), ("defer", true)),
+                [VirtualNodeFactory.Element("span", "deferred")]),
+            ElementWithId("div", "late"));
+        _renderer.Render(tree, _container);
+
+        // After the synchronous render drains its post-flush queue, the span is inside the later div#late.
+        Serialize().ShouldBe("<root><div id=\"late\"><span>deferred</span></div></root>");
+    }
+
+    [Fact]
+    public void NonDeferred_TargetRenderedLater_FailsToResolveAtMount_AndWarns()
+    {
+        using var warnings = new WarningCapture();
+        var tree = VirtualNodeFactory.Fragment(
+            VirtualNodeFactory.Teleport(
+                VirtualNodeFactory.Properties(("to", "#late")),
+                [VirtualNodeFactory.Element("span", "orphan")]),
+            ElementWithId("div", "late"));
+        _renderer.Render(tree, _container);
+
+        // Without defer the target does not yet exist at mount, so the children are not teleported and the
+        // upstream dev warning fires — the contrast that pins what defer actually changes.
+        warnings.Messages.ShouldContain(message => message.Contains("Failed to locate Teleport target"));
+        Serialize().ShouldBe("<root><div id=\"late\"></div></root>");
+    }
+
+    // --- unmount ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Unmount_RemovesChildrenFromTarget_AndRunsUnmountLifecycles()
+    {
+        var target = _renderer.CreateContainer("target");
+        var unmounted = 0;
+        var child = new TestComponent
+        {
+            Name = "Child",
+            SetupFunction = (_, _) =>
+            {
+                Lifecycle.OnUnmounted(() => unmounted++);
+                return () => VirtualNodeFactory.Element("span", "child");
+            },
+        };
+        _renderer.Render(
+            VirtualNodeFactory.Teleport(VirtualNodeFactory.Properties(("to", target)), [VirtualNodeFactory.Component(child)]),
+            _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>child</span></target>");
+
+        // Unmounting the Teleport removes its children from the target and runs their unmount lifecycles.
+        _renderer.Render(null, _container);
+        unmounted.ShouldBe(1);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target></target>");
+        Serialize().ShouldBe("<root></root>");
+    }
+
+    // --- compiled-render dispatch + block form ---------------------------------------------------
+
+    [Fact]
+    public void RenderHelpers_Teleport_DispatchesToTeleportVNode_AndRenders()
+    {
+        var target = _renderer.CreateContainer("target");
+        // The shape the template compiler emits for <Teleport>: the _Teleport marker as the vnode tag,
+        // children as a vnode array (never slots).
+        var vnode = RenderHelpers._createVNode(
+            RenderHelpers._Teleport,
+            RenderHelpers._createProps(("to", target)),
+            new object?[] { RenderHelpers._createElementVNode("span", null, "compiled") });
+
+        vnode.Type.ShouldBe(VirtualNodeType.Teleport);
+        _renderer.Render(vnode, _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><span>compiled</span></target>");
+    }
+
+    [Fact]
+    public void BlockTeleport_PatchesOnlyDynamicChild_AndPreservesStaticChild()
+    {
+        var target = _renderer.CreateContainer("target");
+        // A compiled block Teleport: a static <div> child (patchFlag 0, skipped on update) alongside a
+        // dynamic-text <span> child (PatchFlags.Text, collected into dynamicChildren).
+        VirtualNode Build(string text)
+        {
+            var block = RenderHelpers._openBlock();
+            return RenderHelpers._createBlock(
+                block,
+                RenderHelpers._Teleport,
+                RenderHelpers._createProps(("to", target)),
+                new object?[]
+                {
+                    RenderHelpers._createElementVNode("div", null, "static"),
+                    RenderHelpers._createElementVNode("span", null, text, (int)PatchFlags.Text),
+                });
+        }
+
+        _renderer.Render(Build("one"), _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><div>static</div><span>one</span></target>");
+
+        // The block update patches only the dynamic <span> through the target container; the static
+        // <div> keeps its host node (traverseStaticChildren) and its content.
+        _renderer.Render(Build("two"), _container);
+        TestNodeSerializer.Serialize(target).ShouldBe("<target><div>static</div><span>two</span></target>");
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeDom/test/TeleportDomTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/TeleportDomTests.cs
@@ -1,0 +1,55 @@
+using System.Runtime.Versioning;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.RuntimeCore;
+
+using static Assimalign.Viu.RuntimeCore.VirtualNodeFactory;
+
+namespace Assimalign.Viu.RuntimeDom.Tests;
+
+// Exercises Teleport ([V01.01.03.17]) over the browser-shaped int-handle node-ops (RendererOptions<int>
+// wired to the InMemoryHandleDom exactly as production BrowserNodeOperations wires the JS bridge), so the
+// value-type TNode path — boxing handles into the teleport state, the default(TNode)==0 "no node"
+// sentinel — is covered as well as the reference-type TestNode path is in RuntimeCore. Browser-annotated
+// like the other tests touching the browser-only node-ops types; nothing crosses a real interop boundary.
+[SupportedOSPlatform("browser")]
+public sealed class TeleportDomTests
+{
+    [Fact]
+    public void Teleport_MovesChildrenIntoDirectTargetHandle_ThroughIntHandleNodeOps()
+    {
+        Scheduler.Reset();
+        var dom = new InMemoryHandleDom();
+        using var world = new DirectHandleDomWorld(dom);
+        var renderer = RendererFactory.CreateRenderer(world.Options);
+        var container = dom.CreateElement("root", null);
+        var target = dom.CreateElement("target", null);
+
+        renderer.Render(Teleport(Properties(("to", target)), [Element("span", "boxed")]), container);
+
+        // The teleported <span> lands in the direct target handle; the main container keeps only the
+        // (empty) anchor pair.
+        dom.Serialize(target).ShouldBe("<target><span>boxed</span></target>");
+        dom.Serialize(container).ShouldBe("<root></root>");
+    }
+
+    [Fact]
+    public void Teleport_StringTargetResolvingToTheZeroHandle_IsTreatedAsNotFound_AndDoesNotThrow()
+    {
+        Scheduler.Reset();
+        var dom = new InMemoryHandleDom();
+        // DirectHandleDomWorld stubs querySelector to always return 0 — the "no node" sentinel for int
+        // handles. Without treating 0 as not-found the renderer would try to insert anchors into handle 0
+        // and throw; the sentinel guard in resolveTarget keeps the browser adapter safe.
+        using var world = new DirectHandleDomWorld(dom);
+        var renderer = RendererFactory.CreateRenderer(world.Options);
+        var container = dom.CreateElement("root", null);
+
+        Should.NotThrow(() => renderer.Render(Teleport(Properties(("to", "#anywhere")), [Element("span", "x")]), container));
+
+        // Nothing is teleported (no valid target); the container holds only the anchor pair.
+        dom.Serialize(container).ShouldBe("<root></root>");
+    }
+}

--- a/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
@@ -9,10 +9,19 @@ and [`@vue/test-utils`](https://test-utils.vuejs.org).
 `Assimalign.Viu.RuntimeCore`'s renderer is platform-agnostic: it drives whatever
 `RendererOptions<TNode>` it is given (see
 [`Assimalign.Viu.RuntimeCore/docs/DESIGN.md`](../../Assimalign.Viu.RuntimeCore/docs/DESIGN.md)).
-`TestNodeOperations.Create(log)` supplies node-ops over a plain in-memory tree
+`TestNodeOperations.Create(log, teleportTargetRoots?)` supplies node-ops over a plain in-memory tree
 (`TestElement`/`TestText`/`TestComment`), so component behavior is exercised through the *same*
 mount/patch/unmount pipeline the browser uses — just with no DOM and no interop. This is exactly
 `@vue/runtime-test`'s role, and it is why a component tested here behaves as it will in the browser.
+
+The one platform op the browser has that a bare in-memory tree lacks is `querySelector` — which the
+renderer uses only to resolve a `<Teleport>` string target ([V01.01.03.17]). The test adapter supplies
+it as a search over the registered *target roots* (each render container is auto-registered;
+`TestRenderer.RegisterQueryRoot` adds a detached target container), matching against the same CSS subset
+`@vue/test-utils` accepts (tag/`#id`/`.class`/`[attr]`). This keeps Teleport exercised DOM-free — a
+selector target rendered later in the same tree resolves through the ordinary tree walk, so `defer`
+behaves as it does in the browser. A renderer built without target roots simply declares no
+`querySelector`, so a string Teleport target then warns as unsupported (as an SSR string renderer would).
 
 ## The op log is the assertion surface
 

--- a/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
@@ -12,8 +12,10 @@ toolchain, no JS interop. Area: `V01.01.11`.
   component against the in-memory renderer and returns a `ComponentWrapper`. The caller supplies the
   component instance (source-generated factories, never reflection activation).
 - **`TestRenderer`** — the ready-to-use in-memory renderer (`@vue/runtime-test`'s `render` + `nodeOps`
-  pair): `Render`, `CreateContainer`, the underlying `Renderer<TestNode>`, and the `OperationLog`
-  every node operation is recorded into.
+  pair): `Render`, `CreateContainer`, `RegisterQueryRoot` (makes an element findable by a
+  `<Teleport>` string target — the in-memory stand-in for the DOM `querySelector`; render containers
+  are auto-registered), the underlying `Renderer<TestNode>`, and the `OperationLog` every node
+  operation is recorded into.
 - **The in-memory node tree** (`Nodes/`) — `TestNode` (abstract), `TestElement`, `TestText`,
   `TestComment`; `TestNodeOperations` (the `RendererOptions<TestNode>` factory); the op log
   (`TestNodeOperationLog`, `TestNodeOperation`, `TestNodeOperationType`); `TestNodeSerializer`

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Assimalign.Viu.RuntimeCore;
 
@@ -15,8 +16,18 @@ public static class TestNodeOperations
 {
     /// <summary>Creates the node-ops set, recording into <paramref name="log"/>.</summary>
     /// <param name="log">The op log to record into.</param>
+    /// <param name="teleportTargetRoots">
+    /// The live set of roots the <c>querySelector</c> node-op searches to resolve a <c>&lt;Teleport&gt;</c>
+    /// string target (each root and its subtree, using the <c>@vue/test-utils</c> selector subset —
+    /// tag/<c>#id</c>/<c>.class</c>/<c>[attr]</c>). Null leaves the renderer without a <c>querySelector</c>
+    /// option, so a string Teleport target warns as unsupported — matching a renderer that declares none.
+    /// The browser adapter resolves targets through the real DOM <c>querySelector</c>; this registered-root
+    /// search is the in-memory stand-in ([V01.01.03.17]).
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="log"/> is null.</exception>
-    public static RendererOptions<TestNode> Create(TestNodeOperationLog log)
+    public static RendererOptions<TestNode> Create(
+        TestNodeOperationLog log,
+        IReadOnlyList<TestElement>? teleportTargetRoots = null)
     {
         ArgumentNullException.ThrowIfNull(log);
         return new RendererOptions<TestNode>
@@ -136,7 +147,33 @@ public static class TestNodeOperations
                     TestNodeOperationType.InsertStaticContent, staticNode, parentElement, anchor, Text: content));
                 return (staticNode, staticNode);
             },
+            // The in-memory stand-in for the DOM querySelector node-op (upstream nodeOps.querySelector):
+            // the first element in the registered roots' subtrees matching the selector, or null. Only
+            // wired when target roots are supplied, so a renderer built without them behaves like one
+            // that declares no querySelector option (a string Teleport target then warns as unsupported).
+            QuerySelector = teleportTargetRoots is null ? null : selector => ResolveTarget(teleportTargetRoots, selector),
         };
+    }
+
+    private static TestNode? ResolveTarget(IReadOnlyList<TestElement> roots, string selector)
+    {
+        foreach (var root in roots)
+        {
+            // A registered root is itself a candidate (a detached target container), then its subtree
+            // (an in-tree target such as a rendered <div id="modal">), in document order.
+            if (TestQuery.Matches(root, selector))
+            {
+                return root;
+            }
+            foreach (var descendant in TestQuery.DescendantElementsOf(root))
+            {
+                if (TestQuery.Matches(descendant, selector))
+                {
+                    return descendant;
+                }
+            }
+        }
+        return null;
     }
 
     private static void Detach(TestNode node)

--- a/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
+++ b/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Assimalign.Viu.RuntimeCore;
 
 namespace Assimalign.Viu.Testing;
@@ -11,11 +13,15 @@ namespace Assimalign.Viu.Testing;
 /// </summary>
 public sealed class TestRenderer
 {
+    // The live roots the querySelector node-op searches to resolve a <Teleport> string target; every
+    // render container is auto-registered, and RegisterQueryRoot adds detached target containers.
+    private readonly List<TestElement> _teleportTargetRoots = [];
+
     /// <summary>Creates a renderer over a fresh op log.</summary>
     public TestRenderer()
     {
         OperationLog = new TestNodeOperationLog();
-        Renderer = RendererFactory.CreateRenderer(TestNodeOperations.Create(OperationLog));
+        Renderer = RendererFactory.CreateRenderer(TestNodeOperations.Create(OperationLog, _teleportTargetRoots));
     }
 
     /// <summary>The underlying platform-agnostic renderer.</summary>
@@ -31,8 +37,30 @@ public sealed class TestRenderer
     /// <param name="tag">The container tag.</param>
     public TestElement CreateContainer(string tag = "root") => new(tag, null);
 
+    /// <summary>
+    /// Registers <paramref name="root"/> (and its subtree) as searchable by a <c>&lt;Teleport&gt;</c>
+    /// string <c>to</c> target — the in-memory analogue of an element being present in the document the
+    /// browser's <c>querySelector</c> searches. Render containers are registered automatically; use this
+    /// for a detached target container that a Teleport selects by <c>#id</c>/<c>.class</c>/tag rather than
+    /// by a direct node reference ([V01.01.03.17]).
+    /// </summary>
+    /// <param name="root">The element to make findable.</param>
+    public void RegisterQueryRoot(TestElement root)
+    {
+        if (!_teleportTargetRoots.Contains(root))
+        {
+            _teleportTargetRoots.Add(root);
+        }
+    }
+
     /// <summary>Renders <paramref name="node"/> into <paramref name="container"/> (null unmounts).</summary>
     /// <param name="node">The tree to render, or null to unmount.</param>
     /// <param name="container">The container element.</param>
-    public void Render(VirtualNode? node, TestElement container) => Renderer.Render(node, container);
+    public void Render(VirtualNode? node, TestElement container)
+    {
+        // A render container is a queryable root for Teleport string targets (an in-tree #id/.class/tag
+        // resolves against the tree the renderer just built).
+        RegisterQueryRoot(container);
+        Renderer.Render(node, container);
+    }
 }


### PR DESCRIPTION
## Summary
- Ports vuejs/core `KeepAlive.ts`: a real component (unlike Teleport) whose cached subtrees move to a hidden storage container on deactivate and back on activate, driven by the `ComponentShouldKeepAlive`/`ComponentKeptAlive` shape-flag branches in the renderer's process/unmount paths — mirroring upstream's `instance.ctx.renderer` internal-access split via an attached `KeepAliveContext`.
- **Singleton-safe state model**: `KeepAlive.Instance` is shared, so all per-mount state (cache, LRU list, pruning watcher) is `Setup` closure state — no static leakage, inherently per-app. Cache keyed by `vnode.Key ?? componentDefinition` (typed references, no reflected names); `include`/`exclude` match declared component names via comma-string, list, or predicate; `max` evicts least-recently-used with the flags cleared so evicted instances fully unmount.
- `Activated`/`Deactivated` lifecycle hooks fire on initial mount and each cycle, nested child-before-parent per upstream's `registerKeepAliveHook` aggregation; a post-flush watcher on `include`/`exclude` prunes newly excluded entries immediately; unmounting the KeepAlive itself tears down every cached instance.
- Divergences documented in XML docs + DESIGN.md: Suspense unwrapping deferred to [V01.01.03.20]; upstream's `invalidateMount` guard is unnecessary under Viu's synchronous per-render flush (reasoned and pinned by the mounted-fires-once test); aggregated hooks run with the KeepAlive root as ambient instance (pinned).
- Compiled-template routing: `RenderHelpers._KeepAlive` now resolves to the component (previously a throwing marker).

**Stacked on #196** (Teleport) — merge that first; both features edit the renderer's dispatch paths, which is why this branch carries Teleport as its base.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings (WASM example included) · RuntimeCore **242/242** (11 new KeepAlive tests with pinned counts: setup-once across cycles, mounted-once, activated=2/deactivated=1 per switch cycle, unmounted only on real eviction/parent unmount) · Testing 18, RuntimeDom 162, CompiledRender 7 all green.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)