### PR TITLE
feat(single-file-component): bridge generated .viu partials to mountable components [V01.01.06.07]

### DIFF
--- a/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
+++ b/analyzers/Assimalign.Viu.Syntax.Generators/src/Internal/SingleFileComponentSourceEmitter.cs
@@ -44,6 +44,15 @@ internal static class SingleFileComponentSourceEmitter
     /// </summary>
     private const string DomRenderHelperSurface = "global::Assimalign.Viu.RuntimeDom.DomRenderHelpers";
 
+    /// <summary>
+    /// The fully qualified runtime-core namespace the generated <c>IComponentDefinition</c> bridge
+    /// ([V01.01.06.07]) names by <c>global::</c> reference — the generator never references the runtime
+    /// assembly, exactly as the render-helper surfaces are bound by name. The bridge members
+    /// (<c>IComponentDefinition</c>, <c>ComponentProperties</c>, <c>ComponentSetupContext</c>,
+    /// <c>ComponentSlots</c>, <c>VirtualNode</c>, and <c>RenderHelpers.NormalizeRoot</c>) all live here.
+    /// </summary>
+    private const string RuntimeCoreNamespace = "global::Assimalign.Viu.RuntimeCore";
+
     /// <summary>Emits the full generated source for <paramref name="model"/>.</summary>
     /// <param name="model">The scaffold to render.</param>
     /// <returns>The generated C# source text.</returns>
@@ -100,7 +109,18 @@ internal static class SingleFileComponentSourceEmitter
             .Append(", custom=").Append(Count(model.CustomBlockCount)).Append(".\n");
 
         AppendIndent(builder, indent);
-        builder.Append("partial class ").Append(model.ClassName).Append('\n');
+        builder.Append("partial class ").Append(model.ClassName);
+        if (model.RenderBody is not null)
+        {
+            // [V01.01.06.07] A @template-bearing .viu is a mountable component: the generated partial
+            // implements IComponentDefinition (base list added here, the sole class-declaration site) so it
+            // can be passed to CreateApp/VirtualNodeFactory.Component. A @style-only or scriptless .viu with
+            // no render body stays a plain partial class — no interface, no Setup — so the CSS-bundle .viu
+            // files keep compiling unchanged. Named by global:: reference, never an assembly reference.
+            builder.Append(" : ").Append(RuntimeCoreNamespace).Append(".IComponentDefinition");
+        }
+
+        builder.Append('\n');
         AppendIndent(builder, indent);
         builder.Append("{\n");
 
@@ -138,6 +158,8 @@ internal static class SingleFileComponentSourceEmitter
             builder.Append(renderBody);
             AppendIndent(builder, bodyIndent);
             builder.Append("}\n");
+
+            AppendComponentDefinitionBridge(builder, bodyIndent, model);
         }
         else
         {
@@ -160,6 +182,137 @@ internal static class SingleFileComponentSourceEmitter
         }
 
         return builder.ToString();
+    }
+
+    // [V01.01.06.07] The IComponentDefinition bridge — the generated Name + Setup that turn a compiled
+    // @template/@script partial into a component the runtime can instantiate and mount (CreateApp,
+    // VirtualNodeFactory.Component) with no hand-written wiring. Emitted only alongside a render body (the
+    // base list is added to match, in Emit); a render-less .viu never reaches here. The members are
+    // EXPLICIT interface implementations, so they never collide with a merged @script member named Name or
+    // Setup, and the class surface the render's _ctx sees stays exactly the @script members. Setup runs once
+    // per instance with the instance current (upstream setup(props, context)): it allocates the per-instance
+    // render cache, captures the setup context for the compiled render's slot outlets when the template uses
+    // them, applies the v-bind() CSS custom properties when the component declares any, and returns the
+    // render delegate that normalizes the compiled static Render(_ctx, _cache) result to a vnode. Reactive
+    // @script members (a Reference<T> read as _ctx.name.Value, a [Reactive] field) are tracked by the render
+    // effect that runs the returned delegate, so a mutation drives a re-render — the .viu analogue of Vue's
+    // <script setup> binding semantics.
+    private static void AppendComponentDefinitionBridge(StringBuilder builder, int indent, in SingleFileComponentModel model)
+    {
+        // The compiled render reads parent-provided slots as `_ctx.__slots` (docs/DESIGN.md: `$slots` is not
+        // a legal C# identifier). Only wire the slot accessor when the render actually reads it, so a
+        // slotless component stays minimal.
+        var usesSlots = model.RenderBody is { } renderBody
+            && renderBody.IndexOf("_ctx.__slots", StringComparison.Ordinal) >= 0;
+        var appliesCssVariables = model.CssVariableBindings.Count > 0;
+        var displayName = model.ClassName.Length > 0 && model.ClassName[0] == '@'
+            ? model.ClassName.Substring(1)
+            : model.ClassName;
+
+        builder.Append('\n');
+        AppendIndent(builder, indent);
+        builder.Append("// [V01.01.06.07] The IComponentDefinition bridge: the generated Name + Setup that make this\n");
+        AppendIndent(builder, indent);
+        builder.Append("// compiled @template component mountable through CreateApp / VirtualNodeFactory.Component with no\n");
+        AppendIndent(builder, indent);
+        builder.Append("// hand-written wiring. Explicitly implemented so they never collide with a merged @script member.\n");
+
+        AppendIndent(builder, indent);
+        builder.Append("/// <summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// The component's display name (upstream: the component <c>name</c> option, inferred from the\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// <c>.viu</c> file name) — surfaced to runtime warnings and devtools.\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// </summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("string? ").Append(RuntimeCoreNamespace).Append(".IComponentDefinition.Name => ")
+            .Append(Literal(displayName)).Append(";\n");
+
+        if (usesSlots)
+        {
+            builder.Append('\n');
+            AppendIndent(builder, indent);
+            builder.Append("/// <summary>The setup context captured for the compiled render's slot outlets; held so a\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// slot-affecting parent update is reflected live.</summary>\n");
+            AppendIndent(builder, indent);
+            builder.Append("private ").Append(RuntimeCoreNamespace).Append(".ComponentSetupContext? __setupContext;\n");
+            builder.Append('\n');
+            AppendIndent(builder, indent);
+            builder.Append("/// <summary>\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// The parent-provided slots (upstream: <c>_ctx.$slots</c>; <c>$</c> is not legal in C#, so the\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// compiled render spells it <c>__slots</c>) — the by-name binding site the render's\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// <c>_renderSlot</c> calls read.\n");
+            AppendIndent(builder, indent);
+            builder.Append("/// </summary>\n");
+            AppendIndent(builder, indent);
+            builder.Append("private ").Append(RuntimeCoreNamespace).Append(".ComponentSlots? __slots => __setupContext?.Slots;\n");
+        }
+
+        builder.Append('\n');
+        AppendIndent(builder, indent);
+        builder.Append("/// <summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// The Composition API entry point (upstream: <c>setup(props, context)</c>,\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// https://vuejs.org/api/composition-api-setup.html) generated for this <c>@template</c> component\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// ([V01.01.06.07]). It runs once per instance: it allocates the per-instance render cache\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// (<see cref=\"RenderCacheSize\"/> slots) and returns the render delegate, which re-executes the\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// compiled <see cref=\"Render\"/> on every reactive update. State is the merged <c>@script</c>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// members the render reads through <c>_ctx</c>, so a reactive member drives re-render.\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// </summary>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// <param name=\"properties\">The instance's shallow-reactive props (upstream: <c>setup</c>'s <c>props</c>).</param>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// <param name=\"context\">The setup context: attrs, emit, expose, and slots.</param>\n");
+        AppendIndent(builder, indent);
+        builder.Append("/// <returns>The render function producing the component's subtree.</returns>\n");
+        AppendIndent(builder, indent);
+        builder.Append("global::System.Func<").Append(RuntimeCoreNamespace).Append(".VirtualNode?> ")
+            .Append(RuntimeCoreNamespace).Append(".IComponentDefinition.Setup(\n");
+        AppendIndent(builder, indent + 1);
+        builder.Append(RuntimeCoreNamespace).Append(".ComponentProperties properties,\n");
+        AppendIndent(builder, indent + 1);
+        builder.Append(RuntimeCoreNamespace).Append(".ComponentSetupContext context)\n");
+        AppendIndent(builder, indent);
+        builder.Append("{\n");
+
+        if (usesSlots)
+        {
+            AppendIndent(builder, indent + 1);
+            builder.Append("__setupContext = context;\n");
+        }
+
+        AppendIndent(builder, indent + 1);
+        builder.Append("// The per-instance render cache (v-once subtrees and cached handlers), allocated once and\n");
+        AppendIndent(builder, indent + 1);
+        builder.Append("// captured by the render delegate so cached slots persist across re-renders.\n");
+        AppendIndent(builder, indent + 1);
+        builder.Append("var _cache = new object?[RenderCacheSize];\n");
+
+        if (appliesCssVariables)
+        {
+            AppendIndent(builder, indent + 1);
+            builder.Append("// Apply this component's v-bind() CSS custom properties ([V01.01.06.06]); the UseCssVars\n");
+            AppendIndent(builder, indent + 1);
+            builder.Append("// runtime re-applies them reactively after each flush without re-rendering.\n");
+            AppendIndent(builder, indent + 1);
+            builder.Append("ApplyCssVariables();\n");
+        }
+
+        AppendIndent(builder, indent + 1);
+        builder.Append("return () => ").Append(RenderHelperSurface).Append(".NormalizeRoot(Render(this, _cache));\n");
+        AppendIndent(builder, indent);
+        builder.Append("}\n");
     }
 
     // [V01.01.06.03]/[V01.01.06.03.01] The @script member seam. Leading using directives are hoisted

--- a/analyzers/Assimalign.Viu.Syntax.Generators/test/SingleFileComponentGeneratorTests.cs
+++ b/analyzers/Assimalign.Viu.Syntax.Generators/test/SingleFileComponentGeneratorTests.cs
@@ -46,7 +46,8 @@ public sealed class SingleFileComponentGeneratorTests
         // [V01.01.05.05] render function (helpers bound BY NAME through the file-level using static of
         // the runtime render-helper surface) wrapped in the [V01.01.05.08] #line span map (the dynamic
         // {{ message }} access anchors a directive that points a C# error at the .viu template line 2,
-        // column 13), whose @script seam ([V01.01.06.03]) stays untouched, whose scoped @style block
+        // column 13), whose [V01.01.06.07] IComponentDefinition bridge (base list + explicit Name + Setup)
+        // makes it mountable, whose @script seam ([V01.01.06.03]) stays untouched, whose scoped @style block
         // ([V01.01.06.04]) compiles to the ScopeId + ExtractedStyles constants at the class tail, and
         // whose render body binds by name against both helper surfaces — the runtime-core import and
         // the DOM import ([V01.01.04.09]).
@@ -64,7 +65,7 @@ namespace Demo
     // "Counter.viu" by the Assimalign.Viu.Syntax source generator ([V01.01.06.02]).
     //
     // Parsed blocks: @template=present, @script=present, @style=1, custom=0.
-    partial class Counter
+    partial class Counter : global::Assimalign.Viu.RuntimeCore.IComponentDefinition
     {
         /// <summary>
         /// The number of render cache slots (<c>v-once</c> subtrees and cached handlers) the
@@ -82,6 +83,36 @@ namespace Demo
 #line (2,13)-(2,20) 88 "C:/proj/Counter.viu"
             return _createElementBlock(_openBlock(), "div", null, _toDisplayString(_ctx.message), 1 /* TEXT */);
 #line default
+        }
+
+        // [V01.01.06.07] The IComponentDefinition bridge: the generated Name + Setup that make this
+        // compiled @template component mountable through CreateApp / VirtualNodeFactory.Component with no
+        // hand-written wiring. Explicitly implemented so they never collide with a merged @script member.
+        /// <summary>
+        /// The component's display name (upstream: the component <c>name</c> option, inferred from the
+        /// <c>.viu</c> file name) — surfaced to runtime warnings and devtools.
+        /// </summary>
+        string? global::Assimalign.Viu.RuntimeCore.IComponentDefinition.Name => "Counter";
+
+        /// <summary>
+        /// The Composition API entry point (upstream: <c>setup(props, context)</c>,
+        /// https://vuejs.org/api/composition-api-setup.html) generated for this <c>@template</c> component
+        /// ([V01.01.06.07]). It runs once per instance: it allocates the per-instance render cache
+        /// (<see cref="RenderCacheSize"/> slots) and returns the render delegate, which re-executes the
+        /// compiled <see cref="Render"/> on every reactive update. State is the merged <c>@script</c>
+        /// members the render reads through <c>_ctx</c>, so a reactive member drives re-render.
+        /// </summary>
+        /// <param name="properties">The instance's shallow-reactive props (upstream: <c>setup</c>'s <c>props</c>).</param>
+        /// <param name="context">The setup context: attrs, emit, expose, and slots.</param>
+        /// <returns>The render function producing the component's subtree.</returns>
+        global::System.Func<global::Assimalign.Viu.RuntimeCore.VirtualNode?> global::Assimalign.Viu.RuntimeCore.IComponentDefinition.Setup(
+            global::Assimalign.Viu.RuntimeCore.ComponentProperties properties,
+            global::Assimalign.Viu.RuntimeCore.ComponentSetupContext context)
+        {
+            // The per-instance render cache (v-once subtrees and cached handlers), allocated once and
+            // captured by the render delegate so cached slots persist across re-renders.
+            var _cache = new object?[RenderCacheSize];
+            return () => global::Assimalign.Viu.RuntimeCore.RenderHelpers.NormalizeRoot(Render(this, _cache));
         }
 
         // [V01.01.06.03] Merged @script block. The block's C# is emitted verbatim below, wrapped in
@@ -132,6 +163,30 @@ namespace Demo
         generated.ShouldContain("// [V01.01.05.05] No @template block: no render function is emitted for this component.");
         generated.ShouldNotContain("using static");
         generated.ShouldNotContain("internal static object? Render(");
+    }
+
+    [Fact]
+    public void RenderlessComponent_StaysAPlainPartialClass_WithNoComponentDefinitionBridge()
+    {
+        // [V01.01.06.07] The bridge is emitted ONLY for a @template-bearing .viu: a @style-only .viu (the
+        // AppStyles.viu / HackerNews CSS-bundle shape) must keep compiling as a plain partial class — no
+        // IComponentDefinition base list, no Setup — so it never suddenly demands a template or a runtime
+        // reference. Pins the "keep @style-only files compiling exactly as today" requirement.
+        const string source =
+            "@style scoped {\n" +
+            "    .box { color: red; }\n" +
+            "}\n";
+
+        var outcome = GeneratorTestHarness.Run($"{ProjectDirectory}/AppStyles.viu", source, RootNamespace, ProjectDirectory);
+
+        outcome.Diagnostics.ShouldBeEmpty();
+        var generated = GeneratorTestHarness.GeneratedSource(outcome, "AppStyles.SingleFileComponent.g.cs");
+        generated.ShouldContain("partial class AppStyles\n");
+        generated.ShouldNotContain("IComponentDefinition");
+        generated.ShouldNotContain(".Setup(");
+        generated.ShouldNotContain("using static");
+        // The @style seam still compiles to the scope id + extracted CSS exactly as before.
+        generated.ShouldContain("internal const string ExtractedStyles = ");
     }
 
     [Fact]

--- a/analyzers/Assimalign.Viu.Syntax.Generators/test/SingleFileComponentTemplateSourceMapTests.cs
+++ b/analyzers/Assimalign.Viu.Syntax.Generators/test/SingleFileComponentTemplateSourceMapTests.cs
@@ -199,21 +199,33 @@ public sealed class SingleFileComponentTemplateSourceMapTests
         => new(new Position(0, startLine, startColumn), new Position(source.Length, endLine, endColumn), source);
 
     // Compiles the generated .g.cs together with a minimal runtime render-helper stub so every emitted
-    // helper call (_openBlock/_createElementBlock/_toDisplayString) binds, leaving the unresolved template
-    // member (`_ctx.Cont`) as the SOLE compile error — the one the #line map must relocate. The stub lives
-    // in the namespace the generated `using static` names. The generator emits a second `using static` of
-    // the DOM helper surface ([V01.01.04.09]) alongside the runtime-core one, so an (empty) DomRenderHelpers
-    // stub must resolve too — these static-only templates use no DOM helper, so no members are needed.
+    // helper call (_openBlock/_createElementBlock/_toDisplayString) and the [V01.01.06.07]
+    // IComponentDefinition bridge (IComponentDefinition/ComponentProperties/ComponentSetupContext/
+    // VirtualNode/NormalizeRoot) binds, leaving the unresolved template member (`_ctx.Cont`) as the SOLE
+    // compile error — the one the #line map must relocate. The stub lives in the namespace the generated
+    // `using static` names. The generator emits a second `using static` of the DOM helper surface
+    // ([V01.01.04.09]) alongside the runtime-core one, so an (empty) DomRenderHelpers stub must resolve too —
+    // these static-only templates use no DOM helper, so no members are needed.
     private static ImmutableArray<RoslynDiagnostic> CompileGeneratedWithHelperStub(string generated)
     {
         const string helperStub =
             "namespace Assimalign.Viu.RuntimeCore\n" +
             "{\n" +
+            "    internal sealed class VirtualNode { }\n" +
+            "    internal sealed class ComponentProperties { }\n" +
+            "    internal sealed class ComponentSlots { }\n" +
+            "    internal sealed class ComponentSetupContext { public ComponentSlots? Slots => null; }\n" +
+            "    internal interface IComponentDefinition\n" +
+            "    {\n" +
+            "        string? Name { get; }\n" +
+            "        System.Func<VirtualNode?> Setup(ComponentProperties properties, ComponentSetupContext context);\n" +
+            "    }\n" +
             "    internal static class RenderHelpers\n" +
             "    {\n" +
             "        internal static object _openBlock(bool disableTracking = false) => null!;\n" +
             "        internal static object? _createElementBlock(object token, object tag, object? props = null, object? children = null, int patchFlag = 0, string[]? dynamicProps = null) => null;\n" +
             "        internal static string _toDisplayString(object? value) => \"\";\n" +
+            "        internal static VirtualNode NormalizeRoot(object? value) => null!;\n" +
             "    }\n" +
             "}\n" +
             "namespace Assimalign.Viu.RuntimeDom\n" +

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -291,8 +291,10 @@ schedules a re-render — no reflection, fully trimming- and AOT-safe.
 
 Viu's single-file component is the `.viu` file — the counterpart of Vue's `.vue`, using
 `@template`/`@script`/`@style` `@`-blocks instead of HTML-like tags (the exact grammar is in
-[`FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md)). Its
-production-ready role today is **scoped, bundled CSS**. Add a `.viu` file with a `@style` block:
+[`FORMAT.md`](../../libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md)). A `.viu` with
+an `@template`/`@script` compiles to a **mountable component** (see the note below,
+[#216](https://github.com/assimalign/viu/issues/216)); a `.viu` also serves as a **scoped, bundled CSS**
+unit. Add a `.viu` file with a `@style` block:
 
 **`AppStyles.viu`**:
 
@@ -334,12 +336,31 @@ intact. You write no manual link tag. This is why `index.html` above has none; t
 [`sdks/README.md`](../../sdks/README.md) and the injection mechanism is
 [V01.01.12.12.01](https://github.com/assimalign/viu/issues/167).
 
-> **`.viu` `@template`/`@script` today.** The `@template` (standard Vue template markup) and `@script`
-> (C#) blocks already **compile** at build time — the generator emits a render function and merges the
-> script into a partial class. What is still in progress is the runtime bridge that turns that
-> generated partial into a **mountable** component; until it lands
-> ([#216](https://github.com/assimalign/viu/issues/216)), author your components in C# with
-> `IComponentDefinition` (as above) and use `.viu` for `@style`.
+> **`.viu` `@template`/`@script` components are mountable ([#216](https://github.com/assimalign/viu/issues/216)).**
+> A `.viu` with an `@template` (standard Vue template markup) and an `@script` (C#) block now compiles to a
+> **mountable component**: the generator emits the render function, merges the script into the partial
+> class, **and** generates the `IComponentDefinition` bridge (a `Setup` that returns the render delegate),
+> so you mount it exactly like a hand-written component — `BrowserRuntime.CreateApp(new Greeting()).Mount("#app")`
+> or `VirtualNodeFactory.Component(new Greeting(), props)` — with no manual wiring beyond the package
+> reference. Reactive `@script` members (a `Reference<T>`, a `[Reactive]` field) drive re-render, and a
+> template event handler (`@click="Increment"`) calls the like-named `@script` method:
+>
+> ```
+> @template {
+>     <button class="counter" @click="Increment">{{ Count }}</button>
+> }
+> @script {
+>     using Assimalign.Viu.Reactivity;
+>     public readonly Reference<int> Count = Reactive.Reference(0);
+>     public void Increment() => Count.Value++;
+> }
+> ```
+>
+> Still in progress ([#227](https://github.com/assimalign/viu/issues/227)): declared props/emits (the
+> `defineProps`/`defineEmits` analogues) and lifecycle hooks authored inside `@script`. Until those land,
+> undeclared attributes fall through to the component's root element, and a parent composes a child `.viu`
+> by explicit instantiation (`new Greeting()`). Hand-authored `IComponentDefinition` components (as above)
+> remain fully supported.
 
 ## Run and publish
 
@@ -400,8 +421,10 @@ This guide is intentionally scoped to what a consumer can build and publish toda
 
 - **A `dotnet new` project template** — [V01.01.12.04] (W05); until then, create the project by hand as
   above.
-- **Mountable `.viu` single-file components** — [#216](https://github.com/assimalign/viu/issues/216);
-  today `.viu` provides `@style` bundling and compiles `@template`/`@script`.
+- **Declared props/emits and lifecycle hooks in a `.viu` `@script`** — the `defineProps`/`defineEmits`
+  analogues and `@script`-authored lifecycle, still in progress
+  ([#227](https://github.com/assimalign/viu/issues/227)). Mountable `.viu` `@template`/`@script` components
+  themselves already work ([#216](https://github.com/assimalign/viu/issues/216), see the note above).
 - **A template-syntax reference and the API reference site** — the Documentation area
   [V01.01.13](https://github.com/assimalign/viu/issues/97).
 

--- a/examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj
+++ b/examples/Assimalign.Viu.HackerNews/Assimalign.Viu.HackerNews.csproj
@@ -7,7 +7,7 @@
          $(ViuBundleSingleFileComponentCss), so the ViuBundleCss task emits the Styles/*.viu @style blocks into
          the fingerprinted Assimalign.Viu.HackerNews.viu.css bundle that the build splices into index.html — no
          manual <link> tag. This sample authors component styling in .viu @style blocks (the logic-bearing
-         components are C# render functions; see README.md "Why .viu is CSS-only today"). -->
+         components are hand-written C# render functions; see README.md "Why .viu here is @style-only"). -->
     <ViuUseSingleFileComponents>true</ViuUseSingleFileComponents>
   </PropertyGroup>
 

--- a/examples/Assimalign.Viu.HackerNews/README.md
+++ b/examples/Assimalign.Viu.HackerNews/README.md
@@ -95,17 +95,15 @@ renderer and a **memory-history** router (no network, no browser):
 dotnet test examples/Assimalign.Viu.HackerNews.Tests
 ```
 
-## Why `.viu` is CSS-only today
+## Why `.viu` here is `@style`-only
 
-The logic-bearing components are C# `IComponentDefinition` render functions (like the `WebApp`
-sample's `StopwatchApplication`), and the `.viu` files carry only `@style` blocks. That is a current
-framework limitation, not a preference: the `.viu` single-file-component generator emits a `partial
-class` with a static `Render(...)` method but **no `IComponentDefinition`/`Setup` bridge**, so a
-`.viu` file cannot yet be authored as a mountable component (tracked by [V01.01.06.07], #216).
-The `.viu` `@style` blocks are global (unscoped) selectors matched by class name — scoped CSS relies
-on the renderer stamping a scope id onto a component *generated from* the `.viu`, which the same gap
-blocks. When the SFC→component bridge lands, these views can migrate to full `.viu` components with
-scoped `<template>`s with no change to the app's shape.
+The logic-bearing components are hand-written C# `IComponentDefinition` render functions (like the
+`WebApp` sample's `StopwatchApplication`), and the `.viu` files carry only `@style` blocks. This is now a
+migration the sample has not yet made, not a framework limitation: as of [V01.01.06.07] (#216) a
+`@template`-bearing `.viu` compiles to a **mountable component** — the generator emits the
+`IComponentDefinition`/`Setup` bridge — so these views could be authored as full `.viu` components. The
+`.viu` `@style` blocks here are global (unscoped) selectors matched by class name; converting a view to a
+scoped `@template` `.viu` component is future cleanup with no change to the app's shape.
 
 ## Deep-link hosting note
 

--- a/examples/Assimalign.Viu.HackerNews/Styles/app.viu
+++ b/examples/Assimalign.Viu.HackerNews/Styles/app.viu
@@ -2,9 +2,9 @@
     /* App chrome, view frame, loading/error, and user page. Authored as .viu @style blocks so the
        ViuBundleCss task compiles every **/*.viu into the fingerprinted
        Assimalign.Viu.HackerNews.viu.css bundle, whose <link> the build auto-injects into index.html
-       (no manual stylesheet tag). These are global (unscoped) selectors matched by class name, because
-       the logic-bearing components are C# render functions rather than generated .viu components —
-       see README.md "Why .viu is CSS-only today". */
+       (no manual stylesheet tag). These are global (unscoped) selectors matched by class name: the
+       logic-bearing components here are hand-written C# render functions rather than .viu components
+       (a not-yet-made migration, not a gap — see README.md "Why .viu here is @style-only"). */
 
     .hn-app {
         display: flex;

--- a/examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj
+++ b/examples/Assimalign.Viu.WebApp/Assimalign.Viu.WebApp.csproj
@@ -16,5 +16,12 @@
 
   <ItemGroup>
     <ViuProjectReference Include="Assimalign.Viu.RuntimeDom" />
+    <!-- Run the .viu single-file-component source generator ([V01.01.06.02]/[V01.01.06.07]) so ViuBadge.viu
+         compiles to a mountable IComponentDefinition component (StopwatchApplication mounts it via
+         VirtualNodeFactory.Component). In-repo this must be referenced directly alongside
+         $(ViuUseSingleFileComponents) above (the buildTransitive analyzer wiring only flows to packaged
+         consumers); packaged consumers get it from the Viu SDK's shared framework. This makes the WASM
+         sample the trimmed + AOT canary for the generated component bridge (budget-gates.yml). -->
+    <ViuAnalyzerReference Include="Assimalign.Viu.Syntax.Generators" />
   </ItemGroup>
 </Project>

--- a/examples/Assimalign.Viu.WebApp/StopwatchApplication.cs
+++ b/examples/Assimalign.Viu.WebApp/StopwatchApplication.cs
@@ -6,11 +6,14 @@ using System.Threading.Tasks;
 
 using Assimalign.Viu.Reactivity;
 using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.WebApp;
 
 // The root component of the demo ([V01.01.03.06]): Setup runs once, closes over refs, and
 // returns the render function. The timer starts OnMounted and stops OnUnmounted, so unmounting
 // the app tears everything down. The elapsed display is a child component exercising props and
-// emits ([V01.01.03.07]/[V01.01.03.08]) live.
+// emits ([V01.01.03.07]/[V01.01.03.08]) live, and the badge is a compiled .viu single-file
+// component mounted as a child ([V01.01.06.07]) — the sample's proof that a .viu @template
+// component mounts, is reactive, and publishes trimmed + AOT (the budget-gates canary).
 internal sealed class StopwatchApplication : IComponentDefinition
 {
     public string? Name => "StopwatchApplication";
@@ -21,6 +24,10 @@ internal sealed class StopwatchApplication : IComponentDefinition
         var isRunning = Reactive.Reference(false);
         var elapsedText = Reactive.Reference("00:00:00");
         var display = new ElapsedDisplay();
+        // The compiled .viu child ([V01.01.06.07]). Instantiated once in Setup (like `display`) so it is
+        // a stable component identity across the parent's re-renders — the runtime patches it in place and
+        // its @script reactive state (the click count) persists rather than remounting each stopwatch tick.
+        var badge = new ViuBadge();
         CancellationTokenSource? ticking = null;
 
         void Toggle()
@@ -96,7 +103,8 @@ internal sealed class StopwatchApplication : IComponentDefinition
                     VirtualNodeFactory.Element(
                         "button",
                         VirtualNodeFactory.Properties(("class", "primary"), ("onClick", (Action)Toggle), ("type", "button")),
-                        VirtualNodeFactory.Text(isRunning.Value ? "Pause" : "Start")))));
+                        VirtualNodeFactory.Text(isRunning.Value ? "Pause" : "Start"))),
+                VirtualNodeFactory.Component(badge)));
     }
 }
 

--- a/examples/Assimalign.Viu.WebApp/ViuBadge.viu
+++ b/examples/Assimalign.Viu.WebApp/ViuBadge.viu
@@ -1,0 +1,20 @@
+@template {
+    <div class="viu-badge">
+        <span class="eyebrow">Rendered from a .viu component</span>
+        <button class="secondary" type="button" @click="Increment">
+            Clicked {{ Count }} time(s)
+        </button>
+    </div>
+}
+
+@script {
+    using Assimalign.Viu.Reactivity;
+
+    // A self-contained .viu single-file component ([V01.01.06.07]): the @script holds the reactive
+    // state and the click handler, the generator emits the IComponentDefinition bridge, and the parent
+    // mounts it with VirtualNodeFactory.Component — no hand-written wiring. This is the WASM sample's
+    // proof that a compiled .viu component publishes trimmed + AOT (the budget-gates canary).
+    public readonly Reference<int> Count = Reactive.Reference(0);
+
+    public void Increment() => Count.Value++;
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/test/Assimalign.Viu.RuntimeCore.CompiledRenderTests/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/Assimalign.Viu.RuntimeCore.CompiledRenderTests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+// The scheduler and reactivity engine use ambient static state (single-threaded JS event-loop
+// model), so tests must not run in parallel. This became load-bearing once [V01.01.06.07] added a
+// second test class (SingleFileComponentMountTests) alongside CompiledRenderEndToEndTests: both drive
+// the process-global Scheduler through ViuTest.Mount / TestSchedulerPump, so a parallel run of the two
+// classes would reset the scheduler out from under an in-flight mount.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/libraries/Assimalign.Viu.RuntimeCore/test/Assimalign.Viu.RuntimeCore.CompiledRenderTests/SingleFileComponentMountTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/Assimalign.Viu.RuntimeCore.CompiledRenderTests/SingleFileComponentMountTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.CompiledRenderTests;
+
+/// <summary>
+/// [V01.01.06.07] The <c>.viu</c> component-runtime proof of life — the criterion the epic
+/// ([V01.01.06], #56) waited on. A real single-file component (<c>@template</c> + reactive
+/// <c>@script</c> state + an event handler) is compiled by the ACTUAL
+/// <see cref="Assimalign.Viu.Syntax.Generators.SingleFileComponentGenerator"/>, the generated partial —
+/// now a mountable <see cref="IComponentDefinition"/> through the generated Name + Setup bridge — is
+/// Roslyn-compiled against the runtime helper surface (as in <see cref="CompiledRenderEndToEndTests"/>),
+/// and the reflectively-loaded definition is mounted through the shipping <see cref="ViuTest"/> renderer:
+/// the real <c>MountComponent → SetupComponent → Setup → render effect</c> path. This proves the closed
+/// loop the compiler investment always implied: <c>.viu</c> → generator → generated <c>Setup</c> →
+/// runtime → a mounted, reactive component, with NO hand-written wiring beyond authoring the file. Upstream
+/// parity: Vue SFC + Composition API <c>setup()</c> (https://vuejs.org/api/sfc-spec.html).
+/// </summary>
+public sealed class SingleFileComponentMountTests
+{
+    // A fully self-contained .viu — no hand-written partial half. @script holds all of the state: a
+    // readonly Reference<int> (classified SETUP_REF, so {{ Count }} unwraps to _ctx.Count.Value and its
+    // reads are tracked by the render effect), a readonly string (SETUP_CONST -> _ctx.Message), and the
+    // click handler that mutates the ref. The `using Assimalign.Viu.Reactivity;` is hoisted above the
+    // namespace by the generator ([V01.01.06.03.01]).
+    private const string GreetingViu =
+        "@template {\n" +
+        "    <div class=\"greeting\">\n" +
+        "        <p class=\"message\">{{ Message }}</p>\n" +
+        "        <button class=\"counter\" @click=\"Increment\">{{ Count }}</button>\n" +
+        "    </div>\n" +
+        "}\n" +
+        "\n" +
+        "@script {\n" +
+        "    using Assimalign.Viu.Reactivity;\n" +
+        "    public readonly string Message = \"hello\";\n" +
+        "    public readonly Reference<int> Count = Reactive.Reference(0);\n" +
+        "    public void Increment() => Count.Value++;\n" +
+        "}\n";
+
+    [Fact]
+    public async Task SingleFileComponent_MountsThroughTheRuntime_AndReactsToAClick()
+    {
+        var definition = CompileSingleFileComponent("Greeting", GreetingViu);
+
+        // The generated bridge makes the .viu partial a real, named component definition.
+        definition.ShouldBeAssignableTo<IComponentDefinition>();
+        definition.Name.ShouldBe("Greeting"); // the generated IComponentDefinition.Name, inferred from the file
+
+        // Mount through the shipping Testing renderer: the real MountComponent -> SetupComponent ->
+        // Definition.Setup(...) -> render-effect path, exactly as a hand-written component mounts.
+        using var wrapper = ViuTest.Mount(definition);
+
+        // Initial render: the static @script field and the reactive ref, both read through _ctx.
+        wrapper.Get(".message").Text().ShouldBe("hello");
+        wrapper.Get(".counter").Text().ShouldBe("0");
+
+        // A DOM click runs the @script Increment(), whose Count.Value++ triggers the ref the render read,
+        // enqueuing a scheduled re-render (the wrapper awaits the flush) — a .viu component reacting to
+        // state with no hand-written wiring.
+        await wrapper.Get(".counter").Trigger("click");
+        wrapper.Get(".counter").Text().ShouldBe("1");
+        wrapper.Get(".message").Text().ShouldBe("hello"); // the TEXT patch-flag update never touched the sibling
+
+        await wrapper.Get(".counter").Trigger("click");
+        wrapper.Get(".counter").Text().ShouldBe("2"); // exactly one increment per click — the reactive contract
+    }
+
+    [Fact]
+    public void SingleFileComponent_WithoutInteraction_RendersItsInitialTree()
+    {
+        // The html() shape pins that the compiled render produced the whole subtree, not just a fragment,
+        // through the generated Setup's NormalizeRoot(Render(this, _cache)) bridge.
+        var definition = CompileSingleFileComponent("Greeting", GreetingViu);
+        using var wrapper = ViuTest.Mount(definition);
+
+        wrapper.Html().ShouldBe(
+            "<div class=\"greeting\"><p class=\"message\">hello</p><button class=\"counter\">0</button></div>");
+    }
+
+    // v-bind() in @style makes the generator emit ApplyCssVariables(), and the [V01.01.06.07] Setup calls it
+    // during setup. Under the DOM-free test renderer UseCssVars applies to no host element (no browser
+    // operations), so this pins that the Setup CSS-var wiring runs without throwing and the component still
+    // mounts and renders — AC: "invokes ApplyCssVariables() when the component declares v-bind() CSS vars".
+    private const string ThemedViu =
+        "@template {\n" +
+        "    <div class=\"themed\">{{ Label }}</div>\n" +
+        "}\n" +
+        "\n" +
+        "@script {\n" +
+        "    public readonly string Label = \"themed\";\n" +
+        "    public readonly string Accent = \"#0a0\";\n" +
+        "}\n" +
+        "\n" +
+        "@style {\n" +
+        "    .themed { color: v-bind(Accent); }\n" +
+        "}\n";
+
+    [Fact]
+    public void SingleFileComponent_WithVBindCssVariable_MountsThroughApplyCssVariablesDuringSetup()
+    {
+        var generated = Assimalign.Viu.RuntimeCore.CompiledRenderTests.CompiledRenderSupport.Generate("Themed", ThemedViu);
+        // The generator emitted the CSS-var seam AND the Setup call to it.
+        generated.ShouldContain("internal void ApplyCssVariables()");
+        generated.ShouldContain("ApplyCssVariables();");
+
+        var definition = LoadDefinition("Themed", generated);
+        using var wrapper = ViuTest.Mount(definition);
+
+        // Mounting exercised the generated Setup, which called ApplyCssVariables() with the instance current;
+        // it did not throw and the component rendered.
+        wrapper.Get(".themed").Text().ShouldBe("themed");
+    }
+
+    private static IComponentDefinition CompileSingleFileComponent(string name, string viu)
+    {
+        var generated = CompiledRenderSupport.Generate(name, viu);
+        // The generated partial is now a mountable component — the [V01.01.06.07] bridge is present.
+        generated.ShouldContain(": global::Assimalign.Viu.RuntimeCore.IComponentDefinition");
+        generated.ShouldContain("global::Assimalign.Viu.RuntimeCore.IComponentDefinition.Setup(");
+        generated.ShouldContain("NormalizeRoot(Render(this, _cache))");
+        return LoadDefinition(name, generated);
+    }
+
+    private static IComponentDefinition LoadDefinition(string name, string generated)
+    {
+        // The .viu is self-contained, so the second Roslyn tree is empty (no hand-written half).
+        var assembly = Assembly.Load(CompiledRenderSupport.CompileToAssembly(generated, "// self-contained .viu component\n"));
+        var type = assembly.GetType($"Demo.{name}")
+            ?? throw new InvalidOperationException($"The compiled assembly did not contain Demo.{name}.");
+        return (IComponentDefinition)Activator.CreateInstance(type, nonPublic: true)!;
+    }
+}

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/DESIGN.md
@@ -20,7 +20,10 @@ normalizes block content. The termination rule is purely structural ("column 0 i
 line whose first column is `}` closes a block), so it needs no knowledge of C#, CSS, or HTML syntax.
 Downstream libraries parse the block contents: the template compiler
 (`Assimalign.Viu.Syntax.Templates`) for `@template`, the CSS library for `@style`, and script
-analysis for `@script` ([V01.01.06.03]).
+analysis for `@script` ([V01.01.06.03]). The source generator that composes those parsers then
+assembles the result into the mountable component — the compiled render, the merged `@script`, and the
+`IComponentDefinition` bridge that makes a `@template`-bearing `.viu` a real runtime component
+([V01.01.06.07]). None of that lives here: this library's output is the descriptor, nothing more.
 
 ## The registration seam
 

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/FORMAT.md
@@ -39,6 +39,16 @@ slices the file into blocks and records their source spans. The template markup 
 template compiler (`Assimalign.Viu.Syntax.Templates`, [V01.01.05.01]); the C# in `@script` is analysed by
 [V01.01.06.03].
 
+A `.viu` with an `@template` compiles to a **mountable component**: the source generator emits the
+compiled render function ([V01.01.05.05]), merges the `@script` C# into the partial class ([V01.01.06.03]),
+and — as of [V01.01.06.07] — generates the `IComponentDefinition` bridge (a `Name` plus a `Setup` that
+allocates the render cache, wires slots, applies any `v-bind()` CSS custom properties, and returns the
+render delegate). So a `@template`-bearing `.viu` is passed straight to `BrowserRuntime.CreateApp(...)` /
+`VirtualNodeFactory.Component(...)` with no hand-written wiring, and reactive `@script` members drive
+re-render. A `.viu` with **no** `@template` (a `@style`-only CSS-bundle unit, or a `@script`-only partial)
+stays a plain partial class — no component bridge — so it keeps compiling exactly as before. This library
+still only *slices*; the bridge is emitted by the generator that consumes the descriptor.
+
 ### Upstream-semantics mapping
 
 | `.viu`                         | Vue SFC                          | Meaning (per the Vue SFC spec)                    |

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/docs/OVERVIEW.md
@@ -6,6 +6,11 @@ The build-time parser for the `.viu` single-file component (SFC) — the Viu cou
 **not** parse the contents of a block — the template markup, C#, and CSS inside are parsed by other
 libraries. Area: `V01.01.06`.
 
+Downstream, the source generator turns a `@template`-bearing `.viu` into a **mountable component** — the
+compiled render function, the merged `@script`, and the `IComponentDefinition` bridge ([V01.01.06.07]) that
+lets it be passed straight to `CreateApp` / `VirtualNodeFactory.Component`. A `@style`-only `.viu` stays a
+CSS-bundle unit. This library owns none of that; it only produces the descriptor those consumers read.
+
 The exact container syntax (the `@template`/`@script`/`@style` `@`-block grammar, the column-0
 termination rule, options, diagnostics) is specified in [FORMAT.md](FORMAT.md) — the authoritative
 spec that the test suite pins.


### PR DESCRIPTION
## Summary
- Closes the repo's most-confirmed gap (hit independently by three sessions): a `@template`-bearing `.viu` now compiles to a **mountable `IComponentDefinition`** — the generator emits the base list plus explicit `Name`/`Setup` implementations (cache allocation, conditional slots accessor, `ApplyCssVariables()` wiring, and the render delegate over the instance), so `CreateApp(new X()).Mount(...)` works with zero hand-written wiring. `@script` members flow through unchanged as `_ctx.<member>` reads; a `Reference<T>` field drives re-render through the normal effect.
- **Conditional emission protects everything that exists**: render-less `.viu` files (`@style`-only fixtures like `AppStyles.viu` and the HackerNews styles) get no base list and no Setup — pinned by a new snapshot test. Explicit interface implementations keep the bridge collision-free with user `@script` members. No new generator-model fields, so the incremental cache holds.
- **Proof of life**: a self-contained `.viu` (template + reactive state + `@click`) compiled by the REAL generator, Roslyn-compiled, and mounted through the real Setup → render-effect path — asserting output and a pinned `0 → 1 → 2` click cycle. The WebApp gains `ViuBadge.viu` as the first true `.viu` component in a sample (first example to wire the SFC generator), with a locally verified clean trimmed publish — the budget-gate canary.
- Docs rewritten to the new truth: the getting-started guide's #216 caveat, FORMAT/DESIGN/OVERVIEW's component contract, and the HackerNews "CSS-only" notes.
- **Honest scope cut, filed not absorbed**: declared props/emits and lifecycle-in-`@script` need script-setup semantics (`defineProps`/`defineEmits` analogue + a setup-body execution model) — [#227 [V01.01.06.08]](https://github.com/assimalign/viu/issues/227). Until then generated components take props as attribute fallthrough.
- Test-infrastructure note: the second CompiledRender test class exposed a latent shared-Scheduler collision — parallelization disabled for that assembly, matching eight other test projects.

## Verification
`dotnet build Assimalign.Viu.slnx`: 0 warnings · Generators **73**, SingleFileComponent **60**, Templates **495**, RuntimeCore **262**, Testing **18**, CompiledRender **10** — all green · WebApp trimmed publish clean.

Closes #216
Refs #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)