### PR TITLE
feat(syntax-css): add the programmatic CSS construction and emission surface [V01.01.12.11]

### DIFF
--- a/libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.Css/docs/DESIGN.md
@@ -128,6 +128,61 @@ but **not** `scoped` is serialized by **`CssStylesheetWriter`**, the plain (unsc
 `CssScopedRewriter` sharing its canonical two-space form; a non-scoped block with neither feature is still
 emitted verbatim and never reaches the writer, so only rewritten blocks lose their original whitespace.
 
+## Programmatic construction — the [V01.01.12.11] surface
+
+The parser turns CSS *text* into the record graph; `CssSyntaxFactory` (and the fluent
+`CssStylesheetBuilder`) build the **same** graph from code, so a build-time generator can synthesize rules
+from scratch and hand them to the same canonical serializer. Scoped CSS ([V01.01.06.04]) and the module /
+`v-bind()` rewrites all transform an *already-parsed* tree, so none of them ever needed to *create* a rule;
+the utility-first CSS engine ([V01.01.12.16]) generates rules from scratch and does. The surface is
+deliberately **language-agnostic generic CSS construction** — it knows nothing about utilities, variants, or
+themes — so `Assimalign.Viu.Syntax.Css` stays a leaf in the cluster (the utility grammar/theme/resolver live
+in Tooling, which may reference Css; Css never references back). `CssSyntaxFactory.QualifiedRule`,
+`Declaration`, `Media`/`ConditionalGroupAtRule`, `Stylesheet`, and the selector builders
+(`SimpleSelector`/`Combinator`/`Pseudo`/`ComplexSelector`/`SelectorList`) mint the existing node types; a
+constructed rule renders its `Prelude` from its parts (via the internal `CssSelectorWriter`) so the node is
+self-consistent, though the serializers read the parts, never the prelude.
+
+### The synthetic-location divergence
+
+Every parser-produced node upholds the exact-slice `SourceLocation` invariant (`Location.Source ==
+source.Substring(Start.Offset, End.Offset - Start.Offset)`), pinned by `CssSyntaxParserTests`. A
+constructed node has **no source string**, so that invariant cannot and does not apply — it is scoped to
+parser output, and construction is a distinct path. Rather than fabricate a span into a non-existent
+source, a constructed node carries a **synthetic** location (`CssSyntheticLocation`): both ends are the
+sentinel `Position` with `Offset == -1` (a value no real, zero-based parse position takes), and its `Source`
+carries only the exact text the node contributes where the serializer reads text back — a pseudo's
+`:hover`, a simple selector's `.foo` — and the empty string for the container and declaration nodes the
+serializer composes from typed properties. `CssSyntheticLocation.IsSynthetic` classifies a node off the
+sentinel offset, so the check is exact and total. This is the one deliberate, **tested** divergence from
+the invariant (`CssConstructionTests` walks a constructed graph asserting every node is synthetic, and
+re-asserts a parsed graph is *not*). Because the sentinel is constant and the carried `Source` is derived
+deterministically from the node's inputs, synthetic locations preserve record value-equality: two graphs
+built from equal inputs are equal and equally hashed (the incremental-cache contract), and a synthetic node
+never compares equal to a parsed node with the same text, because their offsets differ (`-1` versus a real
+position).
+
+### Deterministic serialization order
+
+The canonical serializer (`CssStylesheetWriter`, and `CssScopedRewriter` for scoped output) emits **in
+exact graph order and never reorders**:
+
+- **Property/declaration order within a rule** — declarations serialize in the order they appear in
+  `CssQualifiedRuleNode.Declarations` (and `CssKeyframeRuleNode.Declarations`).
+- **Rule and media order across a stylesheet** — top-level rules serialize in `CssStylesheetNode.Rules`
+  order; rules nested in a conditional-group at-rule in `CssAtRuleNode.Body` order (recursively, so a
+  nested `@media` inside a `@media` is faithful — pinned by `CssConstructionTests`).
+- Grouped selectors serialize in `CssSelectorListNode.Selectors` order; a complex selector's parts in
+  `CssComplexSelectorNode.Parts` order.
+
+Determinism is therefore a property of **construction**: identical node lists serialize byte-for-byte
+identically, and construction converges on the same canonical text as parsing the equivalent source
+(pinned against a parsed graph in `CssConstructionTests`). The construction surface preserves the order it
+is given and applies no canonicalization of its own — so a consumer that needs a canonical ordering (e.g.
+the utility engine de-duplicating and ordering utilities for a byte-stable bundle) sorts **before**
+constructing. Keeping ordering policy in the consumer is exactly what lets Css stay language-agnostic: it
+holds no opinion on how utilities, media queries, or properties "should" be ordered.
+
 ## Composition boundary
 
 The library never wires itself into the `.viu` parser. The [V01.01.06.02] generator composition root
@@ -164,5 +219,12 @@ only the scope-id string.
   compound/complex/grouped scoping are covered.
 - **Comment preservation in scoped output.** Comments are tokenized (for exact spans) but dropped by the
   canonical serializer; scoped CSS is machine-generated.
-- **Tailwind / utility-class generation** — [#129] is a separate consumer of this parser. It reuses the
-  tokenizer, tree, and (for its own scoping) `CssScopedRewriter`; it does not need changes here.
+- **Tailwind / utility-class generation** — [#129] is a separate consumer of this library. It reuses the
+  tokenizer, tree, (for its own scoping) `CssScopedRewriter`, and the programmatic construction surface
+  added by [V01.01.12.11]; the utility grammar, theme, and resolver stay in Tooling, never here.
+- **Reserved functional pseudos, `@keyframes`, and statement at-rules are not *constructed*.** The
+  [V01.01.12.11] factory builds ordinary selectors, declarations, qualified rules, and conditional-group
+  at-rules — what a utility generator needs. `:deep()`/`:slotted()`/`:global()` are *consumed* by the
+  scoped rewrite, not built from code (utilities emit unscoped global CSS); `@keyframes`/keyframe-rule and
+  `;`-terminated statement at-rules have no construction entry point yet. All are additive if a later
+  consumer needs them, and the parser still produces every one of them.

--- a/libraries/Assimalign.Viu.Syntax.Css/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.Css/docs/OVERVIEW.md
@@ -2,11 +2,12 @@
 
 The build-time CSS language area of the `Assimalign.Viu.Syntax.*` cluster: it tokenizes and rule-parses
 CSS per [CSS Syntax Module Level 3](https://www.w3.org/TR/css-syntax-3/) into a located,
-value-equatable tree, and rewrites that tree into attribute-scoped CSS — the pure-.NET port of Vue 3.5's
-scoped-CSS feature (`@vue/compiler-sfc` `compileStyle()` with the scoped PostCSS plugin). It is reached
-through the aggregate-parser registration seam: the [V01.01.06.02] generator composition root registers
-`CssSyntaxParser` for `.viu` `@style` blocks, and runs `CssScopedRewriter` for the `scoped` ones. See
-[the Vue scoped-CSS docs](https://vuejs.org/api/sfc-css-features.html).
+value-equatable tree, rewrites that tree into attribute-scoped CSS — the pure-.NET port of Vue 3.5's
+scoped-CSS feature (`@vue/compiler-sfc` `compileStyle()` with the scoped PostCSS plugin) — and
+**constructs the same tree programmatically** so a build-time generator can emit CSS from scratch. It is
+reached through the aggregate-parser registration seam: the [V01.01.06.02] generator composition root
+registers `CssSyntaxParser` for `.viu` `@style` blocks, and runs `CssScopedRewriter` for the `scoped`
+ones. See [the Vue scoped-CSS docs](https://vuejs.org/api/sfc-css-features.html).
 
 ## Public surface
 
@@ -18,6 +19,13 @@ through the aggregate-parser registration seam: the [V01.01.06.02] generator com
   an immutable record carrying an exact-slice `SourceLocation`.
 - **`CssScopedRewriter.Rewrite(stylesheet, scopeId)`** — the scoped transform, returning deterministic
   scoped CSS text.
+- **`CssStylesheetWriter.Write(stylesheet)`** — the plain (unscoped) canonical serializer, the emission
+  path a generated stylesheet takes.
+- **The construction surface** ([V01.01.12.11]) — `CssSyntaxFactory` builds the record-graph node types
+  (declarations, qualified rules, `@media`/conditional-group at-rules, selectors) from code; the fluent
+  `CssStylesheetBuilder` accumulates a stylesheet; `CssSyntheticLocation` marks and recognizes the
+  synthetic `SourceLocation`s constructed nodes carry. Generic CSS construction only — it knows nothing of
+  utilities. Consumed by the build-time utility-first CSS engine ([V01.01.12.16]).
 - **`CssError` / `CssErrorCode`** — the Viu-defined recoverable-diagnostic catalog (2000-based).
 
 ## Boundary

--- a/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssStylesheetBuilder.cs
+++ b/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssStylesheetBuilder.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Syntax.Css;
+
+/// <summary>
+/// A small fluent accumulator over <see cref="CssSyntaxFactory"/> for assembling a stylesheet's top-level
+/// rules incrementally, then materializing them into an immutable <see cref="CssStylesheetNode"/>. Rules
+/// serialize in the exact order they are added — the builder never reorders — so a consumer that needs a
+/// canonical ordering (such as the build-time utility-first CSS engine [V01.01.12.16]) adds its rules in
+/// that order.
+/// </summary>
+/// <remarks>
+/// The builder is a transient, single-threaded construction helper; only its <see cref="Build"/> output —
+/// an immutable value-equatable record graph — participates in equality and the incremental-generator
+/// cache. <see cref="Build"/> snapshots the accumulated rules, so it may be called more than once and the
+/// builder may be reused afterward without the earlier result changing.
+/// </remarks>
+public sealed class CssStylesheetBuilder
+{
+    private readonly List<CssSyntaxNode> rules = new();
+
+    /// <summary>The number of top-level rules accumulated so far.</summary>
+    public int Count => rules.Count;
+
+    /// <summary>Appends a top-level rule (a qualified rule or at-rule).</summary>
+    /// <param name="rule">The rule to append.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rule"/> is <see langword="null"/>.</exception>
+    public CssStylesheetBuilder Add(CssSyntaxNode rule)
+    {
+        if (rule is null)
+        {
+            throw new ArgumentNullException(nameof(rule));
+        }
+
+        rules.Add(rule);
+        return this;
+    }
+
+    /// <summary>Appends a sequence of top-level rules, in order.</summary>
+    /// <param name="rulesToAdd">The rules to append.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rulesToAdd"/> or any element is <see langword="null"/>.</exception>
+    public CssStylesheetBuilder AddRange(IEnumerable<CssSyntaxNode> rulesToAdd)
+    {
+        if (rulesToAdd is null)
+        {
+            throw new ArgumentNullException(nameof(rulesToAdd));
+        }
+
+        foreach (var rule in rulesToAdd)
+        {
+            Add(rule);
+        }
+
+        return this;
+    }
+
+    /// <summary>Materializes the accumulated rules into an immutable stylesheet, snapshotting the current contents.</summary>
+    /// <returns>The constructed stylesheet.</returns>
+    public CssStylesheetNode Build() => CssSyntaxFactory.Stylesheet(rules);
+}

--- a/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssSyntaxFactory.cs
+++ b/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssSyntaxFactory.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Syntax.Css;
+
+/// <summary>
+/// Constructs <see cref="CssStylesheetNode"/> graphs — qualified rules, declarations, conditional-group
+/// at-rules (<c>@media</c> and friends), and the selector model — <b>from code</b>, as the same
+/// record-graph node types the <see cref="CssSyntaxParser"/> produces, following the CSS Syntax Module
+/// Level 3 parser output model (https://www.w3.org/TR/css-syntax-3/#parsing). The parser turns text into
+/// that graph; this factory builds the identical graph without any text, so a downstream generator (the
+/// build-time utility-first CSS engine [V01.01.12.16]) can synthesize rules from scratch and hand them to
+/// the same deterministic canonical serializer (<see cref="CssStylesheetWriter"/> /
+/// <see cref="CssScopedRewriter"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every node this factory mints carries a synthetic <see cref="SourceLocation"/> (see
+/// <see cref="CssSyntheticLocation"/>): constructed nodes have no source span, the base cluster's
+/// exact-slice invariant does not apply to them, and they are explicitly marked so. Construction is
+/// otherwise value-pure — the factory copies every incoming collection into an owned array so the returned
+/// record graph is immutable and its value equality is stable, and it produces no lazy or shared mutable
+/// state. Two graphs built from equal inputs are equal and hash equally; serialization order is exactly the
+/// order of the lists passed in (the factory never reorders — a consumer that needs a canonical ordering
+/// sorts before constructing).
+/// </para>
+/// <para>
+/// The surface is language-agnostic generic CSS construction: it knows nothing about utilities, variants,
+/// or themes. It builds ordinary selectors and Vue's reserved functional pseudos (<c>:deep()</c>,
+/// <c>:slotted()</c>, <c>:global()</c>) — which only the parser produces, and which the scoped rewrite,
+/// not construction, consumes — are intentionally out of scope; the factory builds ordinary pseudos only.
+/// Invalid arguments throw <see cref="ArgumentNullException"/>, matching the serializer entry points; the
+/// recoverable never-throw contract applies to <em>parsing</em>, not to programmatic misuse.
+/// </para>
+/// </remarks>
+public static class CssSyntaxFactory
+{
+    /// <summary>
+    /// Builds a declaration — a property/value pair, the CSS Syntax Level 3 <c>&lt;declaration&gt;</c>
+    /// (https://www.w3.org/TR/css-syntax-3/#declaration).
+    /// </summary>
+    /// <param name="property">The property name (e.g. <c>color</c>, <c>background-color</c>).</param>
+    /// <param name="value">The declaration value, excluding any <c>!important</c> flag (emitted verbatim).</param>
+    /// <param name="important">Whether the declaration carries <c>!important</c>.</param>
+    /// <returns>The constructed declaration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="property"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
+    public static CssDeclarationNode Declaration(string property, string value, bool important = false)
+    {
+        if (property is null)
+        {
+            throw new ArgumentNullException(nameof(property));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return new CssDeclarationNode
+        {
+            Property = property,
+            Value = value,
+            Important = important,
+            Location = CssSyntheticLocation.Create(),
+        };
+    }
+
+    /// <summary>
+    /// Builds a simple selector part — a type, universal, class, id, or attribute selector, per the W3C
+    /// Selectors Level 4 simple selectors (https://www.w3.org/TR/selectors-4/#simple).
+    /// </summary>
+    /// <param name="kind">The simple-selector kind.</param>
+    /// <param name="text">The exact selector text the serializer emits verbatim (e.g. <c>.foo</c>, <c>#bar</c>, <c>div</c>, <c>*</c>, <c>[type="text"]</c>).</param>
+    /// <returns>The constructed simple selector.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is <see langword="null"/>.</exception>
+    public static CssSimpleSelectorNode SimpleSelector(CssSimpleSelectorKind kind, string text)
+    {
+        if (text is null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        return new CssSimpleSelectorNode
+        {
+            Selector = kind,
+            Text = text,
+            // A simple selector's own text is what the serializer emits; mirror the parser, whose
+            // Location.Source equals the selector text, so the synthetic node is self-consistent.
+            Location = CssSyntheticLocation.Create(text),
+        };
+    }
+
+    /// <summary>
+    /// Builds a combinator part between two compound selectors, per the W3C Selectors Level 4 combinators
+    /// (https://www.w3.org/TR/selectors-4/#combinators). The serializer renders a combinator from its
+    /// <paramref name="combinator"/> kind, so the synthetic location carries no text.
+    /// </summary>
+    /// <param name="combinator">The combinator kind (descendant, child, next-sibling, subsequent-sibling).</param>
+    /// <returns>The constructed combinator.</returns>
+    public static CssCombinatorNode Combinator(CssCombinatorKind combinator)
+        => new()
+        {
+            Combinator = combinator,
+            Location = CssSyntheticLocation.Create(),
+        };
+
+    /// <summary>
+    /// Builds an ordinary pseudo-class or pseudo-element selector part (e.g. <c>:hover</c>, <c>::before</c>).
+    /// The serializer reads a pseudo's text back from its <see cref="SourceLocation.Source"/>, so the
+    /// synthetic location carries the leading-colon form (<c>:name</c> or <c>::name</c>).
+    /// </summary>
+    /// <param name="name">The pseudo name without its leading colon(s) (e.g. <c>hover</c>, <c>before</c>).</param>
+    /// <param name="isElement">Whether to write the double-colon pseudo-element form (<c>::name</c>).</param>
+    /// <returns>The constructed pseudo selector (always <see cref="CssPseudoSelectorKind.Normal"/>; reserved functional pseudos are parser-only).</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public static CssPseudoSelectorNode Pseudo(string name, bool isElement = false)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        var text = (isElement ? "::" : ":") + name;
+        return new CssPseudoSelectorNode
+        {
+            Pseudo = CssPseudoSelectorKind.Normal,
+            Name = name,
+            IsElement = isElement,
+            Argument = null,
+            Location = CssSyntheticLocation.Create(text),
+        };
+    }
+
+    /// <summary>
+    /// Builds a complex selector — a flat, source-order sequence of parts (simple selectors, pseudo
+    /// selectors, and the combinators between compounds), the W3C Selectors Level 4
+    /// <c>&lt;complex-selector&gt;</c> (https://www.w3.org/TR/selectors-4/#typedef-complex-selector).
+    /// </summary>
+    /// <param name="parts">The selector parts, in the order they should serialize.</param>
+    /// <returns>The constructed complex selector.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="parts"/> or any element is <see langword="null"/>.</exception>
+    public static CssComplexSelectorNode ComplexSelector(IReadOnlyList<CssSelectorPartNode> parts)
+        => new()
+        {
+            Parts = ToOwnedList(parts, nameof(parts)),
+            Location = CssSyntheticLocation.Create(),
+        };
+
+    /// <summary>
+    /// Builds a selector list — the comma-separated complex selectors of a rule prelude, the W3C Selectors
+    /// Level 4 <c>&lt;complex-selector-list&gt;</c> (https://www.w3.org/TR/selectors-4/#typedef-complex-selector-list).
+    /// </summary>
+    /// <param name="selectors">The complex selectors, in the order they should serialize.</param>
+    /// <returns>The constructed selector list.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selectors"/> or any element is <see langword="null"/>.</exception>
+    public static CssSelectorListNode SelectorList(IReadOnlyList<CssComplexSelectorNode> selectors)
+        => new()
+        {
+            Selectors = ToOwnedList(selectors, nameof(selectors)),
+            Location = CssSyntheticLocation.Create(),
+        };
+
+    /// <summary>
+    /// Builds a qualified rule — a selector prelude and a declaration block, the CSS Syntax Level 3
+    /// <c>&lt;qualified-rule&gt;</c> (https://www.w3.org/TR/css-syntax-3/#qualified-rule). The rule's
+    /// <see cref="CssQualifiedRuleNode.Prelude"/> is rendered from <paramref name="selectors"/> so it stays
+    /// consistent with the parsed parts the serializer emits.
+    /// </summary>
+    /// <param name="selectors">The rule's selector list.</param>
+    /// <param name="declarations">The rule's declarations, in the order they should serialize.</param>
+    /// <returns>The constructed qualified rule.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selectors"/>, <paramref name="declarations"/>, or any declaration is <see langword="null"/>.</exception>
+    public static CssQualifiedRuleNode QualifiedRule(CssSelectorListNode selectors, IReadOnlyList<CssDeclarationNode> declarations)
+    {
+        if (selectors is null)
+        {
+            throw new ArgumentNullException(nameof(selectors));
+        }
+
+        return new CssQualifiedRuleNode
+        {
+            Prelude = CssSelectorWriter.Render(selectors),
+            Selectors = selectors,
+            Declarations = ToOwnedList(declarations, nameof(declarations)),
+            Location = CssSyntheticLocation.Create(),
+        };
+    }
+
+    /// <summary>
+    /// Builds a qualified rule from a single complex selector — a convenience over
+    /// <see cref="QualifiedRule(CssSelectorListNode, IReadOnlyList{CssDeclarationNode})"/> that wraps
+    /// <paramref name="selector"/> in a one-element selector list.
+    /// </summary>
+    /// <param name="selector">The rule's single complex selector.</param>
+    /// <param name="declarations">The rule's declarations, in the order they should serialize.</param>
+    /// <returns>The constructed qualified rule.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/>, <paramref name="declarations"/>, or any declaration is <see langword="null"/>.</exception>
+    public static CssQualifiedRuleNode QualifiedRule(CssComplexSelectorNode selector, IReadOnlyList<CssDeclarationNode> declarations)
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return QualifiedRule(SelectorList(new[] { selector }), declarations);
+    }
+
+    /// <summary>
+    /// Builds a conditional-group at-rule — a <c>{ … }</c> block at-rule whose body is a list of nested
+    /// rules, the CSS Conditional Rules <c>&lt;conditional-group-rule&gt;</c>
+    /// (https://www.w3.org/TR/css-conditional-3/). Use for <c>@media</c>, <c>@supports</c>,
+    /// <c>@container</c>, and similar.
+    /// </summary>
+    /// <param name="name">The at-keyword without its leading <c>@</c> (e.g. <c>media</c>, <c>supports</c>).</param>
+    /// <param name="prelude">The condition text between the name and the block (e.g. <c>(min-width: 768px)</c>), or empty.</param>
+    /// <param name="body">The nested rules, in the order they should serialize.</param>
+    /// <returns>The constructed at-rule with <see cref="CssAtRuleNode.HasBlock"/> set.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/>, <paramref name="prelude"/>, <paramref name="body"/>, or any body element is <see langword="null"/>.</exception>
+    public static CssAtRuleNode ConditionalGroupAtRule(string name, string prelude, IReadOnlyList<CssSyntaxNode> body)
+    {
+        if (name is null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (prelude is null)
+        {
+            throw new ArgumentNullException(nameof(prelude));
+        }
+
+        return new CssAtRuleNode
+        {
+            Name = name,
+            Prelude = prelude,
+            HasBlock = true,
+            Body = ToOwnedList(body, nameof(body)),
+            Location = CssSyntheticLocation.Create(),
+        };
+    }
+
+    /// <summary>
+    /// Builds a <c>@media</c> conditional-group at-rule — a convenience over
+    /// <see cref="ConditionalGroupAtRule(string, string, IReadOnlyList{CssSyntaxNode})"/> with the name
+    /// <c>media</c> (https://www.w3.org/TR/css-conditional-3/#at-media).
+    /// </summary>
+    /// <param name="condition">The media condition (e.g. <c>(min-width: 768px)</c>).</param>
+    /// <param name="body">The nested rules, in the order they should serialize.</param>
+    /// <returns>The constructed <c>@media</c> rule.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="condition"/>, <paramref name="body"/>, or any body element is <see langword="null"/>.</exception>
+    public static CssAtRuleNode Media(string condition, IReadOnlyList<CssSyntaxNode> body)
+        => ConditionalGroupAtRule("media", condition, body);
+
+    /// <summary>
+    /// Builds the stylesheet root — the CSS Syntax Level 3 top-level list of rules
+    /// (https://www.w3.org/TR/css-syntax-3/#parse-stylesheet).
+    /// </summary>
+    /// <param name="rules">The top-level rules, in the order they should serialize.</param>
+    /// <returns>The constructed stylesheet.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rules"/> or any element is <see langword="null"/>.</exception>
+    public static CssStylesheetNode Stylesheet(IReadOnlyList<CssSyntaxNode> rules)
+        => new()
+        {
+            Rules = ToOwnedList(rules, nameof(rules)),
+            Location = CssSyntheticLocation.Create(),
+        };
+
+    // Copies an incoming collection into a fresh owned array wrapped as a SyntaxList<T>, so the returned
+    // node graph is immutable regardless of what the caller later does with its list, and rejects null
+    // elements up front rather than letting a null child silently corrupt serialization or hashing.
+    private static SyntaxList<T> ToOwnedList<T>(IReadOnlyList<T> items, string parameterName) where T : class
+    {
+        if (items is null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
+
+        if (items.Count == 0)
+        {
+            return SyntaxList<T>.Empty;
+        }
+
+        var owned = new T[items.Count];
+        for (var index = 0; index < items.Count; index++)
+        {
+            owned[index] = items[index] ?? throw new ArgumentException("The collection must not contain a null element.", parameterName);
+        }
+
+        return new SyntaxList<T>(owned);
+    }
+}

--- a/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssSyntheticLocation.cs
+++ b/libraries/Assimalign.Viu.Syntax.Css/src/Construction/CssSyntheticLocation.cs
@@ -1,0 +1,102 @@
+using System;
+
+namespace Assimalign.Viu.Syntax.Css;
+
+/// <summary>
+/// Produces and recognizes the <b>synthetic</b> <see cref="SourceLocation"/>s carried by CSS nodes that are
+/// built programmatically through the construction surface (<see cref="CssSyntaxFactory"/> and
+/// <see cref="CssStylesheetBuilder"/>) rather than parsed from source text. It is the single, documented,
+/// tested divergence from the base cluster's exact-slice <see cref="SourceLocation"/> invariant.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every node a <see cref="CssSyntaxParser"/> emits upholds the exact-slice invariant:
+/// <c>Location.Source == source.Substring(Start.Offset, End.Offset - Start.Offset)</c> — the literal
+/// characters the node spans in the parser's source string (see <see cref="SourceLocation"/>). A
+/// programmatically constructed node has <em>no</em> source string, so that invariant cannot hold and does
+/// not apply — the invariant is scoped to parser output, and construction is a distinct path. Rather than
+/// invent a fake span into a non-existent source, a constructed node is stamped with a synthetic location:
+/// its <see cref="SourceLocation.Start"/> and <see cref="SourceLocation.End"/> are the sentinel
+/// <see cref="SyntheticPosition"/> (offset <c>-1</c>, which no real parse position ever takes), and its
+/// <see cref="SourceLocation.Source"/> carries the exact text the node contributes to serialization where
+/// the canonical serializer reads that text back (selector leaves — see <see cref="CssSyntaxFactory"/>),
+/// or the empty string for nodes the serializer composes from typed properties.
+/// </para>
+/// <para>
+/// The sentinel offset — not the <see cref="SourceLocation.Source"/> — is what marks a node synthetic, so
+/// <see cref="IsSynthetic(SourceLocation)"/> is exact and total. Because the sentinel is a constant and the
+/// carried <see cref="SourceLocation.Source"/> is derived deterministically from the node's inputs, two
+/// synthetic locations built from the same inputs compare equal and hash equally — the record value
+/// semantics the incremental-generator cache depends on hold for constructed graphs exactly as they do for
+/// parsed ones. A synthetic node never compares equal to a parsed node with the same text, because their
+/// offsets differ (<c>-1</c> versus a real position).
+/// </para>
+/// </remarks>
+public static class CssSyntheticLocation
+{
+    /// <summary>
+    /// The sentinel position stamped on both ends of every synthetic location. Its <see cref="Position.Offset"/>
+    /// is <c>-1</c> — a value no real parse position takes (parser offsets are zero-based and non-negative) —
+    /// which is the marker <see cref="IsSynthetic(SourceLocation)"/> tests. Its line and column are <c>0</c>,
+    /// outside the one-based coordinate space real positions use, reinforcing that it names no point in any
+    /// source.
+    /// </summary>
+    public static readonly Position SyntheticPosition = new(Offset: -1, Line: 0, Column: 0);
+
+    /// <summary>
+    /// Creates a synthetic <see cref="SourceLocation"/> carrying <paramref name="source"/> as the exact text
+    /// the node contributes to serialization (empty when the serializer composes the node's text from typed
+    /// properties). Both ends are <see cref="SyntheticPosition"/>.
+    /// </summary>
+    /// <param name="source">The node's contributed text, or the empty string when it has none.</param>
+    /// <returns>A synthetic location for a constructed node.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+    public static SourceLocation Create(string source)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return new SourceLocation(SyntheticPosition, SyntheticPosition, source);
+    }
+
+    /// <summary>Creates a synthetic <see cref="SourceLocation"/> with an empty <see cref="SourceLocation.Source"/>.</summary>
+    /// <returns>A synthetic location with no contributed text.</returns>
+    public static SourceLocation Create() => Create(string.Empty);
+
+    /// <summary>
+    /// Reports whether <paramref name="location"/> is synthetic — i.e. was stamped by the construction surface
+    /// rather than produced by a parser — by testing the sentinel offset. A synthetic location is exempt from
+    /// the exact-slice invariant.
+    /// </summary>
+    /// <param name="location">The location to classify.</param>
+    /// <returns><see langword="true"/> when the location is synthetic; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="location"/> is <see langword="null"/>.</exception>
+    public static bool IsSynthetic(SourceLocation location)
+    {
+        if (location is null)
+        {
+            throw new ArgumentNullException(nameof(location));
+        }
+
+        return location.Start.Offset < 0;
+    }
+
+    /// <summary>
+    /// Reports whether <paramref name="node"/> carries a synthetic <see cref="SourceLocation"/> — a
+    /// convenience over <see cref="IsSynthetic(SourceLocation)"/> for <c>node.Location</c>.
+    /// </summary>
+    /// <param name="node">The node to classify.</param>
+    /// <returns><see langword="true"/> when the node's location is synthetic; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="node"/> is <see langword="null"/>.</exception>
+    public static bool IsSynthetic(CssSyntaxNode node)
+    {
+        if (node is null)
+        {
+            throw new ArgumentNullException(nameof(node));
+        }
+
+        return IsSynthetic(node.Location);
+    }
+}

--- a/libraries/Assimalign.Viu.Syntax.Css/src/Internal/CssSelectorWriter.cs
+++ b/libraries/Assimalign.Viu.Syntax.Css/src/Internal/CssSelectorWriter.cs
@@ -1,0 +1,67 @@
+using System.Text;
+
+namespace Assimalign.Viu.Syntax.Css;
+
+/// <summary>
+/// Renders a <see cref="CssSelectorListNode"/> back to its canonical selector text, in the same
+/// two-space-normalized form <see cref="CssStylesheetWriter"/> emits a rule prelude in. Used by
+/// <see cref="CssSyntaxFactory"/> to fill a constructed <see cref="CssQualifiedRuleNode.Prelude"/> from its
+/// parts so the node is internally consistent (its prelude text and parsed <see cref="CssQualifiedRuleNode.Selectors"/>
+/// agree) and deterministic — two rules built from equal selector lists carry equal preludes.
+/// </summary>
+/// <remarks>
+/// The prelude is <em>not</em> what the serializers emit — <see cref="CssStylesheetWriter"/> and
+/// <see cref="CssScopedRewriter"/> both render a rule's selector from its parsed parts, never from the raw
+/// prelude — so this renderer's output only has to match the parts (which it does, sharing the same
+/// part-walking logic) and stay deterministic; it is deliberately independent of the serializers so this
+/// construction-only path can never perturb them.
+/// </remarks>
+internal static class CssSelectorWriter
+{
+    /// <summary>Renders <paramref name="list"/> to canonical selector text.</summary>
+    /// <param name="list">The selector list to render.</param>
+    /// <returns>The comma-joined complex selectors.</returns>
+    public static string Render(CssSelectorListNode list)
+    {
+        var builder = new StringBuilder();
+        for (var index = 0; index < list.Selectors.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(", ");
+            }
+
+            RenderComplexSelector(list.Selectors[index], builder);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void RenderComplexSelector(CssComplexSelectorNode complex, StringBuilder builder)
+    {
+        foreach (var part in complex.Parts)
+        {
+            switch (part)
+            {
+                case CssCombinatorNode combinator:
+                    builder.Append(RenderCombinator(combinator.Combinator));
+                    break;
+                case CssSimpleSelectorNode simple:
+                    builder.Append(simple.Text);
+                    break;
+                case CssPseudoSelectorNode pseudo:
+                    builder.Append(pseudo.Location.Source);
+                    break;
+            }
+        }
+    }
+
+    private static string RenderCombinator(CssCombinatorKind kind)
+        => kind switch
+        {
+            CssCombinatorKind.Child => " > ",
+            CssCombinatorKind.NextSibling => " + ",
+            CssCombinatorKind.SubsequentSibling => " ~ ",
+            _ => " ",
+        };
+}

--- a/libraries/Assimalign.Viu.Syntax.Css/test/CssConstructionTests.cs
+++ b/libraries/Assimalign.Viu.Syntax.Css/test/CssConstructionTests.cs
@@ -1,0 +1,345 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.Syntax.Css;
+
+// The programmatic CSS construction and deterministic emission surface ([V01.01.12.11]): building the
+// existing record-graph node types from code (CssSyntaxFactory / CssStylesheetBuilder) and serializing them
+// through the same canonical serializer path CssStylesheetWriter / CssScopedRewriter use, per CSS Syntax
+// Module Level 3 (https://www.w3.org/TR/css-syntax-3/). Pins construction + serialization against fixed
+// expected CSS text (including nested @media), the synthetic-location divergence from the exact-slice
+// SourceLocation invariant, byte-identical determinism (the incremental-cache contract), and value equality.
+public class CssConstructionTests
+{
+    // ---- construction of the node types ----
+
+    [Fact]
+    public void Declaration_SetsPropertyValueImportant()
+    {
+        var declaration = CssSyntaxFactory.Declaration("color", "red", important: true);
+
+        declaration.Property.ShouldBe("color");
+        declaration.Value.ShouldBe("red");
+        declaration.Important.ShouldBeTrue();
+        declaration.Kind.ShouldBe(CssSyntaxNodeKind.Declaration);
+    }
+
+    [Fact]
+    public void QualifiedRule_RendersPreludeFromSelectors()
+    {
+        var rule = ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red"));
+
+        rule.Prelude.ShouldBe(".foo");
+        rule.Selectors.Selectors.Count.ShouldBe(1);
+        rule.Declarations.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void QualifiedRule_RendersPreludeFromCompoundAndCombinator()
+    {
+        var selector = CssSyntaxFactory.ComplexSelector(new CssSelectorPartNode[]
+        {
+            CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, ".dark"),
+            CssSyntaxFactory.Combinator(CssCombinatorKind.Descendant),
+            CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, ".foo"),
+            CssSyntaxFactory.Pseudo("hover"),
+        });
+
+        var rule = CssSyntaxFactory.QualifiedRule(selector, Array.Empty<CssDeclarationNode>());
+
+        rule.Prelude.ShouldBe(".dark .foo:hover");
+    }
+
+    // ---- serialization pinned to fixed canonical CSS text ----
+
+    [Fact]
+    public void Write_SimpleRule_ProducesFixedCanonicalText()
+    {
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(".foo {\n  color: red;\n}\n");
+    }
+
+    [Fact]
+    public void Write_ImportantDeclaration_EmitsImportant()
+    {
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red", important: true)),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(".foo {\n  color: red !important;\n}\n");
+    }
+
+    [Fact]
+    public void Write_PseudoAndCombinatorSelectors_SerializeFromParts()
+    {
+        var selector = CssSyntaxFactory.ComplexSelector(new CssSelectorPartNode[]
+        {
+            CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, ".dark"),
+            CssSyntaxFactory.Combinator(CssCombinatorKind.Descendant),
+            CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, ".foo"),
+            CssSyntaxFactory.Pseudo("hover"),
+        });
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            CssSyntaxFactory.QualifiedRule(selector, new[] { CssSyntaxFactory.Declaration("color", "red") }),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(".dark .foo:hover {\n  color: red;\n}\n");
+    }
+
+    [Fact]
+    public void Write_MediaBlock_ProducesFixedText()
+    {
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            CssSyntaxFactory.Media("(min-width: 768px)", new CssSyntaxNode[]
+            {
+                ClassRule(".foo", CssSyntaxFactory.Declaration("display", "flex")),
+            }),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(
+            "@media (min-width: 768px) {\n  .foo {\n    display: flex;\n  }\n}\n");
+    }
+
+    [Fact]
+    public void Write_NestedMedia_ProducesFixedText()
+    {
+        // A conditional-group at-rule nested inside another — the AC's explicit nested-@media case.
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            CssSyntaxFactory.Media("screen", new CssSyntaxNode[]
+            {
+                CssSyntaxFactory.Media("(min-width: 768px)", new CssSyntaxNode[]
+                {
+                    ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")),
+                }),
+            }),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(
+            "@media screen {\n  @media (min-width: 768px) {\n    .foo {\n      color: red;\n    }\n  }\n}\n");
+    }
+
+    [Fact]
+    public void Write_PreservesConstructionOrder_WithoutReordering()
+    {
+        // The serializer emits declarations and rules in exactly the order they were added — it never sorts.
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".b",
+                CssSyntaxFactory.Declaration("z-index", "1"),
+                CssSyntaxFactory.Declaration("color", "red")),
+            ClassRule(".a", CssSyntaxFactory.Declaration("color", "blue")),
+        });
+
+        CssStylesheetWriter.Write(stylesheet).ShouldBe(
+            ".b {\n  z-index: 1;\n  color: red;\n}\n.a {\n  color: blue;\n}\n");
+    }
+
+    // ---- byte-identical determinism (the incremental-cache contract) ----
+
+    [Fact]
+    public void Write_ConstructedGraph_IsByteIdenticalToParsedGraph()
+    {
+        // Constructed graphs and parsed graphs converge on the same canonical text through the same serializer.
+        var constructed = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")),
+        });
+        var parsed = CssTestHelpers.ParseStylesheet(".foo{color:red}");
+
+        CssStylesheetWriter.Write(constructed).ShouldBe(CssStylesheetWriter.Write(parsed));
+    }
+
+    [Fact]
+    public void Write_IdenticalConstructionsFromSeparateCalls_AreByteIdentical()
+    {
+        CssStylesheetWriter.Write(BuildSample()).ShouldBe(CssStylesheetWriter.Write(BuildSample()));
+    }
+
+    // ---- value equality and equal hashing ----
+
+    [Fact]
+    public void Construction_EqualInputs_ProduceEqualAndEquallyHashedGraphs()
+    {
+        var first = BuildSample();
+        var second = BuildSample();
+
+        first.ShouldBe(second);
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void Construction_DifferentInputs_AreNotEqual()
+    {
+        var red = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[] { ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")) });
+        var blue = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[] { ClassRule(".foo", CssSyntaxFactory.Declaration("color", "blue")) });
+
+        red.ShouldNotBe(blue);
+    }
+
+    [Fact]
+    public void Declaration_EqualInputs_AreEqual_ImportantFlagDistinguishes()
+    {
+        CssSyntaxFactory.Declaration("color", "red").ShouldBe(CssSyntaxFactory.Declaration("color", "red"));
+        CssSyntaxFactory.Declaration("color", "red").ShouldNotBe(CssSyntaxFactory.Declaration("color", "red", important: true));
+    }
+
+    // ---- the synthetic-location divergence (documented, tested) ----
+
+    [Fact]
+    public void ConstructedNodes_AreMarkedSynthetic_ThroughoutTheGraph()
+    {
+        AssertAllSynthetic(BuildSample());
+    }
+
+    [Fact]
+    public void ParsedNodes_AreNotSynthetic()
+    {
+        var parsed = CssTestHelpers.ParseStylesheet("@media screen {\n  .foo { color: red; }\n}\n");
+
+        CssSyntheticLocation.IsSynthetic(parsed).ShouldBeFalse();
+        // And the parsed tree still upholds the exact-slice invariant it always has.
+        CssTestHelpers.AssertExactSlice(parsed, "@media screen {\n  .foo { color: red; }\n}\n");
+    }
+
+    [Fact]
+    public void Pseudo_SyntheticSource_CarriesColonPrefixedText()
+    {
+        CssSyntaxFactory.Pseudo("hover").Location.Source.ShouldBe(":hover");
+        CssSyntaxFactory.Pseudo("before", isElement: true).Location.Source.ShouldBe("::before");
+        CssSyntheticLocation.IsSynthetic(CssSyntaxFactory.Pseudo("hover")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SyntheticLocation_SentinelOffset_IsNegative()
+    {
+        CssSyntheticLocation.SyntheticPosition.Offset.ShouldBe(-1);
+        CssSyntheticLocation.Create("x").Start.Offset.ShouldBe(-1);
+        CssSyntheticLocation.Create("x").End.Offset.ShouldBe(-1);
+        CssSyntheticLocation.Create("x").Source.ShouldBe("x");
+    }
+
+    // ---- the builder, and flow through the scoped rewriter ----
+
+    [Fact]
+    public void Builder_AccumulatesRules_EqualsFactoryStylesheet()
+    {
+        var ruleA = ClassRule(".a", CssSyntaxFactory.Declaration("color", "red"));
+        var ruleB = ClassRule(".b", CssSyntaxFactory.Declaration("color", "blue"));
+
+        var built = new CssStylesheetBuilder().Add(ruleA).Add(ruleB).Build();
+
+        built.ShouldBe(CssSyntaxFactory.Stylesheet(new CssSyntaxNode[] { ruleA, ruleB }));
+        new CssStylesheetBuilder().Add(ruleA).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Scope_ConstructedGraph_FlowsThroughScopedRewriter()
+    {
+        // A constructed graph is a faithful record graph, so the scoped rewrite (which needs the parsed
+        // parts to find the attribute-insertion point) handles it exactly as a parsed one.
+        var stylesheet = CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")),
+        });
+
+        CssScopedRewriter.Rewrite(stylesheet, "data-v-test")
+            .ShouldBe(".foo[data-v-test] {\n  color: red;\n}\n");
+    }
+
+    // ---- argument validation (matches the serializer entry points) ----
+
+    [Fact]
+    public void Factory_NullArguments_Throw()
+    {
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.Declaration(null!, "red"));
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.Declaration("color", null!));
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, null!));
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.Pseudo(null!));
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.Stylesheet(null!));
+        Should.Throw<ArgumentNullException>(() => CssSyntaxFactory.Media(null!, Array.Empty<CssSyntaxNode>()));
+    }
+
+    [Fact]
+    public void Factory_NullCollectionElement_Throws()
+        => Should.Throw<ArgumentException>(() => CssSyntaxFactory.Stylesheet(new CssSyntaxNode[] { null! }));
+
+    // ---- helpers ----
+
+    private static CssQualifiedRuleNode ClassRule(string className, params CssDeclarationNode[] declarations)
+        => CssSyntaxFactory.QualifiedRule(
+            CssSyntaxFactory.ComplexSelector(new CssSelectorPartNode[]
+            {
+                CssSyntaxFactory.SimpleSelector(CssSimpleSelectorKind.Class, className),
+            }),
+            declarations);
+
+    private static CssStylesheetNode BuildSample()
+        => CssSyntaxFactory.Stylesheet(new CssSyntaxNode[]
+        {
+            ClassRule(".foo", CssSyntaxFactory.Declaration("color", "red")),
+            CssSyntaxFactory.Media("(min-width: 768px)", new CssSyntaxNode[]
+            {
+                ClassRule(".foo",
+                    CssSyntaxFactory.Declaration("color", "blue"),
+                    CssSyntaxFactory.Declaration("display", "flex", important: true)),
+            }),
+        });
+
+    // The synthetic counterpart of CssTestHelpers.AssertExactSlice: every node in a constructed graph is
+    // marked synthetic (the divergence), pinned recursively rather than node-by-node at each call site.
+    private static void AssertAllSynthetic(CssSyntaxNode node)
+    {
+        CssSyntheticLocation.IsSynthetic(node).ShouldBeTrue();
+
+        switch (node)
+        {
+            case CssStylesheetNode stylesheet:
+                foreach (var rule in stylesheet.Rules)
+                {
+                    AssertAllSynthetic(rule);
+                }
+
+                break;
+            case CssQualifiedRuleNode qualified:
+                AssertAllSynthetic(qualified.Selectors);
+                foreach (var declaration in qualified.Declarations)
+                {
+                    AssertAllSynthetic(declaration);
+                }
+
+                break;
+            case CssAtRuleNode atRule:
+                foreach (var child in atRule.Body)
+                {
+                    AssertAllSynthetic(child);
+                }
+
+                break;
+            case CssSelectorListNode list:
+                foreach (var complex in list.Selectors)
+                {
+                    AssertAllSynthetic(complex);
+                }
+
+                break;
+            case CssComplexSelectorNode complex:
+                foreach (var part in complex.Parts)
+                {
+                    AssertAllSynthetic(part);
+                }
+
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the programmatic construction surface the utility-first CSS engine ([V01.01.12.16]) needs: `CssSyntaxFactory` (declarations, selectors incl. pseudo/combinator forms, qualified rules, `@media` conditional groups, stylesheets) and the fluent `CssStylesheetBuilder` — building the EXISTING record-graph node types from code, serialized through the same canonical path `CssScopedRewriter` uses.
- **Synthetic-location design stays inside the Css leaf**: constructed nodes carry a sentinel `SourceLocation` (offset −1, a position no real parse produces) with `Source` holding exactly the text the serializer reads back — the base cluster's exact-slice invariant remains scoped to parser output (re-verified by a walker test on parsed graphs), value equality/hashing hold, and a synthetic node never equals a parsed one. No base-cluster edits; the library remains a leaf knowing nothing of utilities/variants/themes.
- **Serialization order documented in DESIGN.md**: the canonical serializer emits in exact graph order and never reorders — determinism is a construction property, so ordering policy stays with consumers (what keeps Css language-agnostic).
- Strictly extend-only: no existing production or test file touched.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · Syntax.Css **80/80** (22 new: fixed-text pins incl. nested `@media`, byte-identical separate-construction and **constructed-vs-parsed convergence** pins, value-equality/hash trio, scoped-rewriter flow-through, argument validation) · ripple check green across Syntax 17, Templates 495, SingleFileComponent 60, Generators 72, Tooling.Css 10.

Documented non-goals (DESIGN.md): constructing reserved functional pseudos, `@keyframes`, statement at-rules — additive when [V01.01.12.16] needs them.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)