### PR TITLE
feat(examples): add the HackerNews Wave 4 exit demo [V01.01.13.06]

### DIFF
--- a/.github/workflows/hackernews.yml
+++ b/.github/workflows/hackernews.yml
@@ -1,0 +1,58 @@
+# HackerNews sample build+test ([V01.01.13.06], #103): the Wave-4 exit demo composing the router,
+# store, async components, transitions, and the .viu CSS bundle. Mirrors webapp.yml (a warnings-as-
+# errors WASM build) and adds a test lane (Testing renderer + memory-history router). The trimmed
+# publish + size/trimming gate for this sample runs in budget-gates.yml (it is in the budget manifest).
+# The sample references every runtime area transitively, so a change to any library or the build
+# system re-runs this workflow.
+name: hackernews
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/Assimalign.Viu.HackerNews/**'
+      - 'examples/Assimalign.Viu.HackerNews.Tests/**'
+      - 'examples/Directory.Build.props'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/hackernews.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/Assimalign.Viu.HackerNews/**'
+      - 'examples/Assimalign.Viu.HackerNews.Tests/**'
+      - 'examples/Directory.Build.props'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/hackernews.yml'
+
+jobs:
+  build-test:
+    name: build+test HackerNews sample
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The test project references the WebAssembly sample project, whose build pulls the browser-wasm
+      # runtime pack, so the wasm-tools workload is required for both the build and the test lanes.
+      - name: Set up .NET (with wasm-tools)
+        uses: ./.github/actions/setup-dotnet-wasm
+        with:
+          install-wasm-tools: 'true'
+
+      - name: Build the sample (warnings are errors)
+        run: dotnet build examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj --configuration Release -warnaserror
+
+      - name: Build + test (Testing renderer + memory-history router)
+        run: dotnet test examples/Assimalign.Viu.HackerNews.Tests/Assimalign.Viu.HackerNews.Tests.csproj --configuration Release -warnaserror

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -152,6 +152,12 @@
 	<Folder Name="/viu/examples/Assimalign.Viu.WebApp/">
 		<Project Path="examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj" />
 	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.HackerNews/">
+		<Project Path="examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj" />
+	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.HackerNews.Tests/">
+		<Project Path="examples/Assimalign.Viu.HackerNews.Tests/Assimalign.Viu.HackerNews.Tests.csproj" />
+	</Folder>
 	<Folder Name="/viu/libraries/">
 		<File Path="libraries/Directory.Build.props" />
 		<File Path="libraries/Directory.Build.targets" />

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ runtime template compilation. They never ship in the runtime assemblies.
 | Sample | What it shows |
 | --- | --- |
 | [`Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp) | A browser WASM app: a stopwatch rendered from C# through the handle-based DOM bridge. Its `?diagnostics=1` mode runs the interop marshaling benchmark behind [RuntimeDom ADR-0001](libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md). |
+| [`Assimalign.Viu.HackerNews`](examples/Assimalign.Viu.HackerNews) | The Wave-4 exit demo — a routed, stored HackerNews client. Composes the router (+ the browser click bridge), a Pinia-style store, async route views, keyed `TransitionGroup` story lists, source-generated `System.Text.Json` over the HackerNews API, and the auto-injected `.viu` CSS bundle. See its [README](examples/Assimalign.Viu.HackerNews/README.md). |
 
 ### Packaging (`sdks/`, `frameworks/`)
 

--- a/examples/Assimalign.Viu.HackerNews.Tests/Assimalign.Viu.HackerNews.Tests.csproj
+++ b/examples/Assimalign.Viu.HackerNews.Tests/Assimalign.Viu.HackerNews.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <!-- The Testing renderer + memory-history router drive the sample's stores, route table, and views. -->
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
+    <ViuProjectReference Include="Assimalign.Viu.Router" />
+    <ViuProjectReference Include="Assimalign.Viu.Store" />
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+  </ItemGroup>
+
+  <!--
+    The sample app under test. examples/ is deliberately OUTSIDE the ViuProjectReference index
+    (Build.References.Projects.targets indexes only libraries/ and analyzers/) because libraries must
+    never reference examples. A sample's own test project therefore has no by-name option and references
+    the app by path. Documented, narrowly-scoped deviation from the repo build-system rule (no raw
+    <ProjectReference>): it is a test -> example edge with no NuGet-dependency implications (IsPackable=false;
+    examples are not packed), which is exactly the case the by-name index intentionally excludes.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Assimalign.Viu.HackerNews\Assimalign.Viu.HackerNews.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.HackerNews.Tests/FakeHackerNewsClient.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/FakeHackerNewsClient.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.HackerNews;
+
+namespace Assimalign.Viu.HackerNews.Tests;
+
+/// <summary>
+/// An in-memory <see cref="IHackerNewsClient"/> for tests — the swap the injectable data seam exists
+/// for (#103). Serves canned feeds/items/users, counts calls, honors cancellation, and can inject an
+/// error or gate the feed read (for the store's superseded-load cancellation test). No network.
+/// </summary>
+internal sealed class FakeHackerNewsClient : IHackerNewsClient
+{
+    private readonly Dictionary<StoryFeed, IReadOnlyList<long>> _feeds = new();
+    private readonly Dictionary<long, HackerNewsItem> _items = new();
+    private readonly Dictionary<string, HackerNewsUser> _users = new();
+
+    /// <summary>Number of <see cref="GetFeedAsync"/> calls.</summary>
+    public int FeedCalls { get; private set; }
+
+    /// <summary>Number of <see cref="GetItemAsync"/> calls.</summary>
+    public int ItemCalls { get; private set; }
+
+    /// <summary>Number of <see cref="GetUserAsync"/> calls.</summary>
+    public int UserCalls { get; private set; }
+
+    /// <summary>When set, <see cref="GetFeedAsync"/> awaits this before returning (for ordering/cancellation tests).</summary>
+    public TaskCompletionSource? FeedGate { get; set; }
+
+    /// <summary>When set, <see cref="GetFeedAsync"/> throws it (error-path tests).</summary>
+    public Exception? FeedError { get; set; }
+
+    public FakeHackerNewsClient AddFeed(StoryFeed feed, params long[] ids)
+    {
+        _feeds[feed] = ids;
+        return this;
+    }
+
+    public FakeHackerNewsClient AddItem(HackerNewsItem item)
+    {
+        _items[item.Id] = item;
+        return this;
+    }
+
+    public FakeHackerNewsClient AddUser(HackerNewsUser user)
+    {
+        _users[user.Id] = user;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<long>> GetFeedAsync(StoryFeed feed, CancellationToken cancellationToken = default)
+    {
+        FeedCalls++;
+        if (FeedGate is not null)
+        {
+            await FeedGate.Task;
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        if (FeedError is not null)
+        {
+            throw FeedError;
+        }
+        return _feeds.TryGetValue(feed, out var ids) ? ids : Array.Empty<long>();
+    }
+
+    /// <inheritdoc />
+    public Task<HackerNewsItem?> GetItemAsync(long id, CancellationToken cancellationToken = default)
+    {
+        ItemCalls++;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_items.TryGetValue(id, out var item) ? item : null);
+    }
+
+    /// <inheritdoc />
+    public Task<HackerNewsUser?> GetUserAsync(string id, CancellationToken cancellationToken = default)
+    {
+        UserCalls++;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_users.TryGetValue(id, out var user) ? user : null);
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews.Tests/RouteTableTests.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/RouteTableTests.cs
@@ -1,0 +1,109 @@
+using System.Threading.Tasks;
+
+using Assimalign.Viu.HackerNews;
+using Assimalign.Viu.Router;
+
+using Shouldly;
+
+using Xunit;
+
+using ViuRouter = Assimalign.Viu.Router.Router;
+
+namespace Assimalign.Viu.HackerNews.Tests;
+
+/// <summary>
+/// Covers the sample's route table resolution and the root-redirect guard against a memory-history
+/// router (no browser). The route table is plain Viu code, so it is unit-testable directly.
+/// </summary>
+public sealed class RouteTableTests
+{
+    private static ViuRouter CreateRouter()
+    {
+        var router = new ViuRouter(RouterHistory.CreateMemory(), AppRoutes.Create());
+        router.BeforeEach(AppRoutes.RedirectRoot);
+        return router;
+    }
+
+    [Theory]
+    [InlineData("/top", "top", 0)]
+    [InlineData("/new", "new", 0)]
+    [InlineData("/show/3", "show", 3)]
+    [InlineData("/ask/2", "ask", 2)]
+    [InlineData("/jobs", "jobs", 0)]
+    public void Feed_routes_resolve_feed_and_page(string path, string expectedFeed, int expectedPage)
+    {
+        var route = CreateRouter().Resolve(path);
+
+        route.Name.ShouldBe("feed");
+        route.Parameters.GetString("feed").ShouldBe(expectedFeed);
+        route.Parameters.TryGetInteger("page", out var page);
+        (page).ShouldBe(expectedPage == 0 ? 0 : expectedPage);
+    }
+
+    [Fact]
+    public void Item_route_resolves_numeric_id()
+    {
+        var route = CreateRouter().Resolve("/item/8863");
+
+        route.Name.ShouldBe("item");
+        route.Parameters.GetInteger("id").ShouldBe(8863);
+    }
+
+    [Fact]
+    public void User_route_resolves_id()
+    {
+        var route = CreateRouter().Resolve("/user/pg");
+
+        route.Name.ShouldBe("user");
+        route.Parameters.GetString("id").ShouldBe("pg");
+    }
+
+    [Fact]
+    public void Static_item_segment_outranks_the_dynamic_feed_route()
+    {
+        // /item/42 must match the item route, not /:feed/:page (specificity: static > dynamic).
+        CreateRouter().Resolve("/item/42").Name.ShouldBe("item");
+    }
+
+    [Fact]
+    public void Non_numeric_item_id_falls_through_to_not_found()
+    {
+        // /item/:id(\d+) rejects a non-numeric id, and the second segment blocks the feed route too.
+        CreateRouter().Resolve("/item/abc").Name.ShouldBe("not-found");
+    }
+
+    [Fact]
+    public void Deep_unknown_path_resolves_to_not_found()
+    {
+        CreateRouter().Resolve("/a/b/c/d").Name.ShouldBe("not-found");
+    }
+
+    [Fact]
+    public async Task Root_redirects_to_the_top_feed_in_session()
+    {
+        // The BeforeEach root redirect fires for an in-session navigation to "/" (e.g. clicking the
+        // logo). Navigate away from the router's pre-resolved initial "/" first, so this Push is not a
+        // deduplicated same-location no-op. (The initial page-load "/" case is handled in bootstrap —
+        // Program.Main — because the router resolves its initial location without running guards; see
+        // [V01.01.08.07], #219.)
+        var router = CreateRouter();
+        await router.Push("/new");
+
+        await router.Push("/");
+
+        router.CurrentRoute.Value.Name.ShouldBe("feed");
+        router.CurrentRoute.Value.Parameters.GetString("feed").ShouldBe("top");
+    }
+
+    [Fact]
+    public async Task Navigating_a_feed_page_updates_the_current_route()
+    {
+        var router = CreateRouter();
+
+        await router.Push("/show/2");
+
+        router.CurrentRoute.Value.Name.ShouldBe("feed");
+        router.CurrentRoute.Value.Parameters.GetString("feed").ShouldBe("show");
+        router.CurrentRoute.Value.Parameters.GetInteger("page").ShouldBe(2);
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews.Tests/StoreTests.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/StoreTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.HackerNews;
+using Assimalign.Viu.Store;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.HackerNews.Tests;
+
+/// <summary>
+/// Covers the stores' observable behavior with a fake client: loading/error modeling, filtering,
+/// pagination, the feed cache, comment-tree assembly, and superseded-load cancellation. State is
+/// asserted directly (the reactive setters run synchronously inside the store's <c>Patch</c>), so no
+/// scheduler pump is needed. All fetched state flows through the store (#103).
+/// </summary>
+public sealed class StoreTests
+{
+    private static StoriesStore Stories(FakeHackerNewsClient client)
+        => new HackerNewsStores(client).Stories.UseStore(new StoreRegistry());
+
+    private static ItemStore Item(FakeHackerNewsClient client)
+        => new HackerNewsStores(client).Item.UseStore(new StoreRegistry());
+
+    private static UserStore Users(FakeHackerNewsClient client)
+        => new HackerNewsStores(client).User.UseStore(new StoreRegistry());
+
+    // ---- StoriesStore ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadPage_populates_items_in_order_and_clears_loading()
+    {
+        var client = new FakeHackerNewsClient().AddFeed(StoryFeed.Top, 1, 2, 3)
+            .AddItem(TestData.Story(1, "First"))
+            .AddItem(TestData.Story(2, "Second"))
+            .AddItem(TestData.Story(3, "Third"));
+        var store = Stories(client);
+
+        await store.LoadPageAsync(StoryFeed.Top, 1);
+
+        store.State.IsLoading.ShouldBeFalse();
+        store.State.Error.ShouldBeNull();
+        store.State.TotalCount.ShouldBe(3);
+        store.State.Items.Count.ShouldBe(3);
+        store.State.Items[0].Id.ShouldBe(1L);
+        store.State.Items[2].Id.ShouldBe(3L);
+    }
+
+    [Fact]
+    public async Task LoadPage_drops_missing_and_dead_items()
+    {
+        var client = new FakeHackerNewsClient().AddFeed(StoryFeed.Top, 1, 2, 3, 4)
+            .AddItem(TestData.Story(1, "Kept"))
+            .AddItem(TestData.Story(3, "Dead") with { Dead = true })
+            .AddItem(TestData.Story(4, "Also kept"));
+        // id 2 has no item (null); id 3 is dead — both dropped, order preserved.
+        var store = Stories(client);
+
+        await store.LoadPageAsync(StoryFeed.Top, 1);
+
+        store.State.Items.Count.ShouldBe(2);
+        store.State.Items[0].Id.ShouldBe(1L);
+        store.State.Items[1].Id.ShouldBe(4L);
+        store.State.TotalCount.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task LoadPage_paginates_and_computes_page_count()
+    {
+        var ids = new long[25];
+        var client = new FakeHackerNewsClient();
+        for (var i = 0; i < 25; i++)
+        {
+            ids[i] = i + 1;
+            client.AddItem(TestData.Story(i + 1, $"Story {i + 1}"));
+        }
+        client.AddFeed(StoryFeed.New, ids);
+        var store = Stories(client);
+
+        await store.LoadPageAsync(StoryFeed.New, 2);
+
+        store.State.ActivePage.ShouldBe(2);
+        store.State.Items.Count.ShouldBe(5); // items 21..25
+        store.State.Items[0].Id.ShouldBe(21L);
+        store.PageCount.Value.ShouldBe(2); // ceil(25 / 20)
+    }
+
+    [Fact]
+    public async Task LoadPage_models_a_fetch_error_as_state()
+    {
+        var client = new FakeHackerNewsClient { FeedError = new InvalidOperationException("boom") };
+        var store = Stories(client);
+
+        await store.LoadPageAsync(StoryFeed.Top, 1);
+
+        store.State.IsLoading.ShouldBeFalse();
+        store.State.Error.ShouldBe("boom");
+        store.State.Items.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadPage_caches_the_feed_id_list_across_pages()
+    {
+        var ids = new long[25];
+        var client = new FakeHackerNewsClient();
+        for (var i = 0; i < 25; i++)
+        {
+            ids[i] = i + 1;
+            client.AddItem(TestData.Story(i + 1, $"Story {i + 1}"));
+        }
+        client.AddFeed(StoryFeed.Top, ids);
+        var store = Stories(client);
+
+        await store.LoadPageAsync(StoryFeed.Top, 1);
+        await store.LoadPageAsync(StoryFeed.Top, 2);
+
+        client.FeedCalls.ShouldBe(1); // the id list is fetched once, then paged from cache
+    }
+
+    [Fact]
+    public async Task A_superseded_load_does_not_clobber_the_newer_one()
+    {
+        var client = new FakeHackerNewsClient()
+            .AddFeed(StoryFeed.Top, 1).AddItem(TestData.Story(1, "Old"))
+            .AddFeed(StoryFeed.New, 10).AddItem(TestData.Story(10, "New"));
+        client.FeedGate = new TaskCompletionSource();
+        var store = Stories(client);
+
+        var first = store.LoadPageAsync(StoryFeed.Top, 1);  // suspends at the gate
+        var second = store.LoadPageAsync(StoryFeed.New, 1); // cancels the first, also suspends
+        client.FeedGate.SetResult();
+        await Task.WhenAll(first, second);
+
+        store.State.ActiveFeed.ShouldBe(StoryFeed.New);
+        store.State.Items.Count.ShouldBe(1);
+        store.State.Items[0].Id.ShouldBe(10L);
+        store.State.Error.ShouldBeNull();
+    }
+
+    // ---- ItemStore ------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadItem_builds_a_bounded_comment_tree()
+    {
+        var client = new FakeHackerNewsClient()
+            .AddItem(TestData.Story(100, "Story", descendants: 3, kids: [101, 102]))
+            .AddItem(TestData.Comment(101, "top comment", kids: [201]))
+            .AddItem(TestData.Comment(102, "another top"))
+            .AddItem(TestData.Comment(201, "reply", kids: [301])); // 201 sits at MaxDepth, its kids aren't fetched
+        var store = Item(client);
+
+        await store.LoadItemAsync(100);
+
+        store.State.Story!.Id.ShouldBe(100L);
+        store.State.Comments.Count.ShouldBe(2);
+        store.State.Comments[0].Comment.Id.ShouldBe(101L);
+        store.State.Comments[0].Replies.Count.ShouldBe(1);
+        store.State.Comments[0].Replies[0].Comment.Id.ShouldBe(201L);
+        store.State.Comments[0].Replies[0].HasMoreReplies.ShouldBeTrue(); // depth bound reached
+        store.State.Comments[1].Comment.Id.ShouldBe(102L);
+        store.State.Comments[1].Replies.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadItem_models_a_missing_item_as_an_error()
+    {
+        var store = Item(new FakeHackerNewsClient());
+
+        await store.LoadItemAsync(999);
+
+        store.State.Story.ShouldBeNull();
+        store.State.IsLoading.ShouldBeFalse();
+        store.State.Error.ShouldNotBeNull();
+    }
+
+    // ---- UserStore ------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task LoadUser_populates_the_profile()
+    {
+        var client = new FakeHackerNewsClient().AddUser(TestData.User("pg", karma: 155000));
+        var store = Users(client);
+
+        await store.LoadUserAsync("pg");
+
+        store.State.Profile!.Id.ShouldBe("pg");
+        store.State.Profile!.Karma.ShouldBe(155000);
+        store.State.Error.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadUser_models_a_missing_user_as_an_error()
+    {
+        var store = Users(new FakeHackerNewsClient());
+
+        await store.LoadUserAsync("ghost");
+
+        store.State.Profile.ShouldBeNull();
+        store.State.Error.ShouldNotBeNull();
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews.Tests/TestData.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/TestData.cs
@@ -1,0 +1,61 @@
+using System;
+
+using Assimalign.Viu.HackerNews;
+
+namespace Assimalign.Viu.HackerNews.Tests;
+
+/// <summary>Terse builders for the domain records used across the tests.</summary>
+internal static class TestData
+{
+    private static readonly DateTimeOffset When = DateTimeOffset.FromUnixTimeSeconds(1_200_000_000);
+
+    public static HackerNewsItem Story(
+        long id,
+        string title,
+        int score = 10,
+        string by = "alice",
+        int descendants = 0,
+        string? url = null,
+        long[]? kids = null)
+        => new(
+            id,
+            "story",
+            by,
+            When,
+            title,
+            url,
+            HackerNewsClient.ToHost(url),
+            null,
+            score,
+            descendants,
+            kids ?? Array.Empty<long>(),
+            0,
+            Deleted: false,
+            Dead: false);
+
+    public static HackerNewsItem Comment(
+        long id,
+        string text,
+        string by = "bob",
+        long[]? kids = null,
+        bool deleted = false,
+        bool dead = false)
+        => new(
+            id,
+            "comment",
+            by,
+            When,
+            null,
+            null,
+            null,
+            text,
+            0,
+            0,
+            kids ?? Array.Empty<long>(),
+            0,
+            deleted,
+            dead);
+
+    public static HackerNewsUser User(string id, int karma = 100, string? about = null, int submitted = 0)
+        => new(id, When, karma, about, submitted);
+}

--- a/examples/Assimalign.Viu.HackerNews.Tests/ViewTests.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/ViewTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.HackerNews;
+using Assimalign.Viu.Router;
+using Assimalign.Viu.Store;
+using Assimalign.Viu.Testing;
+
+using Shouldly;
+
+using Xunit;
+
+using ViuRouter = Assimalign.Viu.Router.Router;
+
+namespace Assimalign.Viu.HackerNews.Tests;
+
+/// <summary>
+/// Covers the views end-to-end through the in-memory Testing renderer: the story list renders from
+/// store state, and the loading and error states render their own UI. The router (memory history) and
+/// the store-definitions container are provided into the tree; the store registry is the active one so
+/// the views' argument-less <c>UseStore()</c> resolves it.
+/// </summary>
+public sealed class ViewTests
+{
+    private static ViuRouter RouterAt(string path)
+    {
+        var router = new ViuRouter(RouterHistory.CreateMemory(), AppRoutes.Create());
+        router.BeforeEach(AppRoutes.RedirectRoot);
+        _ = router.Push(path);
+        return router;
+    }
+
+    private static ComponentMountOptions Options(ViuRouter router, HackerNewsStores stores)
+        => new ComponentMountOptions()
+            .Provide(RouterInjectionKeys.Router, router)
+            .Provide(HackerNewsStores.InjectionKey, stores);
+
+    private static async Task WithActiveRegistry(HackerNewsStores stores, StoreRegistry registry, Func<Task> body)
+    {
+        Stores.SetActiveRegistry(registry);
+        try
+        {
+            await body();
+        }
+        finally
+        {
+            Stores.SetActiveRegistry(null);
+            registry.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Story_list_renders_keyed_rows_from_the_store()
+    {
+        var client = new FakeHackerNewsClient().AddFeed(StoryFeed.Top, 1, 2)
+            .AddItem(TestData.Story(1, "Alpha", score: 42))
+            .AddItem(TestData.Story(2, "Beta", url: "https://example.com/beta"));
+        var stores = new HackerNewsStores(client);
+        var router = RouterAt("/top");
+        var registry = new StoreRegistry();
+
+        await WithActiveRegistry(stores, registry, async () =>
+        {
+            using var wrapper = ViuTest.Mount(StoriesView.Instance, Options(router, stores));
+            await wrapper.FlushAsync();
+            await wrapper.NextTickAsync();
+
+            var html = wrapper.Html();
+            html.ShouldContain("Alpha");
+            html.ShouldContain("Beta");
+            html.ShouldContain("42 points");
+            html.ShouldContain("example.com");   // host of the external story
+            html.ShouldContain("/item/1");        // internal (self) story links to its discussion
+        });
+    }
+
+    [Fact]
+    public async Task Story_list_shows_the_loading_state_while_the_feed_is_pending()
+    {
+        var client = new FakeHackerNewsClient().AddFeed(StoryFeed.Top, 1).AddItem(TestData.Story(1, "Alpha"));
+        client.FeedGate = new System.Threading.Tasks.TaskCompletionSource();
+        var stores = new HackerNewsStores(client);
+        var router = RouterAt("/top");
+        var registry = new StoreRegistry();
+
+        await WithActiveRegistry(stores, registry, async () =>
+        {
+            using var wrapper = ViuTest.Mount(StoriesView.Instance, Options(router, stores));
+            await wrapper.FlushAsync();
+
+            wrapper.Html().ShouldContain("Loading");
+
+            client.FeedGate!.SetResult();
+            await wrapper.FlushAsync();
+            await wrapper.NextTickAsync();
+
+            wrapper.Html().ShouldContain("Alpha");
+        });
+    }
+
+    [Fact]
+    public async Task Story_list_shows_the_error_state_on_failure()
+    {
+        var client = new FakeHackerNewsClient { FeedError = new System.InvalidOperationException("offline") };
+        var stores = new HackerNewsStores(client);
+        var router = RouterAt("/top");
+        var registry = new StoreRegistry();
+
+        await WithActiveRegistry(stores, registry, async () =>
+        {
+            using var wrapper = ViuTest.Mount(StoriesView.Instance, Options(router, stores));
+            await wrapper.FlushAsync();
+            await wrapper.NextTickAsync();
+
+            var html = wrapper.Html();
+            html.ShouldContain("offline");
+        });
+    }
+
+    [Fact]
+    public async Task Unknown_feed_renders_a_not_found_message()
+    {
+        var stores = new HackerNewsStores(new FakeHackerNewsClient());
+        var router = RouterAt("/nonsense");
+        var registry = new StoreRegistry();
+
+        await WithActiveRegistry(stores, registry, async () =>
+        {
+            using var wrapper = ViuTest.Mount(StoriesView.Instance, Options(router, stores));
+            await wrapper.FlushAsync();
+            await wrapper.NextTickAsync();
+
+            wrapper.Html().ShouldContain("nonsense");
+        });
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj
+++ b/examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkLatest)</TargetFramework>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <!-- Dogfood the .viu single-file-component CSS pipeline ([V01.01.12.12]) and its auto-injected
+         <link> ([V01.01.12.12.01], #167): enabling this flows every **/*.viu to the generator AND turns on
+         $(ViuBundleSingleFileComponentCss), so the ViuBundleCss task emits the Styles/*.viu @style blocks into
+         the fingerprinted Assimalign.Viu.HackerNews.viu.css bundle that the build splices into index.html — no
+         manual <link> tag. This sample authors component styling in .viu @style blocks (the logic-bearing
+         components are C# render functions; see README.md "Why .viu is CSS-only today"). -->
+    <ViuUseSingleFileComponents>true</ViuUseSingleFileComponents>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]!" />
+  </ItemGroup>
+
+  <!-- The full Wave-4 surface this capstone exercises: the DOM runtime, the router + its browser click
+       bridge (RouterLinkDomBridge, installed at bootstrap), and the Pinia-style store. RuntimeCore,
+       Reactivity, and Shared flow transitively. Libraries never reference examples (one-way edge). -->
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+    <ViuProjectReference Include="Assimalign.Viu.Router" />
+    <ViuProjectReference Include="Assimalign.Viu.Router.RuntimeDom" />
+    <ViuProjectReference Include="Assimalign.Viu.Store" />
+  </ItemGroup>
+
+  <!-- The store state classes are [Reactive] partial classes the Reactivity source generator expands.
+       In-repo the generator attaches only through a direct analyzer reference (it is not transitive via
+       ViuProjectReference); packaged consumers instead get it from the Reactivity nupkg's analyzers/. -->
+  <ItemGroup>
+    <ViuAnalyzerReference Include="Assimalign.Viu.Reactivity.Generators" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.HackerNews/Data/CommentNode.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/CommentNode.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// A node in a fetched comment tree: the <see cref="Comment"/> item plus its already-loaded
+/// <see cref="Replies"/>. The item-detail store assembles this tree (depth- and count-bounded so a
+/// large thread never triggers a fetch storm), and the recursive comment view renders it with each
+/// node keyed by its comment id.
+/// </summary>
+/// <param name="Comment">The comment item.</param>
+/// <param name="Replies">The loaded child replies (may be empty even when the comment has more kids beyond the fetch bound).</param>
+/// <param name="HasMoreReplies">Whether the comment has child kids that were not fetched (the bound was reached).</param>
+internal sealed record CommentNode(
+    HackerNewsItem Comment,
+    IReadOnlyList<CommentNode> Replies,
+    bool HasMoreReplies);

--- a/examples/Assimalign.Viu.HackerNews/Data/HackerNewsClient.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/HackerNewsClient.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The live <see cref="IHackerNewsClient"/>: reads the public HackerNews Firebase API
+/// (<c>https://hacker-news.firebaseio.com/v0/</c>, https://github.com/HackerNews/API) over
+/// <see cref="HttpClient"/> and deserializes with the source-generated
+/// <see cref="HackerNewsJsonSerializerContext"/> — no reflection-based serialization anywhere, so the
+/// trimmed WASM publish stays clean. In the browser the injected <see cref="HttpClient"/> is backed
+/// by the fetch handler; the API sends permissive CORS headers, so the client can read it directly.
+/// </summary>
+internal sealed class HackerNewsClient : IHackerNewsClient
+{
+    /// <summary>The HackerNews Firebase API base address (v0).</summary>
+    public static readonly Uri BaseAddress = new("https://hacker-news.firebaseio.com/");
+
+    private readonly HttpClient _httpClient;
+
+    /// <summary>Creates the client over <paramref name="httpClient"/> (its base address must be <see cref="BaseAddress"/>).</summary>
+    /// <param name="httpClient">The HTTP client to read the API with.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="httpClient"/> is null.</exception>
+    public HackerNewsClient(HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        _httpClient = httpClient;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<long>> GetFeedAsync(StoryFeed feed, CancellationToken cancellationToken = default)
+    {
+        // The story-id list is a bare JSON array of numbers; JsonDocument reads it reflection-free and
+        // trim-safe, so no source-generated array metadata is needed (see HackerNewsJsonSerializerContext).
+        var json = await _httpClient.GetStringAsync(StoryFeeds.ToEndpoint(feed), cancellationToken);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<long>();
+        }
+        var ids = new List<long>(root.GetArrayLength());
+        foreach (var element in root.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Number)
+            {
+                ids.Add(element.GetInt64());
+            }
+        }
+        return ids;
+    }
+
+    /// <inheritdoc />
+    public async Task<HackerNewsItem?> GetItemAsync(long id, CancellationToken cancellationToken = default)
+    {
+        var json = await _httpClient.GetStringAsync($"v0/item/{id}.json", cancellationToken);
+        // The API returns the JSON literal null for a missing item.
+        var payload = JsonSerializer.Deserialize(json, HackerNewsJsonSerializerContext.Default.ItemPayload);
+        return payload is null ? null : MapItem(payload);
+    }
+
+    /// <inheritdoc />
+    public async Task<HackerNewsUser?> GetUserAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+        var json = await _httpClient.GetStringAsync($"v0/user/{Uri.EscapeDataString(id)}.json", cancellationToken);
+        var payload = JsonSerializer.Deserialize(json, HackerNewsJsonSerializerContext.Default.UserPayload);
+        return payload is null || payload.Id is null ? null : MapUser(payload);
+    }
+
+    private static HackerNewsItem MapItem(ItemPayload payload) => new(
+        payload.Id,
+        payload.Type ?? "story",
+        payload.By,
+        DateTimeOffset.FromUnixTimeSeconds(payload.Time),
+        payload.Title,
+        payload.Url,
+        ToHost(payload.Url),
+        payload.Text,
+        payload.Score,
+        payload.Descendants,
+        payload.Kids ?? Array.Empty<long>(),
+        payload.Parent,
+        payload.Deleted,
+        payload.Dead);
+
+    private static HackerNewsUser MapUser(UserPayload payload) => new(
+        payload.Id!,
+        DateTimeOffset.FromUnixTimeSeconds(payload.Created),
+        payload.Karma,
+        payload.About,
+        payload.Submitted?.Length ?? 0);
+
+    /// <summary>Derives the display host (without a leading <c>www.</c>) from a story URL.</summary>
+    /// <param name="url">The story URL, or null.</param>
+    /// <returns>The host, or null when there is no absolute URL.</returns>
+    internal static string? ToHost(string? url)
+    {
+        if (string.IsNullOrEmpty(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+        var host = uri.Host;
+        return host.StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? host[4..] : host;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/HackerNewsItem.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/HackerNewsItem.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// A HackerNews item — the domain projection of the unified <c>/v0/item/{id}</c> resource
+/// (https://github.com/HackerNews/API#items), which represents a story, job, Ask/Show HN post, poll,
+/// or comment depending on <see cref="Type"/>. Immutable with a stable <see cref="Id"/>, so story
+/// lists render as keyed rows with stable identity (no per-item ad-hoc interop) and a virtualization
+/// strategy can be added later without touching the views. The wire shape is mapped in
+/// <see cref="HackerNewsClient"/> from the internal <c>ItemPayload</c> DTO.
+/// </summary>
+/// <param name="Id">The item's unique id.</param>
+/// <param name="Type">The item kind: <c>story</c>, <c>comment</c>, <c>job</c>, <c>poll</c>, or <c>pollopt</c>.</param>
+/// <param name="By">The submitting user's id, or null for a deleted item.</param>
+/// <param name="Time">The submission time (converted from the API's Unix seconds).</param>
+/// <param name="Title">The story/poll title, or null for a comment.</param>
+/// <param name="Url">The story's target URL, or null (Ask/Show/self posts have none).</param>
+/// <param name="Host">The display host derived from <see cref="Url"/> (e.g. <c>example.com</c>), or null.</param>
+/// <param name="Text">The HTML body of a comment or self/Ask post, or null.</param>
+/// <param name="Score">The story's score, or 0.</param>
+/// <param name="Descendants">The total comment count for a story/poll, or 0.</param>
+/// <param name="Kids">The direct child comment ids in ranked display order.</param>
+/// <param name="Parent">The parent item id for a comment, or 0.</param>
+/// <param name="Deleted">Whether the item was deleted.</param>
+/// <param name="Dead">Whether the item is dead (flagged/removed).</param>
+internal sealed record HackerNewsItem(
+    long Id,
+    string Type,
+    string? By,
+    DateTimeOffset Time,
+    string? Title,
+    string? Url,
+    string? Host,
+    string? Text,
+    int Score,
+    int Descendants,
+    IReadOnlyList<long> Kids,
+    long Parent,
+    bool Deleted,
+    bool Dead);

--- a/examples/Assimalign.Viu.HackerNews/Data/HackerNewsUser.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/HackerNewsUser.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// A HackerNews user profile — the domain projection of <c>/v0/user/{id}</c>
+/// (https://github.com/HackerNews/API#users). Immutable; the user page renders from it.
+/// </summary>
+/// <param name="Id">The case-sensitive user id (also the display name).</param>
+/// <param name="Created">The account creation time (converted from the API's Unix seconds).</param>
+/// <param name="Karma">The user's karma.</param>
+/// <param name="About">The self-description HTML, or null.</param>
+/// <param name="SubmittedCount">The number of items the user has submitted.</param>
+internal sealed record HackerNewsUser(
+    string Id,
+    DateTimeOffset Created,
+    int Karma,
+    string? About,
+    int SubmittedCount);

--- a/examples/Assimalign.Viu.HackerNews/Data/IHackerNewsClient.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/IHackerNewsClient.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The sample's data-layer seam: every network read goes through this typed abstraction, never
+/// through ad-hoc component fetches. The browser app binds it to <see cref="HackerNewsClient"/>
+/// (HttpClient + source-generated <see cref="System.Text.Json"/>); tests and any future prerenderer
+/// bind a fake, satisfying the "isolated behind an injectable API-client abstraction so the data
+/// layer can be swapped for prerendering and tests" acceptance criterion (#103).
+/// <para>
+/// All methods are async and non-blocking, honoring the single-threaded WASM event loop, and take a
+/// <see cref="CancellationToken"/> so a store can cancel a superseded in-flight load.
+/// </para>
+/// </summary>
+internal interface IHackerNewsClient
+{
+    /// <summary>Fetches the ordered story-id list for <paramref name="feed"/>.</summary>
+    /// <param name="feed">The feed whose ranking to read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The story ids in display order (empty when the feed is empty).</returns>
+    Task<IReadOnlyList<long>> GetFeedAsync(StoryFeed feed, CancellationToken cancellationToken = default);
+
+    /// <summary>Fetches a single item (story, comment, job, or poll) by id.</summary>
+    /// <param name="id">The item id.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The item, or null when it does not exist.</returns>
+    Task<HackerNewsItem?> GetItemAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>Fetches a user profile by id.</summary>
+    /// <param name="id">The case-sensitive user id.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The profile, or null when it does not exist.</returns>
+    Task<HackerNewsUser?> GetUserAsync(string id, CancellationToken cancellationToken = default);
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/Internal/HackerNewsJsonSerializerContext.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/Internal/HackerNewsJsonSerializerContext.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The System.Text.Json <b>source-generated</b> serialization context for the HackerNews wire DTOs —
+/// the sanctioned trimming/NativeAOT-safe JSON path for Viu apps, and the pattern this (the first
+/// networked sample) establishes.
+/// <para>
+/// Reflection-based System.Text.Json is forbidden by the repo's AOT rules: the reflection
+/// <c>JsonSerializer.Deserialize&lt;T&gt;(string, JsonSerializerOptions)</c> overloads are annotated
+/// <c>[RequiresUnreferencedCode]</c>/<c>[RequiresDynamicCode]</c> and would fail the trimmed publish
+/// under <c>-warnaserror</c>. Instead, every DTO is registered with <see cref="JsonSerializableAttribute"/>
+/// here; the generator emits the metadata at build time on the host, and <see cref="HackerNewsClient"/>
+/// deserializes through the generated <c>JsonTypeInfo&lt;T&gt;</c> (<c>Default.ItemPayload</c> /
+/// <c>Default.UserPayload</c>) overloads, which carry no reflection/codegen requirement.
+/// </para>
+/// <para>
+/// Only the two object DTOs are registered. The feed endpoints return a bare JSON array of numeric
+/// ids, which <see cref="HackerNewsClient"/> reads with <c>JsonDocument</c> — itself reflection-free
+/// and trim-safe — so no array metadata is generated. <see cref="JsonSourceGenerationOptionsAttribute.PropertyNameCaseInsensitive"/>
+/// binds the PascalCase DTO members to the API's lowercase JSON keys.
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(ItemPayload))]
+[JsonSerializable(typeof(UserPayload))]
+internal partial class HackerNewsJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/Internal/ItemPayload.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/Internal/ItemPayload.cs
@@ -1,0 +1,38 @@
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The wire shape of a HackerNews <c>/v0/item/{id}</c> response, deserialized by the
+/// source-generated <see cref="HackerNewsJsonSerializerContext"/> (never by reflection).
+/// Mutable auto-properties are the DTO surface System.Text.Json's source generator binds to;
+/// <see cref="HackerNewsClient"/> maps this to the immutable <see cref="HackerNewsItem"/> domain
+/// record. Property names bind case-insensitively to the API's lowercase JSON keys.
+/// </summary>
+internal sealed class ItemPayload
+{
+    public long Id { get; set; }
+
+    public string? Type { get; set; }
+
+    public string? By { get; set; }
+
+    /// <summary>Submission time in Unix seconds (mapped to a <see cref="System.DateTimeOffset"/>).</summary>
+    public long Time { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? Url { get; set; }
+
+    public string? Text { get; set; }
+
+    public int Score { get; set; }
+
+    public int Descendants { get; set; }
+
+    public long[]? Kids { get; set; }
+
+    public long Parent { get; set; }
+
+    public bool Deleted { get; set; }
+
+    public bool Dead { get; set; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/Internal/UserPayload.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/Internal/UserPayload.cs
@@ -1,0 +1,20 @@
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The wire shape of a HackerNews <c>/v0/user/{id}</c> response, deserialized by the
+/// source-generated <see cref="HackerNewsJsonSerializerContext"/>. Mapped to the immutable
+/// <see cref="HackerNewsUser"/> domain record by <see cref="HackerNewsClient"/>.
+/// </summary>
+internal sealed class UserPayload
+{
+    public string? Id { get; set; }
+
+    /// <summary>Account creation time in Unix seconds (mapped to a <see cref="System.DateTimeOffset"/>).</summary>
+    public long Created { get; set; }
+
+    public int Karma { get; set; }
+
+    public string? About { get; set; }
+
+    public long[]? Submitted { get; set; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/StoryFeed.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/StoryFeed.cs
@@ -1,0 +1,24 @@
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The five HackerNews story feeds this sample surfaces, mirroring the front-page tabs of
+/// vuejs/vue-hackernews-2.0 (top / new / show / ask / jobs). Each maps to a HackerNews API
+/// story-id list endpoint (see <see cref="StoryFeeds"/>).
+/// </summary>
+internal enum StoryFeed
+{
+    /// <summary>The front-page "top" ranking (<c>topstories.json</c>).</summary>
+    Top,
+
+    /// <summary>The newest submissions (<c>newstories.json</c>).</summary>
+    New,
+
+    /// <summary>Show HN submissions (<c>showstories.json</c>).</summary>
+    Show,
+
+    /// <summary>Ask HN submissions (<c>askstories.json</c>).</summary>
+    Ask,
+
+    /// <summary>Job postings (<c>jobstories.json</c>).</summary>
+    Jobs,
+}

--- a/examples/Assimalign.Viu.HackerNews/Data/StoryFeeds.cs
+++ b/examples/Assimalign.Viu.HackerNews/Data/StoryFeeds.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// Reflection-free (AOT/trimming-safe) mapping between <see cref="StoryFeed"/> values and their
+/// URL slug, HackerNews API endpoint, and display label. Every mapping is an explicit switch — the
+/// sample never uses <c>Enum.Parse</c>/reflection so nothing here fights the trimmer.
+/// </summary>
+internal static class StoryFeeds
+{
+    /// <summary>All feeds in navigation order (the header tabs render from this).</summary>
+    public static readonly StoryFeed[] All =
+    [
+        StoryFeed.Top,
+        StoryFeed.New,
+        StoryFeed.Show,
+        StoryFeed.Ask,
+        StoryFeed.Jobs,
+    ];
+
+    /// <summary>The URL slug for <paramref name="feed"/> (the <c>:feed</c> route parameter value).</summary>
+    public static string ToSlug(StoryFeed feed) => feed switch
+    {
+        StoryFeed.Top => "top",
+        StoryFeed.New => "new",
+        StoryFeed.Show => "show",
+        StoryFeed.Ask => "ask",
+        StoryFeed.Jobs => "jobs",
+        _ => "top",
+    };
+
+    /// <summary>The human label for <paramref name="feed"/> (header tab text).</summary>
+    public static string ToLabel(StoryFeed feed) => feed switch
+    {
+        StoryFeed.Top => "Top",
+        StoryFeed.New => "New",
+        StoryFeed.Show => "Show",
+        StoryFeed.Ask => "Ask",
+        StoryFeed.Jobs => "Jobs",
+        _ => "Top",
+    };
+
+    /// <summary>
+    /// The HackerNews API relative endpoint for <paramref name="feed"/>'s story-id list, e.g.
+    /// <c>v0/topstories.json</c> (https://github.com/HackerNews/API#new-top-and-best-stories).
+    /// </summary>
+    public static string ToEndpoint(StoryFeed feed) => feed switch
+    {
+        StoryFeed.Top => "v0/topstories.json",
+        StoryFeed.New => "v0/newstories.json",
+        StoryFeed.Show => "v0/showstories.json",
+        StoryFeed.Ask => "v0/askstories.json",
+        StoryFeed.Jobs => "v0/jobstories.json",
+        _ => "v0/topstories.json",
+    };
+
+    /// <summary>
+    /// Parses a route slug back to a <see cref="StoryFeed"/>. Returns false for an unknown slug so a
+    /// view can fall back to a not-found rendering (the <c>:feed</c> route parameter is unconstrained).
+    /// </summary>
+    /// <param name="slug">The <c>:feed</c> parameter value.</param>
+    /// <param name="feed">The parsed feed when recognized.</param>
+    /// <returns>Whether <paramref name="slug"/> names a known feed.</returns>
+    public static bool TryParse(string? slug, out StoryFeed feed)
+    {
+        switch (slug)
+        {
+            case "top":
+                feed = StoryFeed.Top;
+                return true;
+            case "new":
+                feed = StoryFeed.New;
+                return true;
+            case "show":
+                feed = StoryFeed.Show;
+                return true;
+            case "ask":
+                feed = StoryFeed.Ask;
+                return true;
+            case "jobs":
+                feed = StoryFeed.Jobs;
+                return true;
+            default:
+                feed = StoryFeed.Top;
+                return false;
+        }
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Program.cs
+++ b/examples/Assimalign.Viu.HackerNews/Program.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Router;
+using Assimalign.Viu.Router.RuntimeDom;
+using Assimalign.Viu.RuntimeDom;
+using Assimalign.Viu.Store;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The browser bootstrap — the one place that touches browser-only interop, so it (and only it) is
+/// marked <see cref="SupportedOSPlatformAttribute">browser</see>. Every other type in the app stays
+/// platform-neutral and testable. Bootstrap composes the whole Wave-4 surface: the DOM runtime, the
+/// router with its click bridge (<see cref="RouterLinkDomBridge"/>), the Pinia-style store registry,
+/// and the injectable data client.
+/// </summary>
+internal static class Program
+{
+    [SupportedOSPlatform("browser")]
+    internal static async Task Main()
+    {
+        // Initialize the DOM bridge and the router's browser history, then enable client-side
+        // navigation (maps real DOM clicks on RouterLinks into router.Push, suppressing full reloads).
+        await BrowserRuntime.InitializeAsync();
+        await RouterHistory.InitializeAsync();
+        RouterLinkDomBridge.Install();
+
+        // The injectable data seam, bound to the live HackerNews Firebase API (fetch-backed in WASM).
+        var httpClient = new HttpClient { BaseAddress = HackerNewsClient.BaseAddress };
+        var stores = new HackerNewsStores(new HackerNewsClient(httpClient));
+
+        // Web history = clean deep-link URLs (/item/8863). Route table + root redirect are shared with tests.
+        var history = RouterHistory.CreateWeb();
+        // Fully qualified: the simple name Router binds to the Assimalign.Viu.Router namespace here.
+        var router = new Assimalign.Viu.Router.Router(history, AppRoutes.Create());
+        router.BeforeEach(AppRoutes.RedirectRoot);
+
+        // Resolve the initial URL before mounting. The router resolves its initial location eagerly and
+        // without running guards (no vue-router START sentinel — [V01.01.08.07], #219), so the BeforeEach
+        // root redirect cannot fire for a page loaded directly at "/". Map it to the top feed here; the
+        // guard still handles in-session navigations to "/" (e.g. the logo).
+        var initialLocation = history.Location is "/" or "" ? "/top" : history.Location;
+        await router.Replace(initialLocation);
+
+        // A per-app store registry, provided app-wide so UseStore() resolves through component context;
+        // the store-definitions container and the router are provided under their injection keys.
+        var registry = new StoreRegistry();
+        BrowserRuntime.CreateApp(AppShell.Instance)
+            .Use(registry.AsPlugin<int>())
+            .Provide(HackerNewsStores.InjectionKey, stores)
+            .Provide(RouterInjectionKeys.Router, router)
+            .Mount("#app");
+
+        // Keep the WASM main loop alive; rendering is reactive from here.
+        await Task.Delay(Timeout.Infinite);
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Properties/AssemblyInfo.cs
+++ b/examples/Assimalign.Viu.HackerNews/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+// The app's testable surface (data client, stores, route table, view models) is internal — an app
+// exposes no public API — and the sibling test project drives it through the Testing renderer and
+// memory-history router. Deliberately NO assembly-level [SupportedOSPlatform("browser")]: only the
+// bootstrap (Program.Main) touches browser-only interop and is marked there, so every logic-bearing
+// type stays platform-neutral and referenceable from the (host-run) test project without CA1416.
+[assembly: InternalsVisibleTo("Assimalign.Viu.HackerNews.Tests")]

--- a/examples/Assimalign.Viu.HackerNews/Properties/launchSettings.json
+++ b/examples/Assimalign.Viu.HackerNews/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+    "profiles": {
+      "Assimalign.Viu.HackerNews": {
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "https://localhost:7205;http://localhost:5233",
+        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}"
+      }
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/README.md
+++ b/examples/Assimalign.Viu.HackerNews/README.md
@@ -1,0 +1,113 @@
+# Assimalign.Viu.HackerNews
+
+The Wave-4 **exit demo** ([V01.01.13.06], #103): a HackerNews client that composes the whole W04
+surface together — the Viu counterpart of [vuejs/vue-hackernews-2.0](https://github.com/vuejs/vue-hackernews-2.0).
+It exercises, in one app:
+
+- **Routing** — `Assimalign.Viu.Router` with **web history**, plus the `Assimalign.Viu.Router.RuntimeDom`
+  **click bridge** installed at bootstrap so `RouterLink` navigations are client-side.
+- **Store** — a Pinia-style `Assimalign.Viu.Store` (`Store<TState>` member model over `[Reactive]`
+  state); *all* fetched state flows through stores, never through component fields.
+- **Async components** — the item/user route views are `AsyncComponents.DefineAsyncComponent`
+  definitions with loading/error components.
+- **Transitions** — story lists render under `TransitionGroup` (keyed rows; FLIP move animation).
+- **Networked data** — `HttpClient` + **source-generated** `System.Text.Json` against the public
+  HackerNews API (reflection-free; trimming/AOT-safe).
+- **Styling** — `.viu` `@style` bundles compiled into the fingerprinted, **auto-injected** CSS
+  `<link>` (no manual stylesheet tag).
+
+## Run it
+
+```sh
+dotnet run --project examples/Assimalign.Viu.HackerNews
+```
+
+(Requires the `wasm-tools` workload: `dotnet workload install wasm-tools`.) The app fetches live data
+from `https://hacker-news.firebaseio.com/v0/`, which sends permissive CORS headers.
+
+## Routes
+
+| Path | Name | View | Notes |
+| --- | --- | --- | --- |
+| `/:feed/:page(\d+)?` | `feed` | `StoriesView` | Feed ∈ top/new/show/ask/jobs; optional numeric page. Paged, 20/page. |
+| `/item/:id(\d+)` | `item` | `ItemView` (async) | Story header + a bounded recursive comment tree. |
+| `/user/:id` | `user` | `UserView` (async) | User profile. |
+| `/:pathMatch(.*)*` | `not-found` | `NotFoundView` | Catch-all 404. |
+
+`/` is mapped to `/top` at bootstrap, and a `beforeEach` guard redirects in-session navigations to `/`
+(e.g. the logo) to `/top`.
+
+## Architecture
+
+```
+Data/     StoryFeed(+StoryFeeds mapping) · HackerNewsItem/HackerNewsUser/CommentNode (domain records)
+          IHackerNewsClient (the injectable seam) · HackerNewsClient (live: HttpClient + source-gen JSON)
+          Internal/ ItemPayload, UserPayload (DTOs) + HackerNewsJsonSerializerContext (source generator)
+Stores/   StoriesStore/ItemStore/UserStore (+ their [Reactive] *State) · HackerNewsStores (definitions container)
+Views/    AppShell · StoriesView · ItemView · UserView · NotFoundView · StoryItem · CommentView (recursive)
+          LoadingView · ErrorView · Ui (render helpers + shared RouterLink/RouterView singletons) · HtmlText
+Routing/  AppRoutes (route table + root-redirect guard)
+Styles/   app.viu · stories.viu · item.viu  (@style bundles)
+Program.cs  browser bootstrap (the only [SupportedOSPlatform("browser")] type)
+```
+
+**Data flow.** Views inject the router and the `HackerNewsStores` container, resolve their store with
+`UseStore()`, and drive it from a route-watching effect (`Reactive.Watch(..., Immediate)`), so the
+initial mount and every navigation fetch. Loading and error are explicit `[Reactive]` state; a
+superseded load is cancelled so navigation never leaves a stale page. Story lists render as **keyed**
+rows (stable `Id`), with no per-item interop — a list-virtualization strategy can be added later
+without touching the views. Nothing touches the DOM or interop during setup/render (SSR-ready): the
+data client is the only I/O boundary, behind the `IHackerNewsClient` seam.
+
+**Injectable data client.** `IHackerNewsClient` is the swap point the acceptance criteria call for:
+`Program` binds the live `HackerNewsClient`; the tests bind a `FakeHackerNewsClient`. A prerenderer
+would bind its own.
+
+## The source-generated JSON pattern (first networked Viu sample)
+
+Reflection-based `System.Text.Json` is **forbidden** by the repo's AOT rules — the reflection
+`Deserialize<T>(string, JsonSerializerOptions)` overloads are `[RequiresUnreferencedCode]`/
+`[RequiresDynamicCode]` and fail the trimmed publish under `-warnaserror`. This sample establishes the
+sanctioned pattern:
+
+1. Wire DTOs (`ItemPayload`, `UserPayload`) into a `JsonSerializerContext` with
+   `[JsonSerializable(...)]` (`Data/Internal/HackerNewsJsonSerializerContext.cs`).
+2. Deserialize through the generated `JsonTypeInfo<T>` — `JsonSerializer.Deserialize(json,
+   HackerNewsJsonSerializerContext.Default.ItemPayload)` — which carries no reflection/codegen
+   requirement.
+3. The feed endpoints return a bare JSON array of ids, read with reflection-free `JsonDocument.Parse`.
+
+The trimmed publish is clean under `-warnaserror` and stays within the size budget
+(`scripts/budgets/PublishBudgets.json`).
+
+## Tests
+
+`../Assimalign.Viu.HackerNews.Tests` drives the plain-Viu logic through the `Assimalign.Viu.Testing`
+renderer and a **memory-history** router (no network, no browser):
+
+- **Route table** resolution and the root-redirect guard (`RouteTableTests`).
+- **Store behavior** with the fake client: loading/error modeling, filtering, pagination, the feed
+  cache, comment-tree assembly, and superseded-load cancellation (`StoreTests`).
+- **View rendering**: the story list from store state, and the loading/error/unknown-feed states
+  (`ViewTests`).
+
+```sh
+dotnet test examples/Assimalign.Viu.HackerNews.Tests
+```
+
+## Why `.viu` is CSS-only today
+
+The logic-bearing components are C# `IComponentDefinition` render functions (like the `WebApp`
+sample's `StopwatchApplication`), and the `.viu` files carry only `@style` blocks. That is a current
+framework limitation, not a preference: the `.viu` single-file-component generator emits a `partial
+class` with a static `Render(...)` method but **no `IComponentDefinition`/`Setup` bridge**, so a
+`.viu` file cannot yet be authored as a mountable component (tracked by [V01.01.06.07], #216).
+The `.viu` `@style` blocks are global (unscoped) selectors matched by class name — scoped CSS relies
+on the renderer stamping a scope id onto a component *generated from* the `.viu`, which the same gap
+blocks. When the SFC→component bridge lands, these views can migrate to full `.viu` components with
+scoped `<template>`s with no change to the app's shape.
+
+## Deep-link hosting note
+
+Web history produces clean URLs (`/item/8863`). A production static host must serve `index.html` for
+unknown routes (SPA fallback); the `dotnet run` dev server already does.

--- a/examples/Assimalign.Viu.HackerNews/Routing/AppRoutes.cs
+++ b/examples/Assimalign.Viu.HackerNews/Routing/AppRoutes.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Router;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The route table and the root-redirect guard, factored out of bootstrap so both the browser app
+/// (web history) and the tests (memory history) build the same routes. Three distinct route groups
+/// satisfy #103: the paged story lists, item detail, and user pages.
+/// <para>
+/// The item and user routes are <b>async components</b> (<see cref="AsyncComponents.DefineAsyncComponent"/>):
+/// their loader resolves the already-authored view definition. Lazy route views are the vue-hn shape;
+/// Viu has no per-view assembly code-splitting yet ([V01.01.08.05]), so this exercises the
+/// async-component runtime-resolution contract and its loading/error UI, not a network download.
+/// </para>
+/// </summary>
+internal static class AppRoutes
+{
+    private static readonly IComponentDefinition ItemRouteComponent = AsyncComponents.DefineAsyncComponent(
+        new AsyncComponentOptions
+        {
+            Loader = () => Task.FromResult<IComponentDefinition>(ItemView.Instance),
+            LoadingComponent = LoadingView.Instance,
+            ErrorComponent = ErrorView.Instance,
+        });
+
+    private static readonly IComponentDefinition UserRouteComponent = AsyncComponents.DefineAsyncComponent(
+        new AsyncComponentOptions
+        {
+            Loader = () => Task.FromResult<IComponentDefinition>(UserView.Instance),
+            LoadingComponent = LoadingView.Instance,
+            ErrorComponent = ErrorView.Instance,
+        });
+
+    /// <summary>Builds the route table (fresh records each call so history and matcher stay independent).</summary>
+    /// <returns>The routes: feed lists, item detail, user page, and a catch-all.</returns>
+    public static IReadOnlyList<RouteRecord> Create() =>
+    [
+        // Story lists: /top, /new/2, /show, /ask, /jobs/3 … (page optional, numeric).
+        new RouteRecord(
+            "/:feed/:page(\\d+)?",
+            name: "feed",
+            component: StoriesView.Instance,
+            propertiesResolver: RouteComponentProperties.FromParameters()),
+
+        // Item detail with the comment tree.
+        new RouteRecord(
+            "/item/:id(\\d+)",
+            name: "item",
+            component: ItemRouteComponent,
+            propertiesResolver: RouteComponentProperties.FromParameters()),
+
+        // User profile.
+        new RouteRecord(
+            "/user/:id",
+            name: "user",
+            component: UserRouteComponent,
+            propertiesResolver: RouteComponentProperties.FromParameters()),
+
+        // Catch-all → 404.
+        new RouteRecord(
+            "/:pathMatch(.*)*",
+            name: "not-found",
+            component: NotFoundView.Instance),
+    ];
+
+    /// <summary>
+    /// Redirects the bare root <c>/</c> to the top feed. <see cref="RouteRecord"/> carries no redirect
+    /// field, so — as vue-router does for redirects that depend on the target — this is a global
+    /// <c>beforeEach</c> guard.
+    /// </summary>
+    /// <param name="to">The target location.</param>
+    /// <param name="from">The current location.</param>
+    /// <param name="cancellationToken">Cancels the guard.</param>
+    /// <returns>A redirect to <c>/top</c> at the root, otherwise allow.</returns>
+    public static Task<NavigationGuardResult> RedirectRoot(RouteLocation to, RouteLocation from, CancellationToken cancellationToken)
+        => Task.FromResult(to.Path is "/" or ""
+            ? NavigationGuardResult.RedirectTo("/top")
+            : NavigationGuardResult.Allow);
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/HackerNewsStores.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/HackerNewsStores.cs
@@ -1,0 +1,39 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Store;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The app's store definitions, built once over an injected <see cref="IHackerNewsClient"/> and
+/// provided app-wide under <see cref="InjectionKey"/>. This is how the injectable data client reaches
+/// the stores while keeping <c>UseStore()</c> component-context resolution intact: the browser app
+/// builds one over the live client, tests build one over a fake, and both provide it to the tree.
+/// Each <see cref="StoreDefinition{TStore}"/> is resolved lazily and once per registry.
+/// </summary>
+internal sealed class HackerNewsStores
+{
+    /// <summary>The provide/inject key components resolve the store definitions under.</summary>
+    public static readonly InjectionKey<HackerNewsStores> InjectionKey = new("hn:stores");
+
+    /// <summary>Creates the definitions over <paramref name="client"/>.</summary>
+    /// <param name="client">The data client every store reads through.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is null.</exception>
+    public HackerNewsStores(IHackerNewsClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        Stories = Assimalign.Viu.Store.Stores.DefineStore("stories", () => new StoriesStore(client));
+        Item = Assimalign.Viu.Store.Stores.DefineStore("item", () => new ItemStore(client));
+        User = Assimalign.Viu.Store.Stores.DefineStore("user", () => new UserStore(client));
+    }
+
+    /// <summary>The paged story-list store definition.</summary>
+    public StoreDefinition<StoriesStore> Stories { get; }
+
+    /// <summary>The item-detail store definition.</summary>
+    public StoreDefinition<ItemStore> Item { get; }
+
+    /// <summary>The user-profile store definition.</summary>
+    public StoreDefinition<UserStore> User { get; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/ItemState.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/ItemState.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The reactive state of <see cref="ItemStore"/> — one story and its bounded comment tree, plus
+/// explicit loading/error. Per-member reactivity means the header and the comment tree re-render
+/// independently as each lands.
+/// </summary>
+[Reactive]
+internal partial class ItemState
+{
+    /// <summary>The item id currently being shown.</summary>
+    public partial long ActiveId { get; set; }
+
+    /// <summary>The loaded story/item, or null while loading or when missing.</summary>
+    public partial HackerNewsItem? Story { get; set; }
+
+    /// <summary>The loaded comment tree (bounded depth/count), each node keyed by its comment id.</summary>
+    public partial IReadOnlyList<CommentNode> Comments { get; set; }
+
+    /// <summary>Whether a load is in flight.</summary>
+    public partial bool IsLoading { get; set; }
+
+    /// <summary>The last load error message, or null (includes the "not found" case).</summary>
+    public partial string? Error { get; set; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/ItemStore.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/ItemStore.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Store;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The Pinia-style store for the item-detail page — a story and its comment thread (the C# port of
+/// vue-hackernews-2.0's item view). It assembles a comment <b>tree</b> from the flat HackerNews item
+/// graph, bounded by <see cref="MaxDepth"/> and <see cref="MaxTotalComments"/> so a large thread
+/// never triggers a client-side fetch storm. Loading and error are explicit state; a superseded load
+/// is cancelled.
+/// </summary>
+internal sealed class ItemStore : Store<ItemState>
+{
+    /// <summary>How many comment levels to fetch (top level + replies).</summary>
+    public const int MaxDepth = 2;
+
+    /// <summary>The ceiling on total comment fetches per thread (bounds network on huge threads).</summary>
+    public const int MaxTotalComments = 60;
+
+    private readonly IHackerNewsClient _client;
+    private CancellationTokenSource? _inFlight;
+
+    /// <summary>Creates the store over <paramref name="client"/>.</summary>
+    /// <param name="client">The data client all reads go through.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is null.</exception>
+    public ItemStore(IHackerNewsClient client)
+        : base(
+            "item",
+            static () => new ItemState
+            {
+                ActiveId = 0,
+                Story = null,
+                Comments = Array.Empty<CommentNode>(),
+                IsLoading = false,
+                Error = null,
+            },
+            static (target, source) =>
+            {
+                target.ActiveId = source.ActiveId;
+                target.Story = source.Story;
+                target.Comments = source.Comments;
+                target.IsLoading = source.IsLoading;
+                target.Error = source.Error;
+            })
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+    }
+
+    /// <summary>
+    /// Loads the story <paramref name="id"/> and its bounded comment tree, modeling loading and error
+    /// as state. A newer call cancels an in-flight older one. Never throws.
+    /// </summary>
+    /// <param name="id">The story/item id.</param>
+    public async Task LoadItemAsync(long id)
+    {
+        _inFlight?.Cancel();
+        _inFlight?.Dispose();
+        var cancellation = new CancellationTokenSource();
+        _inFlight = cancellation;
+        var token = cancellation.Token;
+
+        Patch(state =>
+        {
+            state.ActiveId = id;
+            state.Story = null;
+            state.Comments = Array.Empty<CommentNode>();
+            state.IsLoading = true;
+            state.Error = null;
+        });
+
+        try
+        {
+            var story = await _client.GetItemAsync(id, token);
+            token.ThrowIfCancellationRequested();
+            if (story is null)
+            {
+                Patch(state =>
+                {
+                    state.IsLoading = false;
+                    state.Error = "That item does not exist.";
+                });
+                return;
+            }
+
+            var budget = new int[] { MaxTotalComments };
+            var comments = await BuildTreeAsync(story.Kids, depth: 1, budget, token);
+            token.ThrowIfCancellationRequested();
+
+            Patch(state =>
+            {
+                state.Story = story;
+                state.Comments = comments;
+                state.IsLoading = false;
+                state.Error = null;
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load.
+        }
+        catch (Exception exception)
+        {
+            if (!token.IsCancellationRequested)
+            {
+                Patch(state =>
+                {
+                    state.IsLoading = false;
+                    state.Error = exception.Message;
+                });
+            }
+        }
+    }
+
+    // Depth-first, level-parallel, budget-bounded assembly of the comment tree from the flat item graph.
+    private async Task<IReadOnlyList<CommentNode>> BuildTreeAsync(
+        IReadOnlyList<long> kids,
+        int depth,
+        int[] budget,
+        CancellationToken token)
+    {
+        if (kids.Count == 0 || depth > MaxDepth || budget[0] <= 0)
+        {
+            return Array.Empty<CommentNode>();
+        }
+
+        var take = Math.Min(kids.Count, budget[0]);
+        var pending = new Task<HackerNewsItem?>[take];
+        for (var index = 0; index < take; index++)
+        {
+            pending[index] = _client.GetItemAsync(kids[index], token);
+        }
+        var fetched = await Task.WhenAll(pending);
+        budget[0] -= take;
+
+        var nodes = new List<CommentNode>(take);
+        foreach (var comment in fetched)
+        {
+            if (comment is null || comment.Deleted || comment.Dead)
+            {
+                continue;
+            }
+            var replies = depth < MaxDepth
+                ? await BuildTreeAsync(comment.Kids, depth + 1, budget, token)
+                : Array.Empty<CommentNode>();
+            var hasMoreReplies = comment.Kids.Count > replies.Count;
+            nodes.Add(new CommentNode(comment, replies, hasMoreReplies));
+        }
+        return nodes;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/StoriesState.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/StoriesState.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The reactive state of <see cref="StoriesStore"/> — the current feed page. The
+/// <c>[Reactive]</c> source generator (Vue's <c>reactive()</c>, no proxy) emits per-member
+/// dependencies, so a view reading <see cref="Items"/> re-renders only when the list is replaced,
+/// and a view reading <see cref="IsLoading"/> re-renders only when loading flips. Loading and error
+/// are modeled as explicit state (#103), never thrown out of the store.
+/// </summary>
+[Reactive]
+internal partial class StoriesState
+{
+    /// <summary>The feed the current page belongs to.</summary>
+    public partial StoryFeed ActiveFeed { get; set; }
+
+    /// <summary>The 1-based page number.</summary>
+    public partial int ActivePage { get; set; }
+
+    /// <summary>The total story count in the active feed (drives pagination bounds).</summary>
+    public partial int TotalCount { get; set; }
+
+    /// <summary>Whether a load is in flight.</summary>
+    public partial bool IsLoading { get; set; }
+
+    /// <summary>The last load error message, or null.</summary>
+    public partial string? Error { get; set; }
+
+    /// <summary>The stories on the current page, in rank order, each with a stable <see cref="HackerNewsItem.Id"/>.</summary>
+    public partial IReadOnlyList<HackerNewsItem> Items { get; set; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/StoriesStore.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/StoriesStore.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Store;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The Pinia-style store for the paged story lists (top/new/show/ask/jobs) — the C# port of
+/// vue-hackernews-2.0's list module. All fetched list state flows through here, never through
+/// per-component fields (#103): a view calls <see cref="LoadPageAsync"/> and renders from
+/// <see cref="Store{TState}.State"/>. Built on the <c>Store&lt;TState&gt;</c> member model over
+/// <see cref="StoriesState"/>, with a computed getter (<see cref="PageCount"/>) and the load action.
+/// </summary>
+internal sealed class StoriesStore : Store<StoriesState>
+{
+    /// <summary>Stories per page (vue-hackernews-2.0 parity).</summary>
+    public const int PageSize = 20;
+
+    private readonly IHackerNewsClient _client;
+
+    // The feed id-lists are large and stable within a session; cache them so paging within a feed
+    // fetches only the page's items, not the ranking again. Non-reactive: it is a fetch cache, not view state.
+    private readonly Dictionary<StoryFeed, IReadOnlyList<long>> _feedCache = new();
+
+    // Cancels a superseded load so a slow earlier page cannot clobber a newer one's state.
+    private CancellationTokenSource? _inFlight;
+
+    /// <summary>Creates the store over <paramref name="client"/>.</summary>
+    /// <param name="client">The data client all reads go through.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is null.</exception>
+    public StoriesStore(IHackerNewsClient client)
+        : base(
+            "stories",
+            static () => new StoriesState
+            {
+                ActiveFeed = StoryFeed.Top,
+                ActivePage = 1,
+                TotalCount = 0,
+                IsLoading = false,
+                Error = null,
+                Items = Array.Empty<HackerNewsItem>(),
+            },
+            static (target, source) =>
+            {
+                target.ActiveFeed = source.ActiveFeed;
+                target.ActivePage = source.ActivePage;
+                target.TotalCount = source.TotalCount;
+                target.IsLoading = source.IsLoading;
+                target.Error = source.Error;
+                target.Items = source.Items;
+            })
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+        PageCount = Reactive.Computed(() =>
+        {
+            var total = State.TotalCount;
+            return total <= 0 ? 0 : (total + PageSize - 1) / PageSize;
+        });
+    }
+
+    /// <summary>The number of pages in the active feed (a computed getter over <see cref="StoriesState.TotalCount"/>).</summary>
+    public Computed<int> PageCount { get; }
+
+    /// <summary>
+    /// Loads page <paramref name="page"/> of <paramref name="feed"/> into the store, modeling loading
+    /// and error as state. A newer call cancels an in-flight older one, so navigation never leaves a
+    /// stale page rendered. Never throws — a failure lands in <see cref="StoriesState.Error"/>.
+    /// </summary>
+    /// <param name="feed">The feed to load.</param>
+    /// <param name="page">The 1-based page number (clamped to at least 1).</param>
+    public async Task LoadPageAsync(StoryFeed feed, int page)
+    {
+        if (page < 1)
+        {
+            page = 1;
+        }
+
+        _inFlight?.Cancel();
+        _inFlight?.Dispose();
+        var cancellation = new CancellationTokenSource();
+        _inFlight = cancellation;
+        var token = cancellation.Token;
+
+        Patch(state =>
+        {
+            state.ActiveFeed = feed;
+            state.ActivePage = page;
+            state.IsLoading = true;
+            state.Error = null;
+        });
+
+        try
+        {
+            if (!_feedCache.TryGetValue(feed, out var ids))
+            {
+                ids = await _client.GetFeedAsync(feed, token);
+                token.ThrowIfCancellationRequested();
+                _feedCache[feed] = ids;
+            }
+
+            var start = (page - 1) * PageSize;
+            var pageIds = new List<long>(PageSize);
+            for (var index = start; index < ids.Count && index < start + PageSize; index++)
+            {
+                pageIds.Add(ids[index]);
+            }
+
+            var items = await FetchItemsAsync(pageIds, token);
+            token.ThrowIfCancellationRequested();
+
+            Patch(state =>
+            {
+                state.TotalCount = ids.Count;
+                state.Items = items;
+                state.IsLoading = false;
+                state.Error = null;
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; the newer load owns the state.
+        }
+        catch (Exception exception)
+        {
+            if (!token.IsCancellationRequested)
+            {
+                Patch(state =>
+                {
+                    state.IsLoading = false;
+                    state.Error = exception.Message;
+                });
+            }
+        }
+    }
+
+    // Fetches the page's items concurrently (fetch is async I/O; this respects the single-threaded WASM
+    // loop — no blocking waits) and preserves rank order, dropping deleted/dead items and holes.
+    private async Task<IReadOnlyList<HackerNewsItem>> FetchItemsAsync(IReadOnlyList<long> ids, CancellationToken token)
+    {
+        if (ids.Count == 0)
+        {
+            return Array.Empty<HackerNewsItem>();
+        }
+        var pending = new Task<HackerNewsItem?>[ids.Count];
+        for (var index = 0; index < ids.Count; index++)
+        {
+            pending[index] = _client.GetItemAsync(ids[index], token);
+        }
+        var fetched = await Task.WhenAll(pending);
+        var items = new List<HackerNewsItem>(fetched.Length);
+        foreach (var item in fetched)
+        {
+            if (item is not null && !item.Deleted && !item.Dead)
+            {
+                items.Add(item);
+            }
+        }
+        return items;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/UserState.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/UserState.cs
@@ -1,0 +1,22 @@
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The reactive state of <see cref="UserStore"/> — one user profile, with explicit loading/error.
+/// </summary>
+[Reactive]
+internal partial class UserState
+{
+    /// <summary>The user id currently being shown.</summary>
+    public partial string? ActiveId { get; set; }
+
+    /// <summary>The loaded profile, or null while loading or when missing.</summary>
+    public partial HackerNewsUser? Profile { get; set; }
+
+    /// <summary>Whether a load is in flight.</summary>
+    public partial bool IsLoading { get; set; }
+
+    /// <summary>The last load error message, or null (includes the "not found" case).</summary>
+    public partial string? Error { get; set; }
+}

--- a/examples/Assimalign.Viu.HackerNews/Stores/UserStore.cs
+++ b/examples/Assimalign.Viu.HackerNews/Stores/UserStore.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Store;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The Pinia-style store for the user page (the C# port of vue-hackernews-2.0's user view). Loads a
+/// single profile with explicit loading/error state; a superseded load is cancelled. Never throws.
+/// </summary>
+internal sealed class UserStore : Store<UserState>
+{
+    private readonly IHackerNewsClient _client;
+    private CancellationTokenSource? _inFlight;
+
+    /// <summary>Creates the store over <paramref name="client"/>.</summary>
+    /// <param name="client">The data client all reads go through.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="client"/> is null.</exception>
+    public UserStore(IHackerNewsClient client)
+        : base(
+            "user",
+            static () => new UserState
+            {
+                ActiveId = null,
+                Profile = null,
+                IsLoading = false,
+                Error = null,
+            },
+            static (target, source) =>
+            {
+                target.ActiveId = source.ActiveId;
+                target.Profile = source.Profile;
+                target.IsLoading = source.IsLoading;
+                target.Error = source.Error;
+            })
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+    }
+
+    /// <summary>
+    /// Loads the profile for <paramref name="id"/>, modeling loading and error as state. A newer call
+    /// cancels an in-flight older one. Never throws.
+    /// </summary>
+    /// <param name="id">The case-sensitive user id.</param>
+    public async Task LoadUserAsync(string id)
+    {
+        _inFlight?.Cancel();
+        _inFlight?.Dispose();
+        var cancellation = new CancellationTokenSource();
+        _inFlight = cancellation;
+        var token = cancellation.Token;
+
+        Patch(state =>
+        {
+            state.ActiveId = id;
+            state.Profile = null;
+            state.IsLoading = true;
+            state.Error = null;
+        });
+
+        try
+        {
+            var profile = string.IsNullOrEmpty(id) ? null : await _client.GetUserAsync(id, token);
+            token.ThrowIfCancellationRequested();
+            Patch(state =>
+            {
+                state.Profile = profile;
+                state.IsLoading = false;
+                state.Error = profile is null ? "That user does not exist." : null;
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load.
+        }
+        catch (Exception exception)
+        {
+            if (!token.IsCancellationRequested)
+            {
+                Patch(state =>
+                {
+                    state.IsLoading = false;
+                    state.Error = exception.Message;
+                });
+            }
+        }
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Styles/app.viu
+++ b/examples/Assimalign.Viu.HackerNews/Styles/app.viu
@@ -1,0 +1,136 @@
+@style {
+    /* App chrome, view frame, loading/error, and user page. Authored as .viu @style blocks so the
+       ViuBundleCss task compiles every **/*.viu into the fingerprinted
+       Assimalign.Viu.HackerNews.viu.css bundle, whose <link> the build auto-injects into index.html
+       (no manual stylesheet tag). These are global (unscoped) selectors matched by class name, because
+       the logic-bearing components are C# render functions rather than generated .viu components —
+       see README.md "Why .viu is CSS-only today". */
+
+    .hn-app {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+    }
+
+    .hn-header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        padding: 0.5rem 1rem;
+        background: var(--hn-header);
+    }
+
+    .hn-logo {
+        font-weight: 700;
+        color: #ffffff;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .hn-logo:hover {
+        text-decoration: none;
+    }
+
+    .hn-logo-mark {
+        display: inline-grid;
+        place-items: center;
+        width: 1.25rem;
+        height: 1.25rem;
+        border: 1px solid #ffffff;
+        color: #ffffff;
+        font-size: 0.85rem;
+        line-height: 1;
+    }
+
+    .hn-tabs {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .hn-tab {
+        color: #ffffff;
+        font-weight: 600;
+        opacity: 0.9;
+    }
+
+    .hn-tab.router-link-active {
+        text-decoration: underline;
+        opacity: 1;
+    }
+
+    .hn-main {
+        flex: 1;
+        padding: 1rem;
+    }
+
+    .hn-footer {
+        display: block;
+        padding: 1rem;
+        border-top: 1px solid var(--hn-border);
+        color: var(--hn-muted);
+        font-size: 0.8rem;
+        text-align: center;
+    }
+
+    .hn-view-title {
+        font-size: 1.1rem;
+        margin: 0 0 1rem;
+    }
+
+    .hn-empty {
+        color: var(--hn-muted);
+    }
+
+    .hn-back-link {
+        color: var(--hn-orange);
+        font-weight: 600;
+    }
+
+    .hn-loading {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 2rem 0;
+        color: var(--hn-muted);
+    }
+
+    .hn-spinner {
+        width: 1.1rem;
+        height: 1.1rem;
+        border: 2px solid var(--hn-border);
+        border-top-color: var(--hn-orange);
+        border-radius: 50%;
+        animation: hn-spin 0.8s linear infinite;
+    }
+
+    @keyframes hn-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+
+    .hn-error {
+        padding: 1rem;
+        border: 1px solid #f0c0a8;
+        background: #fff3ec;
+        color: #a8340a;
+        border-radius: 4px;
+    }
+
+    .hn-user-meta {
+        color: var(--hn-muted);
+        margin-bottom: 1rem;
+    }
+
+    .hn-user-about {
+        margin-bottom: 1rem;
+    }
+
+    .hn-external-profile {
+        color: var(--hn-orange);
+        font-weight: 600;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Styles/item.viu
+++ b/examples/Assimalign.Viu.HackerNews/Styles/item.viu
@@ -1,0 +1,82 @@
+@style {
+    /* Item detail header and the recursive comment tree. */
+
+    .hn-item-header {
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--hn-border);
+        margin-bottom: 1rem;
+    }
+
+    .hn-item-head {
+        margin: 0 0 0.25rem;
+        font-size: 1.15rem;
+    }
+
+    .hn-item-title {
+        color: var(--hn-text);
+    }
+
+    .hn-item-meta {
+        color: var(--hn-muted);
+        font-size: 0.85rem;
+    }
+
+    .hn-item-text {
+        margin-top: 0.75rem;
+        color: var(--hn-text);
+    }
+
+    .hn-comments-heading {
+        font-size: 1rem;
+        margin: 0 0 0.75rem;
+    }
+
+    .hn-comments,
+    .hn-replies {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .hn-comment {
+        padding: 0.6rem 0;
+        border-top: 1px solid var(--hn-border);
+    }
+
+    .hn-comment-meta {
+        color: var(--hn-muted);
+        font-size: 0.8rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .hn-comment-meta .hn-by {
+        color: var(--hn-muted);
+        font-weight: 600;
+    }
+
+    .hn-comment-text {
+        font-size: 0.9rem;
+    }
+
+    .hn-comment-text p {
+        margin: 0 0 0.5rem;
+    }
+
+    .hn-comment-empty {
+        color: var(--hn-muted);
+        font-style: italic;
+    }
+
+    .hn-replies {
+        margin-left: 1rem;
+        padding-left: 0.75rem;
+        border-left: 2px solid var(--hn-border);
+    }
+
+    .hn-more-replies {
+        display: inline-block;
+        margin-top: 0.35rem;
+        color: var(--hn-orange);
+        font-size: 0.8rem;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Styles/stories.viu
+++ b/examples/Assimalign.Viu.HackerNews/Styles/stories.viu
@@ -1,0 +1,99 @@
+@style {
+    /* Story list, rows, pagination — and the TransitionGroup list choreography. The list is a
+       <TransitionGroup name="story">, so rows animate on enter/leave and FLIP-move on reorder using
+       the story-enter-*/story-leave-*/story-move classes below. */
+
+    .hn-stories {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .hn-story {
+        display: flex;
+        gap: 0.5rem;
+        padding: 0.4rem 0;
+        align-items: baseline;
+    }
+
+    .hn-rank {
+        color: var(--hn-muted);
+        min-width: 1.6rem;
+        text-align: right;
+    }
+
+    .hn-story-body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+    }
+
+    .hn-story-title {
+        color: var(--hn-text);
+        font-size: 0.95rem;
+    }
+
+    .hn-story-host {
+        color: var(--hn-muted);
+        font-size: 0.8rem;
+    }
+
+    .hn-subtext {
+        color: var(--hn-muted);
+        font-size: 0.8rem;
+    }
+
+    .hn-subtext .hn-by,
+    .hn-subtext .hn-comments-link {
+        color: var(--hn-muted);
+    }
+
+    .hn-subtext .hn-by:hover,
+    .hn-subtext .hn-comments-link:hover {
+        color: var(--hn-orange);
+    }
+
+    .hn-pagination {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-top: 1rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--hn-border);
+    }
+
+    .hn-page-link {
+        color: var(--hn-orange);
+        font-weight: 600;
+    }
+
+    .hn-page-link.hn-disabled {
+        color: var(--hn-border);
+        cursor: default;
+    }
+
+    .hn-page-info {
+        color: var(--hn-muted);
+        font-size: 0.85rem;
+    }
+
+    /* TransitionGroup: rows fade+slide on enter/leave, and slide (FLIP) on reorder. */
+    .story-enter-active,
+    .story-leave-active {
+        transition: all 0.4s ease;
+    }
+
+    .story-enter-from,
+    .story-leave-to {
+        opacity: 0;
+        transform: translateX(1.5rem);
+    }
+
+    .story-leave-active {
+        position: absolute;
+    }
+
+    .story-move {
+        transition: transform 0.4s ease;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/AppShell.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/AppShell.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The application root: the HackerNews-style header (logo + feed tabs, all
+/// <see cref="Router.RouterLink"/>s so navigation is client-side through the router) wrapped around
+/// the single <see cref="Router.RouterView"/> outlet that renders the matched route. The whole page
+/// chrome mirrors vuejs/vue-hackernews-2.0's <c>App.vue</c>.
+/// </summary>
+internal sealed class AppShell : IComponentDefinition
+{
+    /// <summary>The shared root definition instance.</summary>
+    public static readonly AppShell Instance = new();
+
+    private AppShell()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "AppShell";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("class", "hn-app")),
+            Header(),
+            VirtualNodeFactory.Element(
+                "main",
+                VirtualNodeFactory.Properties(("class", "hn-main")),
+                VirtualNodeFactory.Component(Ui.RouterView)),
+            Ui.Text("footer", "hn-footer", "Built with Viu — a C#/.NET port of Vue 3. Data from the HackerNews API."));
+
+    private static VirtualNode Header()
+    {
+        var tabs = new List<VirtualNode?>(StoryFeeds.All.Length);
+        foreach (var feed in StoryFeeds.All)
+        {
+            tabs.Add(Ui.Link(Ui.FeedPath(feed, 1), "hn-tab", StoryFeeds.ToLabel(feed)));
+        }
+
+        return VirtualNodeFactory.Element(
+            "header",
+            VirtualNodeFactory.Properties(("class", "hn-header")),
+            // The logo links to "/" so clicking it exercises the BeforeEach root-redirect guard (→ /top).
+            Ui.Link("/", "hn-logo", VirtualNodeFactory.Element("span", VirtualNodeFactory.Properties(("class", "hn-logo-mark")), "Y"), VirtualNodeFactory.Text(" Viu HN")),
+            VirtualNodeFactory.Element("nav", VirtualNodeFactory.Properties(("class", "hn-tabs")), tabs.ToArray()));
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/CommentView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/CommentView.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// A single node in the comment tree, rendered recursively — the C# port of vue-hackernews-2.0's
+/// <c>Comment.vue</c>. A shared, stateless definition that references itself for replies; each node
+/// vnode is keyed by its comment id so the tree reconciles by identity. Comment HTML is rendered as
+/// safe plain-text paragraphs (see <see cref="HtmlText"/>).
+/// </summary>
+internal sealed class CommentView : IComponentDefinition
+{
+    /// <summary>The shared comment definition instance (also the recursion target).</summary>
+    public static readonly CommentView Instance = new();
+
+    private CommentView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "CommentView";
+
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties { get; } =
+    [
+        new ComponentPropertyDefinition("node") { Required = true },
+    ];
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () =>
+        {
+            var node = properties.Get<CommentNode>("node");
+            if (node is null)
+            {
+                return VirtualNodeFactory.Comment();
+            }
+            var comment = node.Comment;
+
+            var children = new List<VirtualNode?>(3)
+            {
+                VirtualNodeFactory.Element(
+                    "div",
+                    VirtualNodeFactory.Properties(("class", "hn-comment-meta")),
+                    Ui.Link($"/user/{comment.By}", "hn-by", comment.By ?? "unknown"),
+                    Ui.Text("span", "hn-comment-time", $" · {Ui.TimeAgo(comment.Time)}")),
+                Body(comment.Text),
+            };
+
+            var replies = Replies(node);
+            if (replies is not null)
+            {
+                children.Add(replies);
+            }
+
+            return VirtualNodeFactory.Element(
+                "li",
+                VirtualNodeFactory.Properties(("class", "hn-comment")),
+                children.ToArray());
+        };
+
+    private static VirtualNode Body(string? text)
+    {
+        var paragraphs = HtmlText.ToParagraphs(text);
+        if (paragraphs.Count == 0)
+        {
+            return Ui.Text("div", "hn-comment-text hn-comment-empty", "[no text]");
+        }
+        var nodes = new VirtualNode?[paragraphs.Count];
+        for (var index = 0; index < paragraphs.Count; index++)
+        {
+            nodes[index] = Ui.Text("p", null, paragraphs[index]);
+        }
+        return VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "hn-comment-text")), nodes);
+    }
+
+    private static VirtualNode? Replies(CommentNode node)
+    {
+        if (node.Replies.Count == 0)
+        {
+            return node.HasMoreReplies
+                ? Ui.Link($"/item/{node.Comment.Id}", "hn-more-replies", "more replies →")
+                : null;
+        }
+
+        var items = new VirtualNode?[node.Replies.Count];
+        for (var index = 0; index < node.Replies.Count; index++)
+        {
+            var reply = node.Replies[index];
+            items[index] = VirtualNodeFactory.Component(
+                Instance,
+                VirtualNodeFactory.Properties(("key", reply.Comment.Id), ("node", reply)));
+        }
+        return VirtualNodeFactory.Element("ul", VirtualNodeFactory.Properties(("class", "hn-replies")), items);
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/ErrorView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/ErrorView.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// An error banner, used both inline (with a <c>message</c> prop, when a store's load fails) and as
+/// the <c>ErrorComponent</c> of the async route components (which passes the failure as an
+/// <c>error</c> prop, per <see cref="AsyncComponents"/>).
+/// </summary>
+internal sealed class ErrorView : IComponentDefinition
+{
+    /// <summary>The shared error definition instance.</summary>
+    public static readonly ErrorView Instance = new();
+
+    private ErrorView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "ErrorView";
+
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties { get; } =
+    [
+        new ComponentPropertyDefinition("message"),
+        new ComponentPropertyDefinition("error"),
+    ];
+
+    /// <summary>Builds an inline error banner vnode with <paramref name="message"/>.</summary>
+    /// <param name="message">The message to show.</param>
+    public static VirtualNode Inline(string message)
+        => VirtualNodeFactory.Component(Instance, VirtualNodeFactory.Properties(("message", message)));
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () =>
+        {
+            var message = properties.Get<string>("message")
+                ?? (properties.Get<Exception>("error"))?.Message
+                ?? "Something went wrong.";
+            return VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Properties(("class", "hn-error"), ("role", "alert")),
+                Ui.Text("strong", null, "Couldn’t load this page. "),
+                Ui.Raw(message));
+        };
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/HtmlText.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/HtmlText.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// Turns HackerNews comment/post HTML into safe, renderer-agnostic plain-text paragraphs. The sample
+/// deliberately does <b>not</b> inject raw HTML (no <c>v-html</c>/<c>innerHTML</c>): that would be a
+/// DOM-only escape hatch and an XSS surface, at odds with the SSR-ready "render through the node-ops
+/// adapter only" boundary (#103). Tags are stripped and entities decoded so the text renders through
+/// ordinary text vnodes on any renderer (browser and the in-memory test renderer alike). The tag
+/// pattern is a <see cref="GeneratedRegexAttribute"/> so it is trimming/NativeAOT-safe (no runtime
+/// regex compilation).
+/// </summary>
+internal static partial class HtmlText
+{
+    [GeneratedRegex("<[^>]+>", RegexOptions.Singleline)]
+    private static partial Regex TagPattern();
+
+    /// <summary>
+    /// Splits <paramref name="html"/> into decoded, tag-free paragraphs (on <c>&lt;p&gt;</c>
+    /// boundaries). Empty/blank input yields an empty list.
+    /// </summary>
+    /// <param name="html">The source HTML, or null.</param>
+    /// <returns>The paragraphs, in order.</returns>
+    public static IReadOnlyList<string> ToParagraphs(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return Array.Empty<string>();
+        }
+
+        var withBreaks = html
+            .Replace("<p>", "\n\n", StringComparison.OrdinalIgnoreCase)
+            .Replace("</p>", "\n\n", StringComparison.OrdinalIgnoreCase);
+        var stripped = TagPattern().Replace(withBreaks, string.Empty);
+        var decoded = WebUtility.HtmlDecode(stripped);
+
+        var paragraphs = new List<string>();
+        foreach (var part in decoded.Split('\n'))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length > 0)
+            {
+                paragraphs.Add(trimmed);
+            }
+        }
+        return paragraphs;
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/ItemView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/ItemView.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Router;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The item-detail route (<c>/item/:id</c>) — the C# port of vue-hackernews-2.0's item view. Reads
+/// <c>:id</c> from the route, drives <see cref="ItemStore"/> through a route-watching effect, and
+/// renders the story header plus the recursive comment tree (<see cref="CommentView"/>). All state
+/// comes from the store. Wrapped as an async route component in <see cref="AppRoutes"/>.
+/// </summary>
+internal sealed class ItemView : IComponentDefinition
+{
+    /// <summary>The shared route-view definition instance.</summary>
+    public static readonly ItemView Instance = new();
+
+    private ItemView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "ItemView";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var router = DependencyInjection.Inject(RouterInjectionKeys.Router)!;
+        var stores = DependencyInjection.Inject(HackerNewsStores.InjectionKey)!;
+        var store = stores.Item.UseStore();
+
+        long ReadId() => router.CurrentRoute.Value.Parameters.TryGetInteger("id", out var id) ? id : 0;
+
+        Reactive.Watch(
+            ReadId,
+            (id, _, _) =>
+            {
+                if (id > 0)
+                {
+                    _ = store.LoadItemAsync(id);
+                }
+            },
+            new WatchOptions { Immediate = true });
+
+        return () =>
+        {
+            var state = store.State;
+            if (state.Error is not null)
+            {
+                return View(ErrorView.Inline(state.Error));
+            }
+            if (state.Story is null)
+            {
+                return View(VirtualNodeFactory.Component(LoadingView.Instance));
+            }
+            return View(Header(state.Story), Comments(state.Comments, state.Story));
+        };
+    }
+
+    private static VirtualNode View(params VirtualNode?[] children)
+        => VirtualNodeFactory.Element("section", VirtualNodeFactory.Properties(("class", "hn-view hn-item-view")), children);
+
+    private static VirtualNode Header(HackerNewsItem story)
+    {
+        var titleText = story.Title ?? "(untitled)";
+        var titleNode = story.Url is { Length: > 0 } url
+            ? Ui.ExternalLink(url, "hn-item-title", titleText)
+            : Ui.Text("span", "hn-item-title", titleText);
+
+        var head = new List<VirtualNode?>(2) { titleNode };
+        if (story.Host is { Length: > 0 } host)
+        {
+            head.Add(Ui.Text("span", "hn-story-host", $" ({host})"));
+        }
+
+        var meta = Ui.Text(
+            "div",
+            "hn-item-meta",
+            $"{Ui.Plural(story.Score, "point")} by {story.By ?? "unknown"} · {Ui.TimeAgo(story.Time)} · {Ui.Plural(story.Descendants, "comment")}");
+
+        var children = new List<VirtualNode?>(3)
+        {
+            VirtualNodeFactory.Element("h1", VirtualNodeFactory.Properties(("class", "hn-item-head")), head.ToArray()),
+            meta,
+        };
+
+        // Ask HN / self posts carry their body in Text.
+        var paragraphs = HtmlText.ToParagraphs(story.Text);
+        if (paragraphs.Count > 0)
+        {
+            var bodyNodes = new VirtualNode?[paragraphs.Count];
+            for (var index = 0; index < paragraphs.Count; index++)
+            {
+                bodyNodes[index] = Ui.Text("p", null, paragraphs[index]);
+            }
+            children.Add(VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "hn-item-text")), bodyNodes));
+        }
+
+        return VirtualNodeFactory.Element("header", VirtualNodeFactory.Properties(("class", "hn-item-header")), children.ToArray());
+    }
+
+    private static VirtualNode Comments(IReadOnlyList<CommentNode> comments, HackerNewsItem story)
+    {
+        var heading = Ui.Text("h2", "hn-comments-heading", Ui.Plural(story.Descendants, "comment"));
+        if (comments.Count == 0)
+        {
+            return VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Properties(("class", "hn-comments-section")),
+                heading,
+                Ui.Text("p", "hn-empty", "No comments yet."));
+        }
+
+        var items = new VirtualNode?[comments.Count];
+        for (var index = 0; index < comments.Count; index++)
+        {
+            var node = comments[index];
+            items[index] = VirtualNodeFactory.Component(
+                CommentView.Instance,
+                VirtualNodeFactory.Properties(("key", node.Comment.Id), ("node", node)));
+        }
+
+        return VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("class", "hn-comments-section")),
+            heading,
+            VirtualNodeFactory.Element("ul", VirtualNodeFactory.Properties(("class", "hn-comments")), items));
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/LoadingView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/LoadingView.cs
@@ -1,0 +1,30 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// A small loading indicator, used both inline (while a store load is in flight) and as the
+/// <c>LoadingComponent</c> of the async route components (<see cref="AppRoutes"/>).
+/// </summary>
+internal sealed class LoadingView : IComponentDefinition
+{
+    /// <summary>The shared loading definition instance.</summary>
+    public static readonly LoadingView Instance = new();
+
+    private LoadingView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "LoadingView";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () => VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("class", "hn-loading"), ("role", "status")),
+            Ui.Element("span", "hn-spinner"),
+            Ui.Text("span", "hn-loading-text", "Loading…"));
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/NotFoundView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/NotFoundView.cs
@@ -1,0 +1,30 @@
+using System;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The catch-all not-found route (<c>/:pathMatch(.*)*</c>).
+/// </summary>
+internal sealed class NotFoundView : IComponentDefinition
+{
+    /// <summary>The shared route-view definition instance.</summary>
+    public static readonly NotFoundView Instance = new();
+
+    private NotFoundView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "NotFoundView";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () => VirtualNodeFactory.Element(
+            "section",
+            VirtualNodeFactory.Properties(("class", "hn-view hn-notfound-view")),
+            Ui.Text("h1", "hn-view-title", "404"),
+            Ui.Text("p", "hn-empty", "That page doesn’t exist."),
+            Ui.Link("/top", "hn-back-link", "← Back to top stories"));
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/StoriesView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/StoriesView.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Router;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.RuntimeDom;
+using Assimalign.Viu.Shared;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The story-list route (<c>/:feed/:page?</c>) — the C# port of vue-hackernews-2.0's list view. It
+/// reads the feed/page from the route, drives <see cref="StoriesStore"/> to load through a
+/// route-watching effect (so both the initial mount and every subsequent navigation fetch), and
+/// renders a keyed <see cref="TransitionGroup"/> list plus pagination. All list state comes from the
+/// store; the view holds none of its own.
+/// </summary>
+internal sealed class StoriesView : IComponentDefinition
+{
+    /// <summary>The shared route-view definition instance.</summary>
+    public static readonly StoriesView Instance = new();
+
+    private StoriesView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "StoriesView";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var router = DependencyInjection.Inject(RouterInjectionKeys.Router)!;
+        var stores = DependencyInjection.Inject(HackerNewsStores.InjectionKey)!;
+        var store = stores.Stories.UseStore();
+
+        (string Slug, int Page) ReadRouteKey()
+        {
+            var route = router.CurrentRoute.Value;
+            var slug = route.Parameters.TryGetString("feed", out var value) ? value : "top";
+            var page = route.Parameters.TryGetInteger("page", out var parsed) && parsed > 0 ? parsed : 1;
+            return (slug, page);
+        }
+
+        // One effect owns loading: fires immediately (initial mount) and again whenever the feed/page
+        // route key changes (client-side navigation). Scoped to this component, so it stops on unmount.
+        Reactive.Watch(
+            ReadRouteKey,
+            (now, _, _) =>
+            {
+                if (StoryFeeds.TryParse(now.Slug, out var feed))
+                {
+                    _ = store.LoadPageAsync(feed, now.Page);
+                }
+            },
+            new WatchOptions { Immediate = true });
+
+        return () =>
+        {
+            var key = ReadRouteKey();
+            if (!StoryFeeds.TryParse(key.Slug, out var feed))
+            {
+                return UnknownFeed(key.Slug);
+            }
+
+            var state = store.State;
+            VirtualNode content;
+            if (state.Error is not null)
+            {
+                content = ErrorView.Inline(state.Error);
+            }
+            else if (state.IsLoading && state.Items.Count == 0)
+            {
+                content = VirtualNodeFactory.Component(LoadingView.Instance);
+            }
+            else if (state.Items.Count == 0)
+            {
+                content = Ui.Text("p", "hn-empty", "No stories here right now.");
+            }
+            else
+            {
+                content = VirtualNodeFactory.Element(
+                    "div",
+                    VirtualNodeFactory.Properties(("class", "hn-stories-body")),
+                    StoryList(state.Items, key.Page),
+                    Pagination(feed, key.Page, store.PageCount.Value));
+            }
+
+            return VirtualNodeFactory.Element(
+                "section",
+                VirtualNodeFactory.Properties(("class", "hn-view hn-stories-view")),
+                Ui.Text("h1", "hn-view-title", $"{StoryFeeds.ToLabel(feed)} stories"),
+                content);
+        };
+    }
+
+    // A keyed list under TransitionGroup: each row is keyed by story id so reorders animate (FLIP) and
+    // rows reconcile by identity. SlotFlags.Dynamic marks the v-for-style slot so structural changes
+    // force the group to re-render its children.
+    private static VirtualNode StoryList(IReadOnlyList<HackerNewsItem> items, int page)
+    {
+        var slots = new ComponentSlots(SlotFlags.Dynamic);
+        slots["default"] = _ =>
+        {
+            var children = new VirtualNode?[items.Count];
+            for (var index = 0; index < items.Count; index++)
+            {
+                var item = items[index];
+                var rank = ((page - 1) * StoriesStore.PageSize) + index + 1;
+                children[index] = VirtualNodeFactory.Component(
+                    StoryItem.Instance,
+                    VirtualNodeFactory.Properties(("key", item.Id), ("story", item), ("rank", rank)));
+            }
+            return children;
+        };
+        return VirtualNodeFactory.Component(
+            TransitionGroup.Instance,
+            VirtualNodeFactory.Properties(("tag", "ol"), ("name", "story"), ("class", "hn-stories")),
+            slots);
+    }
+
+    private static VirtualNode Pagination(StoryFeed feed, int page, int pageCount)
+    {
+        var boundedPageCount = pageCount < 1 ? 1 : pageCount;
+        var children = new List<VirtualNode?>(3)
+        {
+            page > 1
+                ? Ui.Link(Ui.FeedPath(feed, page - 1), "hn-page-link", "‹ prev")
+                : Ui.Text("span", "hn-page-link hn-disabled", "‹ prev"),
+            Ui.Text("span", "hn-page-info", $"page {page} / {boundedPageCount}"),
+            page < boundedPageCount
+                ? Ui.Link(Ui.FeedPath(feed, page + 1), "hn-page-link", "more ›")
+                : Ui.Text("span", "hn-page-link hn-disabled", "more ›"),
+        };
+        return VirtualNodeFactory.Element("nav", VirtualNodeFactory.Properties(("class", "hn-pagination")), children.ToArray());
+    }
+
+    private static VirtualNode UnknownFeed(string slug)
+        => VirtualNodeFactory.Element(
+            "section",
+            VirtualNodeFactory.Properties(("class", "hn-view")),
+            Ui.Text("h1", "hn-view-title", "Not found"),
+            Ui.Text("p", "hn-empty", $"There is no “{slug}” feed."),
+            Ui.Link("/top", "hn-back-link", "← Back to top stories"));
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/StoryItem.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/StoryItem.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// One row in a story list — the C# port of vue-hackernews-2.0's <c>StoryItem.vue</c>. A shared,
+/// stateless definition (see <see cref="Ui"/>): the parent renders one vnode per story keyed by
+/// <see cref="HackerNewsItem.Id"/>, so the keyed diff reconciles rows by identity with no per-item
+/// interop, leaving room for list virtualization later (#103). Its props are declared so the story
+/// object and rank never fall through as DOM attributes.
+/// </summary>
+internal sealed class StoryItem : IComponentDefinition
+{
+    /// <summary>The shared row definition instance.</summary>
+    public static readonly StoryItem Instance = new();
+
+    private StoryItem()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "StoryItem";
+
+    /// <inheritdoc />
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties { get; } =
+    [
+        new ComponentPropertyDefinition("story") { Required = true },
+        new ComponentPropertyDefinition("rank") { DefaultValue = 0 },
+    ];
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+        => () =>
+        {
+            var story = properties.Get<HackerNewsItem>("story");
+            if (story is null)
+            {
+                return VirtualNodeFactory.Comment();
+            }
+            var rank = properties.Get<int>("rank");
+            var itemPath = $"/item/{story.Id}";
+
+            return VirtualNodeFactory.Element(
+                "li",
+                VirtualNodeFactory.Properties(("class", "hn-story")),
+                Ui.Text("span", "hn-rank", rank > 0 ? $"{rank}." : string.Empty),
+                VirtualNodeFactory.Element(
+                    "div",
+                    VirtualNodeFactory.Properties(("class", "hn-story-body")),
+                    Title(story, itemPath),
+                    Subtext(story, itemPath)));
+        };
+
+    private static VirtualNode Title(HackerNewsItem story, string itemPath)
+    {
+        var titleText = story.Title ?? "(untitled)";
+        // A story with an external URL links out (new tab) and shows its host; an Ask/Show/self post
+        // links to its own discussion page.
+        var titleLink = story.Url is { Length: > 0 } url
+            ? Ui.ExternalLink(url, "hn-story-title", titleText)
+            : Ui.Link(itemPath, "hn-story-title", titleText);
+
+        if (story.Host is not { Length: > 0 } host)
+        {
+            return VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "hn-story-head")), titleLink);
+        }
+        return VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("class", "hn-story-head")),
+            titleLink,
+            Ui.Text("span", "hn-story-host", $" ({host})"));
+    }
+
+    private static VirtualNode Subtext(HackerNewsItem story, string itemPath)
+    {
+        var parts = new List<VirtualNode?>(6);
+        var isJob = string.Equals(story.Type, "job", StringComparison.Ordinal);
+
+        if (!isJob)
+        {
+            parts.Add(Ui.Text("span", "hn-points", Ui.Plural(story.Score, "point")));
+            parts.Add(Ui.Raw(" by "));
+            parts.Add(Ui.Link($"/user/{story.By}", "hn-by", story.By ?? "unknown"));
+            parts.Add(Ui.Raw(" "));
+        }
+        parts.Add(Ui.Raw(Ui.TimeAgo(story.Time)));
+        if (!isJob)
+        {
+            parts.Add(Ui.Raw(" | "));
+            parts.Add(Ui.Link(itemPath, "hn-comments-link", Ui.Plural(story.Descendants, "comment")));
+        }
+
+        return VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "hn-subtext")), parts.ToArray());
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/Ui.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/Ui.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Router;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// Small render-function helpers shared by the views. Two things matter here:
+/// <list type="bullet">
+/// <item>The <see cref="RouterLink"/>/<see cref="RouterView"/> definitions are <b>shared singletons</b>.
+/// A component vnode's identity is its definition instance, so reusing one instance everywhere (exactly
+/// how Vue treats a globally-registered component) lets the renderer patch links/outlets in place across
+/// re-renders instead of unmount/remounting them; keys distinguish the per-position instances.</item>
+/// <item>Every node is built through <see cref="VirtualNodeFactory"/> only — no DOM or interop touched
+/// during render, so the views stay SSR-ready and renderer-agnostic (#103).</item>
+/// </list>
+/// </summary>
+internal static class Ui
+{
+    /// <summary>The shared <see cref="Router.RouterLink"/> definition used for every in-app link.</summary>
+    public static readonly RouterLink RouterLink = new();
+
+    /// <summary>The shared <see cref="Router.RouterView"/> outlet definition.</summary>
+    public static readonly RouterView RouterView = new();
+
+    /// <summary>An element with an optional class and child vnodes.</summary>
+    public static VirtualNode Element(string tag, string? cssClass, params VirtualNode?[] children)
+        => VirtualNodeFactory.Element(
+            tag,
+            cssClass is null ? null : VirtualNodeFactory.Properties(("class", cssClass)),
+            children);
+
+    /// <summary>An element with an optional class and text content.</summary>
+    public static VirtualNode Text(string tag, string? cssClass, string content)
+        => VirtualNodeFactory.Element(
+            tag,
+            cssClass is null ? null : VirtualNodeFactory.Properties(("class", cssClass)),
+            content);
+
+    /// <summary>A raw text vnode.</summary>
+    public static VirtualNode Raw(string content) => VirtualNodeFactory.Text(content);
+
+    /// <summary>An in-app <see cref="Router.RouterLink"/> with a text label (client-side navigation).</summary>
+    public static VirtualNode Link(string to, string? cssClass, string label)
+        => Link(to, cssClass, VirtualNodeFactory.Text(label));
+
+    /// <summary>An in-app <see cref="Router.RouterLink"/> whose label is arbitrary child vnodes.</summary>
+    public static VirtualNode Link(string to, string? cssClass, params VirtualNode?[] label)
+    {
+        var slots = new ComponentSlots();
+        slots["default"] = _ => label;
+        var properties = cssClass is null
+            ? VirtualNodeFactory.Properties(("to", to))
+            : VirtualNodeFactory.Properties(("to", to), ("class", cssClass));
+        return VirtualNodeFactory.Component(RouterLink, properties, slots);
+    }
+
+    /// <summary>An external anchor (story targets) that opens in a new, isolated tab.</summary>
+    public static VirtualNode ExternalLink(string href, string? cssClass, string label)
+        => VirtualNodeFactory.Element(
+            "a",
+            cssClass is null
+                ? VirtualNodeFactory.Properties(("href", href), ("target", "_blank"), ("rel", "noopener noreferrer"))
+                : VirtualNodeFactory.Properties(("href", href), ("target", "_blank"), ("rel", "noopener noreferrer"), ("class", cssClass)),
+            label);
+
+    /// <summary>A coarse "N units ago" label (Vue-hn parity display). Uses wall-clock time.</summary>
+    public static string TimeAgo(DateTimeOffset time)
+    {
+        var delta = DateTimeOffset.UtcNow - time;
+        if (delta < TimeSpan.Zero)
+        {
+            delta = TimeSpan.Zero;
+        }
+        if (delta.TotalMinutes < 1)
+        {
+            return "just now";
+        }
+        if (delta.TotalMinutes < 60)
+        {
+            return Plural((int)delta.TotalMinutes, "minute") + " ago";
+        }
+        if (delta.TotalHours < 24)
+        {
+            return Plural((int)delta.TotalHours, "hour") + " ago";
+        }
+        return Plural((int)delta.TotalDays, "day") + " ago";
+    }
+
+    /// <summary>Formats a count with a singular/plural noun, e.g. <c>1 comment</c> / <c>5 comments</c>.</summary>
+    public static string Plural(int count, string singular)
+        => count == 1 ? $"1 {singular}" : $"{count} {singular}s";
+
+    /// <summary>Builds the route path for a feed page (page 1 omits the trailing segment for a clean URL).</summary>
+    public static string FeedPath(StoryFeed feed, int page)
+        => page <= 1 ? $"/{StoryFeeds.ToSlug(feed)}" : $"/{StoryFeeds.ToSlug(feed)}/{page}";
+}

--- a/examples/Assimalign.Viu.HackerNews/Views/UserView.cs
+++ b/examples/Assimalign.Viu.HackerNews/Views/UserView.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Router;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.HackerNews;
+
+/// <summary>
+/// The user-profile route (<c>/user/:id</c>) — the C# port of vue-hackernews-2.0's user view. Reads
+/// <c>:id</c> from the route, drives <see cref="UserStore"/> through a route-watching effect, and
+/// renders the profile from store state. Wrapped as an async route component in <see cref="AppRoutes"/>.
+/// </summary>
+internal sealed class UserView : IComponentDefinition
+{
+    /// <summary>The shared route-view definition instance.</summary>
+    public static readonly UserView Instance = new();
+
+    private UserView()
+    {
+    }
+
+    /// <inheritdoc />
+    public string? Name => "UserView";
+
+    /// <inheritdoc />
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var router = DependencyInjection.Inject(RouterInjectionKeys.Router)!;
+        var stores = DependencyInjection.Inject(HackerNewsStores.InjectionKey)!;
+        var store = stores.User.UseStore();
+
+        string ReadId() => router.CurrentRoute.Value.Parameters.TryGetString("id", out var id) ? id : string.Empty;
+
+        Reactive.Watch(
+            ReadId,
+            (id, _, _) =>
+            {
+                if (!string.IsNullOrEmpty(id))
+                {
+                    _ = store.LoadUserAsync(id);
+                }
+            },
+            new WatchOptions { Immediate = true });
+
+        return () =>
+        {
+            var state = store.State;
+            if (state.Error is not null)
+            {
+                return View(ErrorView.Inline(state.Error));
+            }
+            if (state.Profile is null)
+            {
+                return View(VirtualNodeFactory.Component(LoadingView.Instance));
+            }
+            return View(Profile(state.Profile));
+        };
+    }
+
+    private static VirtualNode View(params VirtualNode?[] children)
+        => VirtualNodeFactory.Element("section", VirtualNodeFactory.Properties(("class", "hn-view hn-user-view")), children);
+
+    private static VirtualNode Profile(HackerNewsUser user)
+    {
+        var children = new List<VirtualNode?>(5)
+        {
+            Ui.Text("h1", "hn-view-title", user.Id),
+            Ui.Text(
+                "div",
+                "hn-user-meta",
+                $"joined {user.Created.UtcDateTime:MMM d, yyyy} · {Ui.Plural(user.Karma, "karma point")} · {Ui.Plural(user.SubmittedCount, "submission")}"),
+        };
+
+        var about = HtmlText.ToParagraphs(user.About);
+        if (about.Count > 0)
+        {
+            var aboutNodes = new VirtualNode?[about.Count];
+            for (var index = 0; index < about.Count; index++)
+            {
+                aboutNodes[index] = Ui.Text("p", null, about[index]);
+            }
+            children.Add(VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "hn-user-about")), aboutNodes));
+        }
+
+        children.Add(Ui.ExternalLink(
+            $"https://news.ycombinator.com/user?id={Uri.EscapeDataString(user.Id)}",
+            "hn-external-profile",
+            "View on news.ycombinator.com →"));
+
+        return VirtualNodeFactory.Element("article", VirtualNodeFactory.Properties(("class", "hn-user")), children.ToArray());
+    }
+}

--- a/examples/Assimalign.Viu.HackerNews/wwwroot/index.html
+++ b/examples/Assimalign.Viu.HackerNews/wwwroot/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Viu HackerNews</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Deep links like /item/8863 and /user/pg load their assets from the site root; the router's web
+       history also reads this <base> to build clean-URL hrefs. -->
+  <base href="/" />
+  <link rel="preload" id="webassembly" />
+  <script type="importmap"></script>
+  <script type="module" src="main#[.{fingerprint}].js"></script>
+  <!-- No manual stylesheet link: the .viu single-file-component CSS bundle's <link> ([V01.01.12.12]) is
+       injected automatically by the build ([V01.01.12.12.01], #167) — the ViuInjectCssBundleLink task
+       splices it into <head> before the SDK's compression pipeline. The Styles/*.viu @style blocks carry
+       the component/layout styling; the small inline sheet below is only the pre-bundle base (reset, theme
+       tokens, app frame) so first paint has no flash of unstyled content. -->
+  <style>
+    :root {
+      color-scheme: light;
+      --hn-orange: #ff6600;
+      --hn-bg: #f6f6ef;
+      --hn-header: #ff6600;
+      --hn-text: #1a1a1a;
+      --hn-muted: #828282;
+      --hn-link: #000000;
+      --hn-surface: #ffffff;
+      --hn-border: #e4e4dc;
+      font-family: Verdana, Geneva, "Segoe UI", system-ui, sans-serif;
+      background: var(--hn-bg);
+      color: var(--hn-text);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    #app {
+      max-width: 56rem;
+      margin: 0 auto;
+      background: var(--hn-surface);
+      min-height: 100vh;
+      box-shadow: 0 0 1.5rem rgba(0, 0, 0, 0.06);
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+</body>
+</html>

--- a/examples/Assimalign.Viu.HackerNews/wwwroot/main.js
+++ b/examples/Assimalign.Viu.HackerNews/wwwroot/main.js
@@ -1,0 +1,7 @@
+// App bootstrap only: the DOM bridge ships with the Assimalign.Viu.RuntimeDom package
+// (loaded by BrowserRuntime.InitializeAsync as /_content/Assimalign.Viu.RuntimeDom/viu-dom.js).
+import { dotnet } from './_framework/dotnet.js'
+
+const { runMain } = await dotnet.create()
+
+await runMain()

--- a/scripts/budgets/PublishBudgets.json
+++ b/scripts/budgets/PublishBudgets.json
@@ -20,13 +20,24 @@
     "",
     "Seed provenance: Assimalign.Viu.WebApp measured 2,097,190 bytes brotli (7,363,995 raw, 19 files) on",
     "2026-07-19 with .NET SDK 10.0.302 / wasm-tools 10.0.110. CI (ubuntu x64) is the authority; if its",
-    "measurement differs materially from this Windows seed, recalibrate via an explicit edit here."
+    "measurement differs materially from this Windows seed, recalibrate via an explicit edit here.",
+    "",
+    "Seed provenance: Assimalign.Viu.HackerNews measured 2,533,416 bytes brotli (8,576,012 raw, 34 files)",
+    "on 2026-07-20 with .NET SDK 10.0.302; budget 2,790,000 seeds ~10% headroom (9.2% of budget). It is",
+    "larger than the WebApp because it pulls in the Router, Store, and Router.RuntimeDom assemblies and",
+    "System.Text.Json (source-generated). CI (ubuntu x64) is the authority; recalibrate here if it differs."
   ],
   "samples": [
     {
       "name": "Assimalign.Viu.WebApp",
       "project": "examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj",
       "compressedPublishSizeBytes": 2310000,
+      "startupBudgetMilliseconds": 5000
+    },
+    {
+      "name": "Assimalign.Viu.HackerNews",
+      "project": "examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj",
+      "compressedPublishSizeBytes": 2790000,
       "startupBudgetMilliseconds": 5000
     }
   ]


### PR DESCRIPTION
## Summary
- The Wave 4 exit demo — "HackerNews client: routed, stored, styled" — exercising the whole W04 surface in one app (`examples/Assimalign.Viu.HackerNews`): typed routes (`/:feed/:page(\d+)?`, item/user detail as **async components**, catch-all 404) on web history with the click bridge installed; three stores on the `Store<TState>` member model over `[Reactive]` state (loading/error, feed cache, superseded-load cancellation, bounded comment trees); keyed `TransitionGroup` story lists exercising FLIP; `.viu` `@style` bundles auto-injected as the fingerprinted CSS link (no manual tag, verified in the published output).
- **Establishes the networked-sample pattern**: `HttpClient` + source-generated `System.Text.Json` (`JsonSerializerContext`, generated `JsonTypeInfo<T>` overloads, reflection-free `JsonDocument` for id arrays) — clean under trimming, documented in the sample README.
- **Own CI lane** (`hackernews.yml`, the webapp pattern) and a **measured budget seed**: 2,533,416 B brotli actual → 2,790,000 budget (~9.2% headroom, the manifest convention); the budget gate now publishes this sample automatically.
- **Framework findings, filed not hidden**: [#219 [V01.01.08.07]](https://github.com/assimalign/viu/issues/219) — the Router runs no guard pipeline for the *initial* navigation (no vue-router START sentinel), bootstrap workaround applied and marked; [#216](https://github.com/assimalign/viu/issues/216) confirmed independently — views are C# render functions with `.viu` as CSS-only until the SFC mountability gap closes (the AC's scoped-CSS component criterion is partially met for exactly that documented reason).
- **Deviation, ratified in review**: the sample's test project uses a raw `ProjectReference` to the sample app — `ViuProjectReference` deliberately indexes only `libraries/`+`analyzers/` (libraries must never reference examples), so a test→example edge has no by-name form; documented at the site per the deviations rule.
- Browser smoke-driving remains the deferred Playwright lane's job ([#87](https://github.com/assimalign/viu/issues/87)); headless coverage stands in: **26/26 tests** (route resolution, store semantics incl. cancellation, view states) via the Testing renderer + memory history + fake client.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · sample Release `-warnaserror` + trimmed publish clean · `Measure-PublishBudget.ps1` **PASS** · sample tests 26/26 · spot-runs: Router 191, Store 48, RuntimeCore 257.

Closes #103
Refs #216, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)