### PR TITLE
docs(guide): add the getting-started guide for the packaged SDK [V01.01.13.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ dotnet run --project examples/Assimalign.Viu.WebApp
 - [Architecture decisions](docs/adr/) — the append-only decision log (founding C#/WASM divergences).
 - [Documentation conventions](docs/CONTRIBUTING.md) — where `OVERVIEW.md`, `DESIGN.md`, and ADRs
   live, what belongs in each, and when they must be updated.
+- [Getting started guide](docs/guide/getting-started.md) — build, run, and publish a Viu app with the
+  packaged `Assimalign.Viu.Sdk` (prerequisites → first component → reactivity → publish).
 - [Project board](https://github.com/orgs/assimalign/projects/15) — the authoritative backlog
   (`[V01.01.*]` WBS items: program → area epics → features → tasks).
 - Work-item intake: [`.claude/skills/viu-work-items`](.claude/skills/viu-work-items/SKILL.md).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,409 @@
+# Getting started with Viu
+
+Viu is a faithful re-implementation of [Vue.js 3](https://vuejs.org) in C#/.NET that runs in the
+browser through the .NET WebAssembly build tools. This guide takes you from an empty folder to a
+running, publishable Viu app using the packaged **`Assimalign.Viu.Sdk`** — the surface an external
+consumer uses. It is the Viu counterpart of Vue's
+[Quick Start](https://vuejs.org/guide/quick-start.html), rewritten for the C#/WASM reality.
+
+If you are coming from Vue, three deliberate C#/WASM divergences shape everything below (they are the
+[founding design decisions](../PLAN.md#founding-design-decisions-cwasm-divergences)):
+
+- **Refs are explicit.** `ref()` becomes `Reference<T>` and you read/write it through `.Value`. There
+  is no JavaScript `Proxy`, so reactivity never happens "invisibly."
+- **`reactive()` is a source generator, not a Proxy.** A `[Reactive]` partial class has its reactive
+  property wrappers emitted at build time by a Roslyn source generator.
+- **Templates compile at build time.** WASM has no `new Function`, so there is no runtime template
+  compiler; `.viu` single-file components and templates are compiled by source generators during the
+  build ([ADR-0005](../adr/0005-no-runtime-template-compilation.md)).
+
+> **Preview status.** Viu is pre-release. There is **no `dotnet new` template yet** — that lands with
+> [V01.01.12.04] (wave W05), so this guide creates the project by hand. Package versions and the local
+> feed below reflect the current preview; once Viu publishes to nuget.org the feed step goes away.
+
+## Prerequisites
+
+- **The .NET SDK** pinned in the repo's [`global.json`](../../global.json) — currently **`10.0.301`**
+  (any `10.0.3xx` SDK in the same feature band works). Check with:
+
+  ```sh
+  dotnet --version
+  ```
+
+- **The WebAssembly tools workload**, which supplies the browser runtime pack, trimming, and the
+  ahead-of-time (AOT) native toolchain:
+
+  ```sh
+  dotnet workload install wasm-tools
+  ```
+
+  Confirm it is present with `dotnet workload list` (look for `wasm-tools`).
+
+## How a Viu app is packaged
+
+A Viu app project uses the Viu MSBuild SDK instead of a plain `Microsoft.NET.Sdk`:
+
+```xml
+<Project Sdk="Assimalign.Viu.Sdk">
+```
+
+That one line chains `Microsoft.NET.Sdk.WebAssembly`, references the `Assimalign.Viu.App` shared
+framework (the reactivity, runtime-core, and runtime-dom libraries), and turns on `.viu` single-file
+component compilation and CSS bundling — with no per-project wiring. The full consumer surface,
+including every opt-out property, is documented in [`sdks/README.md`](../../sdks/README.md); the
+packaging model is [founding decision 8](../PLAN.md#founding-design-decisions-cwasm-divergences).
+
+While Viu is pre-release you consume it from a **repo-local NuGet feed**. From a clone of
+[`assimalign/viu`](https://github.com/assimalign/viu), pack the SDK and framework into `_out/packages`:
+
+```sh
+pwsh scripts/Install-Local.ps1
+```
+
+This produces `Assimalign.Viu.Sdk`, `Assimalign.Viu.App.Ref`, and
+`Assimalign.Viu.App.Runtime.browser-wasm` packages (see the
+[local development loop](../../sdks/README.md#local-development-loop)). Your app points a
+`nuget.config` at that folder, shown below.
+
+## Create the project by hand
+
+Make a new folder (for example `HelloViu`) and add these files.
+
+**`global.json`** — pin the Viu SDK version so restore resolves it from the local feed. Match the
+package version produced by `Install-Local.ps1` (it tracks the repo's
+[`build/Targets/Build.Version.props`](../../build/Targets/Build.Version.props)):
+
+```json
+{
+    "sdk": {
+        "version": "10.0.300",
+        "rollForward": "latestFeature"
+    },
+    "msbuild-sdks": {
+        "Assimalign.Viu.Sdk": "10.0.1-preview.2"
+    }
+}
+```
+
+**`nuget.config`** — add the local feed alongside nuget.org (point `value` at your clone's
+`_out/packages`; this mirrors the [`sdks/README.md`](../../sdks/README.md#local-development-loop)
+pattern):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="viu-local" value="C:\Source\repos\assimalign\viu\_out\packages" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>
+```
+
+**`HelloViu.csproj`** — the whole project file:
+
+```xml
+<Project Sdk="Assimalign.Viu.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <!-- Let the WebAssembly SDK resolve the index.html boot placeholders
+             (the importmap and the main#[.{fingerprint}].js reference) at build
+             and publish. The .viu CSS-bundle <link> injection rides the same
+             host-page rewrite. -->
+        <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]!" />
+    </ItemGroup>
+
+</Project>
+```
+
+> **Why `OverrideHtmlAssetPlaceholders`?** It tells the WebAssembly SDK to statically resolve the
+> boot placeholders in `index.html` (the import map and the fingerprinted `main.js` reference) at
+> build and publish. The automatic `.viu` stylesheet `<link>` injection rides that same host-page
+> rewrite, so today the property is required for both to work. Making the SDK default it is tracked in
+> [#215](https://github.com/assimalign/viu/issues/215); until then, set it explicitly.
+
+**`wwwroot/index.html`** — the host page. It has a mount target (`#app`), the WebAssembly boot
+placeholders, and — importantly — **no manual stylesheet `<link>`**: the build injects the `.viu` CSS
+bundle link for you (see [Styling](#styling-with-viu-single-file-components) below).
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hello Viu</title>
+    <link rel="preload" id="webassembly" />
+    <script type="importmap"></script>
+    <script type="module" src="main#[.{fingerprint}].js"></script>
+</head>
+<body>
+    <main id="app"></main>
+</body>
+</html>
+```
+
+**`wwwroot/main.js`** — the standard .NET WebAssembly boot:
+
+```js
+import { dotnet } from './_framework/dotnet.js'
+
+const { runMain } = await dotnet.create()
+
+await runMain()
+```
+
+## Your first component
+
+A Viu component is a plain C# object implementing `IComponentDefinition`. Its `Setup` method — the C#
+port of Vue's [`setup()`](https://vuejs.org/api/composition-api-setup.html) — runs **once** per
+instance, closes over the reactive state, and returns a **render function** that re-runs whenever the
+state it read changes. Because C# has no `Proxy`, that closure *is* the proxy-free realization of Vue's
+state object ([ADR-0004](../adr/0004-composition-only-component-model.md): Viu is composition-only —
+no Options API).
+
+**`Program.cs`** — a Viu WASM app's whole bootstrap: initialize the DOM bridge, create the app from a
+root component, mount it by selector, then keep the WASM main loop alive (rendering is reactive from
+there on):
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.RuntimeDom;
+
+using HelloViu;
+
+await BrowserRuntime.InitializeAsync();
+
+BrowserRuntime.CreateApp(new Counter()).Mount("#app");
+
+await Task.Delay(Timeout.Infinite);
+```
+
+**`Counter.cs`** — a working counter:
+
+```csharp
+using System;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+
+namespace HelloViu;
+
+internal sealed class Counter : IComponentDefinition
+{
+    public string? Name => "Counter";
+
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        // ref() -> Reactive.Reference: a reactive box read and written through .Value.
+        var count = Reactive.Reference(0);
+
+        // computed(): a cached, lazily recomputed derived value.
+        var label = Reactive.Computed(() => count.Value == 1 ? "1 click" : $"{count.Value} clicks");
+
+        void Increment() => count.Value++;
+
+        return () => VirtualNodeFactory.Element(
+            "section",
+            VirtualNodeFactory.Properties(("class", "counter")),
+            VirtualNodeFactory.Element("h1", "Hello from Viu"),
+            VirtualNodeFactory.Element(
+                "p",
+                VirtualNodeFactory.Properties(("class", "count")),
+                VirtualNodeFactory.Text(label.Value)),
+            VirtualNodeFactory.Element(
+                "button",
+                VirtualNodeFactory.Properties(
+                    ("class", "primary"),
+                    ("type", "button"),
+                    ("onClick", (Action)Increment)),
+                VirtualNodeFactory.Text("Increment")));
+    }
+}
+```
+
+The render function builds a **virtual node** tree with `VirtualNodeFactory`; the runtime diffs it and
+applies only the changed nodes to the real DOM. This matters more on WASM than in JavaScript: **every
+DOM mutation crosses the JS-interop boundary**, so idiomatic Viu leans on the compiled render function
+and the renderer's batched updates rather than imperative DOM access
+([ADR-0003](../adr/0003-batched-interop-dom-operations.md)). `VirtualNodeFactory`, `IComponentDefinition`,
+`ComponentProperties`, and `ComponentSetupContext` all live in
+[`Assimalign.Viu.RuntimeCore`](../../libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md); the
+browser entry point `BrowserRuntime` lives in
+[`Assimalign.Viu.RuntimeDom`](../../libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md). For a larger
+component — props, emitted events, and lifecycle hooks (`Lifecycle.OnMounted`/`OnUnmounted`) — read the
+[`Assimalign.Viu.WebApp`](../../examples/Assimalign.Viu.WebApp) sample.
+
+## Reactivity basics
+
+Viu ports [`@vue/reactivity`](https://vuejs.org/guide/essentials/reactivity-fundamentals.html) to C#.
+The API surface is the static `Reactive` facade; the map from Vue to Viu:
+
+| Vue 3 | Viu | Notes |
+| --- | --- | --- |
+| `ref(0)` | `Reactive.Reference(0)` → `Reference<T>` | Read/write through `.Value`. |
+| `computed(() => …)` | `Reactive.Computed(() => …)` → `Computed<T>` | Lazy, cached, versioned. |
+| `watch(src, cb)` | `Reactive.Watch(source, callback)` | Scheduler-integrated. |
+| `reactive(obj)` | `[Reactive]` **partial class** | Property wrappers emitted by a source generator. |
+| `reactive([])` / arrays | `ReactiveList<T>`, `ReactiveDictionary<TKey,TValue>`, `ReactiveSet<T>` | Dedicated reactive collections. |
+
+The C# deltas a Vue developer must internalize:
+
+- **Explicit `.Value`.** There is no auto-unwrapping in your C# code; `count.Value++` where Vue would
+  write `count.value++` (templates compiled from `.viu` do unwrap refs for you).
+- **No `Proxy`, so no destructuring footgun.** `Reference<T>` is a reference type — passing it around
+  or capturing it in a closure keeps the reactive connection. There is no "reactivity lost on
+  destructure" trap because there is no proxy to destructure away from.
+- **Reactive collections are dedicated types.** Instead of proxying a `List<T>`, use `ReactiveList<T>`
+  and friends, which implement the BCL collection interfaces while tracking reads and triggering on
+  writes.
+
+`[Reactive]` is the counterpart of `reactive()` — Vue's `Proxy` becomes a build-time source generator
+(see [ADR-0002](../adr/0002-ref-first-reactivity.md) and the
+[Reactivity overview](../../libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md)). The class must be
+`partial`, and every reactive property is declared `partial`:
+
+```csharp
+using Assimalign.Viu.Reactivity;
+
+namespace HelloViu;
+
+[Reactive]
+internal partial class TodoItem
+{
+    public partial string Title { get; set; }
+    public partial bool Done { get; set; }
+}
+```
+
+The generator emits the tracking/triggering bodies and makes the class implement `IReactiveObject`, so
+reading `todo.Title` inside a render function or `Computed` establishes a dependency, and assigning it
+schedules a re-render — no reflection, fully trimming- and AOT-safe.
+
+## Styling with .viu single-file components
+
+Viu's single-file component is the `.viu` file — the counterpart of Vue's `.vue`, using
+`@template`/`@script`/`@style` `@`-blocks instead of HTML-like tags (the exact grammar is in
+[`FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md)). Its
+production-ready role today is **scoped, bundled CSS**. Add a `.viu` file with a `@style` block:
+
+**`AppStyles.viu`**:
+
+```
+@style {
+    .counter {
+        display: grid;
+        gap: 1rem;
+        max-width: 24rem;
+        margin: 4rem auto;
+        padding: 2rem;
+        border-radius: 1rem;
+        font-family: system-ui, sans-serif;
+        background: #f2f4f7;
+        color: #10243b;
+    }
+
+    .count {
+        font-size: 2rem;
+        font-weight: 700;
+    }
+
+    .primary {
+        padding: 0.75rem 1.25rem;
+        border: none;
+        border-radius: 999px;
+        background: #f05a28;
+        color: white;
+        font-weight: 700;
+        cursor: pointer;
+    }
+}
+```
+
+At build the SDK extracts every `@style` block, bundles it into a **content-fingerprinted** static web
+asset (`<AssemblyName>.viu.css`), and **injects the `<link rel="stylesheet">` into `index.html`
+automatically** — before the SDK's gzip/brotli compression pipeline, so compression negotiation stays
+intact. You write no manual link tag. This is why `index.html` above has none; the details are in
+[`sdks/README.md`](../../sdks/README.md) and the injection mechanism is
+[V01.01.12.12.01](https://github.com/assimalign/viu/issues/167).
+
+> **`.viu` `@template`/`@script` today.** The `@template` (standard Vue template markup) and `@script`
+> (C#) blocks already **compile** at build time — the generator emits a render function and merges the
+> script into a partial class. What is still in progress is the runtime bridge that turns that
+> generated partial into a **mountable** component; until it lands
+> ([#216](https://github.com/assimalign/viu/issues/216)), author your components in C# with
+> `IComponentDefinition` (as above) and use `.viu` for `@style`.
+
+## Run and publish
+
+**Build:**
+
+```sh
+dotnet build
+```
+
+**Run** the dev server (it serves the app and resolves the boot placeholders; it prints the localhost
+URL it binds — the port is chosen for you):
+
+```sh
+dotnet run
+```
+
+Open the printed URL and you will see the counter; clicking **Increment** updates the rendered count
+reactively, and the styles from `AppStyles.viu` are applied through the auto-injected link.
+
+**Publish** a trimmed, statically hostable build:
+
+```sh
+dotnet publish -c Release
+```
+
+The published `bin/Release/net10.0/publish/wwwroot` contains:
+
+- your compiled component and the Viu framework assemblies, fingerprinted and trimmed, under
+  `_framework/` (e.g. `HelloViu.<hash>.wasm`, `Assimalign.Viu.RuntimeCore.<hash>.wasm`, …);
+- the fingerprinted CSS bundle `HelloViu.viu.css` with its `.gz` and `.br` variants;
+- `index.html` with the injected `<link rel="stylesheet" href="HelloViu.viu.css" />` (carried into the
+  compressed `index.html.gz` / `index.html.br` too);
+- the `viu-dom.js` interop bridge under `_content/Assimalign.Viu.RuntimeDom/`.
+
+That folder is a static site — host it on any static web host.
+
+## Where to go next
+
+- **The repository map** in the [root `README.md`](../../README.md) — every library, generator, sample,
+  and packaging project.
+- **Per-library overviews** — each library documents itself in `docs/OVERVIEW.md` (what it is) and
+  `docs/DESIGN.md` (why it is shaped that way). Start with
+  [Reactivity](../../libraries/Assimalign.Viu.Reactivity/docs/OVERVIEW.md),
+  [RuntimeCore](../../libraries/Assimalign.Viu.RuntimeCore/docs/OVERVIEW.md), and
+  [RuntimeDom](../../libraries/Assimalign.Viu.RuntimeDom/docs/OVERVIEW.md).
+- **The sample app** — [`examples/Assimalign.Viu.WebApp`](../../examples/Assimalign.Viu.WebApp) is a
+  component tree with props, emits, and lifecycle hooks, and it dogfoods the `.viu` CSS pipeline.
+- **The delivery plan** — [`docs/PLAN.md`](../PLAN.md) maps each Vue 3 package to its Viu library and
+  records the founding decisions; the [architecture decisions](../adr/) log the C#/WASM divergences.
+- **The Vue 3 guides this parallels** — [Quick Start](https://vuejs.org/guide/quick-start.html) and
+  [Reactivity Fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html).
+
+## Not yet available
+
+This guide is intentionally scoped to what a consumer can build and publish today. Coming later:
+
+- **A `dotnet new` project template** — [V01.01.12.04] (W05); until then, create the project by hand as
+  above.
+- **Mountable `.viu` single-file components** — [#216](https://github.com/assimalign/viu/issues/216);
+  today `.viu` provides `@style` bundling and compiles `@template`/`@script`.
+- **A template-syntax reference and the API reference site** — the Documentation area
+  [V01.01.13](https://github.com/assimalign/viu/issues/97).
+
+---
+
+This guide follows the repo's [documentation conventions](../CONTRIBUTING.md); every code block is
+extracted verbatim from a Viu app that was built, run, and published against the packaged SDK.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -369,7 +369,9 @@ The published `bin/Release/net10.0/publish/wwwroot` contains:
 
 - your compiled component and the Viu framework assemblies, fingerprinted and trimmed, under
   `_framework/` (e.g. `HelloViu.<hash>.wasm`, `Assimalign.Viu.RuntimeCore.<hash>.wasm`, …);
-- the fingerprinted CSS bundle `HelloViu.viu.css` with its `.gz` and `.br` variants;
+- the CSS bundle `HelloViu.viu.css` — registered as a content-fingerprinted static web asset, though
+  a standalone publish ships the stable plain-named file that any static host can serve — with its
+  `.gz` and `.br` variants;
 - `index.html` with the injected `<link rel="stylesheet" href="HelloViu.viu.css" />` (carried into the
   compressed `index.html.gz` / `index.html.br` too);
 - the `viu-dom.js` interop bridge under `_content/Assimalign.Viu.RuntimeDom/`.


### PR DESCRIPTION
## Summary
- Adds `docs/guide/getting-started.md` — the external-consumer walkthrough for `<Project Sdk="Assimalign.Viu.Sdk">`: prerequisites, the local pack loop, creating the project by hand (the `dotnet new` template is [V01.01.12.04], W05 — stated plainly), first component + bootstrap, reactivity basics with a Vue→Viu delta table, `.viu` styling with the automatic bundle link, run/publish, and where to go next. One README docs-link row added.
- **Every command validated by running it** — this PR finally exercises the packed-SDK consumer path that two tooling rounds had to defer: `Install-Local.ps1` → scratch app outside the repo → `dotnet build` (0 warnings, `[Reactive]` generator ran) → `dotnet run` (served page carried the injected link + importmap; bundle 200) → trimmed `dotnet publish` (fingerprinted framework assemblies; `index.html` + its `.gz` + `.br` all carry the injected link).
- **Two real gaps surfaced and filed, guide scoped honestly around them**:
  - [#215 [V01.01.12.12.07]](https://github.com/assimalign/viu/issues/215) — a minimal consumer ships broken (empty importmap, no CSS link) without manually setting `OverrideHtmlAssetPlaceholders=true`; the guide documents the property as required until that lands.
  - [#216 [V01.01.06.07]](https://github.com/assimalign/viu/issues/216) — `.viu` `@template`/`@script` compiles but the generated partial implements no `IComponentDefinition` and emits no `Setup`, so `.viu` components are not yet mountable end-to-end; the guide covers the working subset (C# components + `.viu` `@style`) and the full template reference is deferred with it.
- Honest deferrals recorded: no in-repo CI snippet project (the external scratch app exercises the *actual* consumer surface, which in-repo dogfooding cannot), Windows-only validation (no docs CI yet), 86 relative links all resolve.

Closes #100
Refs #215, #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)