### PR TITLE
feat(tooling): fingerprint the CSS bundle through the static-web-assets pipeline [V01.01.12.12.03]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# .viu single-file components must check out LF on every platform. The ViuBundleCss task
+# ([V01.01.12.12]) emits a component's non-scoped @style block as verbatim pass-through, so
+# source line endings flow into the bundle bytes. The static-web-asset content fingerprint
+# ([V01.01.12.12.03]) is a SHA-256 hash of those bytes, so a CRLF checkout (autocrlf on
+# Windows) would otherwise yield a different fingerprint than a LF checkout (Linux/CI) for
+# identical source — breaking the bundler's byte-stable-across-machines contract. Pin LF.
+*.viu text eol=lf

--- a/build/Targets/Build.Css.Bundling.targets
+++ b/build/Targets/Build.Css.Bundling.targets
@@ -17,12 +17,36 @@
          same DefineStaticWebAssets path Blazor scoped CSS uses for <App>.styles.css), so build/publish copy
          and fingerprint it and the dev host serves it. Runs just before ResolveStaticWebAssetsInputs.
 
+    FINGERPRINTING ([V01.01.12.12.03]): when the SDK's static-web-asset fingerprinting is on (the WASM /
+    Blazor default, $(StaticWebAssetFingerprintingEnabled) == 'true') the bundle's logical URL carries the
+    #[.{fingerprint}] token, via the same DefineStaticWebAssets path Blazor's scoped-CSS application bundle
+    uses ($(PackageId)#[.{fingerprint}]?.styles.css). The SDK computes the token from a SHA-256 hash of the
+    bundle's CONTENT (no timestamps), so the fingerprint is deterministic: identical styles across rebuilds
+    keep the same hash, changed styles get a new one — the browser cache-busts only on real change. We use
+    the OPTIONAL form ('?'): the SDK emits BOTH a fingerprinted route (WebApp.<hash>.viu.css, served
+    immutable) and the stable plain route (WebApp.viu.css). Each fingerprinted endpoint carries a `label`
+    equal to the plain route, plus the content hash and integrity — that endpoint is the resolution mechanism
+    an ASP.NET Core host, a CDN, or the future auto-injection ([V01.01.12.12.01]) uses to serve the immutable
+    URL. In a statically hosted WASM app the plain-named physical file is the one that ships, so the demo's
+    explicit <link> keeps resolving.
+
+    Why not the '!' (required) form the WASM SDK uses for main#[.{fingerprint}]!.js: the host-page
+    #[.{fingerprint}] placeholder resolution (OverrideHtmlAssetPlaceholders) is scoped to JS ES modules /
+    the import map; it does NOT rewrite a CSS <link> href to the hashed name (it strips the token to the
+    plain name). '!' would therefore ship ONLY the hashed physical file while the demo's static <link>
+    resolved to the plain name — a 404. '?' keeps the plain file serving AND registers the fingerprinted
+    identity/endpoint, which is exactly what this task owns; delivering the hashed URL into the host page is
+    [V01.01.12.12.01]'s job (build-time link injection off the endpoint this task registers).
+
     LOAD THE BUNDLE: add, inside <head> of the host page (wwwroot/index.html),
       <link rel="stylesheet" href="<AssemblyName>.viu.css" />
-    — the bundle's stable, unfingerprinted logical URL (the static-web-asset endpoint resolves it; a class
-    library's bundle is at _content/<PackageId>/<AssemblyName>.viu.css). Automatic <link> injection is a
-    deferred follow-up: rewriting the host page's static web asset in place desyncs the .NET SDK's
-    compression/endpoint negotiation graph, so the explicit reference is the shipped, publish-safe path.
+    the bundle's stable logical URL — the plain-named physical file a static host serves, and (with the '?'
+    fingerprinted endpoint registered here) the same asset an ASP.NET Core host serves immutably via its
+    hashed route (a class library's bundle is at _content/<PackageId>/<AssemblyName>.viu.css). Automatic
+    <link> injection of the hashed URL is a deferred follow-up ([V01.01.12.12.01]): rewriting the host page's
+    static web asset in place desyncs the .NET SDK's compression/endpoint negotiation graph, so the explicit
+    reference is the shipped, publish-safe path. The injector resolves the fingerprinted endpoint (by its
+    `label`) this task registers.
   -->
 
   <PropertyGroup>
@@ -40,19 +64,65 @@
   </PropertyGroup>
 
   <!-- The task lives in analyzers/Assimalign.Viu.Tooling.Tasks; it re-runs the shared Tooling.Css core
-       OUTSIDE the analyzer sandbox so it may write files. Declared only when the built assembly is present,
-       so a project that has not built the task (or disabled bundling) never fails to load the target. -->
+       OUTSIDE the analyzer sandbox so it may write files. Declared whenever bundling is on — NOT gated on
+       Exists($(ViuBundleCssTaskAssembly)). A UsingTask condition is evaluated at static import time, which
+       for the in-repo dogfood path can precede the Tooling.Tasks build (the assembly is loaded through
+       AssemblyFile, not a ProjectReference, so nothing ordered its build first). Gating on Exists there
+       raced the build: the target could run after the DLL appeared while the UsingTask, evaluated earlier
+       against a not-yet-built DLL, was never declared — MSB4036 "task not found". UsingTask resolves its
+       AssemblyFile lazily (only when the task is first invoked), and the invoking target keeps its own
+       Exists gate, so declaring it unconditionally is safe when the task is genuinely absent. The in-repo
+       build-order edge below guarantees the DLL exists by the time the target runs. -->
   <UsingTask TaskName="Assimalign.Viu.Tooling.Tasks.ViuBundleCss"
              AssemblyFile="$(ViuBundleCssTaskAssembly)"
-             Condition="'$(ViuBundleSingleFileComponentCss)' == 'true' and Exists('$(ViuBundleCssTaskAssembly)')" />
+             Condition="'$(ViuBundleSingleFileComponentCss)' == 'true'" />
+
+  <!-- In-repo dogfooding build-order edge ([V01.01.12.12.03]): a consuming project loads ViuBundleCss via
+       <UsingTask AssemblyFile=...>, which is NOT a project reference, so the solution/dependency scheduler
+       has no reason to build Tooling.Tasks before this project. A WASM sample (the first in-repo consumer of
+       CSS bundling) therefore raced the task build and failed with MSB4036 on a clean build. This
+       reference-output-free edge forces Tooling.Tasks to build first. Guarded to the in-repo path
+       ($(ViuRepositoryDirectory) set); the packaged SDK ships the task inside the package (Sdk.Common.props
+       presets $(ViuBundleCssTaskAssembly) to the packaged copy), so an external consumer never takes this
+       edge and never sees a raw ProjectReference.
+       Deviates from the repo build-system rule (no raw <ProjectReference>) per design decision: a build-order
+       edge the ViuProjectReference transform cannot express — a netstandard2.0 task referenced with
+       ReferenceOutputAssembly=false and UndefineProperties to cross the app's TFM/RID boundary, mirroring
+       frameworks/Assimalign.Viu.App.Refs. -->
+  <ItemGroup Condition="'$(ViuBundleSingleFileComponentCss)' == 'true' and '$(ViuRepositoryDirectory)' != '' and Exists('$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Tooling.Tasks\src\Assimalign.Viu.Tooling.Tasks.csproj')">
+    <ProjectReference Include="$(ViuRepositoryDirectory)analyzers\Assimalign.Viu.Tooling.Tasks\src\Assimalign.Viu.Tooling.Tasks.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false"
+                      PrivateAssets="all"
+                      UndefineProperties="TargetFramework;RuntimeIdentifier" />
+  </ItemGroup>
 
   <Target Name="_ViuResolveSingleFileComponentCssConfiguration"
           Condition="'$(ViuBundleSingleFileComponentCss)' == 'true'"
           DependsOnTargets="ResolveStaticWebAssetsConfiguration">
     <PropertyGroup>
-      <!-- Logical file name of the bundle within the static-web-asset base path (e.g. WebApp.viu.css).
-           Unfingerprinted so the explicit <link href> stays stable. -->
-      <ViuSingleFileComponentCssBundleName Condition="'$(ViuSingleFileComponentCssBundleName)' == ''">$(PackageId).viu.css</ViuSingleFileComponentCssBundleName>
+      <!-- The bundle's stable logical name split into base (no extension) and extension primitives, so the
+           plain and fingerprinted relative paths derive from the same pieces and can never drift. Override a
+           primitive to rename the bundle; a consumer overriding the composed $(ViuSingleFileComponentCssBundleName)
+           or $(ViuSingleFileComponentCssBundleFingerprintExpression) directly should override both to keep
+           the two routes in lock-step. -->
+      <ViuSingleFileComponentCssBundleBaseName Condition="'$(ViuSingleFileComponentCssBundleBaseName)' == ''">$(PackageId)</ViuSingleFileComponentCssBundleBaseName>
+      <ViuSingleFileComponentCssBundleExtension Condition="'$(ViuSingleFileComponentCssBundleExtension)' == ''">.viu.css</ViuSingleFileComponentCssBundleExtension>
+      <!-- Stable, unfingerprinted logical file name (e.g. WebApp.viu.css). Also the physical file name under
+           obj/…/viu/ — the on-disk bundle is never renamed; only the served URL gains the content hash. -->
+      <ViuSingleFileComponentCssBundleName Condition="'$(ViuSingleFileComponentCssBundleName)' == ''">$(ViuSingleFileComponentCssBundleBaseName)$(ViuSingleFileComponentCssBundleExtension)</ViuSingleFileComponentCssBundleName>
+      <!-- Fingerprinted logical file name pattern (e.g. WebApp#[.{fingerprint}]?.viu.css). DefineStaticWebAssets
+           substitutes a SHA-256 content hash into the #[.{fingerprint}] token. The trailing '?' makes the
+           fingerprint OPTIONAL — the same token Blazor's scoped-CSS application bundle uses
+           ($(PackageId)#[.{fingerprint}]?.styles.css): the SDK emits BOTH a fingerprinted route
+           (WebApp.<hash>.viu.css, immutable) and the stable plain route (WebApp.viu.css), and in a statically
+           hosted WASM app the plain-named physical file is what ships, so the demo's <link> keeps resolving.
+           The fingerprinted route/endpoint (carrying `label` = the plain route + the content hash + integrity)
+           is what an ASP.NET Core host, a CDN, or the future auto-injection ([V01.01.12.12.01]) resolves for
+           cache-busting. ('!' — required — would instead ship ONLY the hashed physical file; the WASM SDK's
+           #[.{fingerprint}] host-page placeholder resolution is ES-module-only and does not rewrite a CSS
+           <link> href to the hashed name, so '!' would 404 the demo's static link.) -->
+      <ViuSingleFileComponentCssBundleFingerprintExpression Condition="'$(ViuSingleFileComponentCssBundleFingerprintExpression)' == ''">$(ViuSingleFileComponentCssBundleBaseName)#[.{fingerprint}]?$(ViuSingleFileComponentCssBundleExtension)</ViuSingleFileComponentCssBundleFingerprintExpression>
       <_ViuCssBundleContentRoot>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)viu\'))</_ViuCssBundleContentRoot>
       <_ViuCssBundlePath>$(_ViuCssBundleContentRoot)$(ViuSingleFileComponentCssBundleName)</_ViuCssBundlePath>
     </PropertyGroup>
@@ -88,7 +158,13 @@
           DependsOnTargets="_ViuBundleSingleFileComponentCss">
     <ItemGroup Condition="Exists('$(_ViuCssBundlePath)')">
       <_ViuCssBundleStaticWebAssetCandidate Include="$(_ViuCssBundlePath)">
-        <RelativePath>$(ViuSingleFileComponentCssBundleName)</RelativePath>
+        <!-- Fingerprint the served URL when the SDK's static-web-asset fingerprinting is on (the WASM/Blazor
+             default). DefineStaticWebAssets replaces the #[.{fingerprint}] token with a deterministic content
+             hash and (for the '?' optional form) registers both the fingerprinted and the stable plain route.
+             Falls back to the plain name when fingerprinting is disabled. Same DefineStaticWebAssets path as
+             Microsoft.NET.Sdk.StaticWebAssets.ScopedCss ResolveBundledCssAssets. -->
+        <RelativePath Condition="'$(StaticWebAssetFingerprintingEnabled)' == 'true'">$(ViuSingleFileComponentCssBundleFingerprintExpression)</RelativePath>
+        <RelativePath Condition="'$(StaticWebAssetFingerprintingEnabled)' != 'true'">$(ViuSingleFileComponentCssBundleName)</RelativePath>
       </_ViuCssBundleStaticWebAssetCandidate>
     </ItemGroup>
 

--- a/examples/Assimalign.Viu.WebApp/AppStyles.viu
+++ b/examples/Assimalign.Viu.WebApp/AppStyles.viu
@@ -1,0 +1,13 @@
+@style {
+    /* [V01.01.12.12.03] Dogfood fixture: compiled into the fingerprinted Assimalign.Viu.WebApp.viu.css bundle. */
+    .viu-css-bundle-probe {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4rem 0.85rem;
+        border-radius: 999px;
+        background: #10243b;
+        color: #f2f4f7;
+        font-weight: 600;
+    }
+}

--- a/examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj
+++ b/examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj
@@ -3,6 +3,11 @@
     <TargetFramework>$(TargetFrameworkLatest)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <!-- Dogfood the .viu single-file-component CSS pipeline ([V01.01.12.12]) and its static-web-asset
+         fingerprinting ([V01.01.12.12.03]): enabling this flows every **/*.viu to the generator AND turns on
+         $(ViuBundleSingleFileComponentCss), so the ViuBundleCss task emits AppStyles.viu's @style into the
+         fingerprinted Assimalign.Viu.WebApp.viu.css bundle that index.html references. -->
+    <ViuUseSingleFileComponents>true</ViuUseSingleFileComponents>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Assimalign.Viu.WebApp/wwwroot/index.html
+++ b/examples/Assimalign.Viu.WebApp/wwwroot/index.html
@@ -7,6 +7,14 @@
   <link rel="preload" id="webassembly" />
   <script type="importmap"></script>
   <script type="module" src="main#[.{fingerprint}].js"></script>
+  <!-- The .viu single-file-component CSS bundle ([V01.01.12.12]), content-fingerprinted through the
+       static-web-assets pipeline ([V01.01.12.12.03]). This is the bundle's stable plain URL — the file a
+       static host serves. The build ALSO registers a content-fingerprinted route/endpoint
+       (Assimalign.Viu.WebApp.<hash>.viu.css, see obj/**/staticwebassets.*.endpoints.json) that an ASP.NET
+       Core host or CDN serves immutably; unlike main#[.{fingerprint}].js above, the SDK's HTML placeholder
+       resolution is ES-module-only and does not rewrite a CSS <link>, so the hashed URL is delivered by the
+       static-web-asset endpoint (and by automatic link injection, [V01.01.12.12.01]), not by this href. -->
+  <link rel="stylesheet" href="Assimalign.Viu.WebApp.viu.css" />
   <style>
     :root {
       color-scheme: light;

--- a/libraries/Assimalign.Viu.Tooling.Css/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Tooling.Css/docs/DESIGN.md
@@ -72,8 +72,20 @@ blocks — matching the generator's constant exactly.
   opaque CSS strings for the same `ViuBundleCss` task. The bundler already bundles opaque compiled-CSS text
   with no utility-specific knowledge, so the utility stylesheet plugs in without changing this contract. The
   seam is left; the engine is not built here.
-- **Host-page `<link>` injection.** The task registers the bundle as a static web asset with a stable logical
-  URL; loading it is a documented explicit `<link rel="stylesheet" href="<AssemblyName>.viu.css">`.
-  Automatic in-place rewrite of the host page's static web asset is deferred — it desyncs the .NET SDK's
-  static-web-asset compression/endpoint negotiation graph, so the explicit reference is the shipped path.
+- **Static-web-asset fingerprinting ([V01.01.12.12.03], #169) — implemented.** `Build.Css.Bundling.targets`
+  registers the bundle with a content fingerprint through the SDK's `DefineStaticWebAssets` path (the
+  `$(PackageId)#[.{fingerprint}]?.viu.css` RelativePath, the same optional-token form Blazor's scoped-CSS
+  application bundle uses). The SDK derives the fingerprint from a SHA-256 hash of the bundle **content**, so
+  its determinism rides directly on this library's byte-stable output (LF-only, ordinal ordering): identical
+  styles reproduce the same hash across builds, changed styles get a new one, and the `ViuBundleCss` task's
+  no-op-rewrite skip means an unchanged rebuild never perturbs the bytes or the hash. The `?` keeps the plain
+  route (`<AssemblyName>.viu.css`, the file a static WASM host serves) working while registering the
+  fingerprinted route/endpoint (hash + `label` + integrity) that an ASP.NET Core host, a CDN, or the
+  link-injection follow-up resolves for immutable caching.
+- **Host-page `<link>` injection ([V01.01.12.12.01], #167) — deferred.** Loading the bundle today is a
+  documented explicit `<link rel="stylesheet" href="<AssemblyName>.viu.css">` (the stable plain URL; the WASM
+  SDK's `#[.{fingerprint}]` host-page placeholder resolution is ES-module-only and does not rewrite a CSS
+  `<link>` to the hashed name). Automatic in-place rewrite of the host page's static web asset is deferred —
+  it desyncs the .NET SDK's static-web-asset compression/endpoint negotiation graph — so the injector must
+  resolve the fingerprinted endpoint this task already registers rather than editing the asset in place.
 ```

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -38,7 +38,7 @@ dotnet CLI with no installer and no admin rights.
 | The framework libraries (`Assimalign.Viu.Shared`, `.Reactivity`, `.RuntimeCore`, `.RuntimeDom`) | Implicit `<FrameworkReference Include="Assimalign.Viu.App" />` via the `KnownFrameworkReference` registration in [Targets/Assimalign.Viu.Sdk.FrameworkReference.props](Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.FrameworkReference.props) |
 | The `[Reactive]` and `.viu` source generators | Shipped inside the `Assimalign.Viu.App.Ref` targeting pack at `analyzers/dotnet/cs/` and listed as `<File Type="Analyzer">` in its `data/FrameworkList.xml` |
 | `.viu` single-file component compilation | The generator's AdditionalFiles/CompilerVisibleProperty wiring, packed into the SDK's `Targets/` from its in-repo source |
-| `.viu` `@style` CSS bundling | The `ViuBundleCss` MSBuild task (+ parser closure) in the SDK package's `Tasks/`, driven by the packed `Assimalign.Viu.Sdk.Css.Bundling.targets` |
+| `.viu` `@style` CSS bundling | The `ViuBundleCss` MSBuild task (+ parser closure) in the SDK package's `Tasks/`, driven by the packed `Assimalign.Viu.Sdk.Css.Bundling.targets`. The bundle registers as a **content-fingerprinted** static web asset; reference it from `wwwroot/index.html` with `<link rel="stylesheet" href="<AssemblyName>.viu.css" />` — the stable plain URL a static host serves, with a hashed immutable route also registered for hosted/CDN scenarios ([V01.01.12.12.03]) |
 | `viu-dom.js` interop bridge | Packed under `assets/` and copied to the consumer's `wwwroot/_content/Assimalign.Viu.RuntimeDom/` at build |
 
 The framework reference resolves to two NuGet packages (the


### PR DESCRIPTION
## Summary
- The `.viu` `@style` bundle now registers with the SDK's content fingerprinting: the asset's `RelativePath` carries the optional `#[.{fingerprint}]?` token (gated on `StaticWebAssetFingerprintingEnabled`, mirroring Blazor scoped CSS), producing both the fingerprinted route (`<PackageId>.<hash>.viu.css` with `fingerprint`/`label`/`integrity` metadata and gzip/brotli variants) and the stable plain route the demo's manual `<link>` uses.
- **Why optional, not required**: the SDK's host-page placeholder rewriting is ES-module/import-map-only — it does not rewrite CSS link hrefs — so the required token would 404 a statically-hosted WASM app. Optional ships the plain physical file AND the fingerprinted endpoint; resolving that endpoint by `label` into an auto-injected immutable href is exactly the seam [#167](https://github.com/assimalign/viu/issues/167) (stacking on this branch) consumes. AC-3 is thereby satisfied at the endpoint level for the manual mode, with the literal fingerprinted href arriving via #167.
- **Determinism proven across four publishes**: style X → `t6u4c24o37`; changed style → `3mx0sfs8fa`; unchanged rebuild → same; reverted to X → `t6u4c24o37` again (pure content hash, no timestamps).
- Two discoveries fixed in-scope, found by making the WebApp the first in-repo bundling consumer (`AppStyles.viu` dogfood fixture):
  - **Build-order race** (`MSB4036`): unconditional `UsingTask` + a guarded in-repo-only build-order `ProjectReference` edge (dormant for SDK consumers via the `ViuRepositoryDirectory` gate; documented deviation at the site, mirroring `frameworks/`), verified with a from-clean build.
  - **Cross-platform fingerprint determinism**: new `.gitattributes` pins `*.viu` to LF — CRLF checkout would have produced per-platform bundle bytes and divergent fingerprints.
- SDK-consumer path: the same targets file is packed verbatim into the SDK; guards reasoned and pack mapping verified, live packed-consumer run deferred to the packaging area's coverage (noted honestly).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings (incl. from-clean race test) · webapp CI command clean · Tooling.Css 10/10, Generators 72/72 · **`scripts/Measure-PublishBudget.ps1`: PASS** (2.00 MB vs 2.20 MB, 9.0% headroom retained).

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)