### PR TITLE
feat(testing): build the performance benchmark suite [V01.01.11.04]

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,147 @@
+# Performance benchmark suite ([V01.01.11.04], #88). Three lanes with deliberately different cost
+# profiles, mirroring the budget-gates workflow:
+#   - harness-tests + interop-gate: fast, deterministic, run on every PR/push (path-filtered). The gate
+#     compares each scenario's interop-crossing count to the reviewed baseline
+#     (benchmarks/baselines/InteropCounts.json) and fails a regression. Counts are machine-independent, so
+#     this is a real gate, not a noisy timing. libraries/** is watched because a renderer change there can
+#     change crossings.
+#   - timings: BenchmarkDotNet wall-clock numbers are environment-relative and noisy, so this lane is
+#     opt-in (workflow_dispatch or the 'benchmark-run' label), never a gate — the AOT-lane cost-control
+#     pattern. It publishes results as artifacts.
+#   - browser: WIRED-BUT-SKIPPED. Real-browser wall-clock, live command-buffer crossings, and per-assembly
+#     payload size need the Playwright e2e harness ([V01.01.11.03], #87); enabled by the repository
+#     variable ENABLE_BROWSER_BENCHMARKS once it lands (never faked).
+name: benchmarks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, 'release/**']
+    paths:
+      - 'benchmarks/**'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/benchmarks.yml'
+  pull_request:
+    branches: [main, 'release/**']
+    paths:
+      - 'benchmarks/**'
+      - 'libraries/**'
+      - 'build/**'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'global.json'
+      - 'nuget.config'
+      - '.github/actions/**'
+      - '.github/workflows/benchmarks.yml'
+
+jobs:
+  harness-tests:
+    name: benchmark harness tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pure CoreCLR: the suite never touches the browser-wasm runtime, so no wasm-tools workload.
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build (warnings are errors)
+        run: dotnet build benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/Assimalign.Viu.Testing.Benchmarks.Tests.csproj --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/Assimalign.Viu.Testing.Benchmarks.Tests.csproj --configuration Release --no-build
+
+  interop-gate:
+    name: interop-count regression gate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build benchmark app (warnings are errors)
+        run: dotnet build benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj --configuration Release -warnaserror
+
+      # Deterministic gate: runs every scenario through the in-memory adapter, counts node operations (the
+      # interop-crossing proxy), and fails when any scenario exceeds its reviewed ceiling. The ceiling is
+      # raised only by an explicit edit to benchmarks/baselines/InteropCounts.json (no silent ratcheting).
+      - name: Interop-count gate
+        run: >-
+          dotnet run --project benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
+          --configuration Release --no-build
+          -- interop --gate --results _out/benchmarks/interop-results.json
+
+      - name: Upload interop-count results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interop-count-results
+          path: _out/benchmarks/interop-results.json
+          if-no-files-found: ignore
+
+  timings:
+    name: wall-clock timings (opt-in)
+    # Cost control (the AOT-lane pattern): BenchmarkDotNet timings are noisy and environment-relative, so
+    # they never gate and do not run on every PR. Trigger manually (workflow_dispatch) or with the
+    # 'benchmark-run' label. Numbers are published as artifacts for inspection.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmark-run'))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Build benchmark app (Release)
+        run: dotnet build benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj --configuration Release
+
+      # A short run keeps CI time bounded; drop --smoke for full statistical passes when investigating.
+      - name: Run benchmarks (short)
+        run: >-
+          dotnet run --project benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
+          --configuration Release --no-build
+          -- benchmarks --smoke --filter *
+          --artifacts _out/benchmarks/artifacts
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-timings
+          path: _out/benchmarks/artifacts/**
+          if-no-files-found: ignore
+
+  browser:
+    name: real-browser benchmarks (deferred, #87)
+    # WIRED-BUT-SKIPPED. The real-browser axes (wall-clock incl. interop init, live command-buffer
+    # boundary-crossing counts, per-assembly published payload size) depend on the Playwright e2e harness
+    # ([V01.01.11.03], #87). No measurement is faked; the lane turns on once that harness lands by setting
+    # the repository variable ENABLE_BROWSER_BENCHMARKS=true (the startup-gate pattern from budget-gates.yml).
+    # TODO([V01.01.11.03], #87): publish the benchmark app trimmed, serve wwwroot, drive it headless in
+    # Chromium/Firefox/WebKit measuring per-scenario time + command-buffer crossings + payload size.
+    if: ${{ vars.ENABLE_BROWSER_BENCHMARKS == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: ./.github/actions/setup-dotnet-wasm
+
+      - name: Browser benchmarks placeholder
+        run: >-
+          dotnet run --project benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
+          --configuration Release
+          -- browser

--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -60,6 +60,7 @@
 		<File Path=".github/workflows/area-shared.yml" />
 		<File Path=".github/workflows/area-syntax.yml" />
 		<File Path=".github/workflows/area-testing.yml" />
+		<File Path=".github/workflows/benchmarks.yml" />
 		<File Path=".github/workflows/budget-gates.yml" />
 		<File Path=".github/workflows/webapp.yml" />
 	</Folder>
@@ -135,6 +136,15 @@
 	</Folder>
 	<Folder Name="/viu/sdks/Assimalign.Viu.Sdk/Tasks/">
 		<Project Path="sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj" />
+	</Folder>
+	<Folder Name="/viu/benchmarks/Assimalign.Viu.Testing.Benchmarks/">
+		<Project Path="benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj" />
+	</Folder>
+	<Folder Name="/viu/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/">
+		<Project Path="benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/Assimalign.Viu.Testing.Benchmarks.Tests.csproj" />
+	</Folder>
+	<Folder Name="/viu/benchmarks/baselines/">
+		<File Path="benchmarks/baselines/InteropCounts.json" />
 	</Folder>
 	<Folder Name="/viu/scripts/">
 		<File Path="scripts/Install-Local.ps1" />

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/Assimalign.Viu.Testing.Benchmarks.Tests.csproj
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/Assimalign.Viu.Testing.Benchmarks.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Tests for the benchmark suite's harness plumbing ([V01.01.11.04], #88): scenario discovery, the
+    deterministic interop-count counters, baseline load/compare, and the demonstration that a deliberate
+    keyless bypass trips the interop-count gate. It references the benchmark app by name (the build
+    system indexes benchmarks/ alongside libraries/ and analyzers/) and copies the reviewed baseline
+    beside its binary so the gate test loads the real checked-in numbers.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
+    <ViuPackageReference Include="xunit" />
+    <ViuPackageReference Include="xunit.runner.visualstudio" />
+    <ViuPackageReference Include="Shouldly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ViuProjectReference Include="Assimalign.Viu.Testing.Benchmarks" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\baselines\InteropCounts.json" Link="baselines\InteropCounts.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/BenchmarkRowSourceTests.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/BenchmarkRowSourceTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Testing.Benchmarks;
+
+namespace Assimalign.Viu.Testing.Benchmarks.Tests;
+
+// Pins the js-framework-benchmark data helpers: globally unique monotonic keys (so a create-after-clear
+// never reuses a key), reproducible labels, and pure mutation helpers.
+public class BenchmarkRowSourceTests
+{
+    [Fact]
+    public void Build_ProducesTheRequestedCount_WithUniqueMonotonicIds()
+    {
+        var source = new BenchmarkRowSource();
+
+        var rows = source.Build(1_000);
+
+        rows.Count.ShouldBe(1_000);
+        rows.Select(row => row.Identifier).Distinct().Count().ShouldBe(1_000);
+        rows[0].Identifier.ShouldBeLessThan(rows[^1].Identifier);
+    }
+
+    [Fact]
+    public void Build_NeverReusesKeys_AcrossCalls()
+    {
+        var source = new BenchmarkRowSource();
+
+        var first = source.Build(1_000);
+        var second = source.Build(1_000);
+
+        var firstKeys = first.Select(row => row.Identifier).ToHashSet();
+        second.ShouldAllBe(row => !firstKeys.Contains(row.Identifier));
+    }
+
+    [Fact]
+    public void Append_ContinuesTheIdSequence()
+    {
+        var source = new BenchmarkRowSource();
+        var rows = source.Build(10);
+
+        source.Append(rows, 5);
+
+        rows.Count.ShouldBe(15);
+        rows.Select(row => row.Identifier).Distinct().Count().ShouldBe(15);
+    }
+
+    [Fact]
+    public void UpdateEvery_ChangesEveryNthLabel_AndKeepsKeys()
+    {
+        var original = new BenchmarkRowSource().Build(50);
+
+        var updated = BenchmarkRowSource.UpdateEvery(original, 10);
+
+        for (var index = 0; index < original.Count; index++)
+        {
+            updated[index].Identifier.ShouldBe(original[index].Identifier);
+            if (index % 10 == 0)
+            {
+                updated[index].Label.ShouldBe(original[index].Label + " !!!");
+            }
+            else
+            {
+                updated[index].Label.ShouldBe(original[index].Label);
+            }
+        }
+    }
+
+    [Fact]
+    public void Swap_ExchangesTheTwoRows_AndLeavesTheRestUntouched()
+    {
+        var original = new BenchmarkRowSource().Build(1_000);
+
+        var swapped = BenchmarkRowSource.Swap(original, 1, 998);
+
+        swapped[1].ShouldBe(original[998]);
+        swapped[998].ShouldBe(original[1]);
+        swapped[0].ShouldBe(original[0]);
+        swapped[500].ShouldBe(original[500]);
+    }
+
+    [Fact]
+    public void RemoveAt_DropsTheRow_AndPreservesOrder()
+    {
+        var original = new BenchmarkRowSource().Build(10);
+        var removedIdentifier = original[3].Identifier;
+
+        var remaining = BenchmarkRowSource.RemoveAt(original, 3);
+
+        remaining.Count.ShouldBe(9);
+        remaining.ShouldAllBe(row => row.Identifier != removedIdentifier);
+        remaining[3].ShouldBe(original[4]);
+    }
+
+    [Fact]
+    public void SameSeed_ProducesTheSameLabels()
+    {
+        var first = new BenchmarkRowSource(seed: 42).Build(100);
+        var second = new BenchmarkRowSource(seed: 42).Build(100);
+
+        first.Select(row => row.Label).ShouldBe(second.Select(row => row.Label));
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/InteropCountGateTests.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/InteropCountGateTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Testing.Benchmarks;
+
+namespace Assimalign.Viu.Testing.Benchmarks.Tests;
+
+// Pins the regression gate: the reviewed baseline passes the shipped path, a deliberate keyless bypass
+// trips it (the acceptance-criterion demonstration), a scenario without a ceiling is a protection gap,
+// and the tolerance is honored.
+public class InteropCountGateTests
+{
+    private static string BaselinePath => Path.Combine(AppContext.BaseDirectory, "baselines", "InteropCounts.json");
+
+    [Fact]
+    public void CheckedInBaseline_Loads_WithNotesAndEveryScenario()
+    {
+        var baseline = InteropCountBaseline.Load(BaselinePath);
+
+        baseline.Note.ShouldNotBeEmpty();
+        baseline.Scenarios.Length.ShouldBe(InteropScenarioLibrary.Discover().Count);
+    }
+
+    [Fact]
+    public void CheckedInBaseline_PassesTheOptimizedShippedPath()
+    {
+        var baseline = InteropCountBaseline.Load(BaselinePath);
+
+        var comparison = baseline.Compare(InteropCountHarness.MeasureAll(ScenarioVariant.Optimized));
+
+        comparison.Passed.ShouldBeTrue();
+        comparison.RegressionCount.ShouldBe(0);
+        comparison.MissingBaselineCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void DeliberateKeylessBypass_TripsTheGate()
+    {
+        // The acceptance criterion: a change that keeps timings but multiplies boundary crossings still
+        // fails review. Measured against the reviewed (keyed) baseline, the keyless variant regresses.
+        var baseline = InteropCountBaseline.Load(BaselinePath);
+
+        var comparison = baseline.Compare(InteropCountHarness.MeasureAll(ScenarioVariant.KeylessBypass));
+
+        comparison.Passed.ShouldBeFalse();
+        comparison.RegressionCount.ShouldBeGreaterThan(0);
+        var removeRow = comparison.Rows.Single(row => row.Name == "remove-row");
+        removeRow.WithinBaseline.ShouldBeFalse();
+        removeRow.Delta!.Value.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void MeasuredScenarioWithoutACeiling_IsAProtectionGap()
+    {
+        var baseline = new InteropCountBaseline
+        {
+            Scenarios = [new InteropCountBaselineEntry { Name = "create-1000", TotalOperationCount = 26005 }],
+        };
+
+        var comparison = baseline.Compare(
+        [
+            new InteropCountResult { Name = "create-1000", TotalOperationCount = 26005 },
+            new InteropCountResult { Name = "brand-new-scenario", TotalOperationCount = 5 },
+        ]);
+
+        comparison.MissingBaselineCount.ShouldBe(1);
+        comparison.Passed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Tolerance_PermitsAnIncreaseUpToTheCeilingPlusTolerance()
+    {
+        var baseline = new InteropCountBaseline
+        {
+            Scenarios = [new InteropCountBaselineEntry { Name = "swap-rows", TotalOperationCount = 2, Tolerance = 1 }],
+        };
+
+        baseline.Compare([new InteropCountResult { Name = "swap-rows", TotalOperationCount = 3 }])
+            .Passed.ShouldBeTrue();
+        baseline.Compare([new InteropCountResult { Name = "swap-rows", TotalOperationCount = 4 }])
+            .Passed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Load_Throws_WhenTheManifestIsMissing()
+    {
+        var missing = Path.Combine(AppContext.BaseDirectory, "baselines", "does-not-exist.json");
+
+        Should.Throw<FileNotFoundException>(() => InteropCountBaseline.Load(missing));
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/InteropCountHarnessTests.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks.Tests/InteropCountHarnessTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Testing.Benchmarks;
+
+namespace Assimalign.Viu.Testing.Benchmarks.Tests;
+
+// Pins the interop-count harness: scenario discovery, deterministic counters, and the keyed-diff /
+// patch-flag guarantees the epic wants locked in by tests ("N node ops == N interop calls", so a scenario
+// that should cost one crossing must measure exactly one).
+public class InteropCountHarnessTests
+{
+    [Fact]
+    public void Discover_ReturnsTheCanonicalScenarioSet_InAStableOrder()
+    {
+        var names = InteropScenarioLibrary.Discover().Select(scenario => scenario.Name).ToArray();
+
+        names.ShouldBe(
+        [
+            "create-1000",
+            "create-10000",
+            "update-every-10th",
+            "swap-rows",
+            "select-row",
+            "remove-row",
+            "append-1000",
+            "replace-1000",
+            "clear-1000",
+        ]);
+    }
+
+    [Fact]
+    public void MeasureAll_IsDeterministic_AcrossRuns()
+    {
+        var first = ToTotals(InteropCountHarness.MeasureAll(ScenarioVariant.Optimized));
+        var second = ToTotals(InteropCountHarness.MeasureAll(ScenarioVariant.Optimized));
+
+        second.ShouldBe(first);
+    }
+
+    [Theory]
+    [InlineData("update-every-10th", 100)] // 100 of 1,000 labels change -> 100 targeted set-text crossings.
+    [InlineData("swap-rows", 2)]           // Two keyed moves, no content re-patch.
+    [InlineData("select-row", 1)]          // One class patch.
+    [InlineData("remove-row", 1)]          // The keyed diff removes exactly the one node.
+    [InlineData("clear-1000", 1000)]       // 1,000 removals.
+    public void OptimizedVariant_MeasuresTheKeyedDiffGuarantee(string scenarioName, int expectedCrossings)
+    {
+        var totals = ToTotals(InteropCountHarness.MeasureAll(ScenarioVariant.Optimized));
+
+        totals[scenarioName].ShouldBe(expectedCrossings);
+    }
+
+    [Fact]
+    public void MountingScenarios_AreCreationHeavy_WithStructuralOperations()
+    {
+        var results = InteropCountHarness.MeasureAll(ScenarioVariant.Optimized)
+            .ToDictionary(result => result.Name);
+
+        results["create-1000"].TotalOperationCount.ShouldBeGreaterThan(0);
+        results["create-1000"].StructuralOperationCount.ShouldBeGreaterThan(0);
+        results["create-1000"].CreateElementCount.ShouldBeGreaterThan(0);
+        // Ten times the rows costs about ten times the crossings.
+        results["create-10000"].TotalOperationCount
+            .ShouldBeGreaterThan(results["create-1000"].TotalOperationCount * 9);
+    }
+
+    [Fact]
+    public void KeylessBypass_MultipliesCrossings_OnReorderAndRemoval()
+    {
+        var optimized = ToTotals(InteropCountHarness.MeasureAll(ScenarioVariant.Optimized));
+        var keyless = ToTotals(InteropCountHarness.MeasureAll(ScenarioVariant.KeylessBypass));
+
+        // Removing one row from the front is where losing keys hurts most: keyed removes one node, keyless
+        // re-patches every shifted row's content. This is the DOM-free analogue of a command-buffer bypass:
+        // time-neutral, but a large multiple of the boundary crossings.
+        optimized["remove-row"].ShouldBe(1);
+        keyless["remove-row"].ShouldBeGreaterThan(1000);
+
+        // A reorder degrades too (positional content patches instead of moves).
+        keyless["swap-rows"].ShouldBeGreaterThan(optimized["swap-rows"]);
+    }
+
+    private static Dictionary<string, int> ToTotals(IReadOnlyList<InteropCountResult> results)
+        => results.ToDictionary(result => result.Name, result => result.TotalOperationCount);
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    The Viu performance benchmark suite ([V01.01.11.04], #88). A non-shipping, never-packed console
+    app hosting two things on CoreCLR (never a browser, never trimmed/AOT'd — like a test project):
+
+      1. BenchmarkDotNet micro/meso benchmarks of the pure-.NET hot paths the architecture bets on —
+         reactivity track/trigger and renderer diff/patch over the in-memory test adapter. Wall-clock
+         numbers are environment-relative, so they are published as artifacts, never a CI gate.
+      2. A deterministic interop-count harness: it drives the js-framework-benchmark scenarios through
+         the same in-memory adapter and counts node operations. Op count is the DOM-free proxy for
+         JSImport crossings (Assimalign.Viu.Testing's op log == "N node ops == N interop calls"), so it
+         is exact and machine-independent — the metric the regression gate compares to a reviewed
+         baseline (benchmarks/baselines/InteropCounts.json).
+
+    Real-browser wall-clock, live interop-crossing counts, and per-assembly payload size need the
+    Playwright end-to-end harness ([V01.01.11.03], #87) and are deferred honestly (see
+    Browser/DeferredBrowserBenchmarks.cs and .github/workflows/benchmarks.yml), never faked.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Benchmark methods and the harness types are public by contract (BenchmarkDotNet requires public
+         benchmark classes/methods); this app has no public-API surface to document for consumers. -->
+    <RootNamespace>Assimalign.Viu.Testing.Benchmarks</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ViuPackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The in-memory adapter (its op log is the interop proxy) plus the two runtime areas the
+         micro/meso benchmarks measure directly; Shared/RuntimeCore flow transitively through Testing. -->
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
+    <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <ViuProjectReference Include="Assimalign.Viu.RuntimeCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The reviewed interop-count baseline travels with the app so the gate can find it beside the
+         binary in CI, and a local interop run compares against the checked-in numbers. -->
+    <Content Include="..\baselines\InteropCounts.json" Link="baselines\InteropCounts.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/BenchmarkRow.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/BenchmarkRow.cs
@@ -1,0 +1,11 @@
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// A synthetic table row — the unit the js-framework-benchmark scenarios operate on
+/// (https://github.com/krausest/js-framework-benchmark). Carries a stable <see cref="Identifier"/>
+/// (the keyed-diff key, globally unique across a run so a create-after-clear never reuses a key) and a
+/// display <see cref="Label"/>. A readonly value type so a per-frame row list is cheap to snapshot.
+/// </summary>
+/// <param name="Identifier">The stable row id used as the keyed-diff key.</param>
+/// <param name="Label">The row's display text.</param>
+public readonly record struct BenchmarkRow(int Identifier, string Label);

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/BenchmarkRowSource.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/BenchmarkRowSource.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Builds and mutates the synthetic row lists the scenarios operate on — the C# port of
+/// js-framework-benchmark's data helpers (<c>buildData</c>, <c>update</c>, <c>swapRows</c>;
+/// https://github.com/krausest/js-framework-benchmark/blob/master/frameworks/keyed/vanillajs/src/main.js).
+/// Row ids are monotonic across a source so keys stay globally unique (a create-1000 after a clear never
+/// reuses an old key), and labels are drawn from the same adjective/colour/noun word lists with a fixed
+/// seed so a run is reproducible. The mutation helpers are pure — they return a new list, leaving the
+/// input untouched, so a scenario keeps the "previous" tree to diff the "next" one against. Not
+/// thread-safe (single-threaded benchmark host).
+/// </summary>
+public sealed class BenchmarkRowSource
+{
+    private static readonly string[] _adjectives =
+    [
+        "pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain", "quaint",
+        "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd", "unsightly", "adorable",
+        "important", "inexpensive", "cheap", "expensive", "fancy",
+    ];
+
+    private static readonly string[] _colours =
+    [
+        "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange",
+    ];
+
+    private static readonly string[] _nouns =
+    [
+        "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger", "pizza",
+        "mouse", "keyboard",
+    ];
+
+    private readonly Random _random;
+    private int _nextIdentifier = 1;
+
+    /// <summary>Creates a source over a fixed seed so label choices (hence any run) are reproducible.</summary>
+    /// <param name="seed">The random seed; the default keeps every run identical.</param>
+    public BenchmarkRowSource(int seed = 8675309) => _random = new Random(seed);
+
+    /// <summary>Builds a fresh list of <paramref name="count"/> rows with new, never-reused ids.</summary>
+    /// <param name="count">The number of rows.</param>
+    /// <returns>The new row list.</returns>
+    public List<BenchmarkRow> Build(int count)
+    {
+        var rows = new List<BenchmarkRow>(count);
+        Append(rows, count);
+        return rows;
+    }
+
+    /// <summary>Appends <paramref name="count"/> new rows to <paramref name="rows"/> in place.</summary>
+    /// <param name="rows">The list to grow.</param>
+    /// <param name="count">The number of rows to add.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public void Append(List<BenchmarkRow> rows, int count)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        for (var index = 0; index < count; index++)
+        {
+            rows.Add(new BenchmarkRow(_nextIdentifier++, NextLabel()));
+        }
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="rows"/> with every <paramref name="step"/>-th row's label
+    /// suffixed with <c>" !!!"</c> (js-framework-benchmark's "update every 10th row" with step 10) —
+    /// keys are unchanged, so the keyed diff patches only those labels' text.
+    /// </summary>
+    /// <param name="rows">The rows to update.</param>
+    /// <param name="step">The stride (10 for the canonical scenario).</param>
+    /// <returns>The updated copy.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="step"/> is not positive.</exception>
+    public static List<BenchmarkRow> UpdateEvery(IReadOnlyList<BenchmarkRow> rows, int step)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(step);
+        var updated = new List<BenchmarkRow>(rows.Count);
+        for (var index = 0; index < rows.Count; index++)
+        {
+            var row = rows[index];
+            updated.Add((index % step) == 0 ? row with { Label = row.Label + " !!!" } : row);
+        }
+        return updated;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="rows"/> with the rows at <paramref name="first"/> and
+    /// <paramref name="second"/> swapped (js-framework-benchmark's "swap rows", indices 1 and 998 for
+    /// 1000 rows) — the two keys move, exercising the keyed diff's move path.
+    /// </summary>
+    /// <param name="rows">The rows to reorder.</param>
+    /// <param name="first">The first index.</param>
+    /// <param name="second">The second index.</param>
+    /// <returns>The reordered copy.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public static List<BenchmarkRow> Swap(IReadOnlyList<BenchmarkRow> rows, int first, int second)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentOutOfRangeException.ThrowIfNegative(first);
+        ArgumentOutOfRangeException.ThrowIfNegative(second);
+        var swapped = new List<BenchmarkRow>(rows);
+        (swapped[first], swapped[second]) = (swapped[second], swapped[first]);
+        return swapped;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="rows"/> with the row at <paramref name="index"/> removed
+    /// (js-framework-benchmark's "remove row") — the keyed diff removes exactly that node, but a
+    /// keyless diff must re-patch every row after it.
+    /// </summary>
+    /// <param name="rows">The rows to shrink.</param>
+    /// <param name="index">The index to remove.</param>
+    /// <returns>The shrunken copy.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public static List<BenchmarkRow> RemoveAt(IReadOnlyList<BenchmarkRow> rows, int index)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        var remaining = new List<BenchmarkRow>(rows);
+        remaining.RemoveAt(index);
+        return remaining;
+    }
+
+    private string NextLabel()
+        => string.Concat(
+            _adjectives[_random.Next(_adjectives.Length)],
+            " ",
+            _colours[_random.Next(_colours.Length)],
+            " ",
+            _nouns[_random.Next(_nouns.Length)]);
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Browser/DeferredBrowserBenchmarks.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Browser/DeferredBrowserBenchmarks.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The wired-but-deferred real-browser benchmark lane. Three axes can only be measured in a real headless
+/// browser against a published, trimmed WASM benchmark app: wall-clock scenario time including JS-interop
+/// initialization, the live count of command-buffer boundary crossings (buffered vs bypassed), and the
+/// per-assembly published payload size. All three depend on the Playwright end-to-end harness
+/// ([V01.01.11.03], #87) for the shared publish/serve/drive plumbing, which is not built yet.
+/// <para>
+/// Nothing here fakes those numbers: a pure-.NET timer is not a substitute (interop init cost is part of
+/// what is measured), so this lane is skipped by default and turns on — exactly like the startup gate in
+/// <c>budget-gates.yml</c> — once the harness lands, by setting the repository variable
+/// <see cref="EnableVariableName"/> to <c>true</c>. Until then <see cref="PrintDeferralNotice"/> reports
+/// the honest status and the CI job is a no-op placeholder.
+/// </para>
+/// </summary>
+public static class DeferredBrowserBenchmarks
+{
+    /// <summary>The repository variable that activates the browser lane once #87 lands.</summary>
+    public const string EnableVariableName = "ENABLE_BROWSER_BENCHMARKS";
+
+    /// <summary>Writes the honest deferral status to <paramref name="writer"/>.</summary>
+    /// <param name="writer">The destination writer.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="writer"/> is null.</exception>
+    public static void PrintDeferralNotice(TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        writer.WriteLine("Real-browser benchmarks are deferred pending the Playwright end-to-end harness");
+        writer.WriteLine("([V01.01.11.03], #87), which owns the shared publish/serve/drive plumbing.");
+        writer.WriteLine();
+        writer.WriteLine("When that harness lands, this lane will, against a published trimmed WASM app:");
+        writer.WriteLine("  1. measure per-scenario wall-clock time in headless Chromium/Firefox/WebKit");
+        writer.WriteLine("     (navigation start -> settled DOM), including JS-interop initialization;");
+        writer.WriteLine("  2. count live command-buffer boundary crossings per scenario (the metric the");
+        writer.WriteLine("     command buffer exists to drive down) and fail a time-neutral crossing regression;");
+        writer.WriteLine("  3. record the published payload size, compressed and uncompressed, per assembly.");
+        writer.WriteLine();
+        writer.WriteLine(FormattableString.Invariant(
+            $"Enable by setting the repository variable {EnableVariableName}=true once #87 is available."));
+        writer.WriteLine("A pure-.NET timer is NOT an acceptable substitute and is never faked here.");
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Internal/InteropCountJsonContext.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Internal/InteropCountJsonContext.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The System.Text.Json source-generation context for the baseline manifest and the results document.
+/// Source generation (not reflection) keeps the harness trimming/AOT-safe and lets the same camelCase
+/// contract read the checked-in baseline and write the per-run results.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
+[JsonSerializable(typeof(InteropCountBaseline))]
+[JsonSerializable(typeof(InteropCountResultsDocument))]
+internal sealed partial class InteropCountJsonContext : JsonSerializerContext
+{
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountBaseline.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountBaseline.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The reviewed interop-count manifest (<c>benchmarks/baselines/InteropCounts.json</c>) and the gate
+/// comparison against it — the interop-crossing analogue of the publish-size budget manifest
+/// (<c>scripts/budgets/PublishBudgets.json</c>). Loaded via System.Text.Json <b>source generation</b>
+/// (no reflection), so the harness stays trimming/AOT-safe even though the benchmark app itself is never
+/// trimmed.
+/// </summary>
+public sealed class InteropCountBaseline
+{
+    /// <summary>Free-form provenance notes carried in the manifest (not used by the gate).</summary>
+    public string[] Note { get; init; } = [];
+
+    /// <summary>The reviewed per-scenario ceilings.</summary>
+    public InteropCountBaselineEntry[] Scenarios { get; init; } = [];
+
+    /// <summary>Loads a baseline manifest from <paramref name="path"/>.</summary>
+    /// <param name="path">The manifest path.</param>
+    /// <returns>The parsed baseline.</returns>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">The manifest does not exist.</exception>
+    /// <exception cref="InvalidDataException">The manifest is present but does not parse.</exception>
+    public static InteropCountBaseline Load(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Interop-count baseline not found: {path}", path);
+        }
+        var json = File.ReadAllText(path);
+        var baseline = JsonSerializer.Deserialize(json, InteropCountJsonContext.Default.InteropCountBaseline);
+        return baseline ?? throw new InvalidDataException($"Interop-count baseline parsed to null: {path}");
+    }
+
+    /// <summary>Compares <paramref name="measured"/> results to this baseline's ceilings.</summary>
+    /// <param name="measured">The run's measured results.</param>
+    /// <returns>The gate comparison.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="measured"/> is null.</exception>
+    public InteropCountComparison Compare(IReadOnlyList<InteropCountResult> measured)
+    {
+        ArgumentNullException.ThrowIfNull(measured);
+        var ceilings = new Dictionary<string, InteropCountBaselineEntry>(StringComparer.Ordinal);
+        foreach (var entry in Scenarios)
+        {
+            ceilings[entry.Name] = entry;
+        }
+
+        var rows = new List<InteropCountComparisonRow>(measured.Count);
+        foreach (var result in measured)
+        {
+            if (ceilings.TryGetValue(result.Name, out var entry))
+            {
+                var within = result.TotalOperationCount <= entry.TotalOperationCount + entry.Tolerance;
+                rows.Add(new InteropCountComparisonRow(
+                    result.Name,
+                    result.TotalOperationCount,
+                    entry.TotalOperationCount,
+                    entry.Tolerance,
+                    HasBaseline: true,
+                    WithinBaseline: within));
+            }
+            else
+            {
+                rows.Add(new InteropCountComparisonRow(
+                    result.Name,
+                    result.TotalOperationCount,
+                    BaselineTotal: null,
+                    Tolerance: 0,
+                    HasBaseline: false,
+                    WithinBaseline: false));
+            }
+        }
+        return new InteropCountComparison(rows);
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountBaselineEntry.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountBaselineEntry.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// One scenario's reviewed interop-crossing ceiling in the baseline manifest. Interop counts are
+/// deterministic and machine-independent, so <see cref="Tolerance"/> defaults to zero — any increase over
+/// <see cref="TotalOperationCount"/> is a regression. A ceiling is raised only by an explicit, reviewed
+/// edit to the manifest, exactly like the publish-size budget: no silent ratcheting.
+/// </summary>
+public sealed class InteropCountBaselineEntry
+{
+    /// <summary>The scenario id (matches <see cref="InteropScenario.Name"/>).</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>The reviewed total-operation ceiling for the scenario's measured step.</summary>
+    public int TotalOperationCount { get; init; }
+
+    /// <summary>The permitted increase over the ceiling before it counts as a regression (default 0).</summary>
+    public int Tolerance { get; init; }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountComparison.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountComparison.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The outcome of comparing a run's measured interop counts to the reviewed baseline. The gate
+/// <see cref="Passed"/> only when no scenario exceeds its ceiling <b>and</b> every measured scenario has
+/// a baseline entry — a new scenario without a reviewed ceiling is a protection gap, not a silent pass.
+/// </summary>
+public sealed class InteropCountComparison
+{
+    /// <summary>Builds the comparison from its rows.</summary>
+    /// <param name="rows">The per-scenario comparison rows.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public InteropCountComparison(IReadOnlyList<InteropCountComparisonRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        Rows = rows;
+        var regressions = 0;
+        var missing = 0;
+        foreach (var row in rows)
+        {
+            if (!row.HasBaseline)
+            {
+                missing++;
+            }
+            else if (!row.WithinBaseline)
+            {
+                regressions++;
+            }
+        }
+        RegressionCount = regressions;
+        MissingBaselineCount = missing;
+    }
+
+    /// <summary>The per-scenario comparison rows.</summary>
+    public IReadOnlyList<InteropCountComparisonRow> Rows { get; }
+
+    /// <summary>How many scenarios exceeded their ceiling.</summary>
+    public int RegressionCount { get; }
+
+    /// <summary>How many measured scenarios had no baseline entry.</summary>
+    public int MissingBaselineCount { get; }
+
+    /// <summary>Whether the gate passes (no regressions and no missing baselines).</summary>
+    public bool Passed => RegressionCount == 0 && MissingBaselineCount == 0;
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountComparisonRow.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountComparisonRow.cs
@@ -1,0 +1,22 @@
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// One scenario's line in the gate comparison: the measured crossings against the reviewed ceiling.
+/// </summary>
+/// <param name="Name">The scenario id.</param>
+/// <param name="MeasuredTotal">The crossings the measured step performed.</param>
+/// <param name="BaselineTotal">The reviewed ceiling, or null when the scenario has no baseline entry.</param>
+/// <param name="Tolerance">The permitted increase over the ceiling.</param>
+/// <param name="HasBaseline">Whether a baseline entry existed for the scenario.</param>
+/// <param name="WithinBaseline">Whether the measurement is at or under <c>ceiling + tolerance</c>.</param>
+public readonly record struct InteropCountComparisonRow(
+    string Name,
+    int MeasuredTotal,
+    int? BaselineTotal,
+    int Tolerance,
+    bool HasBaseline,
+    bool WithinBaseline)
+{
+    /// <summary>The signed change from the ceiling, or null when there is no baseline entry.</summary>
+    public int? Delta => BaselineTotal is int baseline ? MeasuredTotal - baseline : null;
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountHarness.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountHarness.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Runs the whole scenario catalogue through the in-memory renderer and returns each measured step's
+/// interop counts — the "scenario discovery + counters" plumbing the acceptance criteria call for.
+/// Deterministic: the same variant always yields the same counts, which is what makes them gate-able.
+/// </summary>
+public static class InteropCountHarness
+{
+    /// <summary>Measures every discovered scenario under <paramref name="variant"/>.</summary>
+    /// <param name="variant">The tree shape to measure.</param>
+    /// <returns>The per-scenario results, in catalogue order.</returns>
+    public static IReadOnlyList<InteropCountResult> MeasureAll(ScenarioVariant variant)
+    {
+        var scenarios = InteropScenarioLibrary.Discover();
+        var results = new List<InteropCountResult>(scenarios.Count);
+        foreach (var scenario in scenarios)
+        {
+            results.Add(scenario.Measure(variant));
+        }
+        return results;
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountReport.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountReport.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Renders the interop-count comparison as a human-readable table (for CI logs and local runs) and
+/// persists the machine-readable results — the interop-crossing analogue of the publish-size budget
+/// report. The table is deliberately shaped like that report so the two gates read the same way.
+/// </summary>
+public static class InteropCountReport
+{
+    /// <summary>Writes the comparison table for <paramref name="results"/> to <paramref name="writer"/>.</summary>
+    /// <param name="writer">The destination writer.</param>
+    /// <param name="results">The measured results.</param>
+    /// <param name="comparison">The comparison against the baseline.</param>
+    /// <param name="variant">The measured variant (labels the report).</param>
+    /// <exception cref="ArgumentNullException">A required argument is null.</exception>
+    public static void WriteComparison(
+        TextWriter writer,
+        IReadOnlyList<InteropCountResult> results,
+        InteropCountComparison comparison,
+        ScenarioVariant variant)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(results);
+        ArgumentNullException.ThrowIfNull(comparison);
+
+        writer.WriteLine();
+        writer.WriteLine(FormattableString.Invariant($"Viu interop-count report (variant={variant})"));
+        writer.WriteLine("Each count is a node operation == one JS-interop crossing in the browser.");
+        writer.WriteLine(new string('=', 78));
+        var header = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0,-20} {1,10} {2,12} {3,10} {4,9}  {5}",
+            "Scenario", "Measured", "Structural", "Baseline", "Delta", "Status");
+        writer.WriteLine(header);
+        writer.WriteLine(new string('-', header.Length));
+
+        var structuralByName = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var result in results)
+        {
+            structuralByName[result.Name] = result.StructuralOperationCount;
+        }
+
+        foreach (var row in comparison.Rows)
+        {
+            var structural = structuralByName.TryGetValue(row.Name, out var value) ? value : 0;
+            var baselineText = row.BaselineTotal is int baseline
+                ? baseline.ToString(CultureInfo.InvariantCulture)
+                : "n/a";
+            var deltaText = row.Delta is int delta
+                ? (delta >= 0 ? "+" : "") + delta.ToString(CultureInfo.InvariantCulture)
+                : "n/a";
+            var status = !row.HasBaseline ? "NO BASELINE" : row.WithinBaseline ? "PASS" : "REGRESSION";
+            writer.WriteLine(string.Format(
+                CultureInfo.InvariantCulture,
+                "{0,-20} {1,10} {2,12} {3,10} {4,9}  {5}",
+                row.Name,
+                row.MeasuredTotal,
+                structural,
+                baselineText,
+                deltaText,
+                status));
+        }
+
+        writer.WriteLine(new string('-', header.Length));
+        var passedCount = comparison.Rows.Count - comparison.RegressionCount - comparison.MissingBaselineCount;
+        writer.WriteLine(FormattableString.Invariant(
+            $"Result: {(comparison.Passed ? "PASS" : "FAIL")} ({passedCount}/{comparison.Rows.Count} within baseline)"));
+        if (!comparison.Passed)
+        {
+            writer.WriteLine();
+            if (comparison.RegressionCount > 0)
+            {
+                writer.WriteLine("A scenario crossed the interop boundary more than its reviewed baseline allows.");
+                writer.WriteLine("This is a deliberate-decision gate: reduce crossings, or raise the ceiling in");
+                writer.WriteLine("benchmarks/baselines/InteropCounts.json as a reviewed change (no silent ratcheting).");
+            }
+            if (comparison.MissingBaselineCount > 0)
+            {
+                writer.WriteLine("A measured scenario has no baseline entry. Add its reviewed ceiling to");
+                writer.WriteLine("benchmarks/baselines/InteropCounts.json so the gate protects it.");
+            }
+        }
+    }
+
+    /// <summary>Builds the persisted results document.</summary>
+    /// <param name="results">The measured results.</param>
+    /// <param name="variant">The measured variant.</param>
+    /// <param name="withinBaseline">The gate outcome, or null when measured without a baseline.</param>
+    /// <returns>The results document.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
+    public static InteropCountResultsDocument BuildDocument(
+        IReadOnlyList<InteropCountResult> results,
+        ScenarioVariant variant,
+        bool? withinBaseline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        var scenarios = new InteropCountResult[results.Count];
+        for (var index = 0; index < results.Count; index++)
+        {
+            scenarios[index] = results[index];
+        }
+        return new InteropCountResultsDocument
+        {
+            GeneratedUtc = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+            Variant = variant.ToString(),
+            WithinBaseline = withinBaseline,
+            Scenarios = scenarios,
+        };
+    }
+
+    /// <summary>Writes <paramref name="document"/> as JSON to <paramref name="path"/>, creating directories.</summary>
+    /// <param name="path">The results path.</param>
+    /// <param name="document">The document to persist.</param>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="document"/> is null.</exception>
+    public static void WriteResultsJson(string path, InteropCountResultsDocument document)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(document);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        var json = JsonSerializer.Serialize(document, InteropCountJsonContext.Default.InteropCountResultsDocument);
+        File.WriteAllText(path, json);
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountResult.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountResult.cs
@@ -1,0 +1,76 @@
+using System;
+
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The node operations one scenario's measured step performed, read from the in-memory renderer's op
+/// log. <see cref="TotalOperationCount"/> is the crossing metric the gate compares to the baseline (in
+/// the browser each of these node ops is a JSImport call, per the epic's "N node ops == N interop calls"
+/// equivalence); the per-kind counts explain a total in the report. A plain data record so it round-trips
+/// through the results JSON via source generation.
+/// </summary>
+public sealed class InteropCountResult
+{
+    /// <summary>The scenario id this result belongs to.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Every node operation the measured step logged — the interop-crossing proxy.</summary>
+    public int TotalOperationCount { get; init; }
+
+    /// <summary>The structural operations (inserts plus removes).</summary>
+    public int StructuralOperationCount { get; init; }
+
+    /// <summary>Elements created.</summary>
+    public int CreateElementCount { get; init; }
+
+    /// <summary>Text nodes created.</summary>
+    public int CreateTextCount { get; init; }
+
+    /// <summary>Comment nodes created.</summary>
+    public int CreateCommentCount { get; init; }
+
+    /// <summary>Element text-content replacements.</summary>
+    public int SetElementTextCount { get; init; }
+
+    /// <summary>Text-node content updates.</summary>
+    public int SetTextCount { get; init; }
+
+    /// <summary>Single-property patches.</summary>
+    public int PatchPropertyCount { get; init; }
+
+    /// <summary>Node insertions.</summary>
+    public int InsertCount { get; init; }
+
+    /// <summary>Node removals.</summary>
+    public int RemoveCount { get; init; }
+
+    /// <summary>Raw static-markup insertions.</summary>
+    public int InsertStaticContentCount { get; init; }
+
+    /// <summary>Reads the counts for <paramref name="name"/> out of <paramref name="log"/>.</summary>
+    /// <param name="name">The scenario id.</param>
+    /// <param name="log">The op log after the measured step.</param>
+    /// <returns>The populated result.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="log"/> is null.</exception>
+    public static InteropCountResult From(string name, TestNodeOperationLog log)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+        return new InteropCountResult
+        {
+            Name = name,
+            TotalOperationCount = log.Operations.Count,
+            StructuralOperationCount = log.StructuralOperationCount,
+            CreateElementCount = log.Count(TestNodeOperationType.CreateElement),
+            CreateTextCount = log.Count(TestNodeOperationType.CreateText),
+            CreateCommentCount = log.Count(TestNodeOperationType.CreateComment),
+            SetElementTextCount = log.Count(TestNodeOperationType.SetElementText),
+            SetTextCount = log.Count(TestNodeOperationType.SetText),
+            PatchPropertyCount = log.Count(TestNodeOperationType.PatchProperty),
+            InsertCount = log.Count(TestNodeOperationType.Insert),
+            RemoveCount = log.Count(TestNodeOperationType.Remove),
+            InsertStaticContentCount = log.Count(TestNodeOperationType.InsertStaticContent),
+        };
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountResultsDocument.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropCountResultsDocument.cs
@@ -1,0 +1,21 @@
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The machine-readable results a run persists (per the acceptance criterion "results are persisted per
+/// build, machine-readable, with baseline comparison") — the interop-count analogue of the publish-size
+/// results JSON. CI uploads it as an artifact so a build's crossings are inspectable after the fact.
+/// </summary>
+public sealed class InteropCountResultsDocument
+{
+    /// <summary>When the run was measured (round-trip ISO-8601, UTC).</summary>
+    public string GeneratedUtc { get; init; } = "";
+
+    /// <summary>The tree shape the scenarios were measured under.</summary>
+    public string Variant { get; init; } = "";
+
+    /// <summary>Whether the run was within the reviewed baseline (null when measured without a baseline).</summary>
+    public bool? WithinBaseline { get; init; }
+
+    /// <summary>The per-scenario measured results.</summary>
+    public InteropCountResult[] Scenarios { get; init; } = [];
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropScenario.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropScenario.cs
@@ -1,0 +1,98 @@
+using System;
+
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// One js-framework-benchmark scenario, expressed as a prepare step (mount the baseline tree) and a
+/// measured step (render the next tree). Splitting the two lets the interop harness count only the
+/// measured step's node operations (the op log is reset between them) and lets BenchmarkDotNet time only
+/// the measured step (prepare runs in its iteration setup). The same scenario object therefore feeds both
+/// the deterministic interop-count gate and the wall-clock timings, so the two lenses never drift apart.
+/// </summary>
+public sealed class InteropScenario
+{
+    private readonly Action<ScenarioContext> _prepare;
+    private readonly Action<ScenarioContext> _measured;
+
+    /// <summary>Creates a scenario.</summary>
+    /// <param name="name">The stable scenario id (matches the baseline and the BenchmarkDotNet report).</param>
+    /// <param name="description">A one-line human description.</param>
+    /// <param name="prepare">Mounts the baseline tree; its ops are excluded from the measurement.</param>
+    /// <param name="measured">Renders the next tree; its ops are the measured crossings.</param>
+    /// <exception cref="ArgumentException"><paramref name="name"/> is null or empty.</exception>
+    /// <exception cref="ArgumentNullException">A required argument is null.</exception>
+    public InteropScenario(string name, string description, Action<ScenarioContext> prepare, Action<ScenarioContext> measured)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(prepare);
+        ArgumentNullException.ThrowIfNull(measured);
+        Name = name;
+        Description = description;
+        _prepare = prepare;
+        _measured = measured;
+    }
+
+    /// <summary>The stable scenario id.</summary>
+    public string Name { get; }
+
+    /// <summary>The one-line human description.</summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Runs the prepare step and resets the op log, returning the context primed so the next
+    /// <see cref="RunMeasuredStep"/> logs only the measured crossings.
+    /// </summary>
+    /// <param name="variant">The tree shape to render.</param>
+    /// <returns>The primed context.</returns>
+    public ScenarioContext Prepare(ScenarioVariant variant)
+    {
+        var context = new ScenarioContext(new TestRenderer(), variant);
+        _prepare(context);
+        context.Renderer.OperationLog.Reset();
+        return context;
+    }
+
+    /// <summary>Runs the measured step against a context returned by <see cref="Prepare"/>.</summary>
+    /// <param name="context">The primed context.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> is null.</exception>
+    public void RunMeasuredStep(ScenarioContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _measured(context);
+    }
+
+    /// <summary>
+    /// Prepares and runs the measured step, returning the interop-count result read from the op log —
+    /// the harness path used by the deterministic gate.
+    /// </summary>
+    /// <param name="variant">The tree shape to render.</param>
+    /// <returns>The measured interop counts.</returns>
+    public InteropCountResult Measure(ScenarioVariant variant)
+    {
+        var context = Prepare(variant);
+        _measured(context);
+        return InteropCountResult.From(Name, context.Renderer.OperationLog);
+    }
+
+    /// <summary>
+    /// Runs the whole scenario (prepare then measured step) over a fresh renderer and returns the total
+    /// crossings — the BenchmarkDotNet timing path. Each call is self-contained (new renderer, no shared
+    /// state), so BenchmarkDotNet can invoke it many times per iteration; it times the end-to-end
+    /// scenario, the same click-to-settled work js-framework-benchmark times. The returned count is
+    /// consumed by the caller so the render is not eliminated as dead code.
+    /// </summary>
+    /// <param name="variant">The tree shape to render.</param>
+    /// <returns>The total node operations the scenario performed.</returns>
+    public int Run(ScenarioVariant variant)
+    {
+        var context = Prepare(variant);
+        _measured(context);
+        return context.Renderer.OperationLog.Operations.Count;
+    }
+
+    /// <summary>Returns <see cref="Name"/> so BenchmarkDotNet labels the parameter with the scenario id.</summary>
+    public override string ToString() => Name;
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropScenarioLibrary.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/InteropScenarioLibrary.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The scenario catalogue — the js-framework-benchmark canon
+/// (https://github.com/krausest/js-framework-benchmark): create 1,000 and 10,000 rows, update every
+/// 10th row, swap two rows, select a row, remove a row, append 1,000, replace all, and clear. This is
+/// the single source both the interop-count gate and the BenchmarkDotNet renderer timings draw from, so
+/// a scenario is defined once and measured two ways. Discovery is deterministic and ordered.
+/// </summary>
+public static class InteropScenarioLibrary
+{
+    /// <summary>The row count for the standard scenarios.</summary>
+    public const int RowCount = 1_000;
+
+    /// <summary>The row count for the large create scenario.</summary>
+    public const int LargeRowCount = 10_000;
+
+    /// <summary>The stride for the "update every Nth row" scenario.</summary>
+    public const int UpdateStep = 10;
+
+    private const int SwapFirstIndex = 1;
+    private const int SwapSecondIndex = 998;
+    private const int RemoveIndex = 1;
+    private const int SelectIndex = 1;
+
+    /// <summary>Returns the ordered scenario catalogue (variant-independent; variant is applied per measurement).</summary>
+    /// <returns>The scenarios, in a stable order.</returns>
+    public static IReadOnlyList<InteropScenario> Discover()
+    {
+        return
+        [
+            new InteropScenario(
+                "create-1000",
+                "Mount 1,000 rows into an empty container.",
+                static _ => { },
+                static context => context.Render(context.Source.Build(RowCount))),
+
+            new InteropScenario(
+                "create-10000",
+                "Mount 10,000 rows into an empty container.",
+                static _ => { },
+                static context => context.Render(context.Source.Build(LargeRowCount))),
+
+            new InteropScenario(
+                "update-every-10th",
+                "Append \" !!!\" to every 10th label across 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context => context.Render(BenchmarkRowSource.UpdateEvery(context.Rows, UpdateStep))),
+
+            new InteropScenario(
+                "swap-rows",
+                "Swap rows 1 and 998 of 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context => context.Render(BenchmarkRowSource.Swap(context.Rows, SwapFirstIndex, SwapSecondIndex))),
+
+            new InteropScenario(
+                "select-row",
+                "Toggle the selected class on one row of 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context =>
+                {
+                    context.SelectedIdentifier = context.Rows[SelectIndex].Identifier;
+                    context.Render(context.Rows);
+                }),
+
+            new InteropScenario(
+                "remove-row",
+                "Remove one row from near the front of 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context => context.Render(BenchmarkRowSource.RemoveAt(context.Rows, RemoveIndex))),
+
+            new InteropScenario(
+                "append-1000",
+                "Append 1,000 rows to 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context =>
+                {
+                    var grown = new List<BenchmarkRow>(context.Rows);
+                    context.Source.Append(grown, RowCount);
+                    context.Render(grown);
+                }),
+
+            new InteropScenario(
+                "replace-1000",
+                "Replace 1,000 mounted rows with 1,000 freshly keyed rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context => context.Render(context.Source.Build(RowCount))),
+
+            new InteropScenario(
+                "clear-1000",
+                "Clear all 1,000 mounted rows.",
+                static context => context.Render(context.Source.Build(RowCount)),
+                static context => context.Render([])),
+        ];
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/ScenarioContext.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Interop/ScenarioContext.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// The per-run state a scenario mutates — one in-memory renderer, its container, a deterministic row
+/// source, and the current row list. A scenario's prepare step mounts a baseline tree through
+/// <see cref="Render"/>; its measured step renders the next tree, which the renderer diffs against the
+/// mounted one, landing every node operation in the renderer's op log (the interop-crossing proxy).
+/// Not thread-safe (single-threaded benchmark host).
+/// </summary>
+public sealed class ScenarioContext
+{
+    /// <summary>Creates a context over a fresh renderer, container, and (seeded) row source.</summary>
+    /// <param name="renderer">The in-memory renderer whose op log is measured.</param>
+    /// <param name="variant">The tree shape the scenario renders.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="renderer"/> is null.</exception>
+    public ScenarioContext(TestRenderer renderer, ScenarioVariant variant)
+    {
+        ArgumentNullException.ThrowIfNull(renderer);
+        Renderer = renderer;
+        Variant = variant;
+        Container = renderer.CreateContainer();
+        Source = new BenchmarkRowSource();
+        Rows = [];
+    }
+
+    /// <summary>The renderer under measurement.</summary>
+    public TestRenderer Renderer { get; }
+
+    /// <summary>The container the scenario renders into.</summary>
+    public TestElement Container { get; }
+
+    /// <summary>The tree shape (keyed+flagged, or the keyless bypass).</summary>
+    public ScenarioVariant Variant { get; }
+
+    /// <summary>The deterministic row source for this run (fresh per context, so runs are reproducible).</summary>
+    public BenchmarkRowSource Source { get; }
+
+    /// <summary>The currently mounted row list.</summary>
+    public IReadOnlyList<BenchmarkRow> Rows { get; private set; }
+
+    /// <summary>The selected row id applied on the next <see cref="Render"/>, or null for none.</summary>
+    public int? SelectedIdentifier { get; set; }
+
+    /// <summary>
+    /// Renders <paramref name="rows"/> (with the current <see cref="SelectedIdentifier"/> and
+    /// <see cref="Variant"/>) into the container, diffing against whatever is mounted.
+    /// </summary>
+    /// <param name="rows">The rows to render.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public void Render(IReadOnlyList<BenchmarkRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        Rows = rows;
+        Renderer.Render(RowTableBuilder.Build(rows, SelectedIdentifier, Variant), Container);
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Program.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Program.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Entry point for the Viu performance benchmark suite ([V01.01.11.04], #88). Routes between three modes:
+/// <list type="bullet">
+/// <item><c>benchmarks [BenchmarkDotNet args]</c> — the wall-clock micro/meso timings (Release only).</item>
+/// <item><c>interop [--variant …] [--baseline …] [--results …] [--gate]</c> — the deterministic
+/// interop-crossing count harness and its regression gate (fast, runs in Debug).</item>
+/// <item><c>browser</c> — prints the honest deferral status of the real-browser lane (#87).</item>
+/// </list>
+/// </summary>
+public static class Program
+{
+    /// <summary>Dispatches on the first argument.</summary>
+    /// <param name="args">The command-line arguments.</param>
+    /// <returns>0 on success, 1 on a tripped gate, 2 on a usage/configuration error.</returns>
+    public static int Main(string[] args)
+    {
+        var command = args.Length > 0 ? args[0] : "help";
+        switch (command)
+        {
+            case "benchmarks":
+                return RunBenchmarks(args[1..]);
+            case "interop":
+                return RunInterop(args[1..]);
+            case "browser":
+                DeferredBrowserBenchmarks.PrintDeferralNotice(Console.Out);
+                return 0;
+            case "help":
+            case "--help":
+            case "-h":
+                PrintUsage(Console.Out);
+                return 0;
+            default:
+                Console.Error.WriteLine(FormattableString.Invariant($"Unknown command: {command}"));
+                PrintUsage(Console.Error);
+                return 2;
+        }
+    }
+
+    private static int RunBenchmarks(string[] benchmarkArgs)
+    {
+        // --smoke is our own flag (a fast ShortRun); everything else passes through to BenchmarkDotNet.
+        var quick = false;
+        var passthrough = new List<string>(benchmarkArgs.Length);
+        foreach (var argument in benchmarkArgs)
+        {
+            if (argument == "--smoke")
+            {
+                quick = true;
+            }
+            else
+            {
+                passthrough.Add(argument);
+            }
+        }
+
+        if (passthrough.Count == 0)
+        {
+            // BenchmarkDotNet with no arguments opens an interactive menu that reads stdin, which hangs in
+            // CI. Require an explicit filter instead (e.g. `benchmarks --filter *`).
+            Console.Error.WriteLine("The 'benchmarks' command needs a filter, e.g. --filter * or --list flat.");
+            Console.Error.WriteLine("A short smoke run: benchmarks --smoke --filter *ReactivityBenchmarks*");
+            return 2;
+        }
+
+        // The repo's central source-generator/analyzer MSBuild wiring breaks BenchmarkDotNet's default
+        // toolchain: it fails to build the auto-generated boilerplate project nested under the repo tree
+        // (MSB3030 on the generator DLL). Run in-process instead. Trade-off: less per-case isolation than a
+        // child-process toolchain — acceptable because these wall-clock numbers are informational (the
+        // gated metric is the deterministic interop count, not time), and per-case [GlobalSetup]/
+        // [GlobalCleanup] still re-establishes the reactivity/scheduler state each case depends on.
+        var job = (quick ? Job.ShortRun : Job.Default).WithToolchain(InProcessEmitToolchain.Instance);
+        var config = ManualConfig.Create(DefaultConfig.Instance).AddJob(job);
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(passthrough.ToArray(), config);
+        return 0;
+    }
+
+    private static int RunInterop(string[] interopArgs)
+    {
+        var variant = ScenarioVariant.Optimized;
+        var baselinePath = DefaultBaselinePath();
+        string? resultsPath = null;
+        var gate = false;
+
+        for (var index = 0; index < interopArgs.Length; index++)
+        {
+            var argument = interopArgs[index];
+            switch (argument)
+            {
+                case "--variant":
+                    if (!TryTakeValue(interopArgs, ref index, out var variantText)
+                        || !Enum.TryParse(variantText, ignoreCase: true, out variant))
+                    {
+                        Console.Error.WriteLine("--variant requires Optimized or KeylessBypass.");
+                        return 2;
+                    }
+                    break;
+                case "--baseline":
+                    if (!TryTakeValue(interopArgs, ref index, out baselinePath!))
+                    {
+                        Console.Error.WriteLine("--baseline requires a path.");
+                        return 2;
+                    }
+                    break;
+                case "--results":
+                    if (!TryTakeValue(interopArgs, ref index, out resultsPath!))
+                    {
+                        Console.Error.WriteLine("--results requires a path.");
+                        return 2;
+                    }
+                    break;
+                case "--gate":
+                    gate = true;
+                    break;
+                default:
+                    Console.Error.WriteLine(FormattableString.Invariant($"Unknown interop option: {argument}"));
+                    return 2;
+            }
+        }
+
+        var measured = InteropCountHarness.MeasureAll(variant);
+
+        if (baselinePath is not null && File.Exists(baselinePath))
+        {
+            var baseline = InteropCountBaseline.Load(baselinePath);
+            var comparison = baseline.Compare(measured);
+            InteropCountReport.WriteComparison(Console.Out, measured, comparison, variant);
+            if (resultsPath is not null)
+            {
+                InteropCountReport.WriteResultsJson(resultsPath, InteropCountReport.BuildDocument(measured, variant, comparison.Passed));
+            }
+            return gate && !comparison.Passed ? 1 : 0;
+        }
+
+        // No baseline present: seed mode. Print the raw totals so the reviewed manifest can be authored,
+        // but refuse to gate — a gate with no baseline is not a gate.
+        if (gate)
+        {
+            Console.Error.WriteLine(FormattableString.Invariant($"--gate requires a baseline; none found at {baselinePath}."));
+            return 2;
+        }
+        PrintRawResults(Console.Out, measured, variant);
+        if (resultsPath is not null)
+        {
+            InteropCountReport.WriteResultsJson(resultsPath, InteropCountReport.BuildDocument(measured, variant, withinBaseline: null));
+        }
+        return 0;
+    }
+
+    private static void PrintRawResults(TextWriter writer, IReadOnlyList<InteropCountResult> results, ScenarioVariant variant)
+    {
+        writer.WriteLine();
+        writer.WriteLine(FormattableString.Invariant($"Viu interop-count seed (variant={variant}); no baseline — authoring numbers below."));
+        writer.WriteLine(new string('=', 78));
+        var header = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0,-20} {1,10} {2,12} {3,8} {4,8} {5,8} {6,8}",
+            "Scenario", "Total", "Structural", "Create", "SetText", "Patch", "Remove");
+        writer.WriteLine(header);
+        writer.WriteLine(new string('-', header.Length));
+        foreach (var result in results)
+        {
+            writer.WriteLine(string.Format(
+                CultureInfo.InvariantCulture,
+                "{0,-20} {1,10} {2,12} {3,8} {4,8} {5,8} {6,8}",
+                result.Name,
+                result.TotalOperationCount,
+                result.StructuralOperationCount,
+                result.CreateElementCount,
+                result.SetElementTextCount + result.SetTextCount,
+                result.PatchPropertyCount,
+                result.RemoveCount));
+        }
+    }
+
+    private static string DefaultBaselinePath()
+        => Path.Combine(AppContext.BaseDirectory, "baselines", "InteropCounts.json");
+
+    private static bool TryTakeValue(string[] args, ref int index, out string value)
+    {
+        if (index + 1 < args.Length)
+        {
+            value = args[++index];
+            return true;
+        }
+        value = "";
+        return false;
+    }
+
+    private static void PrintUsage(TextWriter writer)
+    {
+        writer.WriteLine("Viu performance benchmark suite ([V01.01.11.04], #88)");
+        writer.WriteLine();
+        writer.WriteLine("Usage: Assimalign.Viu.Testing.Benchmarks <command> [options]");
+        writer.WriteLine();
+        writer.WriteLine("Commands:");
+        writer.WriteLine("  benchmarks [args]   Wall-clock micro/meso timings via BenchmarkDotNet (build Release).");
+        writer.WriteLine("      --smoke         Fast ShortRun (fewer iterations) for a quick end-to-end check.");
+        writer.WriteLine("                      Smoke: benchmarks --smoke --filter *ReactivityBenchmarks*");
+        writer.WriteLine("  interop [options]   Deterministic interop-crossing count harness + regression gate.");
+        writer.WriteLine("      --variant V     Optimized (default) or KeylessBypass.");
+        writer.WriteLine("      --baseline P    Baseline manifest (default: baselines/InteropCounts.json beside the app).");
+        writer.WriteLine("      --results P     Write machine-readable results JSON to P.");
+        writer.WriteLine("      --gate          Exit 1 if any scenario exceeds its reviewed baseline.");
+        writer.WriteLine("  browser             Print the deferred real-browser lane status (#87).");
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/ReactivityBenchmarks.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/ReactivityBenchmarks.cs
@@ -1,0 +1,128 @@
+using System;
+
+using BenchmarkDotNet.Attributes;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// BenchmarkDotNet timings for the reactivity hot paths the architecture bets on — dependency
+/// track/trigger, computed invalidation/recompute, effect trigger fan-out, batched-write coalescing, and
+/// scheduler queue+flush (the version-counter/linked-list design of <c>@vue/reactivity</c>). Pure CoreCLR
+/// with no browser or interop; wall-clock numbers are environment-relative, so they are reported as
+/// artifacts, never gated. BenchmarkDotNet isolates each case in its own process, so the ambient static
+/// reactivity/scheduler state does not leak between cases.
+/// </summary>
+[MemoryDiagnoser]
+public class ReactivityBenchmarks
+{
+    private const int FanOutEffectCount = 100;
+    private const int BatchedWriteCount = 50;
+    private const int SchedulerJobCount = 100;
+
+    private Reference<int> _reference = null!;
+    private Reference<int> _computedChainHead = null!;
+    private Computed<int> _computedTail = null!;
+    private Reference<int> _fanOutReference = null!;
+    private Reference<int> _batchReference = null!;
+    private SchedulerJob[] _jobs = [];
+    private TestSchedulerPump _pump = null!;
+    private int _counter;
+    private int _sink;
+    private int _jobRuns;
+
+    /// <summary>Builds the reactive graphs once per benchmark process.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Single ref observed by one effect: writing it triggers exactly one synchronous re-run.
+        _reference = Reactive.Reference(0);
+        Reactive.Effect(() => _sink = _reference.Value);
+
+        // A three-deep computed chain over a ref: a write invalidates lazily; reading the tail recomputes.
+        var head = Reactive.Reference(0);
+        var first = Reactive.Computed(() => head.Value + 1);
+        var second = Reactive.Computed(() => first.Value + 1);
+        _computedTail = Reactive.Computed(() => second.Value + 1);
+        _computedChainHead = head;
+
+        // One ref observed by many effects: a write fans the trigger out to every subscriber.
+        _fanOutReference = Reactive.Reference(0);
+        for (var index = 0; index < FanOutEffectCount; index++)
+        {
+            Reactive.Effect(() => _sink = _fanOutReference.Value);
+        }
+
+        // One ref observed by one effect, written many times inside a batch: the effect runs once.
+        _batchReference = Reactive.Reference(0);
+        Reactive.Effect(() => _sink = _batchReference.Value);
+
+        // Reusable scheduler jobs and a pump that drains the queue deterministically off the JS event loop.
+        _pump = TestSchedulerPump.Install();
+        _jobs = new SchedulerJob[SchedulerJobCount];
+        for (var index = 0; index < SchedulerJobCount; index++)
+        {
+            _jobs[index] = new SchedulerJob(() => _jobRuns++) { Identifier = index };
+        }
+    }
+
+    /// <summary>Tears down the installed scheduler pump.</summary>
+    [GlobalCleanup]
+    public void Cleanup() => _pump.Dispose();
+
+    /// <summary>The rawest path: write a ref, trigger its one effect, re-run it synchronously.</summary>
+    /// <returns>The effect's captured value (defeats dead-code elimination).</returns>
+    [Benchmark(Baseline = true)]
+    public int DependencyTrackTrigger()
+    {
+        _reference.Value = _counter++;
+        return _sink;
+    }
+
+    /// <summary>Invalidate a three-deep computed chain with a write, then recompute it with a read.</summary>
+    /// <returns>The recomputed tail value.</returns>
+    [Benchmark]
+    public int ComputedChainRecompute()
+    {
+        _computedChainHead.Value = _counter++;
+        return _computedTail.Value;
+    }
+
+    /// <summary>Write one ref observed by many effects, fanning the trigger out to all of them.</summary>
+    /// <returns>The last effect's captured value.</returns>
+    [Benchmark]
+    public int EffectTriggerFanOut()
+    {
+        _fanOutReference.Value = _counter++;
+        return _sink;
+    }
+
+    /// <summary>Coalesce many writes to one ref inside a batch into a single effect run.</summary>
+    /// <returns>The effect's captured value.</returns>
+    [Benchmark]
+    public int BatchedWriteCoalescing()
+    {
+        Reactive.StartBatch();
+        for (var index = 0; index < BatchedWriteCount; index++)
+        {
+            _batchReference.Value = _counter++;
+        }
+        Reactive.EndBatch();
+        return _sink;
+    }
+
+    /// <summary>Queue many scheduler jobs and drain them in one coalesced flush.</summary>
+    /// <returns>The number of flushes the pump ran.</returns>
+    [Benchmark]
+    public int SchedulerQueueAndFlush()
+    {
+        for (var index = 0; index < SchedulerJobCount; index++)
+        {
+            Scheduler.QueueJob(_jobs[index]);
+        }
+        return _pump.RunUntilIdle();
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/RendererScenarioBenchmarks.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/RendererScenarioBenchmarks.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+using BenchmarkDotNet.Attributes;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// BenchmarkDotNet wall-clock timings for the renderer's diff/patch over the js-framework-benchmark
+/// scenarios, driven through the in-memory test adapter (no browser, no interop). Each case runs the
+/// whole scenario end to end over a fresh renderer — the same click-to-settled work js-framework-benchmark
+/// times — so a case is self-contained and stable across BenchmarkDotNet's repeated invocations. Timings
+/// are environment-relative and reported as artifacts, never gated; the mutation's <em>crossing count</em>
+/// (the gated metric) is isolated separately by the interop-count harness, which resets the op log
+/// between mount and mutation. The Optimized variant (keyed rows, patch-flagged labels) is measured — the
+/// shipped path the numbers should track over time.
+/// </summary>
+[MemoryDiagnoser]
+public class RendererScenarioBenchmarks
+{
+    /// <summary>The scenario under measurement (BenchmarkDotNet fills this from <see cref="ScenarioSource"/>).</summary>
+    [ParamsSource(nameof(ScenarioSource))]
+    public InteropScenario Scenario { get; set; } = null!;
+
+    /// <summary>The scenario catalogue BenchmarkDotNet parametrizes over.</summary>
+    /// <returns>The discovered scenarios.</returns>
+    public IEnumerable<InteropScenario> ScenarioSource() => InteropScenarioLibrary.Discover();
+
+    /// <summary>Runs the selected scenario end to end over a fresh renderer.</summary>
+    /// <returns>The scenario's total node operations (consumed so the render is not eliminated).</returns>
+    [Benchmark]
+    public int RenderScenario() => Scenario.Run(ScenarioVariant.Optimized);
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/RowTableBuilder.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/RowTableBuilder.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Shared;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Turns a row list into the virtual-node tree the renderer diffs — the shape js-framework-benchmark
+/// renders (a <c>&lt;table&gt;</c> of keyed <c>&lt;tr&gt;</c> rows, each with an id cell and a label
+/// link; https://github.com/krausest/js-framework-benchmark). The <see cref="ScenarioVariant"/> chooses
+/// between the framework's real output (keyed rows, a <see cref="PatchFlags.Text"/> label so a change is
+/// one targeted set-text) and the keyless bypass the interop-count gate is proven against. Building a
+/// fresh tree per frame mirrors Vue, whose render function re-creates vnodes every update.
+/// </summary>
+public static class RowTableBuilder
+{
+    /// <summary>
+    /// Builds the table for <paramref name="rows"/>, marking the row whose id equals
+    /// <paramref name="selectedIdentifier"/> (if any) selected.
+    /// </summary>
+    /// <param name="rows">The rows to render.</param>
+    /// <param name="selectedIdentifier">The selected row id, or null for none.</param>
+    /// <param name="variant">Keyed+flagged output, or the keyless bypass.</param>
+    /// <returns>The table vnode.</returns>
+    public static VirtualNode Build(
+        IReadOnlyList<BenchmarkRow> rows,
+        int? selectedIdentifier,
+        ScenarioVariant variant)
+    {
+        var rowNodes = new VirtualNode?[rows.Count];
+        for (var index = 0; index < rows.Count; index++)
+        {
+            rowNodes[index] = BuildRow(rows[index], selectedIdentifier, variant);
+        }
+
+        var body = VirtualNodeFactory.Element("tbody", null, rowNodes);
+        return VirtualNodeFactory.Element(
+            "table",
+            VirtualNodeFactory.Properties(("class", "table table-hover table-striped test-data")),
+            body);
+    }
+
+    private static VirtualNode BuildRow(BenchmarkRow row, int? selectedIdentifier, ScenarioVariant variant)
+    {
+        var keyed = variant == ScenarioVariant.Optimized;
+        var isSelected = selectedIdentifier == row.Identifier;
+        var identifierText = row.Identifier.ToString(CultureInfo.InvariantCulture);
+
+        // The label link is the one dynamic cell: in the optimized variant it carries PatchFlags.Text so
+        // a label change is a single targeted set-text; the keyless variant leaves it a plain text
+        // element (a direct text change still costs one set-text, but the row loses its diff key).
+        var labelLink = keyed
+            ? VirtualNodeFactory.Element("a", VirtualNodeFactory.Properties(("class", "lbl")), row.Label, PatchFlags.Text)
+            : VirtualNodeFactory.Element("a", VirtualNodeFactory.Properties(("class", "lbl")), row.Label);
+
+        var cells = new VirtualNode?[]
+        {
+            VirtualNodeFactory.Element("td", VirtualNodeFactory.Properties(("class", "col-md-1")), identifierText),
+            VirtualNodeFactory.Element("td", VirtualNodeFactory.Properties(("class", "col-md-4")), labelLink),
+            VirtualNodeFactory.Element(
+                "td",
+                VirtualNodeFactory.Properties(("class", "col-md-1")),
+                VirtualNodeFactory.Element(
+                    "a",
+                    VirtualNodeFactory.Properties(("class", "remove")),
+                    VirtualNodeFactory.Element(
+                        "span",
+                        VirtualNodeFactory.Properties(("class", "glyphicon glyphicon-remove"), ("aria-hidden", "true"))))),
+            VirtualNodeFactory.Element("td", VirtualNodeFactory.Properties(("class", "col-md-6"))),
+        };
+
+        return VirtualNodeFactory.Element("tr", BuildRowProperties(row.Identifier, isSelected, keyed), cells);
+    }
+
+    private static VirtualNodeProperties? BuildRowProperties(int identifier, bool isSelected, bool keyed)
+    {
+        // No PatchFlag on the row itself: a full prop diff of an unchanged row emits no ops, so the row's
+        // own crossings stay minimal without a block tree, while the keyed diff (driven by the "key"
+        // prop) still gets to move rows instead of rebuilding them. Selection toggles the class only.
+        if (keyed && isSelected)
+        {
+            return VirtualNodeFactory.Properties(("key", identifier), ("class", "danger"));
+        }
+        if (keyed)
+        {
+            return VirtualNodeFactory.Properties(("key", identifier));
+        }
+        if (isSelected)
+        {
+            return VirtualNodeFactory.Properties(("class", "danger"));
+        }
+        return null;
+    }
+}

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/ScenarioVariant.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/ScenarioVariant.cs
@@ -1,0 +1,25 @@
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// How a row list is turned into a virtual-node tree — the two shapes whose interop-crossing costs the
+/// suite contrasts.
+/// </summary>
+public enum ScenarioVariant
+{
+    /// <summary>
+    /// The framework's real compiled output: rows are keyed (the keyed diff with the longest-increasing
+    /// subsequence moves nodes instead of rebuilding them) and dynamic parts carry <c>PatchFlags</c>
+    /// (a label change is one targeted set-text, a selection is one class patch). This is what the
+    /// baseline records and the gate protects.
+    /// </summary>
+    Optimized,
+
+    /// <summary>
+    /// The deliberate optimization bypass: rows carry no key and no patch flag, so the renderer falls
+    /// back to a positional unkeyed diff and a full per-element property/children walk. Structurally
+    /// identical output, but a middle-of-list remove or reorder now re-patches every shifted row —
+    /// the same class of regression a command-buffer bypass would cause in the browser (time-neutral,
+    /// but many more boundary crossings). Used only to prove the interop-count gate is sensitive.
+    /// </summary>
+    KeylessBypass,
+}

--- a/benchmarks/baselines/InteropCounts.json
+++ b/benchmarks/baselines/InteropCounts.json
@@ -1,0 +1,36 @@
+{
+  "note": [
+    "Reviewed interop-crossing baseline for the Viu benchmark suite ([V01.01.11.04], #88).",
+    "The interop-crossing analogue of the publish-size manifest (scripts/budgets/PublishBudgets.json).",
+    "",
+    "totalOperationCount: the number of in-memory node operations the scenario's MEASURED step performs",
+    "against the test adapter (Assimalign.Viu.Testing). Each node op is one JSImport crossing in the",
+    "browser (the epic's 'N node ops == N interop calls' equivalence), so this count is the DOM-free proxy",
+    "the gate protects. It is deterministic and machine-independent, so tolerance is 0 by default: any",
+    "increase is a regression the gate fails.",
+    "",
+    "No silent ratcheting: CI never rewrites this file. Raising a ceiling is an explicit, reviewed edit in",
+    "the pull request, so a crossing increase is always a deliberate decision. Seeded from the measured",
+    "actual of the Optimized (keyed, patch-flagged) variant -- the shipped renderer path.",
+    "",
+    "The keyed advantage this baseline locks in is visible against the KeylessBypass variant (run",
+    "'interop --variant KeylessBypass'): remove-row costs 1 crossing keyed but 1996 keyless, swap-rows 2",
+    "vs 4. A change that silently drops keys or patch flags is time-neutral yet multiplies crossings, and",
+    "trips this gate -- the DOM-free stand-in for a browser command-buffer bypass.",
+    "",
+    "Seed provenance: measured 2026-07-20 with .NET SDK 10.0.301 via 'dotnet run -- interop'. Counts are",
+    "renderer-deterministic (independent of host/label values), so a differing CI measurement means the",
+    "renderer's crossing behavior changed -- investigate rather than re-seed."
+  ],
+  "scenarios": [
+    { "name": "create-1000", "totalOperationCount": 26005, "tolerance": 0 },
+    { "name": "create-10000", "totalOperationCount": 260005, "tolerance": 0 },
+    { "name": "update-every-10th", "totalOperationCount": 100, "tolerance": 0 },
+    { "name": "swap-rows", "totalOperationCount": 2, "tolerance": 0 },
+    { "name": "select-row", "totalOperationCount": 1, "tolerance": 0 },
+    { "name": "remove-row", "totalOperationCount": 1, "tolerance": 0 },
+    { "name": "append-1000", "totalOperationCount": 26000, "tolerance": 0 },
+    { "name": "replace-1000", "totalOperationCount": 27000, "tolerance": 0 },
+    { "name": "clear-1000", "totalOperationCount": 1000, "tolerance": 0 }
+  ]
+}

--- a/build/Targets/Build.References.Packages.targets
+++ b/build/Targets/Build.References.Packages.targets
@@ -26,6 +26,14 @@
         <_ViuPackage Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
     </ItemGroup>
 
+    <!-- Benchmark Dependencies -->
+    <ItemGroup>
+        <!-- BenchmarkDotNet hosts the DOM-free micro/meso benchmarks ([V01.01.11.04], #88): reactivity
+             track/trigger and renderer diff/patch on the in-memory test adapter, on CoreCLR. It never
+             ships and is not trimmed/AOT'd (bench project, like the tests). Restored from dotnet-public. -->
+        <_ViuPackage Include="BenchmarkDotNet" Version="0.15.8" />
+    </ItemGroup>
+
     <!-- XUnit Test Dependencies-->
     <ItemGroup>
         <_ViuPackage Include="Shouldly" Version="4.3.0" />

--- a/build/Targets/Build.References.Projects.targets
+++ b/build/Targets/Build.References.Projects.targets
@@ -38,6 +38,10 @@
              against, so a generator's own snapshot tests resolve it as a ViuPrivateProjectReference. -->
         <_ViuProject Include="$(ViuRepositoryDirectory)libraries\**\*.csproj" />
         <_ViuProject Include="$(ViuRepositoryDirectory)analyzers\**\*.csproj" />
+        <!-- Benchmarks are a first-class non-shipping code area ([V01.01.11.04], #88), like analyzers:
+             indexing them lets the benchmark test project take a by-name compile reference to the
+             benchmark app, and lets both resolve the runtime libraries they measure. -->
+        <_ViuProject Include="$(ViuRepositoryDirectory)benchmarks\**\*.csproj" />
         <_ViuProject Update="@(_ViuProject)" ProjectId="%(_ViuProject.Filename)" ProjectPath="%(_ViuProject.Identity)" />
 
         <!-- Public refs -->


### PR DESCRIPTION
## Summary
- New top-level `benchmarks/` area (justified over `scripts/tests` — it ships a real `Assimalign.Viu.*` assembly; the by-name resolver now indexes `benchmarks/**`, a one-line central-build extension) with **two hosts over one shared scenario catalogue** so timings and counts never drift.
- **The real gate is deterministic**: each js-framework-benchmark scenario's node-operation count (the DOM-free proxy for JSImport crossings) compares against a reviewed baseline (`benchmarks/baselines/InteropCounts.json`, no silent ratcheting — the budget-manifest philosophy). Machine-independent, so it gates every PR. Proof it catches the right regression class: a deliberate keyless-diff bypass sends remove-row from **1 → 1,996 crossings** and swap-rows 2 → 4 — time-neutral, ~2000× the interop cost — and the gate fails 7/9 with exit 1.
- **BenchmarkDotNet timings stay informational** (label-/dispatch-gated in CI, never blocking): reactivity track/trigger **22 ns / 0 alloc**, computed chain 63 ns, 100-effect fan-out 2.2 µs / 0 alloc; renderer create-1000 at 26,005 crossings and update-every-10th at exactly 100 — the keyed-diff/patch-flag guarantees, now executable. Runs the in-process toolchain (the repo's source-generator MSBuild wiring breaks BDN's project generation — documented trade-off, acceptable for informational numbers).
- Real-browser wall-clock and live command-buffer counts stay honestly deferred to the Playwright harness ([#87](https://github.com/assimalign/viu/issues/87)) via the wired-but-skipped `ENABLE_BROWSER_BENCHMARKS` lane — the startup-gate pattern. Per-assembly payload breakdown filed as [#225 [V01.01.11.04.01]](https://github.com/assimalign/viu/issues/225).

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · both bench projects Release `-warnaserror` clean · harness tests **22/22** (Debug + Release) · interop gate PASS 9/9 on the optimized path, FAIL demonstration on the bypass · Testing 18 / Reactivity 113 untouched.

Closes #88
Refs #87, #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)