### PR TITLE
feat(runtime-core): implement async components [V01.01.03.16]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -118,6 +118,83 @@ Deliberate divergences from upstream `KeepAlive.ts`, each documented at its call
   sets no current instance; Viu fires the aggregated list through the root's `InvokeHooks`, so a
   descendant hook that reads `ComponentInstance.Current` sees the root — a minor divergence pinned by test.
 
+## Async components define the runtime contract, not lazy download
+
+`AsyncComponents.DefineAsyncComponent` ([V01.01.03.16], upstream `apiAsyncComponent.ts`,
+https://vuejs.org/guide/components/async.html) returns an internal `AsyncComponentWrapper`
+(`IComponentDefinition`): a loader (`Func<Task<IComponentDefinition>>`) resolves the real component
+asynchronously; a loading component shows after `Delay`, an error component on failure or `Timeout`,
+and the resolved component renders in place. Unlike `KeepAlive` (one shared singleton whose per-mount
+state must be closure-local), each `DefineAsyncComponent` call yields a *fresh* wrapper, so the
+**load state** — the in-flight request, the cached resolved definition, the retry count — lives as
+wrapper **instance fields** shared across every mount of that async component (upstream's
+`pendingRequest`/`resolvedComp` module-closure). The **per-mount UI state** (the reactive
+`loaded`/`error`/`delayed` refs and the timers) is closure-local to each `Setup`, so two simultaneous
+mounts each show their own loading UI while sharing one load. A resolved wrapper's later mounts take a
+fast path that renders the cached inner component without re-invoking the loader; concurrent mounts
+share one in-flight `Load()` (deduplicated on `pendingRequest`).
+
+This ticket is the **runtime contract only**. The loader holds a static reference to (or awaits) the
+real definition; there is no reflection or assembly-download machinery — true lazy-download of
+component assemblies is a WASM lazy-loading concern layered on top later. The Router's guard pipeline
+([V01.01.08.04]) left an async-component-resolution no-op seam for lazy routes; that is
+[V01.01.08.05]'s concern and is deliberately **not** wired here — nothing in this design precludes it.
+
+Resolution drives a reactive re-render, never a poll: settling flips the `loaded`/`error` refs (and
+the delay/timeout timers flip `delayed`/`error`), which the render function reads, so the component's
+render effect re-runs through the scheduler. Unmounting before resolution disposes the timers and
+stops the render effect's scope, so a late resolution or a late timer touches nothing (the pending
+render is discarded cleanly).
+
+### Timers flow through an injected delay seam
+
+Vue schedules the `delay` and `timeout` with `setTimeout`; the Viu `Scheduler` is a *microtask* queue
+with no macrotask timer to reuse, so async components schedule through `AsyncComponentDelay` — the
+injected clock/delay seam the ticket calls for. Its default runs a real `Task.Delay` whose
+continuation resumes on the captured single-threaded synchronization context (the WASM main thread),
+never off-context; a `FlushDispatcher`-style test seam lets a manual controller drive virtual time so
+"the loading component appears only after `Delay`" and the timeout path are pinned deterministically,
+with no wall-clock waits.
+
+Task continuations follow the same rule as upstream (issue #32): they resume on the single-threaded
+WASM `SynchronizationContext` — no `ConfigureAwait(false)` off-context resumption into render code.
+Production always has that context; a plain xUnit host has none, so the tests install a single-threaded
+`SynchronizationContext` that runs continuations inline on the test thread (mirroring WASM) — otherwise
+a shared load with multiple awaiters could hop a continuation to the thread pool non-deterministically.
+
+### KeepAlive interplay and the Suspense seam
+
+A kept-alive async component that resolves forces its `KeepAlive` parent to re-render (upstream:
+mark the parent dirty and `queueJob(parent.update)`) so the parent caches the now-resolved subtree.
+Because `KeepAlive` preserves the *wrapper instance* itself (cached by the child vnode's key / the
+wrapper definition reference), the wrapper's cached `resolvedComp` and `loaded` ref survive a
+deactivate/activate cycle — the resolved inner component keeps its state and the loader never re-runs,
+mirroring upstream and pinned by test.
+
+`Suspensible` (default true, upstream parity) is exposed with a **boundary-registration hook
+contract**: when the flag is set and an enclosing boundary is present (`ComponentInstance.SuspenseBoundary`,
+inherited from the parent or the ambient `SuspenseBoundaryContext` a future Suspense sets while
+mounting its subtree), the async component hands the boundary its in-flight load through
+`ISuspenseBoundary.RegisterAsyncDependency` instead of rendering its own loading UI. The real
+enclosing-Suspense integration completes in [V01.01.03.20] (W06); the contract exists now and is
+validated against a fake boundary in tests. With no boundary present (the case until Suspense lands)
+the flag has no effect and the component renders its own loading/error UI.
+
+Deliberate divergences from upstream `apiAsyncComponent.ts`, each documented at its call site:
+
+- **A synchronously-completing loader resolves on the first render** (no forced placeholder frame).
+  Upstream's loader is always a promise, so it renders the placeholder once before the microtask
+  resolves; a C# `Task` may already be complete, in which case `loaded` flips during `Setup` and the
+  first render is the resolved component. Tests that need the placeholder frame use a
+  `TaskCompletionSource` resolved after mount.
+- **Loader-error routing gates the crash-loudly default on the error component.** Upstream's
+  `handleError` always runs the capture chain and only differs on dev throwing; Viu routes the error
+  through the capture chain / app handler and rethrows to the host only when there is *no* error
+  component to display it (`ComponentErrorHandling.Handle(..., rethrowIfUnhandled: ErrorComponent is
+  null)`), so an async component with an error component never aborts the flush.
+- **The `useId` `markAsyncBoundary` id-stability hook is omitted** — it belongs to SSR id generation,
+  not this client-only runtime contract.
+
 ## Deltas from Vue 3
 
 - **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md
@@ -24,11 +24,14 @@ a platform package supplies the node-ops (the browser's `Assimalign.Viu.RuntimeD
   `ComponentProperties` / `ComponentPropertyDefinition` (props declaration and validation),
   `ComponentAttributes` (attrs fallthrough), `ComponentEmitDefinition` (emits), `ComponentSlots`,
   `Lifecycle` (the hook registration facade, including `OnActivated`/`OnDeactivated`),
-  `DynamicComponents`, the `KeepAlive` caching built-in ([V01.01.03.18]), and the transition
-  scaffolding (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
+  `DynamicComponents`, the `KeepAlive` caching built-in ([V01.01.03.18]), `AsyncComponents`
+  (`DefineAsyncComponent`) with `AsyncComponentOptions` and the `AsyncComponentLoader` /
+  `AsyncComponentErrorHandler` delegates ([V01.01.03.16]), and the transition scaffolding
+  (`BaseTransition`, `BaseTransitionProperties`, `TransitionState`).
 - **Application / plugins** — `Application<TNode>` (Vue's `createApp` shell: one root mounted into
   one container), `ApplicationConfiguration` (error/warn handlers, performance flag),
-  `IComponentDefinition`, `IPlugin<TNode>`.
+  `IComponentDefinition`, `IPlugin<TNode>`, and `ISuspenseBoundary` (the async-component / Suspense
+  registration seam completed by [V01.01.03.20]).
 - **Provide / inject** (`DependencyInjection/`) — `DependencyInjection` and the typed
   `InjectionKey<T>`.
 - **Directives** (`Directives/`) — `IDirective`, `Directive`, `Directives`, `DirectiveBinding`,

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Abstraction/ISuspenseBoundary.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Abstraction/ISuspenseBoundary.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The registration contract an enclosing <c>&lt;Suspense&gt;</c> boundary exposes to a suspensible
+/// async component — the seam the C# port of upstream's async/Suspense handshake registers through
+/// (<c>packages/runtime-core/src/apiAsyncComponent.ts</c> returning a promise for
+/// <c>components/Suspense.ts</c>'s <c>registerDep</c> to await,
+/// https://vuejs.org/guide/built-ins/suspense.html). When
+/// <see cref="AsyncComponentOptions.Suspensible"/> is set and a boundary is present on the instance,
+/// the async component hands the boundary its in-flight load instead of rendering its own
+/// loading/error UI, and the boundary drives the fallback until the load settles.
+/// <para>
+/// The real boundary implementation lands with Suspense ([V01.01.03.20]); this interface exists now
+/// so the async-component contract ([V01.01.03.16]) is complete and validated against a fake
+/// boundary in tests. Not thread-safe (single-threaded JS event-loop model).
+/// </para>
+/// </summary>
+public interface ISuspenseBoundary
+{
+    /// <summary>
+    /// Registers a suspensible async component's in-flight load with this boundary (upstream: the
+    /// async setup's returned promise that <c>Suspense.registerDep</c> awaits). The boundary shows its
+    /// fallback until <paramref name="pendingLoad"/> settles, then lets the registered
+    /// <paramref name="instance"/> render its resolved subtree.
+    /// </summary>
+    /// <param name="instance">The async component instance whose load the boundary awaits.</param>
+    /// <param name="pendingLoad">The in-flight load task shared across mounts of the async component.</param>
+    void RegisterAsyncDependency(ComponentInstance instance, Task pendingLoad);
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/AsyncComponentOptions.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/AsyncComponentOptions.cs
@@ -1,0 +1,57 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The options bag for <see cref="AsyncComponents.DefineAsyncComponent(AsyncComponentOptions)"/> —
+/// the C# port of upstream's <c>AsyncComponentOptions</c>
+/// (<c>packages/runtime-core/src/apiAsyncComponent.ts</c>,
+/// https://vuejs.org/guide/components/async.html). Mirrors the object form of
+/// <c>defineAsyncComponent({ loader, loadingComponent, errorComponent, delay, timeout, suspensible,
+/// onError })</c>. Not thread-safe (single-threaded JS event-loop model).
+/// </summary>
+public sealed class AsyncComponentOptions
+{
+    /// <summary>
+    /// The loader that produces the real component definition (upstream: <c>loader</c>). Runs at most
+    /// once for a successful load; its result is cached and reused by later mounts.
+    /// </summary>
+    public required AsyncComponentLoader Loader { get; init; }
+
+    /// <summary>
+    /// The component shown after <see cref="Delay"/> while the loader is pending (upstream:
+    /// <c>loadingComponent</c>), or null to show nothing (a comment placeholder) while loading.
+    /// </summary>
+    public IComponentDefinition? LoadingComponent { get; init; }
+
+    /// <summary>
+    /// The component shown on loader failure or after <see cref="Timeout"/> elapses (upstream:
+    /// <c>errorComponent</c>), or null. When present it receives an <c>"error"</c> prop carrying the
+    /// failure, and its presence keeps a load failure from crashing the flush.
+    /// </summary>
+    public IComponentDefinition? ErrorComponent { get; init; }
+
+    /// <summary>
+    /// Milliseconds to wait before showing <see cref="LoadingComponent"/> (upstream: <c>delay</c>,
+    /// default 200). 0 shows the loading component immediately on first render.
+    /// </summary>
+    public int Delay { get; init; } = 200;
+
+    /// <summary>
+    /// Milliseconds before an unresolved load settles to the error state (upstream: <c>timeout</c>),
+    /// or null to never time out.
+    /// </summary>
+    public int? Timeout { get; init; }
+
+    /// <summary>
+    /// Whether an enclosing <c>&lt;Suspense&gt;</c> boundary controls this component's loading state
+    /// (upstream: <c>suspensible</c>, default true). With no boundary present it has no effect and the
+    /// component renders its own loading/error UI; with a boundary the component registers its pending
+    /// load through <see cref="ISuspenseBoundary"/> and defers display to the boundary. The real
+    /// enclosing-Suspense integration completes in [V01.01.03.20].
+    /// </summary>
+    public bool Suspensible { get; init; } = true;
+
+    /// <summary>
+    /// The loader-failure retry policy (upstream: <c>onError</c>), or null to fail on the first error.
+    /// </summary>
+    public AsyncComponentErrorHandler? OnError { get; init; }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/AsyncComponents.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/AsyncComponents.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// Defines async components — the C# port of upstream's <c>defineAsyncComponent</c>
+/// (<c>packages/runtime-core/src/apiAsyncComponent.ts</c>,
+/// https://vuejs.org/guide/components/async.html). A loader returns the real component definition
+/// asynchronously; the returned wrapper renders a loading component after <c>Delay</c>, an error
+/// component on failure or <c>Timeout</c>, and the resolved component in place once loaded. The
+/// resolved definition is cached on the wrapper, so subsequent mounts reuse it without re-invoking
+/// the loader, and concurrent mounts share one in-flight load.
+/// </summary>
+public static class AsyncComponents
+{
+    /// <summary>
+    /// Defines an async component from a bare loader (upstream: <c>defineAsyncComponent(loader)</c>),
+    /// with default delay (200ms) and no loading/error/timeout options.
+    /// </summary>
+    /// <param name="loader">The loader producing the real component definition.</param>
+    /// <returns>The async component wrapper definition; mount it like any other component.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="loader"/> is null.</exception>
+    public static IComponentDefinition DefineAsyncComponent(AsyncComponentLoader loader)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+        return new AsyncComponentWrapper(new AsyncComponentOptions { Loader = loader });
+    }
+
+    /// <summary>
+    /// Defines an async component from an options bag (upstream:
+    /// <c>defineAsyncComponent(options)</c>).
+    /// </summary>
+    /// <param name="options">The loader plus the loading/error/delay/timeout/suspensible policy.</param>
+    /// <returns>The async component wrapper definition; mount it like any other component.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> or its loader is null.</exception>
+    public static IComponentDefinition DefineAsyncComponent(AsyncComponentOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.Loader);
+        return new AsyncComponentWrapper(options);
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Components/ComponentInstance.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Components/ComponentInstance.cs
@@ -41,6 +41,11 @@ public sealed class ComponentInstance
         // parent.provides). DependencyInjection.Provide forks a layered copy on this instance's
         // first own provide; until then the reference is shared with every non-providing ancestor.
         Provides = parent?.Provides;
+        // Inherit the enclosing Suspense boundary from the parent, or the ambient one a boundary
+        // sets while mounting its subtree (upstream: suspense = parent ? parent.suspense :
+        // vnode.suspense). Null until Suspense lands ([V01.01.03.20]); a suspensible async component
+        // reads it to register its pending load ([V01.01.03.16]).
+        SuspenseBoundary = parent?.SuspenseBoundary ?? SuspenseBoundaryContext.Current;
         Scope = new EffectScope(detached: true);
         Properties = new ComponentProperties(DisplayName);
         Attributes = new ComponentAttributes();
@@ -103,6 +108,14 @@ public sealed class ComponentInstance
     /// <c>Setup</c> runs; null on every non-KeepAlive instance ([V01.01.03.18]).
     /// </summary>
     internal KeepAliveContext? KeepAliveContext { get; set; }
+
+    /// <summary>
+    /// The enclosing <c>&lt;Suspense&gt;</c> boundary (upstream: <c>instance.suspense</c>), inherited
+    /// from the parent or the ambient <see cref="SuspenseBoundaryContext"/> at creation. A suspensible
+    /// async component registers its pending load with it ([V01.01.03.16]); the real boundary
+    /// implementation lands with Suspense ([V01.01.03.20]). Null when there is no enclosing boundary.
+    /// </summary>
+    internal ISuspenseBoundary? SuspenseBoundary { get; set; }
 
     /// <summary>
     /// The instance whose <c>Setup</c>, render, or lifecycle hook is executing — upstream's

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Delegates/AsyncComponentErrorHandler.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Delegates/AsyncComponentErrorHandler.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// User-controlled loader-failure policy — the C# port of the <c>onError</c> option of
+/// <c>defineAsyncComponent</c> (<c>packages/runtime-core/src/apiAsyncComponent.ts</c>,
+/// https://vuejs.org/guide/components/async.html#handling-errors). Called on every loader failure
+/// with the error, a <paramref name="retry"/> action that re-invokes the loader as a fresh attempt,
+/// a <paramref name="fail"/> action that settles the load to the error state, and the one-based
+/// <paramref name="attempts"/> count made so far. Invoke exactly one of <paramref name="retry"/> or
+/// <paramref name="fail"/>; invoking neither leaves the load pending.
+/// </summary>
+/// <param name="error">The loader failure.</param>
+/// <param name="retry">Re-runs the loader; the next failure reports <paramref name="attempts"/> + 1.</param>
+/// <param name="fail">Settles the load to the error state (renders the error component, if any).</param>
+/// <param name="attempts">The one-based count of load attempts made so far.</param>
+public delegate void AsyncComponentErrorHandler(Exception error, Action retry, Action fail, int attempts);

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Delegates/AsyncComponentLoader.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Delegates/AsyncComponentLoader.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// Loads an async component's real definition asynchronously — the C# port of upstream's
+/// <c>AsyncComponentLoader</c> (<c>packages/runtime-core/src/apiAsyncComponent.ts</c>,
+/// https://vuejs.org/guide/components/async.html). Invoked at most once for a successful load: the
+/// resolved definition is cached on the wrapper and reused by every later mount without re-invoking
+/// the loader, and concurrent mounts of the same async component share one in-flight call. A failed
+/// load may be re-invoked through <see cref="AsyncComponentErrorHandler"/> (retry) or on a later
+/// mount.
+/// <para>
+/// The returned task's continuation resumes on the single-threaded WASM synchronization context —
+/// do not detach it with <c>ConfigureAwait(false)</c> (it would resume render code off-context).
+/// This is the runtime contract only: the loader holds a <b>static</b> reference to the resolved
+/// definition (or awaits a supplied one), never a reflection/assembly-download mechanism — true
+/// lazy-download of component assemblies is a WASM lazy-loading concern layered on top later.
+/// </para>
+/// </summary>
+/// <returns>A task producing the resolved component definition.</returns>
+public delegate Task<IComponentDefinition> AsyncComponentLoader();

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/AsyncComponentDelay.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/AsyncComponentDelay.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The delay/timeout timer seam async components schedule through — the C# stand-in for the two
+/// <c>setTimeout</c> calls in upstream's <c>apiAsyncComponent.ts</c> (the <c>delay</c> before the
+/// loading component and the <c>timeout</c> before the error state). Vue has no scheduler-level timer
+/// abstraction to reuse (the <see cref="Scheduler"/> is a microtask queue, not a macrotask timer), so
+/// this is the injected clock/delay seam the ticket ([V01.01.03.16]) calls for.
+/// <para>
+/// The default schedules a real <see cref="Task.Delay(int, CancellationToken)"/> whose continuation
+/// resumes on the captured single-threaded synchronization context (the WASM main thread) — never
+/// off-context. Tests replace <see cref="Scheduler"/> with a manual controller so time is
+/// deterministic: no wall-clock waits, no ambient timer thread, and "the loading component appears
+/// only after the delay" is pinned by advancing a fake clock. Disposing the returned handle cancels a
+/// not-yet-fired timer, which is how an async component discards its pending timers on unmount.
+/// Ambient static, single-threaded — NOT thread-safe.
+/// </para>
+/// </summary>
+internal static class AsyncComponentDelay
+{
+    /// <summary>
+    /// Test seam: when set, timers are scheduled through this dispatcher (milliseconds + callback →
+    /// cancellation handle) instead of a real <see cref="Task.Delay(int, CancellationToken)"/>.
+    /// Production hosts leave it null.
+    /// </summary>
+    internal static Func<int, Action, IDisposable>? Scheduler;
+
+    /// <summary>Schedules <paramref name="callback"/> to run once after <paramref name="milliseconds"/>.</summary>
+    /// <param name="milliseconds">The delay before the callback runs.</param>
+    /// <param name="callback">The work to run when the delay elapses.</param>
+    /// <returns>A handle; dispose it to cancel the timer before it fires.</returns>
+    internal static IDisposable Schedule(int milliseconds, Action callback)
+    {
+        var scheduler = Scheduler;
+        if (scheduler is not null)
+        {
+            return scheduler(milliseconds, callback);
+        }
+        var timer = new RealTimer();
+        timer.Start(milliseconds, callback);
+        return timer;
+    }
+
+    private sealed class RealTimer : IDisposable
+    {
+        private readonly CancellationTokenSource _cancellation = new();
+
+        internal void Start(int milliseconds, Action callback)
+            => _ = RunAsync(milliseconds, callback, _cancellation.Token);
+
+        private static async Task RunAsync(int milliseconds, Action callback, CancellationToken token)
+        {
+            try
+            {
+                // Context-capturing await (no ConfigureAwait(false)): the continuation resumes on the
+                // single-threaded WASM synchronization context, matching the async-component contract.
+                await Task.Delay(milliseconds, token);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            if (!token.IsCancellationRequested)
+            {
+                callback();
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellation.Cancel();
+            _cancellation.Dispose();
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/AsyncComponentWrapper.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/AsyncComponentWrapper.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The component a <see cref="AsyncComponents.DefineAsyncComponent(AsyncComponentOptions)"/> wrapper
+/// runs — the C# port of upstream's <c>AsyncComponentWrapper</c>
+/// (<c>packages/runtime-core/src/apiAsyncComponent.ts</c>,
+/// https://vuejs.org/guide/components/async.html). One wrapper is created per
+/// <c>DefineAsyncComponent</c> call, and its load state (the in-flight request, the cached resolved
+/// definition, the retry count) lives as instance fields so every mount of <b>this</b> async
+/// component shares one load and one cached result — upstream's <c>pendingRequest</c>/
+/// <c>resolvedComp</c> closure state. Per-mount UI state (the loaded/error/delayed refs and the delay/
+/// timeout timers) is closure state created fresh in each <see cref="Setup"/> instead, so two
+/// simultaneous mounts each show their own loading UI while sharing the one load.
+/// <para>
+/// When the load settles, the reactive <c>loaded</c>/<c>error</c> refs flip and the wrapper re-renders
+/// through the scheduler (no polling). A kept-alive async component forces its <see cref="KeepAlive"/>
+/// parent to re-render on resolution so it caches the now-resolved subtree; because the wrapper
+/// instance itself is what KeepAlive preserves, a resolved kept-alive async component keeps its state
+/// and never re-invokes the loader across switches. Not thread-safe (single-threaded JS event-loop
+/// model).
+/// </para>
+/// </summary>
+internal sealed class AsyncComponentWrapper : IComponentDefinition
+{
+    private readonly AsyncComponentOptions _options;
+
+    // Shared load state across every mount of this async component (upstream: defineAsyncComponent
+    // closure). _pendingToken identifies the in-flight request so a retry that replaced it can be
+    // reconciled (upstream: thisRequest !== pendingRequest).
+    private Task<IComponentDefinition>? _pendingRequest;
+    private object? _pendingToken;
+    private IComponentDefinition? _resolvedComponent;
+    private int _retries;
+
+    internal AsyncComponentWrapper(AsyncComponentOptions options)
+    {
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public string? Name => "AsyncComponentWrapper";
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var instance = ComponentInstance.Current!;
+
+        // Already resolved by an earlier mount: render the inner component directly, no reload
+        // (upstream: if (resolvedComp) return () => createInnerComp(resolvedComp, instance)).
+        if (_resolvedComponent is { } alreadyResolved)
+        {
+            return () => CreateInnerComponent(alreadyResolved, instance);
+        }
+
+        var boundary = instance.SuspenseBoundary;
+        var suspenseControlled = _options.Suspensible && boundary is not null;
+
+        var loaded = Reactive.Reference(false);
+        var error = Reactive.Reference<Exception?>(null);
+        // delayed starts true iff a positive delay is configured (upstream: delayed = ref(!!delay));
+        // a Suspense-controlled load shows no loading UI of its own, so it never delays.
+        var delayed = Reactive.Reference(!suspenseControlled && _options.Delay > 0);
+        IDisposable? delayTimer = null;
+        IDisposable? timeoutTimer = null;
+
+        if (!suspenseControlled)
+        {
+            if (_options.Delay > 0)
+            {
+                // After the delay, reveal the loading component — unless the load already settled
+                // (upstream: setTimeout(() => { delayed.value = false }, delay)).
+                delayTimer = AsyncComponentDelay.Schedule(_options.Delay, () => delayed.Value = false);
+            }
+            if (_options.Timeout is { } timeout)
+            {
+                // On timeout, settle to the error state unless already loaded/errored (upstream:
+                // setTimeout(() => { if (!loaded && !error) { err = ...; onError(err); error.value = err } }, timeout)).
+                timeoutTimer = AsyncComponentDelay.Schedule(timeout, () =>
+                {
+                    if (!loaded.Value && error.Value is null)
+                    {
+                        var timeoutError = new TimeoutException($"Async component timed out after {timeout}ms.");
+                        HandleLoaderError(timeoutError, instance);
+                        error.Value = timeoutError;
+                    }
+                });
+            }
+        }
+
+        // Kick off (or join) the shared load. TrackLoadAsync invokes Load() synchronously before its
+        // first await, so _pendingRequest is set by the time the suspense branch below reads it.
+        _ = TrackLoadAsync(loaded, error, instance);
+
+        if (suspenseControlled)
+        {
+            // Suspense-controlled: hand the boundary the in-flight load and let it drive the fallback
+            // (upstream: the suspensible && instance.suspense arm returns the load promise for
+            // Suspense to await). The render function shows the resolved subtree once loaded, else
+            // nothing — the boundary owns the fallback. Real fallback display lands in [V01.01.03.20].
+            boundary!.RegisterAsyncDependency(instance, _pendingRequest!);
+            return () => loaded.Value && _resolvedComponent is { } resolved
+                ? CreateInnerComponent(resolved, instance)
+                : null;
+        }
+
+        // Discard the pending timers on unmount so a load that never resolves leaks nothing and a
+        // late timer cannot touch a torn-down instance (AC: unmount before resolution is clean).
+        Lifecycle.OnUnmounted(() =>
+        {
+            delayTimer?.Dispose();
+            timeoutTimer?.Dispose();
+        });
+
+        // The render function (upstream: the returned () => { ... }). Reads the reactive refs so the
+        // render effect re-runs when the load settles or the delay elapses.
+        return () =>
+        {
+            if (loaded.Value && _resolvedComponent is { } resolved)
+            {
+                return CreateInnerComponent(resolved, instance);
+            }
+            if (error.Value is { } currentError && _options.ErrorComponent is { } errorComponent)
+            {
+                return VirtualNodeFactory.Component(
+                    errorComponent,
+                    VirtualNodeFactory.Properties(("error", currentError)));
+            }
+            if (_options.LoadingComponent is { } loadingComponent && !delayed.Value)
+            {
+                return VirtualNodeFactory.Component(loadingComponent);
+            }
+            return null;
+        };
+    }
+
+    private async Task TrackLoadAsync(IReference<bool> loaded, IReference<Exception?> error, ComponentInstance instance)
+    {
+        try
+        {
+            // Context-capturing await (no ConfigureAwait(false)): resumes on the WASM sync context.
+            await Load();
+            loaded.Value = true;
+            // A kept-alive async component: force the KeepAlive parent to re-render so it re-evaluates
+            // and caches the now-resolved subtree (upstream: if the parent is KeepAlive, mark its
+            // effect dirty and queueJob(parent.update)). Guarded so a resolve after unmount is a no-op.
+            if (!instance.IsUnmounted
+                && instance.Parent is { Definition: KeepAlive } keepAliveParent
+                && keepAliveParent.UpdateJob is { } parentJob)
+            {
+                Scheduler.QueueJob(parentJob);
+            }
+        }
+        catch (Exception loadError)
+        {
+            HandleLoaderError(loadError, instance);
+            error.Value = loadError;
+        }
+    }
+
+    private void HandleLoaderError(Exception error, ComponentInstance instance)
+    {
+        // Upstream onError: drop the settled request (so a later mount can retry the load) and route
+        // through the error-capture chain. When an error component will display the failure it is
+        // "handled" — do not crash the flush (upstream: handleError(..., throwInDev: !errorComponent));
+        // with no error component, surface it (Viu's crash-loudly default for unhandled errors).
+        _pendingRequest = null;
+        ComponentErrorHandling.Handle(
+            error, instance, "async component loader", rethrowIfUnhandled: _options.ErrorComponent is null);
+    }
+
+    private Task<IComponentDefinition> Load()
+    {
+        // Upstream load(): one in-flight request shared across concurrent mounts (pendingRequest).
+        if (_pendingRequest is not null)
+        {
+            return _pendingRequest;
+        }
+        var token = new object();
+        _pendingToken = token;
+        return _pendingRequest = LoadOnceAsync(token);
+    }
+
+    private Task<IComponentDefinition> Retry()
+    {
+        // Upstream retry(): bump the attempt count, drop the settled request, and load again.
+        _retries++;
+        _pendingRequest = null;
+        return Load();
+    }
+
+    private async Task<IComponentDefinition> LoadOnceAsync(object token)
+    {
+        IComponentDefinition component;
+        try
+        {
+            component = await _options.Loader();
+        }
+        catch (Exception loadError) when (_options.OnError is not null)
+        {
+            // Hand the user retry/fail control (upstream: the loader().catch arm wrapping a new
+            // Promise whose resolve = retry() and reject = the error).
+            var completion = new TaskCompletionSource<IComponentDefinition>();
+            void UserRetry() => _ = BridgeRetryAsync(completion);
+            void UserFail() => completion.TrySetException(loadError);
+            _options.OnError(loadError, UserRetry, UserFail, _retries + 1);
+            component = await completion.Task;
+        }
+        // A retry issued since this request superseded it: defer to the newest request (upstream:
+        // if (thisRequest !== pendingRequest && pendingRequest) return pendingRequest).
+        if (!ReferenceEquals(_pendingToken, token) && _pendingRequest is not null)
+        {
+            return await _pendingRequest;
+        }
+        _resolvedComponent = component;
+        return component;
+    }
+
+    private async Task BridgeRetryAsync(TaskCompletionSource<IComponentDefinition> completion)
+    {
+        // Resolve the onError completion with whatever the retried load settles to, so the awaiting
+        // LoadOnceAsync continues (or fails) once the retry does.
+        try
+        {
+            completion.TrySetResult(await Retry());
+        }
+        catch (Exception retryError)
+        {
+            completion.TrySetException(retryError);
+        }
+    }
+
+    private static VirtualNode CreateInnerComponent(IComponentDefinition resolved, ComponentInstance instance)
+    {
+        // Upstream createInnerComp: createVNode(resolvedComp, parent.vnode.props, parent.vnode.children).
+        // The wrapper declares no props, so its whole prop bag (including the reserved "ref", which the
+        // factory re-extracts onto the inner vnode) and its slots forward to the resolved component,
+        // making the wrapper transparent.
+        var wrapperVNode = instance.VirtualNode;
+        return VirtualNodeFactory.Component(resolved, wrapperVNode.Properties, wrapperVNode.SlotChildren);
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/ComponentErrorHandling.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/ComponentErrorHandling.cs
@@ -13,7 +13,23 @@ namespace Assimalign.Viu.RuntimeCore;
 /// </summary>
 internal static class ComponentErrorHandling
 {
-    internal static void Handle(Exception exception, ComponentInstance? instance, string info)
+    /// <summary>
+    /// Routes <paramref name="exception"/> up <paramref name="instance"/>'s capture chain.
+    /// </summary>
+    /// <param name="exception">The error to route.</param>
+    /// <param name="instance">The erroring instance whose ancestors capture, or null.</param>
+    /// <param name="info">The error-source description (upstream error-code text).</param>
+    /// <param name="rethrowIfUnhandled">
+    /// Whether an error no capture hook and no app-level handler consumed rethrows to the host
+    /// (upstream: <c>handleError</c>'s <c>throwInDev</c>). True is the crash-loudly default; an async
+    /// component with an error component to display the failure passes false so the failure surfaces
+    /// in the UI instead of aborting the flush ([V01.01.03.16]).
+    /// </param>
+    internal static void Handle(
+        Exception exception,
+        ComponentInstance? instance,
+        string info,
+        bool rethrowIfUnhandled = true)
     {
         for (var ancestor = instance?.Parent; ancestor is not null; ancestor = ancestor.Parent)
         {
@@ -47,7 +63,12 @@ internal static class ComponentErrorHandling
             }
             return;
         }
-        // No handler configured: surface the failure with its original stack intact.
-        ExceptionDispatchInfo.Capture(exception).Throw();
+        // No handler configured: surface the failure with its original stack intact — unless the
+        // caller will display the error itself (an async component with an error component), in which
+        // case swallow it here so the flush is not aborted.
+        if (rethrowIfUnhandled)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
     }
 }

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/SuspenseBoundaryContext.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/SuspenseBoundaryContext.cs
@@ -1,0 +1,15 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The ambient enclosing <c>&lt;Suspense&gt;</c> boundary a newly created
+/// <see cref="ComponentInstance"/> inherits when it has no parent boundary — the injection seam a
+/// future Suspense ([V01.01.03.20]) sets while mounting its subtree so descendants pick it up
+/// (mirroring how upstream seeds <c>instance.suspense</c> from the rendering context), and the seam
+/// the fake boundary uses in async-component tests. Null in production today (no Suspense yet).
+/// Ambient static, single-threaded — NOT thread-safe.
+/// </summary>
+internal static class SuspenseBoundaryContext
+{
+    /// <summary>The boundary currently mounting its subtree, or null when there is none.</summary>
+    internal static ISuspenseBoundary? Current;
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/test/AsyncComponentTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/AsyncComponentTests.cs
@@ -1,0 +1,581 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.Tests;
+
+// Pins DefineAsyncComponent against the in-memory renderer, DOM-free — mirroring upstream
+// runtime-core/__tests__/apiAsyncComponent.spec.ts. A loader returns the real component
+// asynchronously; a loading component shows after Delay, an error component on failure or Timeout,
+// and the resolved component renders in place, cached so later mounts reuse it without reloading.
+// Contract: packages/runtime-core/src/apiAsyncComponent.ts and
+// https://vuejs.org/guide/components/async.html. Timers flow through the AsyncComponentDelay seam so
+// a ManualTimeController drives them deterministically (no wall-clock waits). [V01.01.03.16]
+public sealed class AsyncComponentTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestElement _container;
+    private readonly TestSchedulerPump _pump;
+    private readonly ManualTimeController _time;
+    private readonly SynchronizationContext? _previousContext;
+    private int _realSetups;
+    private IReference<int>? _realState;
+
+    public AsyncComponentTests()
+    {
+        Scheduler.Reset();
+        _pump = TestSchedulerPump.Install();
+        _time = new ManualTimeController();
+        // Production runs on the browser's single-threaded WASM SynchronizationContext, so an awaited
+        // loader's continuation always resumes on the main thread. A plain xUnit host has no context,
+        // so awaited continuations can hop to the thread pool non-deterministically — install a
+        // single-threaded context that runs them inline on the test thread (mirroring WASM), keeping
+        // the async flow deterministic and single-threaded.
+        _previousContext = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(new InlineSynchronizationContext());
+        _container = _renderer.CreateContainer();
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        _time.Dispose();
+        _pump.Dispose();
+        // Defensively clear the ambient boundary so a suspensible test can never leak it to the next.
+        SuspenseBoundaryContext.Current = null;
+        SynchronizationContext.SetSynchronizationContext(_previousContext);
+    }
+
+    private string Serialize() => TestNodeSerializer.Serialize(_container);
+
+    // A stateful resolved component: counts its Setup runs and exposes its reactive state ref so a
+    // KeepAlive test can prove the state survives a switch cycle. Renders "<div>{label}{state}</div>".
+    private TestComponent RealComponent(string label = "real") => new()
+    {
+        Name = "Real",
+        SetupFunction = (_, _) =>
+        {
+            _realSetups++;
+            var state = Reactive.Reference(0);
+            _realState = state;
+            return () => VirtualNodeFactory.Element("div", $"{label}{state.Value}");
+        },
+    };
+
+    private static TestComponent LoadingComponent() => new()
+    {
+        Name = "Loading",
+        SetupFunction = (_, _) => () => VirtualNodeFactory.Element("div", "loading"),
+    };
+
+    // Shows the error prop it receives (upstream: errorComponent is passed { error }).
+    private static TestComponent ErrorDisplayComponent() => new()
+    {
+        Name = "ErrorDisplay",
+        Properties = [new ComponentPropertyDefinition("error")],
+        SetupFunction = (properties, _) => () =>
+            VirtualNodeFactory.Element("div", $"error:{(properties["error"] as Exception)?.Message}"),
+    };
+
+    // --- loader invocation / caching -------------------------------------------------------------
+
+    [Fact]
+    public void DefineAsyncComponent_DoesNotInvokeLoaderUntilMounted()
+    {
+        var loaderCalls = 0;
+        _ = AsyncComponents.DefineAsyncComponent(() =>
+        {
+            loaderCalls++;
+            return Task.FromResult<IComponentDefinition>(RealComponent());
+        });
+
+        // Defining the component must not run the loader — it runs on first mount (upstream parity).
+        loaderCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Loader_RunsOnceOnFirstMount_AndResolutionReRendersThroughScheduler()
+    {
+        var loaderCalls = 0;
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(() =>
+        {
+            loaderCalls++;
+            return request.Task;
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+
+        // First mount: loader invoked exactly once; the pending load renders a comment placeholder
+        // (default 200ms delay not elapsed, no loading component).
+        loaderCalls.ShouldBe(1);
+        Serialize().ShouldBe("<root><!----></root>");
+        _pump.PendingFlushCount.ShouldBe(0);
+
+        // Resolving the load flips a ref that schedules a flush (no polling) — pin the scheduled flush.
+        request.SetResult(real);
+        _pump.PendingFlushCount.ShouldBeGreaterThan(0);
+        _pump.RunUntilIdle();
+
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Loader_ConcurrentMountsShareOneInflightLoad_InvokedOnce()
+    {
+        var loaderCalls = 0;
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(() =>
+        {
+            loaderCalls++;
+            return request.Task;
+        });
+
+        // Two mounts of the SAME async component in one turn share one in-flight load.
+        _renderer.Render(
+            VirtualNodeFactory.Fragment(VirtualNodeFactory.Component(async), VirtualNodeFactory.Component(async)),
+            _container);
+        loaderCalls.ShouldBe(1);
+
+        request.SetResult(real);
+        _pump.RunUntilIdle();
+
+        Serialize().ShouldBe("<root><div>real0</div><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ResolvedComponent_CachedAcrossRemounts_LoaderNotReinvoked()
+    {
+        var loaderCalls = 0;
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(() =>
+        {
+            loaderCalls++;
+            return Task.FromResult<IComponentDefinition>(real);
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+
+        // Unmount, then remount: the cached resolved definition is reused without a second load.
+        _renderer.Render(null, _container);
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        _pump.RunUntilIdle();
+
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+    }
+
+    // --- loading / delay -------------------------------------------------------------------------
+
+    [Fact]
+    public void LoadingComponent_AppearsOnlyAfterDelay_ThenResolvedReplacesIt()
+    {
+        var loaderCalls = 0;
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () =>
+            {
+                loaderCalls++;
+                return request.Task;
+            },
+            LoadingComponent = LoadingComponent(),
+            Delay = 200,
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+
+        // Before the delay elapses, the loading component is hidden (upstream: delayed = ref(!!delay)).
+        Serialize().ShouldBe("<root><!----></root>");
+
+        _time.Advance(199);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><!----></root>");
+
+        // The delay elapses: the loading component appears.
+        _time.Advance(1);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>loading</div></root>");
+
+        // The load resolves: the resolved component replaces the loading one; loader ran once.
+        request.SetResult(real);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void LoadingComponent_WithZeroDelay_AppearsImmediately()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            LoadingComponent = LoadingComponent(),
+            Delay = 0,
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+
+        // delay 0 shows the loading component on the first render (upstream: delayed = ref(false)).
+        Serialize().ShouldBe("<root><div>loading</div></root>");
+    }
+
+    // --- error / timeout -------------------------------------------------------------------------
+
+    [Fact]
+    public void ErrorComponent_RendersOnLoaderFailure_WithErrorProp()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            ErrorComponent = ErrorDisplayComponent(),
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+
+        request.SetException(new InvalidOperationException("boom"));
+        _pump.RunUntilIdle();
+
+        // The error component renders, receiving the failure as its "error" prop.
+        Serialize().ShouldBe("<root><div>error:boom</div></root>");
+    }
+
+    [Fact]
+    public void ErrorComponent_RendersAfterTimeoutElapses()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>(); // never resolves
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            ErrorComponent = ErrorDisplayComponent(),
+            Timeout = 100,
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        Serialize().ShouldBe("<root><!----></root>");
+
+        // The timeout elapses without a resolution: the error component renders a timeout error.
+        _time.Advance(100);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>error:Async component timed out after 100ms.</div></root>");
+    }
+
+    [Fact]
+    public void LoaderFailure_WithNoErrorComponent_RoutesToAppErrorHandler_WithoutCrashing()
+    {
+        Exception? handled = null;
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var async = AsyncComponents.DefineAsyncComponent(() => request.Task);
+        var application = _renderer.Renderer.CreateApplication(async);
+        application.Config.ErrorHandler = (exception, _, _) => handled = exception;
+        application.Mount(_container);
+
+        // A load failure with no error component routes through the app error handler (upstream:
+        // handleError) instead of aborting the flush.
+        request.SetException(new InvalidOperationException("unhandled"));
+        _pump.RunUntilIdle();
+
+        handled.ShouldBeOfType<InvalidOperationException>();
+        handled!.Message.ShouldBe("unhandled");
+    }
+
+    // --- onError retry / fail --------------------------------------------------------------------
+
+    [Fact]
+    public void OnError_RetryReinvokesLoader_WithIncrementingAttempts_UntilSuccess()
+    {
+        var loaderCalls = 0;
+        var attempts = new List<int>();
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () =>
+            {
+                loaderCalls++;
+                // Fail the first two attempts, succeed on the third.
+                return loaderCalls < 3
+                    ? Task.FromException<IComponentDefinition>(new InvalidOperationException($"fail{loaderCalls}"))
+                    : Task.FromResult<IComponentDefinition>(real);
+            },
+            OnError = (_, retry, fail, attempt) =>
+            {
+                attempts.Add(attempt);
+                if (attempt <= 2)
+                {
+                    retry();
+                }
+                else
+                {
+                    fail();
+                }
+            },
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        _pump.RunUntilIdle();
+
+        // Retry re-runs the loader with an incrementing one-based attempt count; the third succeeds.
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(3);
+        attempts.ShouldBe([1, 2]);
+    }
+
+    [Fact]
+    public void OnError_FailSettlesToErrorState_LoaderInvokedOnce()
+    {
+        var loaderCalls = 0;
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () =>
+            {
+                loaderCalls++;
+                return Task.FromException<IComponentDefinition>(new InvalidOperationException("nope"));
+            },
+            ErrorComponent = ErrorDisplayComponent(),
+            OnError = (_, _, fail, _) => fail(),
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        _pump.RunUntilIdle();
+
+        // fail() settles to the error state without retrying: loader invoked exactly once.
+        Serialize().ShouldBe("<root><div>error:nope</div></root>");
+        loaderCalls.ShouldBe(1);
+    }
+
+    // --- teardown --------------------------------------------------------------------------------
+
+    [Fact]
+    public void UnmountBeforeResolution_DiscardsPendingRender_NoErrorsOrLeaks()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            LoadingComponent = LoadingComponent(),
+            Delay = 0,
+            Timeout = 100,
+        });
+
+        _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        Serialize().ShouldBe("<root><div>loading</div></root>");
+
+        // Unmount before the load resolves.
+        _renderer.Render(null, _container);
+        Serialize().ShouldBe("<root></root>");
+
+        // A late resolution and a late timeout timer must neither re-render nor throw (the pending
+        // render is discarded, timers disposed): the resolved component never mounts.
+        request.SetResult(real);
+        _time.Advance(100);
+        _pump.RunUntilIdle();
+
+        Serialize().ShouldBe("<root></root>");
+        _realSetups.ShouldBe(0);
+    }
+
+    // --- suspensible seam ([V01.01.03.20] completes the boundary) --------------------------------
+
+    [Fact]
+    public void Suspensible_WithBoundary_RegistersPendingLoad_AndDefersDisplayToBoundary()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var boundary = new FakeSuspenseBoundary();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            LoadingComponent = LoadingComponent(),
+            Delay = 0,
+            Suspensible = true,
+        });
+
+        // A boundary is present while the async component mounts (the seam a future Suspense sets).
+        SuspenseBoundaryContext.Current = boundary;
+        try
+        {
+            _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        }
+        finally
+        {
+            SuspenseBoundaryContext.Current = null;
+        }
+
+        // The boundary received the in-flight load; the component shows none of its own loading UI
+        // (the boundary owns the fallback) — a comment placeholder, not the loading component.
+        boundary.Registrations.Count.ShouldBe(1);
+        boundary.Registrations[0].Instance.ShouldNotBeNull();
+        boundary.Registrations[0].PendingLoad.ShouldNotBeNull();
+        Serialize().ShouldBe("<root><!----></root>");
+
+        // Once resolved, the boundary-controlled component still renders its resolved subtree.
+        request.SetResult(real);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+    }
+
+    [Fact]
+    public void NonSuspensible_WithBoundary_IgnoresBoundary_ShowsOwnLoadingUI()
+    {
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var boundary = new FakeSuspenseBoundary();
+        var async = AsyncComponents.DefineAsyncComponent(new AsyncComponentOptions
+        {
+            Loader = () => request.Task,
+            LoadingComponent = LoadingComponent(),
+            Delay = 0,
+            Suspensible = false,
+        });
+
+        SuspenseBoundaryContext.Current = boundary;
+        try
+        {
+            _renderer.Render(VirtualNodeFactory.Component(async), _container);
+        }
+        finally
+        {
+            SuspenseBoundaryContext.Current = null;
+        }
+
+        // suspensible = false ignores the boundary and renders its own loading component.
+        boundary.Registrations.ShouldBeEmpty();
+        Serialize().ShouldBe("<root><div>loading</div></root>");
+    }
+
+    // --- KeepAlive interplay ([V01.01.03.18]) ----------------------------------------------------
+
+    [Fact]
+    public void KeptAliveAsyncComponent_PreservesResolvedStateAcrossSwitches_LoaderRunsOnce()
+    {
+        var loaderCalls = 0;
+        var request = new TaskCompletionSource<IComponentDefinition>();
+        var real = RealComponent();
+        var other = new TestComponent
+        {
+            Name = "Other",
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element("div", "other"),
+        };
+        var async = AsyncComponents.DefineAsyncComponent(() =>
+        {
+            loaderCalls++;
+            return request.Task;
+        });
+
+        var view = Reactive.Reference("async");
+        var slots = new ComponentSlots();
+        slots["default"] = _ => [view.Value == "async" ? VirtualNodeFactory.Component(async) : VirtualNodeFactory.Component(other)];
+        _renderer.Render(VirtualNodeFactory.Component(KeepAlive.Instance, null, slots), _container);
+
+        // Resolve the async child while kept alive.
+        request.SetResult(real);
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>real0</div></root>");
+        loaderCalls.ShouldBe(1);
+        _realSetups.ShouldBe(1);
+
+        // Mutate the resolved component's state, then switch away and back.
+        _realState!.Value = 7;
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>real7</div></root>");
+
+        view.Value = "other";
+        _pump.RunUntilIdle();
+        Serialize().ShouldBe("<root><div>other</div></root>");
+
+        view.Value = "async";
+        _pump.RunUntilIdle();
+
+        // Reactivated with state intact: the cached (resolved inner) subtree was moved back, not
+        // remounted — Setup ran once and the loader ran once (upstream KeepAlive + async interplay).
+        Serialize().ShouldBe("<root><div>real7</div></root>");
+        loaderCalls.ShouldBe(1);
+        _realSetups.ShouldBe(1);
+    }
+}
+
+/// <summary>
+/// A single-threaded <see cref="SynchronizationContext"/> that runs posted continuations inline on
+/// the current thread — the deterministic test stand-in for the browser's WASM context, so an awaited
+/// loader's continuation resumes synchronously on the test thread instead of hopping to the thread
+/// pool.
+/// </summary>
+internal sealed class InlineSynchronizationContext : SynchronizationContext
+{
+    public override void Post(SendOrPostCallback callback, object? state) => callback(state);
+
+    public override void Send(SendOrPostCallback callback, object? state) => callback(state);
+}
+
+/// <summary>Records async-load registrations so the suspensible seam can be asserted.</summary>
+internal sealed class FakeSuspenseBoundary : ISuspenseBoundary
+{
+    public List<(ComponentInstance Instance, Task PendingLoad)> Registrations { get; } = [];
+
+    public void RegisterAsyncDependency(ComponentInstance instance, Task pendingLoad)
+        => Registrations.Add((instance, pendingLoad));
+}
+
+/// <summary>
+/// A deterministic fake clock installed into the <c>AsyncComponentDelay</c> seam: timers are recorded
+/// and fire only when the test advances virtual time, so "loading appears after the delay" and the
+/// timeout path are pinned without wall-clock waits.
+/// </summary>
+internal sealed class ManualTimeController : IDisposable
+{
+    private readonly List<Entry> _entries = [];
+    private readonly Func<int, Action, IDisposable>? _previous;
+    private long _now;
+
+    public ManualTimeController()
+    {
+        _previous = AsyncComponentDelay.Scheduler;
+        AsyncComponentDelay.Scheduler = Schedule;
+    }
+
+    public void Advance(int milliseconds)
+    {
+        _now += milliseconds;
+        foreach (var entry in _entries.Where(e => !e.Cancelled && !e.Fired && e.DueAt <= _now).OrderBy(e => e.DueAt).ToList())
+        {
+            entry.Fired = true;
+            entry.Callback();
+        }
+    }
+
+    public void Dispose() => AsyncComponentDelay.Scheduler = _previous;
+
+    private IDisposable Schedule(int milliseconds, Action callback)
+    {
+        var entry = new Entry(_now + milliseconds, callback);
+        _entries.Add(entry);
+        return entry;
+    }
+
+    private sealed class Entry(long dueAt, Action callback) : IDisposable
+    {
+        public long DueAt { get; } = dueAt;
+        public Action Callback { get; } = callback;
+        public bool Cancelled { get; private set; }
+        public bool Fired { get; set; }
+        public void Dispose() => Cancelled = true;
+    }
+}


### PR DESCRIPTION
## Summary
- Ports `@vue/runtime-core`'s `apiAsyncComponent.ts`: `AsyncComponents.DefineAsyncComponent(loader | options)` with `LoadingComponent` after `Delay` (default 200ms), `ErrorComponent` on failure or `Timeout`, and `OnError(error, retry, fail, attempts)` for user-controlled retry. The wrapper is a normal component whose reactive load state re-renders through the existing render effect — no renderer special-casing, no polling; the resolved inner component receives the wrapper's full prop bag and slots (upstream's transparent `createInnerComp`).
- **State split matching the KeepAlive precedent**: load state (in-flight task, cached resolved definition, retry count) lives on the wrapper so the loader runs exactly once across mounts and re-renders; per-mount UI state is Setup-closure-local.
- **Deterministic time control**: a new `AsyncComponentDelay` seam (mirroring `Scheduler.FlushDispatcher`) lets tests drive a virtual clock — loading hidden at 199ms, shown at 200ms, timeout paths, zero wall-clock waits. Along the way the agent reproduced and fixed a real 1-in-3 test flake: awaited loader continuations hop to the ThreadPool without WASM's `SynchronizationContext`, so tests install a single-threaded context mirroring production; extracting that helper into the Testing library is filed as [#204 [V01.01.11.05]](https://github.com/assimalign/viu/issues/204).
- **Suspense-ready seam**: `Suspensible` (default true, upstream parity) registers with an `ISuspenseBoundary` when one exists — contract validated against a fake; real boundary display integration is [V01.01.03.20]'s scope per the AC. The Router guard pipeline's async-resolution seam is deliberately untouched ([V01.01.08.05]'s concern; documented in DESIGN.md).
- Divergences documented in place: synchronously-completed loaders resolve on first render (no forced placeholder frame); loader errors crash loudly only when no `ErrorComponent` exists (`rethrowIfUnhandled` defaults to prior behavior for all existing callers); the SSR-only `markAsyncBoundary` hook is omitted. KeepAlive name-matching against the resolved inner's name is tracked as [#205 [V01.01.03.16.01]](https://github.com/assimalign/viu/issues/205).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings (WASM example included) · RuntimeCore **257/257** (15 new, run-count-pinned: loader-once across re-renders/cache-hits/concurrent mounts, retry attempts `[1,2]` with three loader calls, delay boundary at exactly 200ms, timeout→error, unmount-before-resolve cleanliness, kept-alive state preservation) · RuntimeDom 170, Testing 18, Router 191, all other suites green.

Closes #32
Refs #204, #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)