### PR TITLE
feat(runtime-dom): drive persisted v-show transitions from the directive [V01.01.04.07.01]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
@@ -174,7 +174,8 @@ batching everywhere else (one interop crossing per flush is unchanged):
   the buffered applier and asserts, per flush, that from/active land in one frame, the to-swap in a
   distinct later frame, and the leave reflow op lands *between* the from- and active-class writes.
 - FLIP *move* batching (the `<TransitionGroup>` reorder pass) is the next section ([V01.01.04.07.03]);
-  `v-show` transition coalescing is #161.
+  persisted `v-show` transitions (the same barriers on show/hide toggling) are the
+  [V01.01.04.07.01] section below.
 
 ## Transition FLIP move batching ([V01.01.04.07.03])
 
@@ -214,7 +215,59 @@ while collapsing the FLIP to a constant number of crossings:
   child count. `DomCommandBufferTests` round-trips the FLIP opcodes through the buffer and decoder,
   asserting the `float64` deltas survive and the transform/reflow/class/clear order is preserved.
 
+## Persisted v-show transitions ([V01.01.04.07.01])
+
+A `<Transition>` wrapping a `v-show` element must run the enter/leave choreography on the binding
+*toggling* — the element stays mounted and only its visibility changes — where a `<Transition>`
+around a `v-if` runs it on mount/remove. Upstream calls this *persisted* mode (`Transition.ts`
+`persisted` + `directives/vShow.ts`). The pivotal upstream insight is that the `persisted` flag
+changes **who** calls the transition hooks, not the hook contract: the renderer's mount/insert and
+remove paths skip a persisted transition (`needTransition` = `transition && !transition.persisted`),
+and the `v-show` directive drives `beforeEnter`/`enter`/`leave` itself from its `beforeMount`/
+`mounted`/`updated` hooks. `BaseTransition`'s state machine (`Assimalign.Viu.RuntimeCore`) is
+untouched — the enter/leave cancellation that converges an interrupted toggle already lives on the
+shared `TransitionState`, keyed by the once-boxed `node.El` identity that survives every re-render
+(`next.El = current.El`), so the directive just has to call the same hooks with that element.
+
+- **The seam.** `v-show` reads `node.Transition` (the hooks `BaseTransition` stamped on the vnode) and
+  keys on the resolved `Persisted` flag — the exact complement of the renderer's persisted skip
+  (`VirtualNode.Transition is { Persisted: false }`). When persisted: `beforeEnter` (then
+  `setDisplay(true)`, then `enter`) reveals on show; `leave(el, () => setDisplay(false))` hides on
+  hide — the element is hidden only once the leave *completes*, in the leave's `done` callback. This
+  is Viu's explicit form of upstream's coupling, which relies on the compiler injecting `persisted`
+  whenever a `<Transition>` wraps a `v-show` child (the `transformTransition` compiler-dom transform —
+  a separate `Assimalign.Viu.Syntax.Templates` follow-up; the runtime honors a `persisted` flag from
+  any source). Keying on `Persisted` rather than upstream's raw `transition`-truthiness means the
+  directive drives the hooks *exactly* when the renderer does not, so the two never both fire even
+  without that compiler guarantee.
+- **Original-display lifecycle.** The element's original inline `display` is captured **once**, in
+  `beforeMount`, into `BrowserModelState.OriginalDisplay` (derived from the vnode `style` prop, not an
+  interop read — upstream `vShowOriginalDisplay`). Every later reveal restores it (an empty original
+  removes the inline `display` so a stylesheet value wins); every hide sets `display:none` after the
+  leave. The saved value is never overwritten by a toggle, so it survives arbitrarily many cycles. An
+  interrupted toggle converges to the final visibility with the saved display intact: a show
+  interrupting a leave cancels the leave (its `done` writes a transient `display:none`) and then the
+  reveal immediately overwrites it visible; a hide interrupting an enter cancels the enter (no display
+  write) and the leave's completion hides it.
+- **Buffered mode.** The persisted path needs no new command-buffer machinery: the enter/leave class
+  ops ride the same opcodes 21/22/23 with the same reflow + `nextFrame` barriers as a `v-if`
+  transition, and the `setDisplay` writes ride the buffered `SetStyleProperty`/`RemoveStyleProperty`
+  leaves. Because the `v-show` `updated` hook is a post-flush callback, the flush boundary applies the
+  reveal's `beforeEnter` classes and its display write together in one crossing, and the `nextFrame`
+  continuation commits the `*-to` swap in a distinct later frame — the from/active-vs-to barrier holds,
+  and the leave's reflow still lands between `*-leave-from` and `*-leave-active` in a single frame.
+- **Proof.** `VShowTransitionTests` drives the real renderer + real `<Transition>` + real `v-show`
+  through a merged recording adapter (class choreography + display toggles) and pins, run-count-exact,
+  the enter/leave class sequence on toggle without unmounting, the capture-once/restore-across-cycles
+  display lifecycle, and both interruption directions converging with the right visibility and no
+  orphaned classes. `BufferedTransitionSequencingTests` extends the batched-mode battery with the
+  persisted show/hide path, asserting the same one-frame from/active, distinct-frame to-swap, and
+  leave reflow barrier — and that the element stays mounted (display:none, never host-removed).
+
 ## Non-goals (sequenced work)
 
 - App bootstrap (`CreateApp`-equivalent, container clearing) — [V01.01.04.04] (#42).
 - `v-model` runtime — [V01.01.04.06].
+- Compiler `persisted` injection (`transformTransition`: mark a `<Transition>` persisted when its
+  single child carries `v-show`) — a `Assimalign.Viu.Syntax.Templates` follow-up; the runtime already
+  honors the `persisted` flag ([V01.01.04.07.01]).

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Directives/VShow.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Directives/VShow.cs
@@ -19,12 +19,26 @@ namespace Assimalign.Viu.RuntimeDom;
 /// follows JavaScript coercion (<see cref="StyleAndClassNormalization.IsTruthy(object?)"/>).
 /// <para>
 /// The saved display is derived from the vnode's <c>style</c> prop rather than an interop read of
-/// <c>el.style.display</c> — equivalent for inline styles and one fewer boundary crossing. The
-/// <c>&lt;Transition&gt;</c> coordination clause of the acceptance criteria remains a
-/// <b>documented-inert seam</b>: the transition state machine now exists ([V01.01.04.07]) and the
-/// renderer honors a <see cref="TransitionState"/>-persisted transition, but <c>v-show</c> does not yet
-/// build that persisted transition object, so the hook shape is present and its coordination is a
-/// follow-up.
+/// <c>el.style.display</c> — equivalent for inline styles and one fewer boundary crossing.
+/// </para>
+/// <para>
+/// <b>Persisted transitions</b> — a <c>&lt;Transition&gt;</c> wrapping a <c>v-show</c> element
+/// (upstream <c>vShow.ts</c> persisted handling + <c>components/Transition.ts</c>,
+/// https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/components/Transition.ts). When
+/// the vnode carries a <see cref="VirtualNode.Transition"/> resolved as
+/// <see cref="BaseTransitionProperties.Persisted"/>, the element stays mounted and the enter/leave
+/// choreography runs on <em>show/hide</em> instead of mount/unmount: the renderer skips its own
+/// enter/leave for a persisted transition, so this directive drives <c>beforeEnter</c>/<c>enter</c>
+/// on reveal and <c>leave</c> on hide (upstream's <c>persisted</c> flag changes <em>who</em> calls
+/// the hooks, not the hook contract). On reveal, <c>beforeEnter</c> and <see cref="SetDisplay"/> make
+/// the element visible before the enter frame; on hide, the element is hidden only once the leave
+/// transition completes — the leave <c>done</c> callback runs <see cref="SetDisplay"/>. The
+/// transition's own enter/leave cancellation (upstream <c>el[enterCbKey]</c>/<c>el[leaveCbKey]</c>)
+/// converges an interrupted toggle to the final visibility with the saved display value intact and no
+/// orphaned transition classes. Keying on the resolved <c>Persisted</c> flag — the exact complement
+/// of the renderer's persisted skip — is Viu's explicit form of upstream's coupling, which relies on
+/// the compiler injecting <c>persisted</c> whenever a <c>&lt;Transition&gt;</c> wraps a <c>v-show</c>
+/// child.
 /// </para>
 /// Stateless singleton (<see cref="Instance"/>); the saved display lives in
 /// <see cref="BrowserModelState.OriginalDisplay"/>.
@@ -55,19 +69,30 @@ public sealed class VShow : IDirective
         var operations = BrowserDirectiveOperations.Require();
         var handle = BrowserModelDirective.Handle(element);
         var original = OriginalDisplay(node);
+        // Captured once, here, and preserved across every later toggle (upstream vShowOriginalDisplay).
         operations.GetState(handle).OriginalDisplay = original;
-        // Transition seam (still inert): upstream would defer to transition.beforeEnter when a transition
-        // and truthy value are present. The transition state machine now exists ([V01.01.04.07]) but
-        // v-show does not yet mark itself a persisted transition, so this stays a plain toggle. beforeMount
-        // timing means an initially-falsy element is hidden before its first paint.
-        SetDisplay(operations, handle, StyleAndClassNormalization.IsTruthy(binding.Value), original);
+        var value = StyleAndClassNormalization.IsTruthy(binding.Value);
+        // Upstream vShow.beforeMount: with a persisted transition present and a truthy value, defer the
+        // reveal to transition.beforeEnter (the enter choreography drives display); otherwise toggle
+        // display directly. beforeMount timing hides an initially-falsy element before its first paint.
+        if (value && PersistedTransition(node) is { } transition)
+        {
+            transition.BeforeEnter(element!);
+        }
+        else
+        {
+            SetDisplay(operations, handle, value, original);
+        }
     }
 
     private static void OnMounted(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
     {
-        // Deferred-inert transition seam: upstream runs transition.enter here when a transition and
-        // truthy value are present. The transition system exists ([V01.01.04.07]); wiring v-show to build a
-        // persisted transition is a follow-up, so this is a no-op placeholder that keeps the hook shape.
+        // Upstream vShow.mounted: run transition.enter for a truthy persisted-transition element. On the
+        // first mount the transition state is not yet mounted, so enter is a no-op unless `appear` is set.
+        if (StyleAndClassNormalization.IsTruthy(binding.Value) && PersistedTransition(node) is { } transition)
+        {
+            transition.Enter(element!);
+        }
     }
 
     private static void OnUpdated(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
@@ -80,8 +105,28 @@ public sealed class VShow : IDirective
         }
         var operations = BrowserDirectiveOperations.Require();
         var handle = BrowserModelDirective.Handle(element);
-        // Deferred-inert transition seam ([V01.01.04.07]); upstream coordinates enter/leave here.
-        SetDisplay(operations, handle, value, operations.GetState(handle).OriginalDisplay ?? string.Empty);
+        var original = operations.GetState(handle).OriginalDisplay ?? string.Empty;
+        if (PersistedTransition(node) is { } transition)
+        {
+            // Upstream vShow.updated: show -> beforeEnter, setDisplay(true), enter; hide -> leave, then
+            // setDisplay(false) once the leave completes. beforeEnter/leave cancel any in-flight leave/enter
+            // on the same element first, so an interrupted toggle converges to the final visibility with the
+            // saved display intact and no orphaned transition classes.
+            if (value)
+            {
+                transition.BeforeEnter(element!);
+                SetDisplay(operations, handle, true, original);
+                transition.Enter(element!);
+            }
+            else
+            {
+                transition.Leave(element!, () => SetDisplay(operations, handle, false, original));
+            }
+        }
+        else
+        {
+            SetDisplay(operations, handle, value, original);
+        }
     }
 
     private static void OnBeforeUnmount(object? element, DirectiveBinding binding, VirtualNode node, VirtualNode? previousNode)
@@ -92,6 +137,15 @@ public sealed class VShow : IDirective
         SetDisplay(operations, handle, StyleAndClassNormalization.IsTruthy(binding.Value), operations.GetState(handle).OriginalDisplay ?? string.Empty);
         operations.ReleaseState(handle);
     }
+
+    // The resolved persisted transition hooks stamped onto the vnode by an enclosing <Transition>
+    // (upstream: vnode.transition), or null when the element is not a persisted-transition child. Keying
+    // on Persisted — the exact complement of the renderer's persisted skip (VirtualNode.Transition is
+    // { Persisted: false }) — means v-show drives the enter/leave choreography exactly when the renderer
+    // does not, so the two never both fire (upstream couples them through the compiler's guaranteed
+    // `persisted` injection when a <Transition> wraps a v-show child).
+    private static TransitionHooks? PersistedTransition(VirtualNode node)
+        => node.Transition is { Persisted: true } transition ? transition : null;
 
     // Upstream setDisplay: el.style.display = value ? original : 'none'. An empty original removes
     // the inline property so a stylesheet-supplied display is not clobbered.

--- a/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/CommandBuffer/BufferedTransitionSequencingTests.cs
@@ -108,6 +108,72 @@ public sealed class BufferedTransitionSequencingTests
         world.DirectReflowCount.ShouldBe(0);
     }
 
+    [Fact]
+    public void PersistedShow_AppliesEnterFromAndActiveInOneFrame_ThenSwapsToInADistinctFrame_WithoutUnmounting()
+    {
+        using var world = new BufferedTransitionWorld();
+        var show = Reactive.Reference(false);
+        world.Render(PersistedHost(show, ("name", "fade")));
+        var div = world.Dom.FindFirstElement("div");
+        world.Dom.IsMounted(div).ShouldBeTrue(); // v-show keeps the element mounted even while hidden
+
+        // Toggle show: the persisted v-show path drives the enter, so the from + active classes commit
+        // together in ONE buffered frame (one crossing), but NOT the to-class — same barrier as a v-if enter.
+        show.Value = true;
+        world.RunUntilIdle();
+        var enterFrame = world.FirstTransitionFrameContaining("add:fade-enter-from");
+        enterFrame.ShouldBe(["add:fade-enter-from", "add:fade-enter-active"]);
+        enterFrame.ShouldNotContain("add:fade-enter-to");
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-enter-from", "fade-enter-active"], ignoreOrder: true);
+
+        // Next frame: the from -> to swap commits in its OWN distinct frame (never coalesced).
+        world.AdvanceFrame();
+        var swapFrame = world.FirstTransitionFrameContaining("add:fade-enter-to");
+        swapFrame.ShouldBe(["remove:fade-enter-from", "add:fade-enter-to"]);
+        world.FrameIndexOf(swapFrame).ShouldBeGreaterThan(world.FrameIndexOf(enterFrame));
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-enter-active", "fade-enter-to"], ignoreOrder: true);
+
+        // The transition end removes the enter classes; the element was never unmounted.
+        world.FireTransitionEnd(div);
+        world.Dom.TransitionClasses(div).ShouldBeEmpty();
+        world.Dom.IsMounted(div).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PersistedHide_LandsTheReflowBarrierBetweenFromAndActive_ThenHidesAfterTheLeave_WithoutUnmounting()
+    {
+        using var world = new BufferedTransitionWorld();
+        var show = Reactive.Reference(true);
+        world.Render(PersistedHost(show, ("name", "fade")));
+        var div = world.Dom.FindFirstElement("div");
+        world.Dom.ReflowCount.ShouldBe(0); // no appear -> the initial mount runs no choreography or reflow
+
+        // Toggle hide: within a SINGLE flush the buffered adaptor commits leave-from, a real reflow barrier
+        // (document.body.offsetHeight), then leave-active, in that order (upstream #2593) — one crossing. The
+        // element stays MOUNTED and visible; the removal path is never taken (v-show persists it).
+        show.Value = false;
+        world.RunUntilIdle();
+        var leaveFrame = world.FirstTransitionFrameContaining("add:fade-leave-from");
+        leaveFrame.ShouldBe(["add:fade-leave-from", "reflow", "add:fade-leave-active"]);
+        world.Dom.ReflowCount.ShouldBe(1);
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-leave-from", "fade-leave-active"], ignoreOrder: true);
+        world.Dom.IsMounted(div).ShouldBeTrue();
+
+        // Next frame: the from -> to swap is a distinct later frame (never coalesced with from/active).
+        world.AdvanceFrame();
+        var swapFrame = world.FirstTransitionFrameContaining("add:fade-leave-to");
+        swapFrame.ShouldBe(["remove:fade-leave-from", "add:fade-leave-to"]);
+        world.FrameIndexOf(swapFrame).ShouldBeGreaterThan(world.FrameIndexOf(leaveFrame));
+        world.Dom.TransitionClasses(div).ShouldBe(["fade-leave-active", "fade-leave-to"], ignoreOrder: true);
+
+        // The transition end removes the leave classes and applies display:none — but the element stays
+        // MOUNTED (the v-show leave hides in place; it never host-removes like the v-if leave).
+        world.FireTransitionEnd(div);
+        world.Dom.TransitionClasses(div).ShouldBeEmpty();
+        world.Dom.IsMounted(div).ShouldBeTrue();
+        world.Dom.Serialize(div).ShouldContain("style.display=\"none\"");
+    }
+
     // A component rendering <Transition {props}> around a v-if div keyed "a" (mirrors TransitionTests.Host).
     private static RenderComponent Host(Reference<bool> show, params (string Name, object? Value)[] transitionProperties)
         => new((_, _) => () =>
@@ -117,6 +183,22 @@ public sealed class BufferedTransitionSequencingTests
                 ? [Element("div", Properties(("key", "a")), "A")]
                 : [Comment()];
             return Component(Transition.Instance, Properties(transitionProperties), slots);
+        });
+
+    // A component rendering <Transition {props} persisted> around a v-show div keyed "a" — the persisted
+    // path (#161). The persisted flag stands in for the compiler's transformTransition injection for a
+    // single v-show child, so the renderer skips its mount/remove enter/leave and v-show drives them.
+    private static RenderComponent PersistedHost(Reference<bool> show, params (string Name, object? Value)[] transitionProperties)
+        => new((_, _) => () =>
+        {
+            var slots = new ComponentSlots();
+            slots["default"] = _ =>
+            [
+                Directives.WithDirectives(Element("div", Properties(("key", "a")), "A"), VShow.Instance, show.Value),
+            ];
+            var properties = Properties(transitionProperties);
+            properties.Set("persisted", true);
+            return Component(Transition.Instance, properties, slots);
         });
 
     // A DOM-free buffered world: the real renderer over BufferedBrowserNodeOperations, an in-memory

--- a/libraries/Assimalign.Viu.RuntimeDom/test/VShowTransitionTestHarness.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/VShowTransitionTestHarness.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeDom.Tests;
+
+// A DOM-free harness for the PERSISTED v-show transition path ([V01.01.04.07.01]): it drives the real
+// RuntimeCore renderer + the real DOM <Transition> + the real v-show directive over int node handles,
+// installing BOTH a recording DomTransitionOperations (the CSS class choreography) AND a recording
+// BrowserDirectiveOperations (the v-show display toggle), so a <Transition persisted> wrapping a v-show
+// <div> exercises its whole production path with no browser. It is TransitionTestHarness merged with the
+// v-show half of BrowserDirectiveTestHarness — the two seams write to one per-element record, so a test
+// can pin the class sequence, the reflow count, and the display-toggle sequence together. Upstream
+// contract: @vue/runtime-dom directives/vShow.ts persisted handling + components/Transition.ts
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vShow.ts).
+internal sealed class VShowTransitionTestHarness : IDisposable
+{
+    // The sentinel a v-show reveal with no saved inline display logs (RemoveStyleProperty -> "no inline
+    // display", i.e. visible). Distinct from "none" (hidden) and a concrete value like "flex".
+    public const string DisplayRemoved = "";
+
+    private readonly Dictionary<int, RecordingNode> _nodes = [];
+    private readonly Dictionary<int, List<int>> _children = [];
+    private readonly Renderer<int> _renderer;
+    private readonly TestSchedulerPump _pump;
+    private readonly DomTransitionOperations? _previousTransitionOperations;
+    private readonly BrowserDirectiveOperations? _previousDirectiveOperations;
+    private readonly List<Action> _nextFrameQueue = [];
+    private readonly Dictionary<int, Action> _endResolvers = [];
+    private int _nextHandle = 1;
+
+    public VShowTransitionTestHarness()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+
+        _previousTransitionOperations = DomTransitionOperations.Current;
+        DomTransitionOperations.Current = new DomTransitionOperations
+        {
+            AddTransitionClass = (element, cssClass) =>
+            {
+                ClassLog.Add($"add:{cssClass}");
+                Classes(element).Add(cssClass);
+            },
+            RemoveTransitionClass = (element, cssClass) =>
+            {
+                ClassLog.Add($"remove:{cssClass}");
+                Classes(element).Remove(cssClass);
+            },
+            NextFrame = _nextFrameQueue.Add,
+            ForceReflow = () => ReflowCount++,
+            WhenTransitionEnds = (element, _, _, resolve) => _endResolvers[element] = resolve,
+            // FLIP ops are unused by <Transition>; stub them (TransitionGroup has its own coverage).
+            MeasurePositions = handles => new TransitionRectangle[handles.Length],
+            SetMoveTransform = (_, _, _) => { },
+            ClearMoveStyles = _ => { },
+            HasCssTransform = (_, _, _) => false,
+            WhenMoveEnds = (_, resolve) => resolve(),
+        };
+
+        _previousDirectiveOperations = BrowserDirectiveOperations.Current;
+        BrowserDirectiveOperations.Current = new BrowserDirectiveOperations
+        {
+            // v-model channels are unused by v-show; stub them.
+            SetModelListener = (_, _, _) => { },
+            SetValueGuarded = (_, _) => { },
+            SetBooleanProperty = (_, _, _) => { },
+            SetCssVariables = (_, _, _) => { },
+            SetStyleProperty = (element, name, value, _) =>
+            {
+                if (string.Equals(name, "display", StringComparison.Ordinal))
+                {
+                    DisplayLog.Add(value);
+                    Node(element).Display = value;
+                }
+            },
+            RemoveStyleProperty = (element, name) =>
+            {
+                if (string.Equals(name, "display", StringComparison.Ordinal))
+                {
+                    DisplayLog.Add(DisplayRemoved);
+                    Node(element).Display = null;
+                }
+            },
+        };
+
+        _renderer = RendererFactory.CreateRenderer(new RendererOptions<int>
+        {
+            Insert = Insert,
+            Remove = Remove,
+            CreateElement = (tag, _) => Create(new RecordingNode { Tag = tag }),
+            CreateText = text => Create(new RecordingNode { Tag = "#text", Value = text }),
+            CreateComment = text => Create(new RecordingNode { Tag = "#comment", Value = text }),
+            SetText = (node, text) => Node(node).Value = text,
+            SetElementText = (node, text) => Node(node).Value = text,
+            ParentNode = node => Node(node).Parent,
+            NextSibling = NextSibling,
+            // v-show writes display through BrowserDirectiveOperations, not patchProp; no other bound
+            // prop matters to these tests, so the patch leaf is a no-op.
+            PatchProperty = (_, _, _, _, _, _) => { },
+        });
+
+        Container = Create(new RecordingNode { Tag = "#container" });
+    }
+
+    /// <summary>The ordered transition class add/remove operations (the choreography sequence).</summary>
+    public List<string> ClassLog { get; } = [];
+
+    /// <summary>
+    /// The ordered v-show display writes: a concrete value (<c>"none"</c>/<c>"flex"</c>…) for a
+    /// <c>SetStyleProperty</c>, or <see cref="DisplayRemoved"/> for a <c>RemoveStyleProperty</c> (reveal
+    /// with no saved inline display). Pins the run count of display toggles across an interrupted transition.
+    /// </summary>
+    public List<string> DisplayLog { get; } = [];
+
+    /// <summary>The number of forced reflows recorded (the leave barrier).</summary>
+    public int ReflowCount { get; private set; }
+
+    /// <summary>The container handle to render into.</summary>
+    public int Container { get; }
+
+    public void Dispose()
+    {
+        DomTransitionOperations.Current = _previousTransitionOperations;
+        BrowserDirectiveOperations.Current = _previousDirectiveOperations;
+        _pump.Dispose();
+        Scheduler.Reset();
+    }
+
+    /// <summary>Renders a component's tree into the container and drains scheduled flushes.</summary>
+    public void Render(IComponentDefinition component)
+    {
+        _renderer.Render(VirtualNodeFactory.Component(component), Container);
+        _pump.RunUntilIdle();
+    }
+
+    /// <summary>Runs captured scheduler flushes until idle (post-flush mounted/updated hooks).</summary>
+    public void RunUntilIdle() => _pump.RunUntilIdle();
+
+    /// <summary>Runs every queued next-frame callback (the deterministic stand-in for the double rAF).</summary>
+    public void AdvanceFrame()
+    {
+        var pending = new List<Action>(_nextFrameQueue);
+        _nextFrameQueue.Clear();
+        foreach (var callback in pending)
+        {
+            callback();
+        }
+    }
+
+    /// <summary>Fires the transition-end for an element, completing its in-flight enter/leave.</summary>
+    public void FireTransitionEnd(int element)
+    {
+        if (_endResolvers.Remove(element, out var resolve))
+        {
+            resolve();
+        }
+    }
+
+    /// <summary>The transition classes currently applied to an element.</summary>
+    public HashSet<string> Classes(int element)
+        => _nodes.TryGetValue(element, out var node) ? node.TransitionClasses : [];
+
+    /// <summary>The element's inline <c>display</c>, or null when there is no inline display (visible).</summary>
+    public string? Display(int element) => _nodes.TryGetValue(element, out var node) ? node.Display : null;
+
+    /// <summary>Whether an element currently has a pending in-flight transition end (enter or leave).</summary>
+    public bool HasPendingEnd(int element) => _endResolvers.ContainsKey(element);
+
+    /// <summary>The handle of the first recorded element with <paramref name="tag"/>, in creation order.</summary>
+    public int FindElement(string tag)
+    {
+        for (var handle = 1; handle < _nextHandle; handle++)
+        {
+            if (_nodes.TryGetValue(handle, out var node) && string.Equals(node.Tag, tag, StringComparison.Ordinal))
+            {
+                return handle;
+            }
+        }
+        throw new InvalidOperationException($"No <{tag}> was recorded.");
+    }
+
+    /// <summary>Whether the element handle is still registered (not yet removed from the host).</summary>
+    public bool IsMounted(int element) => _nodes.ContainsKey(element);
+
+    // --- recording node-ops --------------------------------------------------------------------
+
+    private int Create(RecordingNode node)
+    {
+        var handle = _nextHandle++;
+        _nodes[handle] = node;
+        return handle;
+    }
+
+    private RecordingNode Node(int handle) => _nodes[handle];
+
+    private void Insert(int child, int parent, int anchor)
+    {
+        _nodes[child].Parent = parent;
+        var siblings = _children.TryGetValue(parent, out var list) ? list : _children[parent] = [];
+        siblings.Remove(child);
+        if (anchor != 0 && siblings.IndexOf(anchor) is var index and >= 0)
+        {
+            siblings.Insert(index, child);
+        }
+        else
+        {
+            siblings.Add(child);
+        }
+    }
+
+    private void Remove(int child)
+    {
+        var parent = _nodes.TryGetValue(child, out var node) ? node.Parent : 0;
+        var released = new List<int>();
+        CollectSubtree(child, released);
+        foreach (var handle in released)
+        {
+            _nodes.Remove(handle);
+            _children.Remove(handle);
+        }
+        if (_children.TryGetValue(parent, out var siblings))
+        {
+            siblings.Remove(child);
+        }
+    }
+
+    private int NextSibling(int node)
+    {
+        var parent = _nodes.TryGetValue(node, out var recording) ? recording.Parent : 0;
+        if (parent == 0 || !_children.TryGetValue(parent, out var siblings))
+        {
+            return 0;
+        }
+        var index = siblings.IndexOf(node);
+        return index >= 0 && index + 1 < siblings.Count ? siblings[index + 1] : 0;
+    }
+
+    private void CollectSubtree(int handle, List<int> released)
+    {
+        released.Add(handle);
+        if (_children.TryGetValue(handle, out var childHandles))
+        {
+            foreach (var child in new List<int>(childHandles))
+            {
+                CollectSubtree(child, released);
+            }
+        }
+    }
+
+    private sealed class RecordingNode
+    {
+        public string Tag = string.Empty;
+        public string Value = string.Empty;
+        public int Parent;
+        // The recorded inline display: null when there is no inline display (visible), else the last
+        // value written ("none"/"flex"/…). Written by the v-show BrowserDirectiveOperations seam.
+        public string? Display;
+        public readonly HashSet<string> TransitionClasses = new(StringComparer.Ordinal);
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeDom/test/VShowTransitionTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/test/VShowTransitionTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+
+using static Assimalign.Viu.RuntimeCore.VirtualNodeFactory;
+
+namespace Assimalign.Viu.RuntimeDom.Tests;
+
+// Pins the PERSISTED v-show transition path ([V01.01.04.07.01]) through the deterministic in-memory
+// adapter: a <Transition persisted> wrapping a v-show <div> runs the enter/leave hooks + CSS classes on
+// each binding toggle WITHOUT unmounting the element, captures the original display once and restores it,
+// and converges a toggle-during-transition interruption to the final visibility with no orphaned classes.
+// The <Transition persisted> stands in for the compiler's transformTransition injection (persisted:true
+// whenever a <transition> wraps a single v-show child). Upstream contract: @vue/runtime-dom
+// directives/vShow.ts persisted handling + components/Transition.ts
+// (https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/directives/vShow.ts,
+// https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/components/Transition.ts).
+public sealed class VShowTransitionTests : IDisposable
+{
+    private readonly VShowTransitionTestHarness _harness = new();
+
+    public void Dispose() => _harness.Dispose();
+
+    [Fact]
+    public void Show_RunsEnterChoreography_WithoutUnmountingTheElement()
+    {
+        var show = Reactive.Reference<object?>(false);
+        _harness.Render(PersistedHost(show));
+        var div = _harness.FindElement("div");
+        // Initially falsy: beforeMount hides it directly (no enter/leave classes, no reflow).
+        _harness.Display(div).ShouldBe("none");
+        _harness.Classes(div).ShouldBeEmpty();
+
+        // Toggle in: the enter choreography runs on SHOW (from+active now, to-swap next frame) and the
+        // element is revealed — but it is the SAME element, never unmounted/remounted.
+        show.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Classes(div).ShouldBe(["fade-enter-from", "fade-enter-active"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // revealed (no saved inline display -> removed)
+        _harness.IsMounted(div).ShouldBeTrue();
+        _harness.FindElement("div").ShouldBe(div); // no new element created -> not remounted
+
+        _harness.AdvanceFrame();
+        _harness.Classes(div).ShouldBe(["fade-enter-active", "fade-enter-to"], ignoreOrder: true);
+
+        _harness.FireTransitionEnd(div);
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.Display(div).ShouldBeNull();
+        _harness.IsMounted(div).ShouldBeTrue();
+        // Run count: display was written exactly twice — hidden at mount, revealed on show.
+        _harness.DisplayLog.ShouldBe(["none", VShowTransitionTestHarness.DisplayRemoved]);
+    }
+
+    [Fact]
+    public void Hide_RunsLeaveChoreography_ThenHidesOnlyAfterItCompletes_WithoutUnmounting()
+    {
+        var show = Reactive.Reference<object?>(true);
+        _harness.Render(PersistedHost(show));
+        var div = _harness.FindElement("div");
+        // Initially truthy, no appear -> no enter choreography and no display write at mount (visible).
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.Display(div).ShouldBeNull();
+        _harness.DisplayLog.ShouldBeEmpty();
+
+        // Toggle out: leave choreography runs on HIDE (from+active + a forced reflow), but the element
+        // stays visible AND mounted until the leave completes.
+        show.Value = false;
+        _harness.RunUntilIdle();
+        _harness.Classes(div).ShouldBe(["fade-leave-from", "fade-leave-active"], ignoreOrder: true);
+        _harness.ReflowCount.ShouldBe(1);
+        _harness.Display(div).ShouldBeNull(); // NOT hidden yet — the leave is still running
+        _harness.IsMounted(div).ShouldBeTrue();
+
+        _harness.AdvanceFrame();
+        _harness.Classes(div).ShouldBe(["fade-leave-active", "fade-leave-to"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // still visible mid-leave
+
+        _harness.FireTransitionEnd(div);
+        // Leave complete: classes cleared, display:none applied by the leave's done callback, element STILL
+        // mounted (v-show persists it; the renderer's remove path was never taken).
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.Display(div).ShouldBe("none");
+        _harness.IsMounted(div).ShouldBeTrue();
+        _harness.DisplayLog.ShouldBe(["none"]); // hidden exactly once, after the leave
+    }
+
+    [Fact]
+    public void InitiallyHidden_IsHiddenAtMount_WithNoTransitionChoreography()
+    {
+        var show = Reactive.Reference<object?>(false);
+        _harness.Render(PersistedHost(show));
+        var div = _harness.FindElement("div");
+        // beforeMount hides an initially-falsy element directly (upstream: transition && value is false, so
+        // setDisplay(el, false)) — no enter/leave classes and no reflow on the first mount.
+        _harness.Display(div).ShouldBe("none");
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.ReflowCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void OriginalInlineDisplay_IsCapturedOnce_AndRestoredAcrossRepeatedToggles()
+    {
+        var show = Reactive.Reference<object?>(false);
+        _harness.Render(PersistedHost(show, inlineDisplay: "flex"));
+        var div = _harness.FindElement("div");
+        // Falsy at mount -> hidden; the author-supplied inline display ("flex") is captured for later.
+        _harness.Display(div).ShouldBe("none");
+
+        // Show -> the captured original "flex" is restored (not the empty/default), driven by the enter.
+        show.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("flex");
+        _harness.AdvanceFrame();
+        _harness.FireTransitionEnd(div);
+        _harness.Display(div).ShouldBe("flex");
+
+        // Hide -> display:none once the leave completes.
+        show.Value = false;
+        _harness.RunUntilIdle();
+        _harness.AdvanceFrame();
+        _harness.FireTransitionEnd(div);
+        _harness.Display(div).ShouldBe("none");
+
+        // Show again -> the SAME original "flex" is restored: captured once at mount, never lost to the
+        // toggles (upstream vShowOriginalDisplay is set only in beforeMount).
+        show.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Display(div).ShouldBe("flex");
+        _harness.AdvanceFrame();
+        _harness.FireTransitionEnd(div);
+        _harness.Display(div).ShouldBe("flex");
+    }
+
+    [Fact]
+    public void HideInterruptingEnter_CancelsTheEnter_ConvergesHidden_WithNoOrphanClasses()
+    {
+        var show = Reactive.Reference<object?>(false);
+        _harness.Render(PersistedHost(show));
+        var div = _harness.FindElement("div");
+
+        // Start entering and let it reach the "to" phase (genuinely mid-transition, waiting on the end).
+        show.Value = true;
+        _harness.RunUntilIdle();
+        _harness.AdvanceFrame();
+        _harness.Classes(div).ShouldBe(["fade-enter-active", "fade-enter-to"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // revealed for the enter
+
+        // Interrupt with a hide before the enter finishes: the enter is cancelled (its classes removed by
+        // finishEnter, upstream el[enterCbKey](true)) and the leave classes take over, with no orphaned
+        // enter class. The element is still visible and mounted — hiding waits for the leave to complete.
+        show.Value = false;
+        _harness.RunUntilIdle();
+        _harness.Classes(div).ShouldNotContain("fade-enter-from");
+        _harness.Classes(div).ShouldNotContain("fade-enter-to");
+        _harness.Classes(div).ShouldNotContain("fade-enter-active");
+        _harness.Classes(div).ShouldBe(["fade-leave-from", "fade-leave-active"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // still visible mid-leave
+
+        // Complete the leave: converges hidden with no orphaned classes; the element is never unmounted.
+        _harness.AdvanceFrame();
+        _harness.FireTransitionEnd(div);
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.Display(div).ShouldBe("none");
+        _harness.IsMounted(div).ShouldBeTrue();
+        // Run count: hidden at mount, revealed for the enter, hidden again once the leave finished.
+        _harness.DisplayLog.ShouldBe(["none", VShowTransitionTestHarness.DisplayRemoved, "none"]);
+    }
+
+    [Fact]
+    public void ShowInterruptingLeave_CancelsTheLeave_ConvergesVisible_WithNoOrphanClasses()
+    {
+        var show = Reactive.Reference<object?>(true);
+        _harness.Render(PersistedHost(show));
+        var div = _harness.FindElement("div");
+
+        // Start leaving and let it reach the "to" phase (genuinely mid-transition, waiting on the end).
+        show.Value = false;
+        _harness.RunUntilIdle();
+        _harness.AdvanceFrame();
+        _harness.Classes(div).ShouldBe(["fade-leave-active", "fade-leave-to"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // still visible while leaving
+
+        // Interrupt with a show before the leave finishes: the leave is cancelled (its classes removed by
+        // finishLeave, upstream el[leaveCbKey](true)) and the enter classes take over, with no orphaned
+        // leave class.
+        show.Value = true;
+        _harness.RunUntilIdle();
+        _harness.Classes(div).ShouldNotContain("fade-leave-from");
+        _harness.Classes(div).ShouldNotContain("fade-leave-to");
+        _harness.Classes(div).ShouldNotContain("fade-leave-active");
+        _harness.Classes(div).ShouldBe(["fade-enter-from", "fade-enter-active"], ignoreOrder: true);
+        _harness.Display(div).ShouldBeNull(); // converged visible
+
+        _harness.AdvanceFrame();
+        _harness.Classes(div).ShouldBe(["fade-enter-active", "fade-enter-to"], ignoreOrder: true);
+        _harness.FireTransitionEnd(div);
+        _harness.Classes(div).ShouldBeEmpty();
+        _harness.Display(div).ShouldBeNull(); // visible
+        _harness.IsMounted(div).ShouldBeTrue();
+        // Run count: the cancelled leave's done callback wrote a transient display:none (upstream
+        // done(cancelled) still calls remove), immediately overwritten by the show's reveal — final: visible.
+        _harness.DisplayLog.ShouldBe(["none", VShowTransitionTestHarness.DisplayRemoved]);
+    }
+
+    // <Transition name="fade" persisted><div key="a" v-show="show">content</div></Transition>. The
+    // persisted flag simulates the compiler's transformTransition injection for a single v-show child.
+    private static RenderComponent PersistedHost(Reference<object?> show, string? inlineDisplay = null)
+        => new((_, _) => () =>
+        {
+            var divProperties = new VirtualNodeProperties();
+            divProperties.Set("key", "a");
+            if (inlineDisplay is not null)
+            {
+                divProperties.Set("style", new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["display"] = inlineDisplay,
+                });
+            }
+            var slots = new ComponentSlots();
+            slots["default"] = _ =>
+            [
+                Directives.WithDirectives(Element("div", divProperties, "content"), VShow.Instance, show.Value),
+            ];
+            var transitionProperties = Properties(("name", "fade"), ("persisted", true));
+            return Component(Transition.Instance, transitionProperties, slots);
+        });
+}


### PR DESCRIPTION
## Summary
- Implements upstream's persisted transition mode: a `<Transition>` wrapping a `v-show` element now runs enter/leave hooks and classes on display toggling, without unmounting. The renderer already skips persisted transitions on mount/remove, so `VShow` drives the complement — reading the transition hooks off the vnode and keying **explicitly on `Persisted`** (a documented divergence from upstream's transition-truthiness: the explicit guard means directive and renderer can never double-fire, even before the compiler transform that injects the flag exists).
- Original display value captured **once** at beforeMount from the style prop (no interop read — upstream `vShowOriginalDisplay`), restored on every reveal (empty → style-property removal so stylesheets win), and `display:none` applied only in the leave's done callback — surviving arbitrarily many cycles.
- Interruptions converge through the existing transition cancellation machinery: hide-mid-enter and show-mid-leave both pin exact display-log sequences (including the faithful transient `none`→`` when a reveal cancels an in-flight leave).
- Buffered interop mode honors the same reflow/next-frame barriers for the persisted path (2 new sequencing tests; element stays mounted, never host-removed).
- The separable compiler piece (`transformTransition` injecting `persisted` from templates) is filed as [#202 [V01.01.04.07.05]](https://github.com/assimalign/viu/issues/202); the runtime honors the flag from any source. `TransitionGroup.cs` untouched (the #164 sibling stacks on this branch).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings (WASM example included) · RuntimeDom **178/178** (8 new), RuntimeCore 242, Testing 18 · existing VShow and Transition suites untouched and green.

Closes #161
Refs #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)