### PR TITLE
feat(examples): add TodoMVC and Forms samples to the gallery [V01.01.13.02]

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -1,6 +1,11 @@
 # WebAssembly example-app build ([V01.01.12.02]): proves the wasm-tools toolchain and the
-# static-web-asset flow stay healthy. Runs when the example, any library, or shared build
-# files change (the app references every area transitively).
+# static-web-asset flow stay healthy across the sample gallery ([V01.01.13.02]). Runs when any
+# example, any library, or the shared build files change (the apps reference every area transitively).
+#
+# The build lane is a matrix over the sample apps rather than one hard-coded project: the gallery is a
+# set (the publish-size manifest already treats it as one — scripts/budgets/PublishBudgets.json), so
+# adding a sample is one matrix entry instead of a duplicated job. The test lane runs the samples'
+# DOM-free test projects (the in-memory Assimalign.Viu.Testing renderer — no browser, no wasm-tools).
 name: webapp
 
 on:
@@ -31,8 +36,15 @@ on:
 
 jobs:
   build:
-    name: build WASM example
+    name: build WASM example (${{ matrix.sample }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sample:
+          - Assimalign.Viu.WebApp
+          - Assimalign.Viu.TodoMvc
+          - Assimalign.Viu.Forms
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,4 +55,22 @@ jobs:
           install-wasm-tools: 'true'
 
       - name: Build
-        run: dotnet build examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj --configuration Release -warnaserror
+        run: dotnet build examples/${{ matrix.sample }}/${{ matrix.sample }}.csproj --configuration Release -warnaserror
+
+  test:
+    name: sample tests (DOM-free)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The example test projects target net10.0 and drive the in-memory renderer, so they need no
+      # wasm-tools workload.
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Test TodoMVC sample
+        run: dotnet test examples/Assimalign.Viu.TodoMvc.Tests/Assimalign.Viu.TodoMvc.Tests.csproj --configuration Release -warnaserror
+
+      - name: Test forms sample
+        run: dotnet test examples/Assimalign.Viu.Forms.Tests/Assimalign.Viu.Forms.Tests.csproj --configuration Release -warnaserror

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -152,6 +152,18 @@
 	<Folder Name="/viu/examples/Assimalign.Viu.WebApp/">
 		<Project Path="examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj" />
 	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.TodoMvc/">
+		<Project Path="examples/Assimalign.Viu.TodoMvc/Assimalign.Viu.TodoMvc.csproj" />
+	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.TodoMvc.Tests/">
+		<Project Path="examples/Assimalign.Viu.TodoMvc.Tests/Assimalign.Viu.TodoMvc.Tests.csproj" />
+	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.Forms/">
+		<Project Path="examples/Assimalign.Viu.Forms/Assimalign.Viu.Forms.csproj" />
+	</Folder>
+	<Folder Name="/viu/examples/Assimalign.Viu.Forms.Tests/">
+		<Project Path="examples/Assimalign.Viu.Forms.Tests/Assimalign.Viu.Forms.Tests.csproj" />
+	</Folder>
 	<Folder Name="/viu/libraries/">
 		<File Path="libraries/Directory.Build.props" />
 		<File Path="libraries/Directory.Build.targets" />

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ runtime template compilation. They never ship in the runtime assemblies.
 | Sample | What it shows |
 | --- | --- |
 | [`Assimalign.Viu.WebApp`](examples/Assimalign.Viu.WebApp) | A browser WASM app: a stopwatch rendered from C# through the handle-based DOM bridge. Its `?diagnostics=1` mode runs the interop marshaling benchmark behind [RuntimeDom ADR-0001](libraries/Assimalign.Viu.RuntimeDom/docs/ADR-0001-interop-marshaling.md). |
+| [`Assimalign.Viu.TodoMvc`](examples/Assimalign.Viu.TodoMvc) | The canonical [TodoMVC](https://github.com/tastejs/todomvc/blob/master/app-spec.md) app built from components: `[Reactive]` source-generated state, a `ReactiveList<T>` with computed filtered/remaining views, keyed list rendering, and typed provide/inject. DOM-free tests in [`Assimalign.Viu.TodoMvc.Tests`](examples/Assimalign.Viu.TodoMvc.Tests). |
+| [`Assimalign.Viu.Forms`](examples/Assimalign.Viu.Forms) | A registration form exercising every implemented `v-model` flavor (text, number, checkbox, checkbox-list, radio, single/multiple `<select>`, textarea) and the `.trim`/`.number`/`.lazy` modifiers, with a `ref`-per-field composition model and a live preview. DOM-free tests in [`Assimalign.Viu.Forms.Tests`](examples/Assimalign.Viu.Forms.Tests). |
 
 ### Packaging (`sdks/`, `frameworks/`)
 

--- a/examples/Assimalign.Viu.Forms.Tests/AssemblyInfo.cs
+++ b/examples/Assimalign.Viu.Forms.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+// The reactivity engine and the renderer's scheduler use ambient static state (single-threaded
+// JS event-loop model), so the model and component tests must not run in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/examples/Assimalign.Viu.Forms.Tests/Assimalign.Viu.Forms.Tests.csproj
+++ b/examples/Assimalign.Viu.Forms.Tests/Assimalign.Viu.Forms.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!--
+    Example projects are not resolvable through ViuProjectReference (it indexes libraries/ and
+    analyzers/ only), and the sample is a Microsoft.NET.Sdk.WebAssembly executable, so this test
+    compiles the sample's platform-neutral source directly (Program.cs and FormsBootstrap.cs, the
+    browser-only files, are excluded). The reactive model and the preview component are exercised
+    DOM-free; the v-model DOM directives are a browser concern covered by the RuntimeDom tests.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Assimalign.Viu.Forms\Composition\**\*.cs" LinkBase="Sample\Composition" />
+    <Compile Include="..\Assimalign.Viu.Forms\Components\**\*.cs" LinkBase="Sample\Components" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeCore" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.Forms.Tests/FormPreviewComponentTests.cs
+++ b/examples/Assimalign.Viu.Forms.Tests/FormPreviewComponentTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Forms.Components;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Forms.Tests;
+
+// Mounts the live-preview component through the in-memory Assimalign.Viu.Testing renderer and asserts
+// it reflects the reactive model — including a reactive update after the model changes and the
+// scheduler flushes. (The form's v-model inputs are a browser concern and are not mounted here.)
+public sealed class FormPreviewComponentTests
+{
+    [Fact]
+    public async Task Preview_ReflectsTheModel_AndUpdatesWhenItChanges()
+    {
+        var form = new RegistrationForm();
+        var options = new ComponentMountOptions
+        {
+            Properties = VirtualNodeFactory.Properties(("form", form)),
+        };
+        using var wrapper = ViuTest.Mount(new FormPreviewComponent(), options);
+
+        wrapper.Get(".status").Text().ShouldBe("Incomplete");
+        wrapper.Get(".summary").Text().ShouldBe(form.Summary.Value);
+        wrapper.Get(".summary").Text().ShouldContain("(no name)");
+
+        form.FullName.Value = "Ada Lovelace";
+        form.Email.Value = "ada@example.com";
+        form.AcceptsTerms.Value = true;
+        await wrapper.FlushAsync();
+
+        wrapper.Get(".status").Text().ShouldBe("Ready to submit");
+        wrapper.Get(".summary").Text().ShouldContain("Ada Lovelace");
+    }
+}

--- a/examples/Assimalign.Viu.Forms.Tests/RegistrationFormTests.cs
+++ b/examples/Assimalign.Viu.Forms.Tests/RegistrationFormTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.Forms.Tests;
+
+// Pins the reactive form model: the derived IsValid/Summary computeds and, where dependency-tracking
+// bugs hide, their *run counts*. IsValid's && short-circuit is a deliberate lazy-tracking assertion
+// (Vue's computed only tracks what it actually reads). Upstream: https://vuejs.org/guide/essentials/forms.html
+public sealed class RegistrationFormTests
+{
+    [Fact]
+    public void IsValid_TracksLazily_ShortCircuitingOnTheFirstFalseTerm()
+    {
+        var form = new RegistrationForm();
+        var runs = 0;
+        var valid = true;
+        var effect = Reactive.Effect(() =>
+        {
+            runs++;
+            valid = form.IsValid.Value;
+        });
+
+        runs.ShouldBe(1);
+        valid.ShouldBeFalse();
+
+        // FullName is empty, so `&&` short-circuits after the first term: Email and AcceptsTerms are
+        // not read this pass, so changing them does not recompute IsValid (Vue's lazy tracking).
+        form.Email.Value = "ada@example.com";
+        form.AcceptsTerms.Value = true;
+        runs.ShouldBe(1);
+        valid.ShouldBeFalse();
+
+        // Changing the one tracked term recomputes, now reading all three terms → valid.
+        form.FullName.Value = "Ada Lovelace";
+        runs.ShouldBe(2);
+        valid.ShouldBeTrue();
+
+        effect.Stop();
+    }
+
+    [Fact]
+    public void Summary_RecomputesOnAnyFieldChange_AndCoalescesEqualWrites()
+    {
+        var form = new RegistrationForm();
+        var runs = 0;
+        var summary = string.Empty;
+        var effect = Reactive.Effect(() =>
+        {
+            runs++;
+            summary = form.Summary.Value;
+        });
+
+        runs.ShouldBe(1);
+        summary.ShouldContain("(no name)");
+
+        form.FullName.Value = "Ada";
+        runs.ShouldBe(2);
+        summary.ShouldContain("Ada");
+
+        // Equal-value write does not trigger, so the computed does not recompute.
+        form.FullName.Value = "Ada";
+        runs.ShouldBe(2);
+
+        form.AcceptsTerms.Value = true;
+        runs.ShouldBe(3);
+        summary.ShouldContain("terms accepted");
+
+        effect.Stop();
+    }
+
+    [Fact]
+    public void Summary_ReflectsInterestListReplacement()
+    {
+        var form = new RegistrationForm();
+
+        form.Interests.Value = new List<string> { "Reactivity", "WASM" };
+
+        form.Summary.Value.ShouldContain("interests [Reactivity, WASM]");
+    }
+
+    [Fact]
+    public void Age_HoldsANumber_ThroughItsReference()
+    {
+        var form = new RegistrationForm();
+
+        form.Age.Value = 36d;
+
+        form.Age.Value.ShouldBe(36d);
+        form.Summary.Value.ShouldContain("age 36");
+    }
+}

--- a/examples/Assimalign.Viu.Forms/Assimalign.Viu.Forms.csproj
+++ b/examples/Assimalign.Viu.Forms/Assimalign.Viu.Forms.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkLatest)</TargetFramework>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]!" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.Forms/Components/FormPreviewComponent.cs
+++ b/examples/Assimalign.Viu.Forms/Components/FormPreviewComponent.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Forms.Components;
+
+/// <summary>
+/// A live, read-only view of the form model — it is handed the <see cref="RegistrationForm"/> by prop
+/// and reads its refs and computeds in its render, so it re-renders whenever a field changes. It uses
+/// no <c>v-model</c> and no event payloads, so (unlike the form itself) it mounts in the in-memory test
+/// renderer and its reactive updates are asserted DOM-free.
+/// </summary>
+public sealed class FormPreviewComponent : IComponentDefinition
+{
+    private static readonly IReadOnlyList<ComponentPropertyDefinition> DeclaredProperties =
+        [new ComponentPropertyDefinition("form")];
+
+    /// <inheritdoc/>
+    public string? Name => "FormPreview";
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties => DeclaredProperties;
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var form = properties.Get<RegistrationForm>("form")!;
+        return () => VirtualNodeFactory.Element(
+            "aside",
+            VirtualNodeFactory.Properties(("class", "preview")),
+            VirtualNodeFactory.Element("h2", "Live model"),
+            VirtualNodeFactory.Element(
+                "p",
+                VirtualNodeFactory.Properties(("class", form.IsValid.Value ? "status is-ready" : "status")),
+                form.IsValid.Value ? "Ready to submit" : "Incomplete"),
+            VirtualNodeFactory.Element(
+                "pre",
+                VirtualNodeFactory.Properties(("class", "summary")),
+                form.Summary.Value));
+    }
+}

--- a/examples/Assimalign.Viu.Forms/Components/RegistrationFormComponent.cs
+++ b/examples/Assimalign.Viu.Forms/Components/RegistrationFormComponent.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.RuntimeDom;
+
+namespace Assimalign.Viu.Forms.Components;
+
+/// <summary>
+/// The registration form — the sample gallery's showcase of every implemented <c>v-model</c> flavor and
+/// modifier. Each field is bound with the matching directive from <see cref="DomRenderHelpers"/> through
+/// <see cref="Directives.WithDirectives(VirtualNode, IDirective, object?, string?, IReadOnlyDictionary{string, bool}?)"/>
+/// and a <see cref="ViuModelBinding"/> (the current value plus a write-back setter — no reflection over
+/// component members, the AOT/trimming contract). The live <see cref="FormPreviewComponent"/> reflects
+/// the model as it changes. See https://vuejs.org/guide/essentials/forms.html.
+/// <list type="bullet">
+///   <item><description>text + <c>.trim</c> (<c>_vModelText</c>), email + <c>.trim</c></description></item>
+///   <item><description>number + <c>.number</c> (edits arrive coerced to a number)</description></item>
+///   <item><description>textarea + <c>.lazy</c> (commits on change, not every keystroke)</description></item>
+///   <item><description>checkbox (boolean) and a checkbox group bound to a list</description></item>
+///   <item><description>radio group and single/multiple <c>&lt;select&gt;</c></description></item>
+/// </list>
+/// </summary>
+public sealed class RegistrationFormComponent : IComponentDefinition
+{
+    private static readonly FormPreviewComponent PreviewView = new();
+
+    private static readonly string[] InterestOptions = ["Reactivity", "Rendering", "Tooling", "WASM"];
+    private static readonly (string Value, string Label)[] ContactOptions =
+        [("email", "Email"), ("phone", "Phone"), ("none", "Do not contact")];
+    private static readonly (string Value, string Label)[] CountryOptions =
+        [("", "Select a country…"), ("us", "United States"), ("gb", "United Kingdom"), ("de", "Germany"), ("jp", "Japan")];
+    private static readonly (string Value, string Label)[] LanguageOptions =
+        [("csharp", "C#"), ("fsharp", "F#"), ("ts", "TypeScript"), ("rust", "Rust")];
+
+    /// <inheritdoc/>
+    public string? Name => "RegistrationForm";
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var form = new RegistrationForm();
+
+        return () => VirtualNodeFactory.Element(
+            "section",
+            VirtualNodeFactory.Properties(("class", "shell")),
+            VirtualNodeFactory.Element(
+                "form",
+                VirtualNodeFactory.Properties(
+                    ("class", "form"),
+                    // A no-op submit handler with the .prevent modifier so pressing Enter never reloads.
+                    ("onSubmit", DomRenderHelpers._withModifiers((Action)(() => { }), "prevent"))),
+                VirtualNodeFactory.Element("h1", "Create your account"),
+
+                // text + .trim
+                Field("name", "Full name", Model(
+                    Control("name", "text"),
+                    DomRenderHelpers._vModelText,
+                    form.FullName.Value,
+                    value => form.FullName.Value = AsString(value),
+                    "trim")),
+
+                // email + .trim
+                Field("email", "Email", Model(
+                    Control("email", "email"),
+                    DomRenderHelpers._vModelText,
+                    form.Email.Value,
+                    value => form.Email.Value = AsString(value),
+                    "trim")),
+
+                // number + .number
+                Field("age", "Age", Model(
+                    Control("age", "number"),
+                    DomRenderHelpers._vModelText,
+                    form.Age.Value,
+                    value => form.Age.Value = AsDouble(value),
+                    "number")),
+
+                // textarea + .lazy
+                Field("bio", "Bio", Model(
+                    VirtualNodeFactory.Element(
+                        "textarea",
+                        VirtualNodeFactory.Properties(("id", "bio"), ("class", "control"), ("rows", 3)),
+                        (VirtualNode?[]?)null),
+                    DomRenderHelpers._vModelText,
+                    form.Bio.Value,
+                    value => form.Bio.Value = AsString(value),
+                    "lazy")),
+
+                // checkbox (boolean)
+                VirtualNodeFactory.Element(
+                    "div",
+                    VirtualNodeFactory.Properties(("class", "field field-inline")),
+                    Model(
+                        VirtualNodeFactory.Element(
+                            "input",
+                            VirtualNodeFactory.Properties(("id", "terms"), ("type", "checkbox")),
+                            (VirtualNode?[]?)null),
+                        DomRenderHelpers._vModelCheckbox,
+                        form.AcceptsTerms.Value,
+                        value => form.AcceptsTerms.Value = AsBool(value)),
+                    VirtualNodeFactory.Element(
+                        "label",
+                        VirtualNodeFactory.Properties(("for", "terms")),
+                        "I accept the terms")),
+
+                // checkbox group bound to a list
+                Field("interests", "Interests", InterestGroup(form)),
+
+                // radio group
+                Field("contact", "Preferred contact", ContactGroup(form)),
+
+                // select (single)
+                Field("country", "Country", Model(
+                    VirtualNodeFactory.Element(
+                        "select",
+                        VirtualNodeFactory.Properties(("id", "country"), ("class", "control")),
+                        BuildOptions(CountryOptions)),
+                    DomRenderHelpers._vModelSelect,
+                    form.Country.Value,
+                    value => form.Country.Value = AsString(value))),
+
+                // select (multiple)
+                Field("languages", "Languages", Model(
+                    VirtualNodeFactory.Element(
+                        "select",
+                        VirtualNodeFactory.Properties(("id", "languages"), ("class", "control"), ("multiple", true)),
+                        BuildOptions(LanguageOptions)),
+                    DomRenderHelpers._vModelSelect,
+                    form.Languages.Value,
+                    value => form.Languages.Value = AsList(value)))),
+
+            VirtualNodeFactory.Component(PreviewView, VirtualNodeFactory.Properties(("form", form))));
+    }
+
+    // --- v-model helper -------------------------------------------------------------------------
+
+    // Attaches a v-model directive to an input, carrying the current value + write-back setter and the
+    // requested modifiers (upstream: withDirectives(vnode, [[dir, value, arg, modifiers]])).
+    private static VirtualNode Model(
+        VirtualNode input,
+        IDirective directive,
+        object? value,
+        Action<object?> setter,
+        params string[] modifiers)
+    {
+        IReadOnlyDictionary<string, bool>? modifierMap = null;
+        if (modifiers.Length > 0)
+        {
+            var map = new Dictionary<string, bool>(modifiers.Length, StringComparer.Ordinal);
+            foreach (var modifier in modifiers)
+            {
+                map[modifier] = true;
+            }
+            modifierMap = map;
+        }
+        return Directives.WithDirectives(input, directive, new ViuModelBinding(value, setter), null, modifierMap);
+    }
+
+    // --- element helpers ------------------------------------------------------------------------
+
+    private static VirtualNode Control(string id, string type) => VirtualNodeFactory.Element(
+        "input",
+        VirtualNodeFactory.Properties(("id", id), ("type", type), ("class", "control")),
+        (VirtualNode?[]?)null);
+
+    private static VirtualNode Field(string forId, string label, VirtualNode control) => VirtualNodeFactory.Element(
+        "div",
+        VirtualNodeFactory.Properties(("class", "field")),
+        VirtualNodeFactory.Element("label", VirtualNodeFactory.Properties(("for", forId)), label),
+        control);
+
+    private static VirtualNode[] BuildOptions((string Value, string Label)[] options)
+    {
+        var nodes = new VirtualNode[options.Length];
+        for (var index = 0; index < options.Length; index++)
+        {
+            var (value, label) = options[index];
+            nodes[index] = VirtualNodeFactory.Element(
+                "option",
+                VirtualNodeFactory.Properties(("value", value)),
+                label);
+        }
+        return nodes;
+    }
+
+    private static VirtualNode InterestGroup(RegistrationForm form)
+    {
+        var boxes = new VirtualNode[InterestOptions.Length];
+        for (var index = 0; index < InterestOptions.Length; index++)
+        {
+            var interest = InterestOptions[index];
+            boxes[index] = VirtualNodeFactory.Element(
+                "label",
+                VirtualNodeFactory.Properties(("class", "option")),
+                Model(
+                    VirtualNodeFactory.Element(
+                        "input",
+                        VirtualNodeFactory.Properties(("type", "checkbox"), ("value", interest)),
+                        (VirtualNode?[]?)null),
+                    DomRenderHelpers._vModelCheckbox,
+                    form.Interests.Value,
+                    value => form.Interests.Value = AsList(value)),
+                VirtualNodeFactory.Text(" " + interest));
+        }
+        return VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "options")), boxes);
+    }
+
+    private static VirtualNode ContactGroup(RegistrationForm form)
+    {
+        var radios = new VirtualNode[ContactOptions.Length];
+        for (var index = 0; index < ContactOptions.Length; index++)
+        {
+            var (value, label) = ContactOptions[index];
+            radios[index] = VirtualNodeFactory.Element(
+                "label",
+                VirtualNodeFactory.Properties(("class", "option")),
+                Model(
+                    VirtualNodeFactory.Element(
+                        "input",
+                        VirtualNodeFactory.Properties(("type", "radio"), ("name", "contact"), ("value", value)),
+                        (VirtualNode?[]?)null),
+                    DomRenderHelpers._vModelRadio,
+                    form.ContactMethod.Value,
+                    selected => form.ContactMethod.Value = AsString(selected)),
+                VirtualNodeFactory.Text(" " + label));
+        }
+        return VirtualNodeFactory.Element("div", VirtualNodeFactory.Properties(("class", "options")), radios);
+    }
+
+    // --- value coercion -------------------------------------------------------------------------
+
+    private static string AsString(object? value) => value as string ?? value?.ToString() ?? string.Empty;
+
+    private static bool AsBool(object? value) => value is bool boolean && boolean;
+
+    private static IList AsList(object? value) => value as IList ?? new List<string>();
+
+    private static double AsDouble(object? value) => value switch
+    {
+        double number => number,
+        int integer => integer,
+        string text when double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) => parsed,
+        _ => 0d,
+    };
+}

--- a/examples/Assimalign.Viu.Forms/Composition/RegistrationForm.cs
+++ b/examples/Assimalign.Viu.Forms/Composition/RegistrationForm.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.Forms;
+
+/// <summary>
+/// The reactive model behind the registration form, written as a composition function: one
+/// <c>Reference&lt;T&gt;</c> per field (Vue's <c>ref()</c>, the natural pairing for <c>v-model</c>)
+/// plus a couple of <c>Computed</c> derivations. It depends only on <c>Assimalign.Viu.Reactivity</c>,
+/// so the sibling test project exercises the field bindings and the derived state with no browser.
+/// The form component binds each field with the matching <c>v-model</c> directive; see
+/// https://vuejs.org/guide/essentials/forms.html.
+/// </summary>
+public sealed class RegistrationForm
+{
+    /// <summary>The full-name text field (bound with <c>.trim</c>).</summary>
+    public Reference<string> FullName { get; } = Reactive.Reference(string.Empty);
+
+    /// <summary>The email text field (bound with <c>.trim</c>).</summary>
+    public Reference<string> Email { get; } = Reactive.Reference(string.Empty);
+
+    /// <summary>The age number field (bound with <c>.number</c>, so edits arrive as a number).</summary>
+    public Reference<double> Age { get; } = Reactive.Reference(0d);
+
+    /// <summary>The multi-line bio (a <c>&lt;textarea&gt;</c> bound with <c>.lazy</c>).</summary>
+    public Reference<string> Bio { get; } = Reactive.Reference(string.Empty);
+
+    /// <summary>The terms checkbox (a single boolean <c>v-model</c>).</summary>
+    public Reference<bool> AcceptsTerms { get; } = Reactive.Reference(false);
+
+    /// <summary>The preferred contact method (a radio group).</summary>
+    public Reference<string> ContactMethod { get; } = Reactive.Reference("email");
+
+    /// <summary>The country (a single <c>&lt;select&gt;</c>).</summary>
+    public Reference<string> Country { get; } = Reactive.Reference(string.Empty);
+
+    /// <summary>The chosen interests (a checkbox group bound to a list — Vue's array checkbox model).</summary>
+    public Reference<IList> Interests { get; } = Reactive.Reference<IList>(new List<string>());
+
+    /// <summary>The known languages (a <c>&lt;select multiple&gt;</c> bound to a list).</summary>
+    public Reference<IList> Languages { get; } = Reactive.Reference<IList>(new List<string>());
+
+    /// <summary>Whether the form may be submitted — a name, an <c>@</c>-bearing email, and accepted terms.</summary>
+    public Computed<bool> IsValid { get; }
+
+    /// <summary>A single-line, live summary of the whole model — recomputes on any field change.</summary>
+    public Computed<string> Summary { get; }
+
+    /// <summary>Creates an empty form model with its derived state wired up.</summary>
+    public RegistrationForm()
+    {
+        IsValid = Reactive.Computed(() =>
+            !string.IsNullOrWhiteSpace(FullName.Value)
+            && Email.Value.Contains('@')
+            && AcceptsTerms.Value);
+
+        Summary = Reactive.Computed(() =>
+        {
+            var name = string.IsNullOrWhiteSpace(FullName.Value) ? "(no name)" : FullName.Value;
+            var age = Age.Value.ToString("0.##", CultureInfo.InvariantCulture);
+            var interests = Join(Interests.Value);
+            var languages = Join(Languages.Value);
+            return $"{name} <{Email.Value}>, age {age}; contact by {ContactMethod.Value}; "
+                + $"country {Emptyable(Country.Value)}; interests [{interests}]; languages [{languages}]; "
+                + $"terms {(AcceptsTerms.Value ? "accepted" : "not accepted")}";
+        });
+    }
+
+    private static string Emptyable(string value) => string.IsNullOrEmpty(value) ? "(none)" : value;
+
+    private static string Join(IList list) => string.Join(", ", list.Cast<object?>().Select(item => item?.ToString()));
+}

--- a/examples/Assimalign.Viu.Forms/FormsBootstrap.cs
+++ b/examples/Assimalign.Viu.Forms/FormsBootstrap.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.Forms.Components;
+using Assimalign.Viu.RuntimeDom;
+
+namespace Assimalign.Viu.Forms;
+
+/// <summary>
+/// The browser bootstrap for the forms sample — the only browser-only code in the app. Initializes
+/// the DOM bridge and mounts the root form component, mirroring Vue's <c>createApp(App).mount('#app')</c>.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static class FormsBootstrap
+{
+    /// <summary>Initializes the runtime and mounts the form into <c>#app</c>.</summary>
+    /// <returns>A task that completes once the app is mounted.</returns>
+    public static async Task RunAsync()
+    {
+        await BrowserRuntime.InitializeAsync();
+        BrowserRuntime.CreateApp(new RegistrationFormComponent()).Mount("#app");
+    }
+}

--- a/examples/Assimalign.Viu.Forms/Program.cs
+++ b/examples/Assimalign.Viu.Forms/Program.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+// The forms sample's entry point. The browser-only bootstrap sits behind OperatingSystem.IsBrowser()
+// so the reactive model (Composition/) and the components (Components/) stay platform-neutral C# that
+// the sibling test project compiles and drives DOM-free. Only FormsBootstrap touches the browser.
+if (OperatingSystem.IsBrowser())
+{
+    await Assimalign.Viu.Forms.FormsBootstrap.RunAsync();
+}
+
+// Keep the WASM main loop alive; rendering is reactive from here.
+await Task.Delay(Timeout.Infinite);

--- a/examples/Assimalign.Viu.Forms/README.md
+++ b/examples/Assimalign.Viu.Forms/README.md
@@ -1,0 +1,42 @@
+# Assimalign.Viu.Forms
+
+A registration form that exercises every implemented `v-model` flavor and modifier — the sample
+gallery's showcase of Viu's form-binding surface. Vue reference:
+[Form Input Bindings](https://vuejs.org/guide/essentials/forms.html).
+
+## What it shows
+
+- **`v-model` across input types** — text, email, number, `<textarea>`, a boolean checkbox, a checkbox
+  group bound to a list, a radio group, and single + `multiple` `<select>`. Each is bound with the
+  matching runtime directive (`_vModelText`, `_vModelCheckbox`, `_vModelRadio`, `_vModelSelect`)
+  through `Directives.WithDirectives` and a `ViuModelBinding` (current value + write-back setter — no
+  reflection, the AOT/trimming contract).
+- **Modifiers** — `.trim` (name, email), `.number` (age arrives coerced to a number), and `.lazy`
+  (the bio commits on change, not every keystroke).
+- **Composition function + computed** — [`RegistrationForm`](Composition/RegistrationForm.cs) is the
+  reactive model as a `ref`-per-field composition unit with `IsValid` and `Summary` computeds; it
+  depends only on `Assimalign.Viu.Reactivity` and is unit-tested with no browser.
+- **A live view component** — [`FormPreviewComponent`](Components/FormPreviewComponent.cs) reflects the
+  model as it changes and, because it uses no `v-model`, mounts in the in-memory test renderer.
+
+All DOM writes flow through the injected node-ops adapter; there is no ad-hoc JS interop in the sample.
+
+## Run it
+
+```sh
+dotnet run --project examples/Assimalign.Viu.Forms
+```
+
+Then open the served URL and edit the fields — the panel on the right updates live. Build a trimmed
+publish (what CI's budget gate measures) with:
+
+```sh
+dotnet publish examples/Assimalign.Viu.Forms -c Release
+```
+
+## Tests
+
+The reactive model and the preview component are covered by
+[`Assimalign.Viu.Forms.Tests`](../Assimalign.Viu.Forms.Tests). The `v-model` DOM directives are a
+browser concern (they require the DOM bridge) and are covered by the framework's own
+`Assimalign.Viu.RuntimeDom` directive tests; here the tests pin the model and the derived state.

--- a/examples/Assimalign.Viu.Forms/wwwroot/index.html
+++ b/examples/Assimalign.Viu.Forms/wwwroot/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Viu Forms &amp; v-model</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preload" id="webassembly" />
+  <script type="importmap"></script>
+  <script type="module" src="main#[.{fingerprint}].js"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif;
+      background: linear-gradient(180deg, #f7f8fa 0%, #eef1f4 100%);
+      color: #1c2531;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: 3rem 1rem;
+      display: flex;
+      justify-content: center;
+    }
+
+    #app { width: min(100%, 56rem); }
+
+    .shell {
+      display: grid;
+      grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    @media (max-width: 44rem) {
+      .shell { grid-template-columns: 1fr; }
+    }
+
+    .form {
+      background: #ffffff;
+      border-radius: 1rem;
+      padding: 1.75rem;
+      box-shadow: 0 1rem 3rem rgba(24, 35, 52, 0.1);
+      display: grid;
+      gap: 1.1rem;
+    }
+
+    .form h1 { margin: 0 0 0.25rem; font-size: 1.6rem; }
+
+    .field { display: grid; gap: 0.35rem; }
+    .field-inline { grid-auto-flow: column; justify-content: start; align-items: center; gap: 0.5rem; }
+
+    .field > label { font-size: 0.85rem; font-weight: 600; color: #46536a; }
+
+    .control {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      font: inherit;
+      border: 1px solid rgba(16, 36, 59, 0.16);
+      border-radius: 0.55rem;
+      background: #fbfcfd;
+    }
+    .control:focus { outline: 2px solid #3d7dfc; outline-offset: 1px; }
+
+    textarea.control { resize: vertical; }
+
+    .options { display: flex; flex-wrap: wrap; gap: 0.4rem 1.1rem; }
+    .option { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.95rem; }
+
+    .preview {
+      position: sticky;
+      top: 1rem;
+      background: #10233b;
+      color: #e7eefb;
+      border-radius: 1rem;
+      padding: 1.5rem;
+      box-shadow: 0 1rem 3rem rgba(16, 35, 59, 0.24);
+    }
+    .preview h2 { margin: 0 0 0.75rem; font-size: 1.05rem; letter-spacing: 0.02em; }
+
+    .status {
+      display: inline-block;
+      margin: 0 0 0.9rem;
+      padding: 0.25rem 0.7rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .status.is-ready { background: #2fae7a; color: #06231a; }
+
+    .summary {
+      margin: 0;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font-family: "Cascadia Code", ui-monospace, "SFMono-Regular", Menlo, monospace;
+      font-size: 0.85rem;
+      line-height: 1.5;
+      color: #b9cdec;
+    }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+</body>
+</html>

--- a/examples/Assimalign.Viu.Forms/wwwroot/main.js
+++ b/examples/Assimalign.Viu.Forms/wwwroot/main.js
@@ -1,0 +1,7 @@
+// App bootstrap only: the DOM bridge ships with the Assimalign.Viu.RuntimeDom package and is loaded
+// by BrowserRuntime.InitializeAsync (/_content/Assimalign.Viu.RuntimeDom/viu-dom.js).
+import { dotnet } from './_framework/dotnet.js'
+
+const { runMain } = await dotnet.create()
+
+await runMain()

--- a/examples/Assimalign.Viu.TodoMvc.Tests/AssemblyInfo.cs
+++ b/examples/Assimalign.Viu.TodoMvc.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+// The reactivity engine and the renderer's scheduler use ambient static state (single-threaded
+// JS event-loop model), so the store and component tests must not run in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/examples/Assimalign.Viu.TodoMvc.Tests/Assimalign.Viu.TodoMvc.Tests.csproj
+++ b/examples/Assimalign.Viu.TodoMvc.Tests/Assimalign.Viu.TodoMvc.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!--
+    Example projects are not resolvable through ViuProjectReference (it indexes libraries/ and
+    analyzers/ only), and the sample is a Microsoft.NET.Sdk.WebAssembly executable, so this test
+    compiles the sample's platform-neutral source directly. Program.cs and TodoMvcBootstrap.cs (the
+    only browser-only files) are deliberately excluded, so the exact store and component code the app
+    ships is exercised DOM-free through the Assimalign.Viu.Testing in-memory renderer.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Assimalign.Viu.TodoMvc\Todos\**\*.cs" LinkBase="Sample\Todos" />
+    <Compile Include="..\Assimalign.Viu.TodoMvc\Components\**\*.cs" LinkBase="Sample\Components" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeCore" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
+    <!-- The linked TodoItem is a [Reactive] partial class, so the reactivity generator must run here
+         too (the PrivateAssets=all analyzer does not flow through a project reference). -->
+    <ViuAnalyzerReference Include="Assimalign.Viu.Reactivity.Generators" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.TodoMvc.Tests/TodoAppComponentTests.cs
+++ b/examples/Assimalign.Viu.TodoMvc.Tests/TodoAppComponentTests.cs
@@ -1,0 +1,142 @@
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Testing;
+using Assimalign.Viu.TodoMvc.Components;
+
+namespace Assimalign.Viu.TodoMvc.Tests;
+
+// Drives the real component tree through the in-memory Assimalign.Viu.Testing renderer (no browser):
+// the store is provided at mount, and the no-argument DOM handlers (toggle, destroy, toggle-all,
+// filter, clear-completed, begin/blur edit) are exercised through trigger(). The two text inputs read
+// a BrowserEvent payload and so are covered in the browser instead; here they are seeded via the store.
+public sealed class TodoAppComponentTests
+{
+    private static (ComponentWrapper Wrapper, TodoStore Store) MountWithTodos(params string[] titles)
+    {
+        var store = new TodoStore();
+        foreach (var title in titles)
+        {
+            store.Add(title);
+        }
+        var options = new ComponentMountOptions().Provide(TodoStore.Key, store);
+        return (ViuTest.Mount(new TodoAppComponent(), options), store);
+    }
+
+    [Fact]
+    public void Mount_RendersOneRowPerTodo_AndTheItemsLeftCount()
+    {
+        var (wrapper, _) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            wrapper.FindAll(".todo-item").Count.ShouldBe(2);
+            wrapper.Get(".todo-count").Text().ShouldBe("2 items left");
+        }
+    }
+
+    [Fact]
+    public void EmptyStore_HidesTheMainAndFooterSections()
+    {
+        var (wrapper, _) = MountWithTodos();
+        using (wrapper)
+        {
+            wrapper.Find(".main").ShouldBeNull();
+            wrapper.Find(".footer").ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task TogglingAnItem_CompletesIt_AndUpdatesTheCount()
+    {
+        var (wrapper, store) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            await wrapper.FindAll(".toggle")[0].Trigger("change");
+
+            store.Items[0].Completed.ShouldBeTrue();
+            wrapper.FindAll(".is-completed").Count.ShouldBe(1);
+            wrapper.Get(".todo-count").Text().ShouldBe("1 item left");
+        }
+    }
+
+    [Fact]
+    public async Task DestroyButton_RemovesTheRow()
+    {
+        var (wrapper, store) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            await wrapper.FindAll(".destroy")[0].Trigger("click");
+
+            store.Items.Count.ShouldBe(1);
+            wrapper.FindAll(".todo-item").Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task ToggleAll_CompletesEveryTodo()
+    {
+        var (wrapper, store) = MountWithTodos("a", "b", "c");
+        using (wrapper)
+        {
+            await wrapper.Get(".toggle-all").Trigger("change");
+
+            store.AllCompleted.Value.ShouldBeTrue();
+            wrapper.FindAll(".is-completed").Count.ShouldBe(3);
+            wrapper.Get(".todo-count").Text().ShouldBe("0 items left");
+        }
+    }
+
+    [Fact]
+    public async Task Filters_NarrowTheVisibleRows()
+    {
+        var (wrapper, _) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            // Complete the first row, then click the "Active" filter (the second of the three links).
+            await wrapper.FindAll(".toggle")[0].Trigger("change");
+            await wrapper.FindAll("a")[1].Trigger("click");
+
+            wrapper.FindAll(".todo-item").Count.ShouldBe(1);
+
+            // "Completed" (third link) shows the other one.
+            await wrapper.FindAll("a")[2].Trigger("click");
+            wrapper.FindAll(".todo-item").Count.ShouldBe(1);
+            wrapper.FindAll(".is-completed").Count.ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task ClearCompleted_AppearsWithCompletedTodos_AndRemovesThem()
+    {
+        var (wrapper, store) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            wrapper.Find(".clear-completed").ShouldBeNull();
+
+            await wrapper.FindAll(".toggle")[0].Trigger("change");
+            wrapper.Find(".clear-completed").ShouldNotBeNull();
+
+            await wrapper.Get(".clear-completed").Trigger("click");
+            store.Items.Count.ShouldBe(1);
+            wrapper.Find(".clear-completed").ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task DoubleClickingALabel_EntersEditMode_AndBlurCommitsAndExits()
+    {
+        var (wrapper, _) = MountWithTodos("a", "b");
+        using (wrapper)
+        {
+            await wrapper.FindAll(".todo-item")[0].Get("label").Trigger("dblclick");
+
+            wrapper.FindAll(".is-editing").Count.ShouldBe(1);
+            wrapper.Find(".edit").ShouldNotBeNull();
+
+            await wrapper.Get(".edit").Trigger("blur");
+            wrapper.FindAll(".is-editing").Count.ShouldBe(0);
+        }
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc.Tests/TodoStoreTests.cs
+++ b/examples/Assimalign.Viu.TodoMvc.Tests/TodoStoreTests.cs
@@ -1,0 +1,183 @@
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.TodoMvc.Tests;
+
+// Pins the reactive TodoMVC store: trimming/blank rules, keyed ids, the mutation actions, and — the
+// part where dependency-tracking bugs hide — the *run counts* of the computed views, so a computed
+// that recomputes too often (or not often enough) fails the suite rather than passing on a
+// coincidentally-correct value. TodoMVC spec: https://github.com/tastejs/todomvc/blob/master/app-spec.md
+public sealed class TodoStoreTests
+{
+    [Fact]
+    public void Add_TrimsTitle_AndIgnoresBlankInput()
+    {
+        var store = new TodoStore();
+
+        var added = store.Add("  Buy milk  ");
+
+        added.ShouldNotBeNull();
+        added!.Title.ShouldBe("Buy milk");
+        store.Items.Count.ShouldBe(1);
+
+        store.Add("   ").ShouldBeNull();
+        store.Add(null).ShouldBeNull();
+        store.Items.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Add_AssignsUniqueIncrementingIds()
+    {
+        var store = new TodoStore();
+
+        var first = store.Add("a");
+        var second = store.Add("b");
+
+        first!.Id.ShouldBe(1);
+        second!.Id.ShouldBe(2);
+    }
+
+    [Fact]
+    public void RemainingCount_RecomputesOnToggle_AndCoalescesEqualWrites()
+    {
+        var store = new TodoStore();
+        store.Add("a");
+        store.Add("b");
+
+        var runs = 0;
+        var remaining = -1;
+        var effect = Reactive.Effect(() =>
+        {
+            runs++;
+            remaining = store.RemainingCount.Value;
+        });
+
+        runs.ShouldBe(1);
+        remaining.ShouldBe(2);
+
+        store.Toggle(store.Items[0]);
+        runs.ShouldBe(2);
+        remaining.ShouldBe(1);
+
+        // An equal-value write does not trigger (Vue's ref/reactive set only notifies on change), so
+        // the computed does not recompute and the effect does not re-run.
+        store.Items[0].Completed = true;
+        runs.ShouldBe(2);
+        remaining.ShouldBe(1);
+
+        effect.Stop();
+    }
+
+    [Fact]
+    public void Visible_FiltersByActiveAndCompleted()
+    {
+        var store = new TodoStore();
+        var a = store.Add("a")!;
+        var b = store.Add("b")!;
+        store.Toggle(b);
+
+        store.SetFilter(TodoFilter.All);
+        store.Visible.Value.ShouldBe(new[] { a, b });
+
+        store.SetFilter(TodoFilter.Active);
+        store.Visible.Value.ShouldBe(new[] { a });
+
+        store.SetFilter(TodoFilter.Completed);
+        store.Visible.Value.ShouldBe(new[] { b });
+    }
+
+    [Fact]
+    public void Visible_IsCached_AndRecomputesOnlyWhenADependencyChanges()
+    {
+        var store = new TodoStore();
+        store.Add("a");
+        store.Add("b");
+
+        var runs = 0;
+        var effect = Reactive.Effect(() =>
+        {
+            runs++;
+            _ = store.Visible.Value;
+        });
+        runs.ShouldBe(1);
+
+        // Re-selecting the current filter is an equal write: no trigger, no recompute.
+        store.SetFilter(TodoFilter.All);
+        runs.ShouldBe(1);
+
+        // A real filter change recomputes exactly once.
+        store.SetFilter(TodoFilter.Active);
+        runs.ShouldBe(2);
+
+        // Adding a todo changes the list (iteration dependency) and recomputes once.
+        store.Add("c");
+        runs.ShouldBe(3);
+
+        effect.Stop();
+    }
+
+    [Fact]
+    public void AllCompleted_IsTrueOnlyWhenNonEmptyAndEveryTodoComplete()
+    {
+        var store = new TodoStore();
+        store.AllCompleted.Value.ShouldBeFalse();
+
+        var a = store.Add("a")!;
+        var b = store.Add("b")!;
+        store.AllCompleted.Value.ShouldBeFalse();
+
+        store.SetAll(true);
+        store.AllCompleted.Value.ShouldBeTrue();
+        a.Completed.ShouldBeTrue();
+        b.Completed.ShouldBeTrue();
+
+        store.SetAll(false);
+        store.AllCompleted.Value.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ClearCompleted_RemovesOnlyCompletedTodos()
+    {
+        var store = new TodoStore();
+        var a = store.Add("a")!;
+        var b = store.Add("b")!;
+        var c = store.Add("c")!;
+        store.Toggle(a);
+        store.Toggle(c);
+
+        store.ClearCompleted();
+
+        store.Items.Count.ShouldBe(1);
+        store.Items[0].ShouldBe(b);
+    }
+
+    [Fact]
+    public void Rename_SetsTrimmedTitle_AndAnEmptyEditRemovesTheTodo()
+    {
+        var store = new TodoStore();
+        var a = store.Add("a")!;
+        var b = store.Add("b")!;
+
+        store.Rename(a, "  renamed  ");
+        a.Title.ShouldBe("renamed");
+        store.Items.Count.ShouldBe(2);
+
+        store.Rename(b, "   ");
+        store.Items.ShouldNotContain(b);
+        store.Items.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void CompletedCount_TracksToggles()
+    {
+        var store = new TodoStore();
+        var a = store.Add("a")!;
+        store.Add("b");
+
+        store.CompletedCount.Value.ShouldBe(0);
+        store.Toggle(a);
+        store.CompletedCount.Value.ShouldBe(1);
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc/Assimalign.Viu.TodoMvc.csproj
+++ b/examples/Assimalign.Viu.TodoMvc/Assimalign.Viu.TodoMvc.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkLatest)</TargetFramework>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <StaticWebAssetFingerprintPattern Include="JS" Pattern="*.js" Expression="#[.{fingerprint}]!" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+    <!-- [Reactive] on TodoItem needs the reactivity generator. The generator ships with
+         Assimalign.Viu.Reactivity as a PrivateAssets=all analyzer, so it does not flow through the
+         (transitive) project reference; an in-repo consumer opts in explicitly, exactly as the
+         Reactivity test project does. -->
+    <ViuAnalyzerReference Include="Assimalign.Viu.Reactivity.Generators" />
+  </ItemGroup>
+</Project>

--- a/examples/Assimalign.Viu.TodoMvc/Components/TodoAppComponent.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Components/TodoAppComponent.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.RuntimeDom;
+
+namespace Assimalign.Viu.TodoMvc.Components;
+
+/// <summary>
+/// The TodoMVC root — header, the todo list, and the footer, driven entirely by the shared
+/// <see cref="TodoStore"/>. It injects the store (falling back to a fresh one so the component mounts
+/// even without an app-level provide) and re-provides it to descendants. The <c>&lt;ul&gt;</c> renders
+/// one <see cref="TodoItemComponent"/> per visible todo, keyed by <see cref="TodoItem.Id"/> so the
+/// renderer reuses instances across filtering and reordering (Vue's keyed <c>v-for</c>). The whole
+/// app spec is at https://github.com/tastejs/todomvc/blob/master/app-spec.md.
+/// </summary>
+public sealed class TodoAppComponent : IComponentDefinition
+{
+    // One shared child definition drives every row; per-row state lives on the instance the renderer
+    // creates for each keyed vnode (see TodoItemComponent).
+    private static readonly TodoItemComponent ItemView = new();
+
+    /// <inheritdoc/>
+    public string? Name => "TodoApp";
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        var store = DependencyInjection.Inject(TodoStore.Key) ?? new TodoStore();
+        DependencyInjection.Provide(TodoStore.Key, store);
+
+        var newTodo = Reactive.Reference(string.Empty);
+
+        void AddFromInput()
+        {
+            store.Add(newTodo.Value);
+            newTodo.Value = string.Empty;
+        }
+
+        VirtualNode Header() => VirtualNodeFactory.Element(
+            "header",
+            VirtualNodeFactory.Properties(("class", "header")),
+            VirtualNodeFactory.Element("h1", "todos"),
+            VirtualNodeFactory.Element(
+                "input",
+                VirtualNodeFactory.Properties(
+                    ("class", "new-todo"),
+                    ("placeholder", "What needs to be done?"),
+                    ("value", newTodo.Value),
+                    ("onInput", (Action<BrowserEvent>)(browserEvent => newTodo.Value = browserEvent.TargetValue ?? string.Empty)),
+                    ("onKeyup", (Action<BrowserEvent>)(browserEvent =>
+                    {
+                        if (string.Equals(browserEvent.Key, "Enter", StringComparison.Ordinal))
+                        {
+                            AddFromInput();
+                        }
+                    }))),
+                (VirtualNode?[]?)null));
+
+        VirtualNode Main()
+        {
+            var visible = store.Visible.Value;
+            var rows = new VirtualNode?[visible.Count];
+            for (var index = 0; index < visible.Count; index++)
+            {
+                var todo = visible[index];
+                rows[index] = VirtualNodeFactory.Component(
+                    ItemView,
+                    VirtualNodeFactory.Properties(("key", todo.Id), ("todo", todo)));
+            }
+
+            return VirtualNodeFactory.Element(
+                "section",
+                VirtualNodeFactory.Properties(("class", "main")),
+                VirtualNodeFactory.Element(
+                    "input",
+                    VirtualNodeFactory.Properties(
+                        ("id", "toggle-all"),
+                        ("class", "toggle-all"),
+                        ("type", "checkbox"),
+                        ("checked", store.AllCompleted.Value),
+                        ("onChange", (Action)(() => store.SetAll(!store.AllCompleted.Value)))),
+                    (VirtualNode?[]?)null),
+                VirtualNodeFactory.Element(
+                    "label",
+                    VirtualNodeFactory.Properties(("for", "toggle-all")),
+                    "Mark all as complete"),
+                VirtualNodeFactory.Element(
+                    "ul",
+                    VirtualNodeFactory.Properties(("class", "todo-list")),
+                    rows));
+        }
+
+        VirtualNode FilterLink(string text, TodoFilter target) => VirtualNodeFactory.Element(
+            "li",
+            VirtualNodeFactory.Element(
+                "a",
+                VirtualNodeFactory.Properties(
+                    ("class", store.Filter.Value == target ? "selected" : string.Empty),
+                    ("href", "#"),
+                    ("onClick", (Action)(() => store.SetFilter(target)))),
+                text));
+
+        VirtualNode Footer()
+        {
+            var remaining = store.RemainingCount.Value;
+            return VirtualNodeFactory.Element(
+                "footer",
+                VirtualNodeFactory.Properties(("class", "footer")),
+                VirtualNodeFactory.Element(
+                    "span",
+                    VirtualNodeFactory.Properties(("class", "todo-count")),
+                    VirtualNodeFactory.Element("strong", remaining.ToString()),
+                    VirtualNodeFactory.Text(remaining == 1 ? " item left" : " items left")),
+                VirtualNodeFactory.Element(
+                    "ul",
+                    VirtualNodeFactory.Properties(("class", "filters")),
+                    FilterLink("All", TodoFilter.All),
+                    FilterLink("Active", TodoFilter.Active),
+                    FilterLink("Completed", TodoFilter.Completed)),
+                store.CompletedCount.Value > 0
+                    ? VirtualNodeFactory.Element(
+                        "button",
+                        VirtualNodeFactory.Properties(
+                            ("class", "clear-completed"),
+                            ("type", "button"),
+                            ("onClick", (Action)store.ClearCompleted)),
+                        "Clear completed")
+                    : null);
+        }
+
+        return () =>
+        {
+            var hasTodos = store.Items.Count > 0;
+            return VirtualNodeFactory.Element(
+                "section",
+                VirtualNodeFactory.Properties(("class", "todoapp")),
+                Header(),
+                hasTodos ? Main() : null,
+                hasTodos ? Footer() : null);
+        };
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc/Components/TodoItemComponent.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Components/TodoItemComponent.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.RuntimeDom;
+
+namespace Assimalign.Viu.TodoMvc.Components;
+
+/// <summary>
+/// One row of the todo list — a child component fed its <c>todo</c> by prop and reaching the shared
+/// <see cref="TodoStore"/> through inject. Its edit state (<c>editing</c>/<c>draft</c>) is local
+/// per-instance <c>ref</c> state created in <see cref="Setup"/>, so a single shared definition renders
+/// every row while each mounted instance keeps its own editing state (Vue's keyed-list reuse:
+/// https://vuejs.org/guide/essentials/list.html#maintaining-state-with-key). Toggle, destroy, and
+/// begin-edit are no-argument handlers so the in-memory test renderer can drive them; the two text
+/// inputs read the typed <see cref="BrowserEvent"/> payload and so run only in the browser.
+/// </summary>
+public sealed class TodoItemComponent : IComponentDefinition
+{
+    private static readonly IReadOnlyList<ComponentPropertyDefinition> DeclaredProperties =
+        [new ComponentPropertyDefinition("todo")];
+
+    /// <inheritdoc/>
+    public string? Name => "TodoItem";
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ComponentPropertyDefinition>? Properties => DeclaredProperties;
+
+    /// <inheritdoc/>
+    public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+    {
+        // The todo reference is stable for the life of this keyed instance, so capturing it once is
+        // correct; its reactive members (read in the render below) drive re-renders on their own.
+        var todo = properties.Get<TodoItem>("todo")!;
+        var store = DependencyInjection.Inject(TodoStore.Key)!;
+
+        var editing = Reactive.Reference(false);
+        var draft = Reactive.Reference(string.Empty);
+
+        void BeginEdit()
+        {
+            draft.Value = todo.Title;
+            editing.Value = true;
+        }
+
+        void Commit()
+        {
+            if (!editing.Value)
+            {
+                return;
+            }
+            editing.Value = false;
+            store.Rename(todo, draft.Value);
+        }
+
+        void Cancel() => editing.Value = false;
+
+        return () =>
+        {
+            var rowClass = "todo-item"
+                + (todo.Completed ? " is-completed" : string.Empty)
+                + (editing.Value ? " is-editing" : string.Empty);
+
+            var view = VirtualNodeFactory.Element(
+                "div",
+                VirtualNodeFactory.Properties(("class", "todo-view")),
+                VirtualNodeFactory.Element(
+                    "input",
+                    VirtualNodeFactory.Properties(
+                        ("class", "toggle"),
+                        ("type", "checkbox"),
+                        ("checked", todo.Completed),
+                        ("onChange", (Action)(() => store.Toggle(todo)))),
+                    (VirtualNode?[]?)null),
+                VirtualNodeFactory.Element(
+                    "label",
+                    VirtualNodeFactory.Properties(("onDblclick", (Action)BeginEdit)),
+                    todo.Title),
+                VirtualNodeFactory.Element(
+                    "button",
+                    VirtualNodeFactory.Properties(
+                        ("class", "destroy"),
+                        ("type", "button"),
+                        ("aria-label", "Delete todo"),
+                        ("onClick", (Action)(() => store.Remove(todo)))),
+                    "×"));
+
+            VirtualNode? editor = editing.Value
+                ? VirtualNodeFactory.Element(
+                    "input",
+                    VirtualNodeFactory.Properties(
+                        ("class", "edit"),
+                        ("value", draft.Value),
+                        ("onInput", (Action<BrowserEvent>)(browserEvent => draft.Value = browserEvent.TargetValue ?? string.Empty)),
+                        ("onBlur", (Action)Commit),
+                        ("onKeyup", (Action<BrowserEvent>)(browserEvent =>
+                        {
+                            if (string.Equals(browserEvent.Key, "Enter", StringComparison.Ordinal))
+                            {
+                                Commit();
+                            }
+                            else if (string.Equals(browserEvent.Key, "Escape", StringComparison.Ordinal))
+                            {
+                                Cancel();
+                            }
+                        }))),
+                    (VirtualNode?[]?)null)
+                : null;
+
+            return VirtualNodeFactory.Element(
+                "li",
+                VirtualNodeFactory.Properties(("class", rowClass)),
+                view,
+                editor);
+        };
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc/Program.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+// The TodoMVC sample's entry point. Everything the app needs to run in the browser lives behind the
+// OperatingSystem.IsBrowser() guard so the components and the reactive store (Components/, Todos/)
+// stay platform-neutral C# that the sibling test project compiles and drives DOM-free through the
+// Assimalign.Viu.Testing in-memory renderer. Only TodoMvcBootstrap touches the browser.
+if (OperatingSystem.IsBrowser())
+{
+    await Assimalign.Viu.TodoMvc.TodoMvcBootstrap.RunAsync();
+}
+
+// Keep the WASM main loop alive; rendering is reactive from here.
+await Task.Delay(Timeout.Infinite);

--- a/examples/Assimalign.Viu.TodoMvc/README.md
+++ b/examples/Assimalign.Viu.TodoMvc/README.md
@@ -1,0 +1,42 @@
+# Assimalign.Viu.TodoMvc
+
+The canonical [TodoMVC](https://github.com/tastejs/todomvc/blob/master/app-spec.md) app, built with
+Viu components and the reactive core — the sample gallery's showcase of `[Reactive]` source-generated
+state, `ReactiveList<T>`, computed views, and typed provide/inject.
+
+## What it shows
+
+- **`[Reactive]` objects** — [`TodoItem`](Todos/TodoItem.cs) is a `[Reactive]` partial class; the
+  `Assimalign.Viu.Reactivity` source generator fills in each property's track/trigger plumbing (Vue's
+  `reactive()`), so toggling one todo re-renders only what read it.
+- **`ReactiveList<T>` + computed views** — [`TodoStore`](Todos/TodoStore.cs) holds a
+  `ReactiveList<TodoItem>` and derives the filtered list, remaining/completed counts, and the
+  toggle-all state as `Computed<T>` values. The store is a composition-style unit that depends on
+  nothing but `Assimalign.Viu.Reactivity`, so it is fully unit-tested with no browser.
+- **Component model** — a root [`TodoAppComponent`](Components/TodoAppComponent.cs) renders a keyed
+  list of [`TodoItemComponent`](Components/TodoItemComponent.cs) rows (props in, per-row local edit
+  state), reused across filtering by `key`.
+- **Typed provide/inject** — one `TodoStore` is `provide`d app-wide under a typed `InjectionKey<T>`
+  and injected by every component (`TodoStore.Key`).
+
+Every mutation (add, toggle, edit, destroy, toggle-all, clear-completed) and the All/Active/Completed
+filters follow the TodoMVC spec. The renderer drives real DOM through the injected node-ops adapter;
+there is no ad-hoc JS interop in the sample.
+
+## Run it
+
+```sh
+dotnet run --project examples/Assimalign.Viu.TodoMvc
+```
+
+Then open the served URL. Build a trimmed publish (what CI's budget gate measures) with:
+
+```sh
+dotnet publish examples/Assimalign.Viu.TodoMvc -c Release
+```
+
+## Tests
+
+The store and the DOM-drivable component behavior are covered by
+[`Assimalign.Viu.TodoMvc.Tests`](../Assimalign.Viu.TodoMvc.Tests) using the in-memory
+`Assimalign.Viu.Testing` renderer (no browser).

--- a/examples/Assimalign.Viu.TodoMvc/TodoMvcBootstrap.cs
+++ b/examples/Assimalign.Viu.TodoMvc/TodoMvcBootstrap.cs
@@ -1,0 +1,31 @@
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.RuntimeDom;
+using Assimalign.Viu.TodoMvc.Components;
+
+namespace Assimalign.Viu.TodoMvc;
+
+/// <summary>
+/// The browser bootstrap for the TodoMVC sample — the only browser-only code in the app. Initializes
+/// the DOM bridge, provides the shared <see cref="TodoStore"/> app-wide through a typed
+/// <c>InjectionKey</c> (the same store the root and each item component inject), and mounts the root.
+/// A Viu app bootstrap mirrors Vue's <c>createApp(App).provide(key, store).mount('#app')</c>
+/// (https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api).
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static class TodoMvcBootstrap
+{
+    /// <summary>Initializes the runtime and mounts the TodoMVC app into <c>#app</c>.</summary>
+    /// <returns>A task that completes once the app is mounted.</returns>
+    public static async Task RunAsync()
+    {
+        await BrowserRuntime.InitializeAsync();
+
+        var store = TodoStore.CreateSeeded();
+        BrowserRuntime
+            .CreateApp(new TodoAppComponent())
+            .Provide(TodoStore.Key, store)
+            .Mount("#app");
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc/Todos/TodoFilter.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Todos/TodoFilter.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Viu.TodoMvc;
+
+/// <summary>
+/// The active view filter — the three routes of the canonical TodoMVC footer
+/// (https://github.com/tastejs/todomvc/blob/master/app-spec.md#routing). Kept as a plain enum held in
+/// a <c>Reference&lt;TodoFilter&gt;</c> rather than wired to the router, so this sample stays focused
+/// on reactivity and the component model.
+/// </summary>
+public enum TodoFilter
+{
+    /// <summary>Every todo, complete or not.</summary>
+    All,
+
+    /// <summary>Only todos that are not yet complete.</summary>
+    Active,
+
+    /// <summary>Only completed todos.</summary>
+    Completed,
+}

--- a/examples/Assimalign.Viu.TodoMvc/Todos/TodoItem.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Todos/TodoItem.cs
@@ -1,0 +1,24 @@
+using Assimalign.Viu.Reactivity;
+
+namespace Assimalign.Viu.TodoMvc;
+
+/// <summary>
+/// A single todo — a source-generated <c>[Reactive]</c> object (Vue 3.5's <c>reactive()</c>,
+/// https://vuejs.org/api/reactivity-core.html#reactive). The <c>Assimalign.Viu.Reactivity.Generators</c>
+/// generator fills in each <c>partial</c> property with track-on-get / trigger-on-change plumbing, so
+/// toggling <see cref="Completed"/> or renaming <see cref="Title"/> re-renders exactly the effects
+/// that read that member — no JavaScript <c>Proxy</c>, no reflection. Held in the store's
+/// <see cref="ReactiveList{T}"/>.
+/// </summary>
+[Reactive]
+public partial class TodoItem
+{
+    /// <summary>The stable identity used as the keyed-list key (never reused within a session).</summary>
+    public partial int Id { get; set; }
+
+    /// <summary>The todo's text.</summary>
+    public partial string Title { get; set; }
+
+    /// <summary>Whether the todo is done.</summary>
+    public partial bool Completed { get; set; }
+}

--- a/examples/Assimalign.Viu.TodoMvc/Todos/TodoStore.cs
+++ b/examples/Assimalign.Viu.TodoMvc/Todos/TodoStore.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.TodoMvc;
+
+/// <summary>
+/// The TodoMVC application state, written as a composition-style store: a <see cref="ReactiveList{T}"/>
+/// of <see cref="TodoItem"/> plus a handful of <c>Computed</c> views and the actions that mutate them.
+/// This is the whole "model" of the app and the primary unit under test — it depends only on
+/// <c>Assimalign.Viu.Reactivity</c>, so the sibling test project drives it with no browser.
+/// <para>
+/// It is shared across components through the typed <see cref="Key"/> (Vue's <c>InjectionKey</c>):
+/// the bootstrap <c>provide</c>s one instance app-wide and every component <c>inject</c>s it, mirroring
+/// the reactivity-store pattern in
+/// https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api.
+/// </para>
+/// </summary>
+public sealed class TodoStore
+{
+    /// <summary>The typed provide/inject key the bootstrap and every component share.</summary>
+    public static readonly InjectionKey<TodoStore> Key = new("todo-store");
+
+    private readonly ReactiveList<TodoItem> _items = [];
+    private readonly Reference<TodoFilter> _filter = Reactive.Reference(TodoFilter.All);
+    private int _nextId;
+
+    /// <summary>Creates an empty store.</summary>
+    public TodoStore()
+    {
+        // Computeds are lazy + versioned (Vue's computed()): each recomputes only when a dependency it
+        // read last time changes, so reading them per render is cheap. Their run counts are pinned by
+        // the tests, which is where reactivity bugs actually hide.
+        Visible = Reactive.Computed<IReadOnlyList<TodoItem>>(() => _filter.Value switch
+        {
+            TodoFilter.Active => _items.Where(item => !item.Completed).ToArray(),
+            TodoFilter.Completed => _items.Where(item => item.Completed).ToArray(),
+            _ => _items.ToArray(),
+        });
+        RemainingCount = Reactive.Computed(() => _items.Count(item => !item.Completed));
+        CompletedCount = Reactive.Computed(() => _items.Count(item => item.Completed));
+        AllCompleted = Reactive.Computed(() => _items.Count > 0 && _items.All(item => item.Completed));
+    }
+
+    /// <summary>The live backing collection (every mutation flows through the actions below).</summary>
+    public ReactiveList<TodoItem> Items => _items;
+
+    /// <summary>The active view filter (settable through <see cref="SetFilter"/>).</summary>
+    public Reference<TodoFilter> Filter => _filter;
+
+    /// <summary>The todos matching <see cref="Filter"/>, in list order (Vue's <c>filteredTodos</c>).</summary>
+    public Computed<IReadOnlyList<TodoItem>> Visible { get; }
+
+    /// <summary>The number of not-yet-complete todos (the footer's "items left").</summary>
+    public Computed<int> RemainingCount { get; }
+
+    /// <summary>The number of completed todos (drives the "Clear completed" affordance).</summary>
+    public Computed<int> CompletedCount { get; }
+
+    /// <summary>Whether there is at least one todo and all todos are complete (the toggle-all state).</summary>
+    public Computed<bool> AllCompleted { get; }
+
+    /// <summary>
+    /// Adds a todo from <paramref name="title"/> after trimming; blank input is ignored (app-spec: "If
+    /// it's empty the input is not added"). Returns the created item, or <see langword="null"/> when
+    /// the trimmed title was empty.
+    /// </summary>
+    /// <param name="title">The raw input text.</param>
+    /// <returns>The new <see cref="TodoItem"/>, or <see langword="null"/> when nothing was added.</returns>
+    public TodoItem? Add(string? title)
+    {
+        var trimmed = title?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return null;
+        }
+        var item = new TodoItem { Id = ++_nextId, Title = trimmed, Completed = false };
+        _items.Add(item);
+        return item;
+    }
+
+    /// <summary>Removes <paramref name="item"/> (the todo's destroy button).</summary>
+    /// <param name="item">The todo to remove.</param>
+    public void Remove(TodoItem item) => _items.Remove(item);
+
+    /// <summary>Flips <paramref name="item"/>'s completed state (the item checkbox).</summary>
+    /// <param name="item">The todo to toggle.</param>
+    public void Toggle(TodoItem item) => item.Completed = !item.Completed;
+
+    /// <summary>Sets every todo's completed state to <paramref name="completed"/> (the toggle-all control).</summary>
+    /// <param name="completed">The state to apply to all todos.</param>
+    public void SetAll(bool completed)
+    {
+        foreach (var item in _items)
+        {
+            item.Completed = completed;
+        }
+    }
+
+    /// <summary>Removes every completed todo (the footer's "Clear completed").</summary>
+    public void ClearCompleted()
+    {
+        foreach (var completed in _items.Where(item => item.Completed).ToArray())
+        {
+            _items.Remove(completed);
+        }
+    }
+
+    /// <summary>
+    /// Renames <paramref name="item"/> to a trimmed <paramref name="title"/>; an empty edit removes the
+    /// todo (app-spec: "If the text is empty the todo should instead be destroyed").
+    /// </summary>
+    /// <param name="item">The todo being edited.</param>
+    /// <param name="title">The new raw text.</param>
+    public void Rename(TodoItem item, string? title)
+    {
+        var trimmed = title?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            _items.Remove(item);
+            return;
+        }
+        item.Title = trimmed;
+    }
+
+    /// <summary>Selects the active view filter.</summary>
+    /// <param name="filter">The filter to activate.</param>
+    public void SetFilter(TodoFilter filter) => _filter.Value = filter;
+
+    /// <summary>Creates a store pre-populated with a couple of demo todos for first load.</summary>
+    /// <returns>A seeded store.</returns>
+    public static TodoStore CreateSeeded()
+    {
+        var store = new TodoStore();
+        store.Add("Learn Viu's reactive core");
+        var done = store.Add("Read the .viu single-file-component format");
+        store.Add("Ship a component to the browser");
+        if (done is not null)
+        {
+            done.Completed = true;
+        }
+        return store;
+    }
+}

--- a/examples/Assimalign.Viu.TodoMvc/wwwroot/index.html
+++ b/examples/Assimalign.Viu.TodoMvc/wwwroot/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Viu TodoMVC</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preload" id="webassembly" />
+  <script type="importmap"></script>
+  <script type="module" src="main#[.{fingerprint}].js"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif;
+      background: linear-gradient(180deg, #f6f7f9 0%, #eef0f3 100%);
+      color: #21232a;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: 4rem 1rem;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    #app { width: min(100%, 34rem); }
+
+    .todoapp {
+      background: #ffffff;
+      border-radius: 1rem;
+      box-shadow: 0 1.25rem 3rem rgba(24, 35, 52, 0.12);
+      overflow: hidden;
+    }
+
+    .header { padding: 1.5rem 1.5rem 0.5rem; }
+
+    .header h1 {
+      margin: 0 0 0.75rem;
+      font-size: 3rem;
+      font-weight: 200;
+      text-align: center;
+      color: #ce4a3f;
+      letter-spacing: 0.04em;
+    }
+
+    .new-todo,
+    .edit {
+      width: 100%;
+      padding: 0.9rem 1rem;
+      font: inherit;
+      border: 1px solid rgba(16, 36, 59, 0.14);
+      border-radius: 0.6rem;
+      background: #fbfbfc;
+    }
+
+    .new-todo:focus, .edit:focus {
+      outline: 2px solid #f05a28;
+      outline-offset: 1px;
+    }
+
+    .main { border-top: 1px solid #eef0f3; padding: 0.5rem 0; }
+
+    .toggle-all { margin: 0 0.5rem 0 1.25rem; }
+    .main label[for="toggle-all"] { font-size: 0.85rem; color: #7a8699; }
+
+    .todo-list { list-style: none; margin: 0.5rem 0 0; padding: 0; }
+
+    .todo-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.65rem 1.25rem;
+      border-top: 1px solid #f1f2f5;
+    }
+
+    .todo-view {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .todo-item .toggle { width: 1.15rem; height: 1.15rem; }
+
+    .todo-item label {
+      flex: 1;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      cursor: pointer;
+    }
+
+    .todo-item.is-completed label {
+      color: #9aa4b2;
+      text-decoration: line-through;
+    }
+
+    .todo-item .destroy {
+      appearance: none;
+      border: none;
+      background: none;
+      color: #c9ccd4;
+      font-size: 1.4rem;
+      line-height: 1;
+      cursor: pointer;
+    }
+    .todo-item .destroy:hover { color: #ce4a3f; }
+
+    .todo-item.is-editing .todo-view { display: none; }
+    .todo-item .edit { margin: 0; }
+
+    .footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      padding: 0.85rem 1.25rem;
+      border-top: 1px solid #eef0f3;
+      font-size: 0.85rem;
+      color: #7a8699;
+    }
+
+    .filters { display: flex; gap: 0.35rem; list-style: none; margin: 0; padding: 0; }
+    .filters a {
+      padding: 0.2rem 0.55rem;
+      border-radius: 0.4rem;
+      color: inherit;
+      text-decoration: none;
+      border: 1px solid transparent;
+    }
+    .filters a.selected {
+      border-color: rgba(240, 90, 40, 0.4);
+      color: #ce4a3f;
+    }
+
+    .clear-completed {
+      appearance: none;
+      border: none;
+      background: none;
+      color: inherit;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+    .clear-completed:hover { color: #ce4a3f; }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+</body>
+</html>

--- a/examples/Assimalign.Viu.TodoMvc/wwwroot/main.js
+++ b/examples/Assimalign.Viu.TodoMvc/wwwroot/main.js
@@ -1,0 +1,7 @@
+// App bootstrap only: the DOM bridge ships with the Assimalign.Viu.RuntimeDom package and is loaded
+// by BrowserRuntime.InitializeAsync (/_content/Assimalign.Viu.RuntimeDom/viu-dom.js).
+import { dotnet } from './_framework/dotnet.js'
+
+const { runMain } = await dotnet.create()
+
+await runMain()

--- a/scripts/budgets/PublishBudgets.json
+++ b/scripts/budgets/PublishBudgets.json
@@ -19,14 +19,29 @@
     "runs when that lane activates.",
     "",
     "Seed provenance: Assimalign.Viu.WebApp measured 2,097,190 bytes brotli (7,363,995 raw, 19 files) on",
-    "2026-07-19 with .NET SDK 10.0.302 / wasm-tools 10.0.110. CI (ubuntu x64) is the authority; if its",
-    "measurement differs materially from this Windows seed, recalibrate via an explicit edit here."
+    "2026-07-19 with .NET SDK 10.0.302 / wasm-tools 10.0.110. Assimalign.Viu.TodoMvc measured 2,105,673",
+    "bytes brotli (7,381,993 raw, 19 files) and Assimalign.Viu.Forms measured 2,191,921 bytes brotli",
+    "(7,650,843 raw, 20 files) on 2026-07-20 with the same toolchain ([V01.01.13.02]). CI (ubuntu x64) is",
+    "the authority; if its measurement differs materially from these Windows seeds, recalibrate via an",
+    "explicit edit here."
   ],
   "samples": [
     {
       "name": "Assimalign.Viu.WebApp",
       "project": "examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj",
       "compressedPublishSizeBytes": 2310000,
+      "startupBudgetMilliseconds": 5000
+    },
+    {
+      "name": "Assimalign.Viu.TodoMvc",
+      "project": "examples/Assimalign.Viu.TodoMvc/Assimalign.Viu.TodoMvc.csproj",
+      "compressedPublishSizeBytes": 2320000,
+      "startupBudgetMilliseconds": 5000
+    },
+    {
+      "name": "Assimalign.Viu.Forms",
+      "project": "examples/Assimalign.Viu.Forms/Assimalign.Viu.Forms.csproj",
+      "compressedPublishSizeBytes": 2420000,
       "startupBudgetMilliseconds": 5000
     }
   ]


### PR DESCRIPTION
## Summary
- Builds the sample gallery with two consumer-shaped apps: **TodoMVC** (`[Reactive]` items, `ReactiveList<T>`, computed filter/remaining views, keyed lists, typed provide/inject, parent/child component split) and **Forms** (every implemented `v-model` flavor — text/email/number/textarea/checkbox/checkbox-list/radio/single+multiple select — plus `.trim`/`.number`/`.lazy` modifiers, with a ref-per-field composition model and computed validity).
- **CI reworked to a matrix**: `webapp.yml` now builds WebApp/TodoMvc/Forms with `-warnaserror` plus a DOM-free test lane over both example test projects — adding a sample is one matrix line (justified over per-file workflows since the budget manifest already treats samples as a set).
- **Budget entries seeded from real measured trimmed publishes**: TodoMvc 2,105,673 B → 2,320,000; Forms 2,191,921 B → 2,420,000 (~10% headroom, the established methodology); `Measure-PublishBudget.ps1` PASSES with both.
- `.viu`-component authoring is blocked by the known [#216](https://github.com/assimalign/viu/issues/216) (independently confirmed here, not duplicated), so samples are idiomatic hand-written `IComponentDefinition` components — exactly what #99's AC names. Filed [#218 [V01.01.11.06]](https://github.com/assimalign/viu/issues/218): payload-carrying event handlers have no single shape that works across both renderers, limiting DOM-free input-handler testing (samples test the reactive model instead).
- Deliberate integration choice: the stopwatch WebApp was left un-renamed/unmodified to avoid colliding with the parallel HackerNews branch and to preserve its budget-seed provenance and `?diagnostics=1` benchmark host — a literal `Assimalign.Viu.Stopwatch` rename remains a trivial follow-up if wanted.
- Beyond the gates, a manual browser smoke: both apps load and render with zero console errors; the Forms `v-model` round-trip verified live (input → setter → ref → computed → re-render). Automated browser driving stays with [#87](https://github.com/assimalign/viu/issues/87).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · each sample Release `-warnaserror` clean · budget gate PASS (9.2%/9.4% headroom) · new tests TodoMvc 17 + Forms 5, existing RuntimeCore 257 / Testing 18 untouched.

Closes #99
Refs #216, #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)