### PR TITLE
feat(router): run guards for the initial navigation via the START location [V01.01.08.07]

### DIFF
--- a/examples/Assimalign.Viu.HackerNews.Tests/RouteTableTests.cs
+++ b/examples/Assimalign.Viu.HackerNews.Tests/RouteTableTests.cs
@@ -79,13 +79,26 @@ public sealed class RouteTableTests
     }
 
     [Fact]
+    public async Task Root_redirects_to_the_top_feed_on_initial_navigation()
+    {
+        // The initial page-load "/" case: the router starts at the START sentinel, so ReadyAsync runs
+        // the RedirectRoot beforeEach for the entry URL and redirects "/" -> "/top" on first resolve —
+        // the exact scenario #219 (a direct load at "/") the bootstrap no longer works around
+        // ([V01.01.08.07]).
+        var router = CreateRouter();
+
+        await router.ReadyAsync();
+
+        router.CurrentRoute.Value.Name.ShouldBe("feed");
+        router.CurrentRoute.Value.Parameters.GetString("feed").ShouldBe("top");
+    }
+
+    [Fact]
     public async Task Root_redirects_to_the_top_feed_in_session()
     {
-        // The BeforeEach root redirect fires for an in-session navigation to "/" (e.g. clicking the
-        // logo). Navigate away from the router's pre-resolved initial "/" first, so this Push is not a
-        // deduplicated same-location no-op. (The initial page-load "/" case is handled in bootstrap —
-        // Program.Main — because the router resolves its initial location without running guards; see
-        // [V01.01.08.07], #219.)
+        // The BeforeEach root redirect also fires for an in-session navigation to "/" (e.g. clicking
+        // the logo). Navigate away from the initial location first, so this Push is not a deduplicated
+        // same-location no-op.
         var router = CreateRouter();
         await router.Push("/new");
 

--- a/examples/Assimalign.Viu.HackerNews/Program.cs
+++ b/examples/Assimalign.Viu.HackerNews/Program.cs
@@ -39,12 +39,11 @@ internal static class Program
         var router = new Assimalign.Viu.Router.Router(history, AppRoutes.Create());
         router.BeforeEach(AppRoutes.RedirectRoot);
 
-        // Resolve the initial URL before mounting. The router resolves its initial location eagerly and
-        // without running guards (no vue-router START sentinel — [V01.01.08.07], #219), so the BeforeEach
-        // root redirect cannot fire for a page loaded directly at "/". Map it to the top feed here; the
-        // guard still handles in-session navigations to "/" (e.g. the logo).
-        var initialLocation = history.Location is "/" or "" ? "/top" : history.Location;
-        await router.Replace(initialLocation);
+        // Run the initial navigation through the full guard pipeline before mounting ([V01.01.08.07],
+        // #219): the router starts at the START sentinel, so ReadyAsync navigates to the current URL
+        // with from = START and the RedirectRoot beforeEach fires even for a page loaded directly at
+        // "/", redirecting it to /top. Awaiting settles the first route so the initial render is correct.
+        await router.ReadyAsync();
 
         // A per-app store registry, provided app-wide so UseStore() resolves through component context;
         // the store-definitions container and the router are provided under their injection keys.

--- a/examples/Assimalign.Viu.HackerNews/README.md
+++ b/examples/Assimalign.Viu.HackerNews/README.md
@@ -34,8 +34,9 @@ from `https://hacker-news.firebaseio.com/v0/`, which sends permissive CORS heade
 | `/user/:id` | `user` | `UserView` (async) | User profile. |
 | `/:pathMatch(.*)*` | `not-found` | `NotFoundView` | Catch-all 404. |
 
-`/` is mapped to `/top` at bootstrap, and a `beforeEach` guard redirects in-session navigations to `/`
-(e.g. the logo) to `/top`.
+A `beforeEach` guard redirects `/` to `/top`. Bootstrap awaits `router.ReadyAsync()` before mounting,
+so this guard runs the initial navigation through the full pipeline — the redirect fires both for a
+page loaded directly at `/` and for in-session navigations to `/` (e.g. clicking the logo).
 
 ## Architecture
 

--- a/libraries/Assimalign.Viu.Router/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Router/docs/DESIGN.md
@@ -250,6 +250,41 @@ ordering test that mounts a real view tree and records every hook.
   `OnError` handlers and faults the returned task — upstream's `triggerError` + promise rejection.
   `RouterLink` observes its fire-and-forget navigation so a fault never strands unobserved.
 
+### The initial navigation runs the pipeline from the START location
+
+`CurrentRoute` begins at `RouteLocation.Start` — the port of upstream's `START_LOCATION_NORMALIZED`
+(`packages/router/src/location.ts`): path `/`, no name, no params, and an **empty matched chain**. The
+constructor deliberately does *not* eagerly resolve `history.Location` into the current route, because
+that pre-resolution is exactly what made the first `Push` to the already-resolved entry URL a
+`Duplicated` no-op that skipped the guard pipeline — so a global `beforeEach` redirect for the entry
+URL (the classic `{ path: '/', redirect: '/x' }`) never fired for a page loaded directly at that URL
+(`[V01.01.08.07]`, #219).
+
+- **Distinguishing the initial pass from an in-session duplicate.** The same-location dedup is gated
+  on `from.Matched.Count > 0` — the port of upstream's `from.matched.length` guard on the duplicate
+  check. START has an empty matched chain, so the initial navigation is never deduplicated and always
+  runs the full pipeline; every in-session navigation starts from a matched route, so same-location
+  pushes still short-circuit to `Duplicated`. The START sentinel is value-equal to an *unmatched* `/`
+  resolution, so this count gate (not value equality) is what keeps them apart.
+- **`ReadyAsync` triggers and awaits the first navigation.** With no `app.use(router)` install hook in
+  Viu, one idempotent method folds upstream's install-time initial `push(routerHistory.location)` and
+  its `router.isReady()`. The first call navigates to the current history location through the full
+  pipeline with `from` = START (so the leave phase is trivially empty and every enter/global guard
+  fires once), memoizes the resulting task, and returns it to every later caller. A bootstrap awaits it
+  before mounting so the first render already reflects the resolved (or redirected) route. Unlike
+  upstream's `isReady()` — which can hang if the initial navigation aborts — Viu's always settles.
+- **The first confirm replaces, never pushes.** `finalizeNavigation` forces a replace when `from` is
+  the START sentinel (`ReferenceEquals`, upstream's `isFirstNavigation`), so the app's entry URL is not
+  left as a stale back-target; through an initial redirect the reference stays START across the whole
+  chain because nothing is committed until the final confirm.
+- **RouterView is empty at START.** With an empty matched chain, every `RouterView` resolves no record
+  at its depth and renders nothing until the initial navigation confirms — matching upstream's empty
+  `matched` at START.
+- **No compensating `go` for the initial resolution.** The initial navigation runs through the
+  application push path (`ReadyAsync` → `Navigate` → `PushWithRedirect`), never the popstate listener,
+  so the pop path's compensating `history.go` (below) cannot fire for it — an aborted initial
+  navigation simply leaves `CurrentRoute` at START and history untouched.
+
 ### In-component guards hook the component lifecycle, never reflection
 
 `beforeRouteLeave`/`beforeRouteUpdate` need per-instance state, so they are **registration-based**

--- a/libraries/Assimalign.Viu.Router/src/RouteLocation.cs
+++ b/libraries/Assimalign.Viu.Router/src/RouteLocation.cs
@@ -18,6 +18,10 @@ namespace Assimalign.Viu.Router;
 /// </remarks>
 public sealed class RouteLocation : IEquatable<RouteLocation>
 {
+    private static readonly IReadOnlyList<RouteRecord> EmptyMatched = Array.Empty<RouteRecord>();
+    private static readonly IReadOnlyDictionary<string, object?> EmptyMeta =
+        new Dictionary<string, object?>(0);
+
     internal RouteLocation(
         string path,
         string? name,
@@ -31,6 +35,19 @@ public sealed class RouteLocation : IEquatable<RouteLocation>
         Matched = matched;
         Meta = meta;
     }
+
+    /// <summary>
+    /// The initial (start) location a <see cref="Router.CurrentRoute"/> holds before its first
+    /// navigation confirms — the C# port of vue-router's <c>START_LOCATION_NORMALIZED</c>
+    /// (<c>packages/router/src/location.ts</c>,
+    /// https://router.vuejs.org/api/#Variables-START-LOCATION). It has path <c>"/"</c>, no name, no
+    /// parameters, and — the defining trait — an <b>empty</b> <see cref="Matched"/> chain, so it is
+    /// never equal to any resolved route and never renders through a <see cref="RouterView"/>. The
+    /// router compares against this exact instance by reference to recognize the first navigation,
+    /// which runs the full guard pipeline with <c>from</c> set to this sentinel.
+    /// </summary>
+    public static RouteLocation Start { get; } =
+        new("/", name: null, RouteParameters.Empty, EmptyMatched, EmptyMeta);
 
     /// <summary>The concrete resolved path.</summary>
     public string Path { get; }

--- a/libraries/Assimalign.Viu.Router/src/Router.cs
+++ b/libraries/Assimalign.Viu.Router/src/Router.cs
@@ -28,6 +28,16 @@ namespace Assimalign.Viu.Router;
 /// in-flight one through a cooperative <see cref="CancellationToken"/>.
 /// </para>
 /// <para>
+/// <b>The initial navigation</b> mirrors upstream's START-location semantics: <see cref="CurrentRoute"/>
+/// begins at <see cref="RouteLocation.Start"/> (empty matched chain), not the eagerly resolved initial
+/// location. <see cref="ReadyAsync"/> runs the first navigation to the history location through the
+/// same full pipeline with <c>from</c> = the START sentinel — so a global <see cref="BeforeEach"/>
+/// redirect fires for a direct page load — and its confirm step replaces (never pushes) the current
+/// history entry, exactly as upstream forces a replace when <c>from === START_LOCATION_NORMALIZED</c>.
+/// The same-location dedup is skipped whenever <c>from</c> has an empty matched chain, so START never
+/// short-circuits the initial pass while in-session duplicates still do.
+/// </para>
+/// <para>
 /// <b>Deliberate C# divergences from vue-router</b> (see <c>docs/DESIGN.md</c>): guards return a
 /// <see cref="NavigationGuardResult"/> instead of calling <c>next()</c>; <see cref="Push"/> resolves
 /// with a <see cref="NavigationFailure"/> for abort/cancel/duplicate and faults only on genuinely
@@ -56,6 +66,7 @@ public sealed class Router : IDisposable
     private readonly Dictionary<RouteRecord, List<NavigationGuard>> _leaveGuards = [];
     private readonly Dictionary<RouteRecord, List<NavigationGuard>> _updateGuards = [];
     private CancellationTokenSource? _pendingNavigation;
+    private Task<NavigationFailure?>? _initialNavigation;
     private bool _disposed;
 
     /// <summary>Creates a router over an existing matcher and history.</summary>
@@ -68,7 +79,11 @@ public sealed class Router : IDisposable
         ArgumentNullException.ThrowIfNull(matcher);
         _history = history;
         _matcher = matcher;
-        _currentRoute = Reactive.ShallowReference(matcher.Resolve(history.Location));
+        // Seed the current route with the START sentinel (empty matched chain), not the eagerly
+        // resolved initial location, so the first navigation runs the full guard pipeline instead of
+        // being deduplicated against a pre-resolved route (upstream: currentRoute starts at
+        // START_LOCATION_NORMALIZED; the initial navigation is a real push from START — [V01.01.08.07]).
+        _currentRoute = Reactive.ShallowReference(RouteLocation.Start);
         _unlisten = history.Listen(OnHistoryNavigation);
     }
 
@@ -211,6 +226,32 @@ public sealed class Router : IDisposable
     public Task<NavigationFailure?> Replace(string location) => Navigate(location, replace: true);
 
     /// <summary>
+    /// Runs the initial navigation and resolves when it settles — the C# port of vue-router's
+    /// <c>router.isReady()</c> combined with the install-time initial push
+    /// (<c>packages/router/src/router.ts</c>, https://router.vuejs.org/api/#isReady). The first call
+    /// navigates to the current history location through the <b>full</b> guard pipeline with
+    /// <c>from</c> = <see cref="RouteLocation.Start"/>, so a global <see cref="BeforeEach"/> redirect
+    /// (the classic <c>/</c> → <c>/x</c>) fires even for a page loaded directly at that URL; the
+    /// confirm step replaces the current history entry rather than pushing a new one. Idempotent —
+    /// every call returns the same task, so the initial navigation runs exactly once.
+    /// </summary>
+    /// <remarks>
+    /// A Viu bootstrap awaits this before mounting so the first render already reflects the resolved
+    /// (or redirected) route. The returned task resolves with the initial navigation's
+    /// <see cref="NavigationFailure"/> (or <see langword="null"/> on success) and faults only on an
+    /// unexpected guard exception. Because there is no <c>app.use(router)</c> install hook in Viu, this
+    /// single method folds upstream's separate install-time trigger and <c>isReady()</c> await; unlike
+    /// upstream's <c>isReady()</c>, it always settles (never hangs) for an aborted initial navigation.
+    /// </remarks>
+    /// <returns>The initial navigation outcome, settling when it completes.</returns>
+    /// <exception cref="ObjectDisposedException">The router has been disposed.</exception>
+    public Task<NavigationFailure?> ReadyAsync()
+    {
+        ThrowIfDisposed();
+        return _initialNavigation ??= Navigate(_history.Location, replace: false);
+    }
+
+    /// <summary>
     /// Moves through the history stack by <paramref name="delta"/> entries, driving the same guard
     /// pipeline as a browser back/forward (upstream: <c>router.go</c>). The resulting navigation runs
     /// asynchronously through the history listener.
@@ -307,7 +348,10 @@ public sealed class Router : IDisposable
         var token = BeginNavigation();
         var from = _currentRoute.Value;
         NavigationFailure? failure;
-        if (IsSameLocation(from, to))
+        // Dedup only when `from` already has a matched chain (upstream gates on `from.matched.length`):
+        // the START sentinel has an empty chain, so the initial navigation is never deduplicated and
+        // always runs the full pipeline, while in-session same-location navigations still short-circuit.
+        if (from.Matched.Count > 0 && IsSameLocation(from, to))
         {
             // Duplicated: skip the pipeline entirely but still notify afterEach (upstream parity).
             failure = new NavigationFailure(NavigationFailureType.Duplicated, to, from);
@@ -341,7 +385,13 @@ public sealed class Router : IDisposable
                     }
                     else
                     {
-                        FinalizeNavigation(to, isPush: true, replace);
+                        // The first navigation (from the START sentinel) replaces the current history
+                        // entry rather than pushing a new one, so the app's entry URL is not left as a
+                        // stale back-target (upstream: isFirstNavigation forces a replace in
+                        // finalizeNavigation). ReferenceEquals stays true through a redirect chain
+                        // because nothing is committed until this confirm.
+                        var isFirstNavigation = ReferenceEquals(from, RouteLocation.Start);
+                        FinalizeNavigation(to, isPush: true, replace || isFirstNavigation);
                         failure = null;
                     }
                     break;

--- a/libraries/Assimalign.Viu.Router/test/InitialNavigationTests.cs
+++ b/libraries/Assimalign.Viu.Router/test/InitialNavigationTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.RuntimeCore;
+
+using static Assimalign.Viu.Router.Tests.RouterComponentsTestSupport;
+
+namespace Assimalign.Viu.Router.Tests;
+
+// Pins the initial-navigation / START-location semantics ([V01.01.08.07], issue #219) against
+// vue-router (packages/router/src/router.ts: currentRoute starts at START_LOCATION_NORMALIZED, the
+// first navigation runs the full pipeline with from === START and finalizeNavigation forces a
+// replace; router.isReady resolves when it settles — https://router.vuejs.org/api/#isReady and
+// #Variables-START-LOCATION). Run counts are pinned so the initial pass fires each guard exactly once
+// with no double resolution. All DOM-free through memory history (the RouterView case adds the
+// in-memory Testing renderer).
+public class InitialNavigationTests
+{
+    private static IReadOnlyList<RouteRecord> Routes() =>
+    [
+        new RouteRecord("/", name: "home"),
+        new RouteRecord("/top", name: "top"),
+        new RouteRecord("/a", name: "a"),
+    ];
+
+    [Fact]
+    public void CurrentRoute_BeforeAnyNavigation_IsTheStartSentinel()
+    {
+        // Upstream: currentRoute initializes to START_LOCATION_NORMALIZED (path "/", empty matched),
+        // never the eagerly resolved initial location.
+        var router = new Router(RouterHistory.CreateMemory(), Routes());
+
+        var current = router.CurrentRoute.Value;
+
+        current.ShouldBeSameAs(RouteLocation.Start);
+        current.Path.ShouldBe("/");
+        current.IsMatched.ShouldBeFalse();
+        current.Matched.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadyAsync_RunsTheFullGuardPipelineFromStart_EachGuardExactlyOnce()
+    {
+        // The initial navigation runs the whole pipeline with from = START: the leave phase is
+        // trivially empty (START has no matched records), and beforeEach / beforeEnter / beforeRouteEnter
+        // / beforeResolve / afterEach each fire exactly once.
+        var log = new List<string>();
+        RouteLocation? beforeEachFrom = null;
+        RouteLocation? afterEachFrom = null;
+        NavigationFailure? afterEachFailure = null;
+        var enterGuard = new EnterGuardComponent(log);
+        var router = new Router(
+            RouterHistory.CreateMemory(),
+            [
+                new RouteRecord(
+                    "/",
+                    name: "home",
+                    component: enterGuard,
+                    beforeEnter: (_, _, _) =>
+                    {
+                        log.Add("beforeEnter");
+                        return Task.FromResult(NavigationGuardResult.Allow);
+                    }),
+            ]);
+        router.BeforeEach((_, from, _) =>
+        {
+            log.Add("beforeEach");
+            beforeEachFrom = from;
+            return Task.FromResult(NavigationGuardResult.Allow);
+        });
+        router.BeforeResolve((_, _, _) =>
+        {
+            log.Add("beforeResolve");
+            return Task.FromResult(NavigationGuardResult.Allow);
+        });
+        router.AfterEach((_, from, failure) =>
+        {
+            log.Add("afterEach");
+            afterEachFrom = from;
+            afterEachFailure = failure;
+        });
+
+        var failure = await router.ReadyAsync();
+
+        failure.ShouldBeNull();
+        log.ShouldBe(["beforeEach", "beforeEnter", "beforeRouteEnter", "beforeResolve", "afterEach"]);
+        beforeEachFrom.ShouldBeSameAs(RouteLocation.Start); // from === START for the initial navigation
+        afterEachFrom.ShouldBeSameAs(RouteLocation.Start);
+        afterEachFailure.ShouldBeNull();
+        router.CurrentRoute.Value.Name.ShouldBe("home");
+        router.CurrentRoute.Value.IsMatched.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ReadyAsync_RunsTheInitialBeforeEachRedirect()
+    {
+        // The exact #219 scenario: a global beforeEach redirect for the app entry URL. The router
+        // starts at START, so the first resolve of "/" is not deduplicated and the redirect fires,
+        // re-entering the pipeline once for "/top".
+        var visited = new List<string>();
+        var router = new Router(RouterHistory.CreateMemory(), Routes());
+        router.BeforeEach((to, _, _) =>
+        {
+            visited.Add(to.Path);
+            return Task.FromResult(to.Path == "/"
+                ? NavigationGuardResult.RedirectTo("/top")
+                : NavigationGuardResult.Allow);
+        });
+
+        var failure = await router.ReadyAsync();
+
+        failure.ShouldBeNull();
+        visited.ShouldBe(["/", "/top"]); // resolved "/" then redirected to "/top" exactly once
+        router.CurrentRoute.Value.Path.ShouldBe("/top");
+        router.CurrentRoute.Value.Name.ShouldBe("top");
+    }
+
+    [Fact]
+    public async Task ReadyAsync_ConfirmReplacesTheInitialHistoryEntry_RatherThanPushing()
+    {
+        // Upstream forces a replace when from === START (isFirstNavigation), so the app entry is not
+        // left as a stale back-target. In memory history a replace preserves the position counter (a
+        // push would advance it to 1), and the redirected initial navigation still writes only once.
+        var history = RouterHistory.CreateMemory();
+        var router = new Router(history, Routes());
+        router.BeforeEach((to, _, _) => Task.FromResult(
+            to.Path == "/" ? NavigationGuardResult.RedirectTo("/top") : NavigationGuardResult.Allow));
+
+        await router.ReadyAsync();
+
+        history.Location.ShouldBe("/top");
+        history.State.Position.ShouldBe(0); // replaced in place, not pushed
+    }
+
+    [Fact]
+    public async Task ReadyAsync_IsIdempotent_RunningTheInitialNavigationOnce()
+    {
+        // Every call returns the same task (upstream: the initial push happens once; isReady resolves
+        // to the settled result), so the guard runs exactly once no matter how many callers await.
+        var beforeEachRuns = 0;
+        var router = new Router(RouterHistory.CreateMemory(), Routes());
+        router.BeforeEach((_, _, _) =>
+        {
+            beforeEachRuns++;
+            return Task.FromResult(NavigationGuardResult.Allow);
+        });
+
+        var first = router.ReadyAsync();
+        var second = router.ReadyAsync();
+        await Task.WhenAll(first, second);
+
+        first.ShouldBeSameAs(second);
+        beforeEachRuns.ShouldBe(1);
+        router.CurrentRoute.Value.Name.ShouldBe("home");
+    }
+
+    [Fact]
+    public async Task ReadyAsync_WhenTheInitialGuardAborts_LeavesStartAndHistoryUntouched()
+    {
+        // An aborted initial navigation reports the failure and leaves CurrentRoute at START with the
+        // history untouched. Because the initial pass runs through the application push path (never the
+        // popstate listener), no compensating history.go fires for the initial resolution.
+        var history = RouterHistory.CreateMemory();
+        var router = new Router(history, Routes());
+        router.BeforeEach((_, _, _) => Task.FromResult(NavigationGuardResult.Abort));
+
+        var failure = await router.ReadyAsync();
+
+        failure.ShouldNotBeNull();
+        failure.Type.ShouldBe(NavigationFailureType.Aborted);
+        router.CurrentRoute.Value.ShouldBeSameAs(RouteLocation.Start);
+        history.Location.ShouldBe("/");
+        history.State.Position.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task AfterInitialNavigation_SameLocationPushIsStillDeduplicated()
+    {
+        // The START dedup skip is scoped to the initial pass only: once CurrentRoute has a matched
+        // chain, an in-session push to the same location is a Duplicated no-op that never runs a guard.
+        var beforeEachRuns = 0;
+        var router = new Router(RouterHistory.CreateMemory(), Routes());
+        await router.ReadyAsync();
+        await router.Push("/a");
+        router.BeforeEach((_, _, _) =>
+        {
+            beforeEachRuns++;
+            return Task.FromResult(NavigationGuardResult.Allow);
+        });
+
+        var failure = await router.Push("/a");
+
+        failure.ShouldNotBeNull();
+        failure.Type.ShouldBe(NavigationFailureType.Duplicated);
+        beforeEachRuns.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RouterView_RendersNothingAtStart_ThenRendersAfterTheInitialNavigation()
+    {
+        // Upstream renders nothing at START (empty matched). The outlet mounted before ReadyAsync shows
+        // nothing, and the matched component renders exactly once after the initial navigation confirms.
+        var view = LabelView("home");
+        var router = new Router(RouterHistory.CreateMemory(), [new RouteRecord("/", component: view)]);
+        using var wrapper = MountView(router);
+
+        wrapper.Find("div").ShouldBeNull();
+        view.RenderCount.ShouldBe(0); // never rendered while the current route is START
+
+        await router.ReadyAsync();
+        await wrapper.NextTickAsync();
+
+        wrapper.Html().ShouldBe("<div class=\"home\">home</div>");
+        view.SetupCount.ShouldBe(1);
+        view.RenderCount.ShouldBe(1); // rendered once — no double resolution of the initial navigation
+    }
+
+    // A route component that contributes a beforeRouteEnter guard (interface-based, no reflection) and
+    // logs when the pipeline invokes it. Never mounted here, so Setup is unused.
+    private sealed class EnterGuardComponent : IComponentDefinition, IRouteEnterGuard
+    {
+        private readonly List<string> _log;
+
+        public EnterGuardComponent(List<string> log) => _log = log;
+
+        public string? Name => "enter";
+
+        public Task<NavigationGuardResult> BeforeRouteEnter(RouteLocation to, RouteLocation from, CancellationToken cancellationToken)
+        {
+            _log.Add("beforeRouteEnter");
+            return Task.FromResult(NavigationGuardResult.Allow);
+        }
+
+        public Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context)
+            => () => null;
+    }
+}


### PR DESCRIPTION
## Summary
- Ports vue-router's `START_LOCATION_NORMALIZED` semantics: `CurrentRoute` now seeds with `RouteLocation.Start` (path `/`, **empty matched chain** — the defining trait) instead of eagerly resolving, and the first navigation runs the FULL guard pipeline with `from = START` — so an initial-load `beforeEach` redirect finally fires for direct page loads (pinned with the exact HackerNews `/`→`/top` scenario).
- **`ReadyAsync()`** is the C# shape folding upstream's install-time initial push and `isReady()` into one idempotent call (Viu has no `app.use(router)` install hook): first call navigates to `history.Location` through the pipeline and memoizes; bootstrap awaits it before mounting. Documented divergences: it always settles (upstream's `isReady()` can hang on an aborted initial navigation) and returns `Task<NavigationFailure?>` consistent with `Push`/`Replace`.
- The same-location dedup is gated on `from.Matched.Count > 0` (upstream's `from.matched.length` guard) — initial never dedups, in-session duplicates still short-circuit; the first navigation confirms as a `replace` via `ReferenceEquals(from, Start)`, stable across redirect chains.
- **HackerNews bootstrap workaround removed**: `Program.cs` drops the pre-mount path mapping in favor of `await router.ReadyAsync()` with the registered guard handling direct loads; sample README and tests updated (+1 initial-load redirect test).
- Discovered and filed, not absorbed: [#222 [V01.01.08.07.01]](https://github.com/assimalign/viu/issues/222) — the popstate listener attaches in the constructor while upstream defers to `markAsReady()`, so a popstate racing an async initial navigation could cancel it (separable parity refinement).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · Router **199/199** (8 new run-count-pinned: every guard exactly once from START, redirect visits `["/", "/top"]` once, `ReadyAsync` idempotency, RouterView `SetupCount == 1`/`RenderCount == 1` — no double resolution) · HackerNews sample 27/27 · Router.RuntimeDom 17/17 · WASM example builds.

Closes #219
Refs #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)