### PR TITLE
feat(runtime-core): implement the hydration walker [V01.01.07.03]

### DIFF
--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -195,6 +195,51 @@ Deliberate divergences from upstream `apiAsyncComponent.ts`, each documented at 
 - **The `useId` `markAsyncBoundary` id-stability hook is omitted** — it belongs to SSR id generation,
   not this client-only runtime contract.
 
+## Client hydration adopts the SSR output ([V01.01.07.03])
+
+Hydration lives here, not in `Assimalign.Viu.ServerRenderer` — the walker is the C# port of
+`@vue/runtime-core`'s `createHydrationFunctions` (`packages/runtime-core/src/hydration.ts`), and like
+upstream it is bound to the renderer internals, so it ships as a `partial` of `Renderer<TNode>`
+(`Renderer.Hydration.cs`) that closes over the same `_options`, `Patch`, `MountComponent`, and `Unmount`
+the mount path uses. `Application<TNode>.Hydrate` (surfaced as each platform's `CreateSSRApp(...).Mount`)
+enters it instead of `Render`.
+
+- **Adopt, don't create.** The walk matches the client vnode tree against the existing server nodes:
+  elements are matched by tag and have only their dynamic bindings reconciled (event listeners are
+  *always* attached), text is adopted with its content asserted, fragments are consumed between their
+  `[`/`]` comment anchors, components hydrate their subtree over the existing nodes, and teleports resolve
+  their target and adopt the content there. A clean hydration performs **zero** node-creating or
+  structural operations.
+- **Reads go through an injected reader; writes through the node-ops.** The walk never touches a platform
+  node except through a `HydrationNodeReader<TNode>` (kind, firstChild, nextSibling, parentNode, tag,
+  data, attribute) and the existing `RendererOptions<TNode>` write ops. That keeps it platform-agnostic —
+  tests read the in-memory tree directly, the browser reads a single batched snapshot — and is why the
+  contract added exactly one node-op (`CreateHydrationReader`), not a chatty per-read surface.
+- **The SSR markers are a shared convention, not shared code.** `HydrationMarkers` duplicates the marker
+  content (`[`, `]`, `teleport start`/`end`/`anchor`) the server renderer's `SsrMarkers` emits, pinned to
+  the same upstream reference. Hydration must **not** take a code dependency on `Assimalign.Viu.ServerRenderer`
+  (issue #66 boundary); only the emitted byte sequences couple the two ends (pinned by the SSR→hydrate
+  round-trip tests in the ServerRenderer suite).
+- **PatchFlag fast paths carry over.** A `CACHED` (hoisted / `v-once`) element is adopted verbatim without
+  inspecting its children or props; an optimized element patches only the listeners and the compiler's
+  `dynamicProps`; static attributes are never touched. Skipping a static subtree during hydration is the
+  same interop saving it is during patching.
+- **Mismatch never crashes; it recovers per subtree.** A node-type/structure mismatch logs a recoverable
+  warning (naming the offending node's path, suppressible per node via `data-allow-mismatch`) and falls
+  back to a client render of just that subtree via `Patch(null, …)` — the rest of the tree is still
+  adopted, the tree converges, and every listener ends up attached exactly once. Text/attribute/class/style
+  mismatches warn and correct in place.
+- **The component bridge mirrors upstream's `componentUpdateFn`.** Before mounting a hydrated component the
+  walker stamps the server node onto its vnode's `El` and arms `_componentHydrationReader`; the first
+  render effect then adopts the subtree (`HydrateNode(el, subTree)`) instead of `Patch(null, …)`. After
+  hydration the `.El` back-pointers are exactly what a mount would set, so reactive re-renders patch the
+  adopted nodes with **no remount**.
+
+Deliberate divergences: **Static** vnodes adopt a single node run (the multi-node `staticCount` the SSR
+compiler records arrives with [V01.01.07.02]); **lazy hydration strategies** (`hydrateOnIdle`/`Visible`/
+`MediaQuery`/`Interaction`) are a browser-API-bound follow-up (see Non-goals) — the async-component
+adoption seam is in place, but the concrete triggers are not.
+
 ## Deltas from Vue 3
 
 - **DOM directives live one layer up.** `v-show` and `v-model` and the DOM transitions are *not*
@@ -211,4 +256,10 @@ Deliberate divergences from upstream `apiAsyncComponent.ts`, each documented at 
 
 - `Suspense` — [V01.01.03.20] (W06).
 - DOM `Transition`/`TransitionGroup` and custom elements — `Assimalign.Viu.RuntimeDom`.
-- Server-side rendering and hydration — `Assimalign.Viu.ServerRenderer` (a later area).
+- Server-side rendering (the string/stream renderer) — `Assimalign.Viu.ServerRenderer`. Client
+  **hydration** of that output lives here (above, [V01.01.07.03]); only the SSR renderer itself is out.
+- **Lazy hydration strategies** (`hydrateOnIdle`/`hydrateOnVisible`/`hydrateOnMediaQuery`/
+  `hydrateOnInteraction`) — a browser-API-bound follow-up ([V01.01.07.03.01]): they need
+  `requestIdleCallback`/`IntersectionObserver`/`matchMedia`/interaction listeners in
+  `Assimalign.Viu.RuntimeDom` and cannot be exercised by the DOM-free suite. The walker already routes
+  async-component subtrees through the scheduler's post-flush queue, which is where the triggers will hook.

--- a/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeCore/docs/DESIGN.md
@@ -221,14 +221,21 @@ enters it instead of `Render`.
   (issue #66 boundary); only the emitted byte sequences couple the two ends (pinned by the SSR→hydrate
   round-trip tests in the ServerRenderer suite).
 - **PatchFlag fast paths carry over.** A `CACHED` (hoisted / `v-once`) element is adopted verbatim without
-  inspecting its children or props; an optimized element patches only the listeners and the compiler's
-  `dynamicProps`; static attributes are never touched. Skipping a static subtree during hydration is the
-  same interop saving it is during patching.
+  inspecting its children or props. Otherwise the walk actively patches only the exact set v3.5 does
+  (`ShouldHydrateProperty`): event listeners (always attached), `.`-prop bindings, forced `input`/`option`
+  values, and every non-reserved prop on a custom element. Server-rendered attributes — static **and**
+  compiler-dynamic — are adopted, not re-patched: hydration trusts the SSR output for them, so it spends no
+  interop per attribute, and the next reactive update reconciles a dynamic attribute through the normal diff.
 - **Mismatch never crashes; it recovers per subtree.** A node-type/structure mismatch logs a recoverable
   warning (naming the offending node's path, suppressible per node via `data-allow-mismatch`) and falls
   back to a client render of just that subtree via `Patch(null, …)` — the rest of the tree is still
-  adopted, the tree converges, and every listener ends up attached exactly once. Text/attribute/class/style
-  mismatches warn and correct in place.
+  adopted, the tree converges, and every listener ends up attached exactly once. A **text** mismatch warns
+  and corrects the content in place; a **class/style/attribute** mismatch is dev-warned but **left as the
+  server rendered it** (v3.5 `propHasMismatch` warns without patching), suppressible via `data-allow-mismatch`
+  (where a `children` allowance also covers `text`, "text being a subset of children"). Because the walk
+  reads structure from a possibly-immutable snapshot (the browser reader is a batched pre-walk), the mismatch
+  and fragment-teardown paths read the whole affected range **before** removing anything — never re-reading a
+  sibling they just mutated.
 - **The component bridge mirrors upstream's `componentUpdateFn`.** Before mounting a hydrated component the
   walker stamps the server node onto its vnode's `El` and arms `_componentHydrationReader`; the first
   render effect then adopts the subtree (`HydrateNode(el, subTree)`) instead of `Patch(null, …)`. After

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Application/Application.TNode.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Application/Application.TNode.cs
@@ -197,7 +197,22 @@ public sealed class Application<TNode>
     /// </summary>
     /// <param name="container">The platform container node.</param>
     /// <returns>The root component instance.</returns>
-    public ComponentInstance? Mount(TNode container)
+    public ComponentInstance? Mount(TNode container) => MountCore(container, hydrate: false);
+
+    /// <summary>
+    /// Mounts by hydrating the existing server-rendered content of <paramref name="container"/>
+    /// (upstream: the <c>mount</c> of an app created with <c>createSSRApp</c>,
+    /// <c>packages/runtime-core/src/renderer.ts</c> — <c>createAppAPI(render, hydrate)</c>,
+    /// https://vuejs.org/guide/scaling-up/ssr.html#client-hydration). The root component adopts the
+    /// server DOM instead of recreating it; a server/client mismatch recovers per subtree without
+    /// crashing. Platform packages surface this as their <c>CreateSSRApp(...).Mount(...)</c> entry.
+    /// A second call warns and no-ops.
+    /// </summary>
+    /// <param name="container">The container holding the server-rendered markup.</param>
+    /// <returns>The root component instance.</returns>
+    internal ComponentInstance? Hydrate(TNode container) => MountCore(container, hydrate: true);
+
+    private ComponentInstance? MountCore(TNode container, bool hydrate)
     {
         if (IsMounted)
         {
@@ -215,7 +230,14 @@ public sealed class Application<TNode>
         }
         _rootVirtualNode = VirtualNodeFactory.Component(_rootComponent, _rootProperties);
         _rootVirtualNode.AppContext = _context;
-        _renderer.Render(_rootVirtualNode, container);
+        if (hydrate)
+        {
+            _renderer.Hydrate(_rootVirtualNode, container);
+        }
+        else
+        {
+            _renderer.Render(_rootVirtualNode, container);
+        }
         _container = container;
         IsMounted = true;
         return RootInstance;

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/HydrationMarkers.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/HydrationMarkers.cs
@@ -1,0 +1,48 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The comment-marker vocabulary the hydration walker matches against the server-rendered DOM —
+/// the C# port of the literal marker strings <c>@vue/runtime-core</c>'s hydration module tests for
+/// (<c>packages/runtime-core/src/hydration.ts</c>: <c>node.data === '['</c>, <c>=== ']'</c>,
+/// <c>=== 'teleport start'</c>, and so on; https://vuejs.org/guide/scaling-up/ssr.html#client-hydration).
+/// These values are the <b>content</b> of the comment nodes (what
+/// <see cref="HydrationNodeReader{TNode}.Data"/> returns — the text between <c>&lt;!--</c> and
+/// <c>--&gt;</c>), so <see cref="FragmentStart"/> is <c>[</c>, not <c>&lt;!--[--&gt;</c>.
+/// <para>
+/// This is a cross-package <b>output convention</b>, not shared code: the SSR renderer
+/// (<c>Assimalign.Viu.ServerRenderer</c>'s <c>SsrMarkers</c>) emits the same byte sequences, and
+/// hydration adopts them. The two ends are deliberately decoupled — hydration must not take a code
+/// dependency on the server renderer (issue #66 architectural boundary) — so the constants are
+/// duplicated here and pinned to the same upstream reference; changing one without the other breaks
+/// the hydration protocol.
+/// </para>
+/// </summary>
+internal static class HydrationMarkers
+{
+    /// <summary>
+    /// The content of a fragment's opening comment (upstream: <c>node.data === '['</c>; the SSR side
+    /// emits <c>&lt;!--[--&gt;</c>). Brackets a fragment vnode's children — a multi-root component, a
+    /// <c>v-for</c> block, a slot outlet — with no element wrapper.
+    /// </summary>
+    public const string FragmentStart = "[";
+
+    /// <summary>The content of a fragment's closing comment (upstream: <c>node.data === ']'</c>; SSR emits <c>&lt;!--]--&gt;</c>).</summary>
+    public const string FragmentEnd = "]";
+
+    /// <summary>
+    /// The content of a teleport's main-tree start anchor (upstream: <c>node.data === 'teleport start'</c>;
+    /// SSR emits <c>&lt;!--teleport start--&gt;</c>). Marks the teleport's origin position; its content lives
+    /// at the resolved target (enabled) or between this and <see cref="TeleportEnd"/> (disabled).
+    /// </summary>
+    public const string TeleportStart = "teleport start";
+
+    /// <summary>The content of a teleport's main-tree end anchor (upstream: <c>'teleport end'</c>; SSR emits <c>&lt;!--teleport end--&gt;</c>).</summary>
+    public const string TeleportEnd = "teleport end";
+
+    /// <summary>
+    /// The content of the anchor terminating a teleport's content inside its target (upstream:
+    /// <c>'teleport anchor'</c>; SSR emits <c>&lt;!--teleport anchor--&gt;</c>). Bounds the target-side range
+    /// the walker adopts.
+    /// </summary>
+    public const string TeleportAnchor = "teleport anchor";
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Internal/HydrationMismatchType.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Internal/HydrationMismatchType.cs
@@ -1,0 +1,27 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// Classifies a server/client hydration mismatch for dev-mode reporting and the
+/// <c>data-allow-mismatch</c> escape hatch — the C# port of the <c>MismatchTypes</c> enum in
+/// <c>@vue/runtime-core</c>'s hydration module (<c>packages/runtime-core/src/hydration.ts</c>,
+/// https://vuejs.org/guide/scaling-up/ssr.html#hydration-mismatch). The string forms
+/// (<c>"text"</c>, <c>"children"</c>, <c>"class"</c>, <c>"style"</c>, <c>"attribute"</c>) are the
+/// tokens a <c>data-allow-mismatch="..."</c> attribute lists to suppress a given kind.
+/// </summary>
+internal enum HydrationMismatchType
+{
+    /// <summary>A text node's content differs (upstream: <c>MismatchTypes.TEXT</c>).</summary>
+    Text,
+
+    /// <summary>An element's child set differs — too many or too few nodes, or a node-type mismatch (upstream: <c>CHILDREN</c>).</summary>
+    Children,
+
+    /// <summary>A <c>class</c> binding differs (upstream: <c>CLASS</c>).</summary>
+    Class,
+
+    /// <summary>A <c>style</c> binding differs (upstream: <c>STYLE</c>).</summary>
+    Style,
+
+    /// <summary>A plain attribute differs (upstream: <c>ATTRIBUTE</c>).</summary>
+    Attribute,
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Properties/AssemblyInfo.cs
@@ -19,3 +19,7 @@ using System.Runtime.CompilerServices;
 // through the real renderer + post-flush pipeline), so they reset it between tests just as the
 // Testing library does per mount ([V01.01.04.06]).
 [assembly: InternalsVisibleTo("Assimalign.Viu.RuntimeDom.Tests")]
+// The SSR->hydration round-trip tests ([V01.01.07.03]) render with the server renderer, then hydrate the
+// parsed output through the real renderer + scheduler, resetting it between tests exactly as the sibling
+// suites do — the same scheduler-reset grant reason as the RuntimeDom tests above.
+[assembly: InternalsVisibleTo("Assimalign.Viu.ServerRenderer.Tests")]

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/HydrationNodeKind.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/HydrationNodeKind.cs
@@ -1,0 +1,28 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The kind of an existing platform node the hydration walker is adopting, as reported by a
+/// <see cref="HydrationNodeReader{TNode}"/> — the C# stand-in for the <c>Node.nodeType</c> reads
+/// in <c>@vue/runtime-core</c>'s hydration module (<c>packages/runtime-core/src/hydration.ts</c>,
+/// the <c>DOMNodeTypes</c> checks; https://vuejs.org/guide/scaling-up/ssr.html#client-hydration).
+/// The walker branches on this to decide whether a server node matches the vnode it is hydrating
+/// against, so the enum is the minimal discriminator hydration needs — element, character data
+/// (text), comment, or anything else (a mismatch).
+/// </summary>
+public enum HydrationNodeKind
+{
+    /// <summary>An element node (upstream: <c>DOMNodeTypes.ELEMENT</c> — <c>nodeType === 1</c>).</summary>
+    Element,
+
+    /// <summary>A text node (upstream: <c>DOMNodeTypes.TEXT</c> — <c>nodeType === 3</c>).</summary>
+    Text,
+
+    /// <summary>A comment node (upstream: <c>DOMNodeTypes.COMMENT</c> — <c>nodeType === 8</c>).</summary>
+    Comment,
+
+    /// <summary>
+    /// Any other node kind. The walker treats it as a mismatch against every vnode type, since the
+    /// SSR output only ever emits elements, text, and comments (the marker vocabulary).
+    /// </summary>
+    Other,
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/HydrationNodeReader{TNode}.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/HydrationNodeReader{TNode}.cs
@@ -1,0 +1,94 @@
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The read-only view of the existing server-rendered node tree the hydration walker adopts —
+/// the C# analog of the <c>nodeType</c>/<c>data</c>/<c>tagName</c>/<c>firstChild</c>/<c>nextSibling</c>
+/// reads <c>@vue/runtime-core</c>'s hydration functions perform directly on DOM <c>Node</c>s
+/// (<c>packages/runtime-core/src/hydration.ts</c>, https://vuejs.org/guide/scaling-up/ssr.html#client-hydration).
+/// The walker never touches a platform node except through these reads and the write-side
+/// <see cref="RendererOptions{TNode}"/> ops, so hydration stays platform-agnostic: tests supply a
+/// reader over the in-memory tree, and the browser supplies one backed by a single batched
+/// interop snapshot of the container subtree (so a whole subtree crosses the JS boundary once
+/// rather than a marshaled call per <c>nextSibling</c>/<c>getAttribute</c>).
+/// <para>
+/// A reader is created per hydration root through
+/// <see cref="RendererOptions{TNode}.CreateHydrationReader"/> and is valid for the nodes reachable
+/// from that root; it answers reads without further platform round-trips. Not thread-safe
+/// (single-threaded JS event-loop model).
+/// </para>
+/// </summary>
+/// <typeparam name="TNode">The platform node type; <c>default</c> means "no node".</typeparam>
+public abstract class HydrationNodeReader<TNode>
+    where TNode : notnull
+{
+    /// <summary>Initializes the base reader.</summary>
+    protected HydrationNodeReader()
+    {
+    }
+
+    /// <summary>
+    /// Reports what kind of node <paramref name="node"/> is (upstream: the <c>node.nodeType</c>
+    /// checks against <c>DOMNodeTypes</c>).
+    /// </summary>
+    /// <param name="node">The node to classify.</param>
+    /// <returns>The node's kind.</returns>
+    public abstract HydrationNodeKind Kind(TNode node);
+
+    /// <summary>
+    /// Returns <paramref name="node"/>'s first child, or <c>default</c> when it has none (upstream:
+    /// <c>node.firstChild</c>). Called to descend into an adopted element's children.
+    /// </summary>
+    /// <param name="node">The parent node.</param>
+    /// <returns>The first child, or <c>default</c>.</returns>
+    public abstract TNode? FirstChild(TNode node);
+
+    /// <summary>
+    /// Returns <paramref name="node"/>'s next sibling, or <c>default</c> at the end (upstream:
+    /// <c>nextSibling(node)</c>). Called to advance the walk to the node after the one just adopted.
+    /// </summary>
+    /// <param name="node">The node whose successor is requested.</param>
+    /// <returns>The next sibling, or <c>default</c>.</returns>
+    public abstract TNode? NextSibling(TNode node);
+
+    /// <summary>
+    /// Returns <paramref name="node"/>'s parent, or <c>default</c> at a root (upstream:
+    /// <c>parentNode(node)</c>). Used to resolve the container a fragment's or component's children
+    /// mount into and to reparent a mismatched subtree.
+    /// </summary>
+    /// <param name="node">The node whose parent is requested.</param>
+    /// <returns>The parent, or <c>default</c>.</returns>
+    public abstract TNode? ParentNode(TNode node);
+
+    /// <summary>
+    /// Returns an element node's tag name (upstream: <c>(node as Element).tagName</c>). Compared
+    /// case-insensitively against the vnode's <see cref="VirtualNode.ElementTag"/> to decide whether
+    /// the element matches. Only called when <see cref="Kind"/> is
+    /// <see cref="HydrationNodeKind.Element"/>.
+    /// </summary>
+    /// <param name="node">The element node.</param>
+    /// <returns>The element's tag name.</returns>
+    public abstract string ElementTag(TNode node);
+
+    /// <summary>
+    /// Returns a text or comment node's character content (upstream: <c>(node as Text).data</c> /
+    /// <c>(node as Comment).data</c>). For a comment this is the content between <c>&lt;!--</c> and
+    /// <c>--&gt;</c>, so the fragment markers <c>[</c>/<c>]</c> and the teleport markers are matched
+    /// on this value. Only called when <see cref="Kind"/> is
+    /// <see cref="HydrationNodeKind.Text"/> or <see cref="HydrationNodeKind.Comment"/>.
+    /// </summary>
+    /// <param name="node">The text or comment node.</param>
+    /// <returns>The node's character content.</returns>
+    public abstract string Data(TNode node);
+
+    /// <summary>
+    /// Returns an element's attribute value, or null when the attribute is absent (upstream:
+    /// <c>el.getAttribute(name)</c>). Used only for dev-mode mismatch reporting — locating the
+    /// <c>data-allow-mismatch</c> escape hatch and comparing server-rendered <c>class</c>/<c>style</c>/
+    /// attribute values against the client vnode. Only called when <see cref="Kind"/> is
+    /// <see cref="HydrationNodeKind.Element"/>.
+    /// </summary>
+    /// <param name="node">The element node.</param>
+    /// <param name="name">The attribute name.</param>
+    /// <returns>The attribute value, or null when absent.</returns>
+    public abstract string? Attribute(TNode node, string name);
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.Hydration.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.Hydration.cs
@@ -294,6 +294,8 @@ public sealed partial class Renderer<TNode>
         if (properties is not null)
         {
             var elementNamespace = NamespaceForTag(tag);
+            // A custom element (tag with a hyphen) has every non-reserved prop hydrated (upstream isCustomElement).
+            var isCustomElement = tag.Contains('-', StringComparison.Ordinal);
             var mustIterate = forcePatch
                 || hasDynamicProperties
                 || !optimized
@@ -302,9 +304,10 @@ public sealed partial class Renderer<TNode>
             {
                 foreach (var (name, value) in properties)
                 {
-                    // Dev-mode mismatch reporting for class/style/attribute bindings (upstream propHasMismatch).
+                    // Dev-mode mismatch reporting for class/style/attribute bindings (upstream propHasMismatch:
+                    // warn only, never patch — the reconciliation set is ShouldHydrateProperty, below).
                     ReportPropertyMismatch(reader, element, name, value, vnode);
-                    if (ShouldHydrateProperty(name, forcePatch, vnode.DynamicProperties))
+                    if (ShouldHydrateProperty(name, forcePatch, isCustomElement))
                     {
                         _options.PatchProperty(element, tag, name, null, value, elementNamespace);
                     }
@@ -343,31 +346,22 @@ public sealed partial class Renderer<TNode>
                 : children[index] = VirtualNodeFactory.Normalize(children[index]);
             if (TryNode(cursor, out var node))
             {
-                // Consecutive client text vnodes served as one server text node: split it so each vnode
-                // adopts its own node (upstream hydrateChildren adjacent-text handling).
+                // Consecutive client text vnodes served as one server text node: peel the server text so each
+                // vnode adopts its own node (upstream hydrateChildren adjacent-text handling). The peel is
+                // snapshot-safe — it creates the split nodes and adopts them by the handle it holds, never
+                // re-reading the reader for nodes an immutable snapshot does not contain.
                 if (!optimized
                     && child.Type == VirtualNodeType.Text
+                    && reader.Kind(node) == HydrationNodeKind.Text
                     && index + 1 < children.Length
-                    && VirtualNodeFactory.Normalize(children[index + 1]).Type == VirtualNodeType.Text
-                    && reader.Kind(node) == HydrationNodeKind.Text)
+                    && VirtualNodeFactory.Normalize(children[index + 1]).Type == VirtualNodeType.Text)
                 {
-                    var serverData = reader.Data(node);
-                    var clientText = child.TextChildren ?? string.Empty;
-                    if (serverData.Length > clientText.Length)
-                    {
-                        var split = _options.CreateText(serverData[clientText.Length..]);
-                        if (TryNode(reader.NextSibling(node), out var afterNode))
-                        {
-                            _options.Insert(split, container, afterNode);
-                        }
-                        else
-                        {
-                            _options.Insert(split, container, default);
-                        }
-                        _options.SetText(node, clientText);
-                    }
+                    index = HydrateAdjacentTextRun(reader, node, container, children, index, out cursor);
                 }
-                cursor = HydrateNode(reader, node, child, parentComponent, optimized);
+                else
+                {
+                    cursor = HydrateNode(reader, node, child, parentComponent, optimized);
+                }
             }
             else if (child.Type == VirtualNodeType.Text && string.IsNullOrEmpty(child.TextChildren))
             {
@@ -394,6 +388,60 @@ public sealed partial class Renderer<TNode>
             }
         }
         return cursor;
+    }
+
+    private int HydrateAdjacentTextRun(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        TNode container,
+        VirtualNode[] children,
+        int startIndex,
+        out TNode? cursor)
+    {
+        // Adopt a run of consecutive client Text vnodes that the server rendered as ONE text node, by peeling
+        // the server text: the first vnode adopts `node`; each subsequent one adopts a freshly created node
+        // carrying the remaining text (upstream splits via node.data.slice + live nextSibling — Viu holds the
+        // created nodes so it needs no live re-read). Snapshot-safe: the only reader call is NextSibling(node)
+        // for the original following sibling (stable), and Data(node) once. Returns the index of the last
+        // vnode consumed (the caller's loop advances past it); `cursor` resumes at that following sibling.
+        var afterRun = reader.NextSibling(node);
+        var currentNode = node;
+        var currentData = reader.Data(node);
+        var index = startIndex;
+        while (true)
+        {
+            var textVnode = children[index] = VirtualNodeFactory.Normalize(children[index]);
+            var clientText = textVnode.TextChildren ?? string.Empty;
+            var hasMoreText = index + 1 < children.Length
+                && VirtualNodeFactory.Normalize(children[index + 1]).Type == VirtualNodeType.Text;
+            if (hasMoreText && currentData.Length > clientText.Length)
+            {
+                // Split off the remainder into a new node inserted before the run's original following sibling
+                // (each split lands after the previous one, preserving order), then trim this node to its share.
+                var overflow = _options.CreateText(currentData[clientText.Length..]);
+                _options.Insert(overflow, container, TryNode(afterRun, out var anchor) ? anchor : default);
+                if (!string.Equals(currentData, clientText, StringComparison.Ordinal))
+                {
+                    _options.SetText(currentNode, clientText);
+                }
+                textVnode.El = currentNode;
+                currentNode = overflow;
+                currentData = currentData[clientText.Length..];
+                index++;
+            }
+            else
+            {
+                // Last vnode of the run (or nothing left to split): adopt the current node, correcting its text.
+                if (!string.Equals(currentData, clientText, StringComparison.Ordinal))
+                {
+                    _options.SetText(currentNode, clientText);
+                }
+                textVnode.El = currentNode;
+                break;
+            }
+        }
+        cursor = afterRun;
+        return index;
     }
 
     private TNode? HydrateFragment(
@@ -549,17 +597,35 @@ public sealed partial class Renderer<TNode>
             WarnNodeMismatch(reader, node, vnode);
         }
         vnode.El = null;
+        TNode? next;
         if (isFragment)
         {
-            // Remove the excess fragment children between the [ marker and its matching ].
+            // Collect the whole [ .. ] range from the reader BEFORE removing anything: a browser hydration
+            // reader is an immutable pre-walk snapshot, so re-reading NextSibling after a Remove would keep
+            // yielding the already-removed child (upstream mutates the live DOM and re-reads; Viu reads first).
+            // `end` is the node after the matching ] (honoring nesting); the collected chain is the children
+            // and the ] marker.
             var end = LocateClosingAnchor(reader, node, HydrationMarkers.FragmentStart, HydrationMarkers.FragmentEnd);
-            while (TryNode(reader.NextSibling(node), out var following)
-                && !(TryNode(end, out var endNode) && NodeComparer.Equals(following, endNode)))
+            var fragmentRange = new List<TNode>();
+            var scan = reader.NextSibling(node);
+            while (TryNode(scan, out var current)
+                && !(TryNode(end, out var endNode) && NodeComparer.Equals(current, endNode)))
             {
-                _options.Remove(following);
+                fragmentRange.Add(current);
+                scan = reader.NextSibling(current);
             }
+            foreach (var removed in fragmentRange)
+            {
+                _options.Remove(removed);
+            }
+            // The range (children + ]) is gone, so the walk resumes at `end` — NOT NextSibling(node), which
+            // the immutable snapshot would still report as the removed first child.
+            next = end;
         }
-        var next = reader.NextSibling(node);
+        else
+        {
+            next = reader.NextSibling(node);
+        }
         if (!TryNode(reader.ParentNode(node), out var container))
         {
             container = node;
@@ -604,10 +670,18 @@ public sealed partial class Renderer<TNode>
         return cursor;
     }
 
-    private static bool ShouldHydrateProperty(string name, bool forcePatch, string[]? dynamicProperties)
+    private static bool ShouldHydrateProperty(string name, bool forcePatch, bool isCustomElement)
     {
-        // Upstream hydrateElement prop-qualification: value-like props on input/option (forcePatch), event
-        // listeners (always attached), .-prefixed DOM properties, and the compiler's dynamic prop list.
+        // Upstream hydrateElement prop qualification (v3.5, packages/runtime-core/src/hydration.ts) — the
+        // exact set of props actively patched during hydration:
+        //   (forcePatch && (endsWith "value" || "indeterminate")) || (isOn && !reserved) || key[0]=='.' || isCustomElement
+        // dynamicProps are deliberately NOT in this set: v3.5 does not re-patch dynamic attributes during
+        // hydration (that would spend interop per dynamic prop and, on a mismatch, overwrite the server value
+        // — e.g. re-setting a dynamic innerHTML and discarding the hydrated children). A dynamic-attribute
+        // mismatch is instead reported by ReportPropertyMismatch and the server value is left in place
+        // (warn-and-leave); the next reactive update patches it through the normal diff. The !reserved guard
+        // on the custom-element clause compensates for Viu keeping key/ref in the prop bag where upstream's
+        // props object never contains them — giving identical effective behavior.
         if (forcePatch
             && (name.EndsWith("value", StringComparison.Ordinal)
                 || string.Equals(name, "indeterminate", StringComparison.Ordinal)))
@@ -622,17 +696,7 @@ public sealed partial class Renderer<TNode>
         {
             return true;
         }
-        if (dynamicProperties is not null)
-        {
-            foreach (var dynamicName in dynamicProperties)
-            {
-                if (string.Equals(dynamicName, name, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return isCustomElement && !IsReservedProperty(name);
     }
 
     private string ReadElementText(HydrationNodeReader<TNode> reader, TNode element)
@@ -820,31 +884,25 @@ public sealed partial class Renderer<TNode>
 
     private static bool IsMismatchAllowedByAttribute(string? attribute, HydrationMismatchType type)
     {
+        // Upstream isMismatchAllowed (v3.5, packages/runtime-core/src/hydration.ts): a null attribute allows
+        // nothing; an empty attribute allows every kind; otherwise the comma-split list must contain the
+        // type's token — with the single special case that a text mismatch is allowed by "children" ("text is
+        // a subset of children"). Matched exactly: the list is NOT trimmed, and there is no "attribute" token
+        // that covers class/style (each kind carries its own token).
         if (attribute is null)
         {
             return false;
         }
         if (attribute.Length == 0)
         {
-            // A bare data-allow-mismatch allows every kind (upstream: attr === '').
             return true;
         }
-        var typeToken = MismatchTypeToken(type);
-        foreach (var raw in attribute.Split(','))
+        var list = attribute.Split(',');
+        if (type == HydrationMismatchType.Text && Array.IndexOf(list, "children") >= 0)
         {
-            var token = raw.Trim();
-            if (string.Equals(token, typeToken, StringComparison.Ordinal))
-            {
-                return true;
-            }
-            // Allowing "attribute" also allows class and style (they are attributes) — upstream parity.
-            if ((type is HydrationMismatchType.Class or HydrationMismatchType.Style)
-                && string.Equals(token, "attribute", StringComparison.Ordinal))
-            {
-                return true;
-            }
+            return true;
         }
-        return false;
+        return Array.IndexOf(list, MismatchTypeToken(type)) >= 0;
     }
 
     private static string MismatchTypeToken(HydrationMismatchType type) => type switch

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.Hydration.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.Hydration.cs
@@ -1,0 +1,933 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Assimalign.Viu.Shared;
+
+namespace Assimalign.Viu.RuntimeCore;
+
+/// <summary>
+/// The client-side hydration walk — the C# port of <c>createHydrationFunctions</c> in
+/// <c>@vue/runtime-core</c> (<c>packages/runtime-core/src/hydration.ts</c>,
+/// https://vuejs.org/guide/scaling-up/ssr.html#client-hydration). Instead of creating platform
+/// nodes, the walker <b>adopts</b> the server-rendered DOM: elements are matched by tag and have
+/// only their dynamic props reconciled (event listeners always attached), text is adopted with its
+/// content asserted, fragments are consumed between their <c>[</c>/<c>]</c> comment anchors,
+/// components hydrate their subtree over the existing nodes, and teleported content hydrates at its
+/// resolved target. A server/client mismatch never crashes: it logs a recoverable warning and falls
+/// back to a client-side render of just the mismatched subtree, so the rest of the tree is still
+/// adopted and every listener ends up attached exactly once.
+/// <para>
+/// The walk drives entirely off a <see cref="HydrationNodeReader{TNode}"/> for reads and the
+/// existing <see cref="RendererOptions{TNode}"/> for writes, so it is platform-agnostic; the browser
+/// supplies a reader backed by one batched interop snapshot, keeping the walk free of per-node
+/// boundary crossings.
+/// </para>
+/// </summary>
+public sealed partial class Renderer<TNode>
+{
+    private const string AllowMismatchAttribute = "data-allow-mismatch";
+
+    // Armed by the component branch immediately before MountComponent so the component's first render
+    // effect (ComponentUpdateFunction) hydrates its subtree against the server node stamped on its
+    // vnode.El instead of mounting fresh — the seam upstream's componentUpdateFn reaches through its
+    // closed-over hydrateNode. Non-null only during a synchronous hydration pass; single-threaded.
+    private HydrationNodeReader<TNode>? _componentHydrationReader;
+
+    /// <summary>
+    /// Hydrates <paramref name="node"/> against the existing server-rendered content of
+    /// <paramref name="container"/> — the C# port of the root <c>hydrate(vnode, container)</c>
+    /// (<c>packages/runtime-core/src/hydration.ts</c>). When the container is empty it falls back to a
+    /// full client mount (upstream parity). Pending post-flush callbacks are drained before returning,
+    /// so mounted lifecycle hooks fire synchronously with the hydrate call.
+    /// </summary>
+    /// <param name="node">The client vnode tree to hydrate onto the server DOM.</param>
+    /// <param name="container">The container holding the server-rendered markup.</param>
+    /// <exception cref="NotSupportedException">The renderer options provide no <c>CreateHydrationReader</c>.</exception>
+    internal void Hydrate(VirtualNode node, TNode container)
+    {
+        if (_options.CreateHydrationReader is null)
+        {
+            throw new NotSupportedException(
+                "This renderer's options do not provide CreateHydrationReader, which hydration requires.");
+        }
+        var reader = _options.CreateHydrationReader(container);
+        var firstChild = reader.FirstChild(container);
+        try
+        {
+            if (TryNode(firstChild, out var start))
+            {
+                HydrateNode(reader, start, node, parentComponent: null, optimized: false);
+            }
+            else
+            {
+                // Empty container: nothing to adopt, so mount fresh (upstream parity).
+                RuntimeWarnings.Warn(
+                    "Attempting to hydrate existing markup but container is empty. Performing full mount instead.");
+                Patch(null, node, container, default, null, null);
+            }
+        }
+        finally
+        {
+            _componentHydrationReader = null;
+        }
+        _containerRoots[container] = node;
+        Scheduler.FlushAfterSynchronousRender();
+    }
+
+    // The C# port of hydrateNode: adopt one server node for one vnode and return the server node that
+    // follows the adopted range (what the caller advances its cursor to). A type/structure mismatch
+    // routes through HandleMismatch, which recovers by client-rendering just this subtree.
+    private TNode? HydrateNode(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool optimized)
+    {
+        optimized = optimized || vnode.DynamicChildren is not null;
+        var kind = reader.Kind(node);
+        var isFragmentStart = kind == HydrationNodeKind.Comment
+            && string.Equals(reader.Data(node), HydrationMarkers.FragmentStart, StringComparison.Ordinal);
+        // Adopt the node onto the vnode up front (upstream: vnode.el = node); a mismatch resets it.
+        vnode.El = node;
+        TNode? nextNode;
+        switch (vnode.Type)
+        {
+            case VirtualNodeType.Text:
+                nextNode = HydrateText(reader, node, vnode, parentComponent, kind, isFragmentStart);
+                break;
+            case VirtualNodeType.Comment:
+                if (kind != HydrationNodeKind.Comment || isFragmentStart)
+                {
+                    nextNode = HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+                }
+                else
+                {
+                    nextNode = reader.NextSibling(node);
+                }
+                break;
+            case VirtualNodeType.Static:
+                nextNode = HydrateStatic(reader, node, vnode, parentComponent, kind, isFragmentStart);
+                break;
+            case VirtualNodeType.Fragment:
+                nextNode = isFragmentStart
+                    ? HydrateFragment(reader, node, vnode, parentComponent, optimized)
+                    : HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+                break;
+            case VirtualNodeType.Element:
+                if (kind != HydrationNodeKind.Element
+                    || !string.Equals(reader.ElementTag(node), vnode.ElementTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    nextNode = HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+                }
+                else
+                {
+                    nextNode = HydrateElement(reader, node, vnode, parentComponent, optimized);
+                }
+                break;
+            case VirtualNodeType.Component:
+                nextNode = HydrateComponent(reader, node, vnode, parentComponent, optimized, isFragmentStart);
+                break;
+            case VirtualNodeType.Teleport:
+                if (kind != HydrationNodeKind.Comment)
+                {
+                    nextNode = HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+                }
+                else
+                {
+                    nextNode = HydrateTeleport(reader, node, vnode, parentComponent, optimized);
+                }
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown vnode type: {vnode.Type}.");
+        }
+        // Template ref is applied after adoption (upstream setRef call at the end of hydrateNode).
+        if (vnode.Reference is { } reference && vnode.El is not null)
+        {
+            SetReference(reference, oldReference: null, vnode, isUnmount: false, parentComponent);
+        }
+        return nextNode;
+    }
+
+    private TNode? HydrateText(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        HydrationNodeKind kind,
+        bool isFragmentStart)
+    {
+        if (kind != HydrationNodeKind.Text)
+        {
+            // #5728: an empty text vnode has no server node (adjacent to a slot) — create it in place
+            // rather than treat the following node as a mismatch (upstream Text case).
+            if (string.IsNullOrEmpty(vnode.TextChildren))
+            {
+                var created = _options.CreateText(string.Empty);
+                vnode.El = created;
+                if (TryNode(reader.ParentNode(node), out var textParent))
+                {
+                    _options.Insert(created, textParent, node);
+                }
+                return node;
+            }
+            return HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+        }
+        var serverText = reader.Data(node);
+        if (!string.Equals(serverText, vnode.TextChildren, StringComparison.Ordinal))
+        {
+            if (!IsMismatchAllowed(reader, node, HydrationMismatchType.Text))
+            {
+                WarnMismatch(
+                    reader,
+                    node,
+                    $"Hydration text mismatch: rendered on server \"{serverText}\", expected on client "
+                    + $"\"{vnode.TextChildren}\".");
+            }
+            // Recover: adopt the node but correct its content to the client value (upstream parity).
+            _options.SetText(node, vnode.TextChildren ?? string.Empty);
+        }
+        return reader.NextSibling(node);
+    }
+
+    private TNode? HydrateStatic(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        HydrationNodeKind kind,
+        bool isFragmentStart)
+    {
+        // Upstream Static case: a static vnode adopts a run of top-level server nodes, capturing the
+        // first as El and the last as the Anchor. When the markup was emitted inside a fragment the run
+        // starts after the [ marker.
+        var current = node;
+        if (isFragmentStart && TryNode(reader.NextSibling(node), out var afterMarker))
+        {
+            current = afterMarker;
+            kind = reader.Kind(current);
+        }
+        if (kind is not (HydrationNodeKind.Element or HydrationNodeKind.Text))
+        {
+            return HandleMismatch(reader, node, vnode, parentComponent, isFragmentStart);
+        }
+        vnode.El = current;
+        // The runtime does not know the static node count the compiler records upstream (staticCount);
+        // Viu emits Static content as a single adopted node run bounded by the client vnode, so the
+        // adopted node stands as both El and Anchor. Multi-node static hydration arrives with the
+        // SSR compiler transforms ([V01.01.07.02]).
+        vnode.Anchor = current;
+        var next = reader.NextSibling(current);
+        return isFragmentStart && TryNode(next, out var afterStatic) ? reader.NextSibling(afterStatic) : next;
+    }
+
+    private TNode? HydrateElement(
+        HydrationNodeReader<TNode> reader,
+        TNode element,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool optimized)
+    {
+        optimized = optimized || vnode.DynamicChildren is not null;
+        var properties = vnode.Properties;
+        var patchFlag = vnode.PatchFlag;
+        var tag = vnode.ElementTag!;
+        // input/option force a value patch even when otherwise static (upstream forcePatch).
+        var forcePatch = string.Equals(tag, "input", StringComparison.Ordinal)
+            || string.Equals(tag, "option", StringComparison.Ordinal);
+        var hasDynamicProperties = vnode.DynamicProperties is not null;
+        // A CACHED (hoisted / v-once) element with no forced/dynamic props is trusted verbatim: adopt it
+        // without inspecting children or props (upstream: the `patchFlag !== CACHED` gate). This is the
+        // PatchFlag fast path — no per-attribute work on static subtrees.
+        if (!forcePatch && !hasDynamicProperties && patchFlag == PatchFlags.Cached)
+        {
+            return reader.NextSibling(element);
+        }
+        InvokeDirectiveHooks(vnode, null, DirectiveHookKind.Created);
+
+        // Children: an array of vnodes is walked; a single text-children element only asserts its text.
+        var hasChildOverride = properties is not null
+            && (properties.ContainsName("innerHTML") || properties.ContainsName("textContent"));
+        if ((vnode.ShapeFlag & ShapeFlags.ArrayChildren) != 0 && !hasChildOverride)
+        {
+            var leftover = HydrateChildren(
+                reader, reader.FirstChild(element), vnode, element, parentComponent, optimized);
+            // Excess server nodes the client vdom did not account for: warn once, then remove them so
+            // the adopted tree converges (upstream hydrateElement trailing while-loop).
+            if (TryNode(leftover, out _) && !IsMismatchAllowed(reader, element, HydrationMismatchType.Children))
+            {
+                WarnMismatch(
+                    reader,
+                    element,
+                    "Hydration children mismatch: server rendered more child nodes than the client vdom.");
+            }
+            var excess = leftover;
+            while (TryNode(excess, out var excessNode))
+            {
+                var following = reader.NextSibling(excessNode);
+                _options.Remove(excessNode);
+                excess = following;
+            }
+        }
+        else if ((vnode.ShapeFlag & ShapeFlags.TextChildren) != 0)
+        {
+            var clientText = vnode.TextChildren ?? string.Empty;
+            var serverText = ReadElementText(reader, element);
+            if (!string.Equals(serverText, clientText, StringComparison.Ordinal))
+            {
+                if (!IsMismatchAllowed(reader, element, HydrationMismatchType.Text))
+                {
+                    WarnMismatch(
+                        reader,
+                        element,
+                        $"Hydration text content mismatch: rendered on server \"{serverText}\", expected on "
+                        + $"client \"{clientText}\".");
+                }
+                _options.SetElementText(element, clientText);
+            }
+        }
+
+        // Props: attach listeners and reconcile only the bindings that can differ. The PatchFlag fast
+        // path keeps a static element off the per-prop loop — it either patches nothing, or only the
+        // click listener (the common interactive case).
+        if (properties is not null)
+        {
+            var elementNamespace = NamespaceForTag(tag);
+            var mustIterate = forcePatch
+                || hasDynamicProperties
+                || !optimized
+                || ((int)patchFlag > 0 && (patchFlag & (PatchFlags.FullProps | PatchFlags.NeedHydration)) != 0);
+            if (mustIterate)
+            {
+                foreach (var (name, value) in properties)
+                {
+                    // Dev-mode mismatch reporting for class/style/attribute bindings (upstream propHasMismatch).
+                    ReportPropertyMismatch(reader, element, name, value, vnode);
+                    if (ShouldHydrateProperty(name, forcePatch, vnode.DynamicProperties))
+                    {
+                        _options.PatchProperty(element, tag, name, null, value, elementNamespace);
+                    }
+                }
+            }
+            else if (properties.TryGetValue("onClick", out var clickHandler))
+            {
+                // Fast path (upstream): a static element still needs its click listener attached.
+                _options.PatchProperty(element, tag, "onClick", null, clickHandler, elementNamespace);
+            }
+        }
+
+        InvokeHook(vnode, null, "onVnodeBeforeMount");
+        InvokeDirectiveHooks(vnode, null, DirectiveHookKind.BeforeMount);
+        QueuePostHook(vnode, null, "onVnodeMounted");
+        QueuePostDirectiveHooks(vnode, null, DirectiveHookKind.Mounted);
+        return reader.NextSibling(element);
+    }
+
+    private TNode? HydrateChildren(
+        HydrationNodeReader<TNode> reader,
+        TNode? firstNode,
+        VirtualNode parentVnode,
+        TNode container,
+        ComponentInstance? parentComponent,
+        bool optimized)
+    {
+        optimized = optimized || parentVnode.DynamicChildren is not null;
+        var children = parentVnode.ArrayChildren ?? [];
+        var cursor = firstNode;
+        var warnedInsufficient = false;
+        for (var index = 0; index < children.Length; index++)
+        {
+            var child = optimized
+                ? children[index]
+                : children[index] = VirtualNodeFactory.Normalize(children[index]);
+            if (TryNode(cursor, out var node))
+            {
+                // Consecutive client text vnodes served as one server text node: split it so each vnode
+                // adopts its own node (upstream hydrateChildren adjacent-text handling).
+                if (!optimized
+                    && child.Type == VirtualNodeType.Text
+                    && index + 1 < children.Length
+                    && VirtualNodeFactory.Normalize(children[index + 1]).Type == VirtualNodeType.Text
+                    && reader.Kind(node) == HydrationNodeKind.Text)
+                {
+                    var serverData = reader.Data(node);
+                    var clientText = child.TextChildren ?? string.Empty;
+                    if (serverData.Length > clientText.Length)
+                    {
+                        var split = _options.CreateText(serverData[clientText.Length..]);
+                        if (TryNode(reader.NextSibling(node), out var afterNode))
+                        {
+                            _options.Insert(split, container, afterNode);
+                        }
+                        else
+                        {
+                            _options.Insert(split, container, default);
+                        }
+                        _options.SetText(node, clientText);
+                    }
+                }
+                cursor = HydrateNode(reader, node, child, parentComponent, optimized);
+            }
+            else if (child.Type == VirtualNodeType.Text && string.IsNullOrEmpty(child.TextChildren))
+            {
+                // #7215: an empty text vnode with no server node — create it (upstream parity).
+                var created = _options.CreateText(string.Empty);
+                child.El = created;
+                _options.Insert(created, container, default);
+            }
+            else
+            {
+                // Too few server nodes: warn once, then client-render the remaining vnodes (upstream).
+                if (!warnedInsufficient)
+                {
+                    warnedInsufficient = true;
+                    if (!IsMismatchAllowed(reader, container, HydrationMismatchType.Children))
+                    {
+                        WarnMismatch(
+                            reader,
+                            container,
+                            "Hydration children mismatch: server rendered fewer child nodes than the client vdom.");
+                    }
+                }
+                Patch(null, child, container, default, NamespaceForTag(parentVnode.ElementTag), parentComponent);
+            }
+        }
+        return cursor;
+    }
+
+    private TNode? HydrateFragment(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool optimized)
+    {
+        // The [ marker is the fragment's El; its children hydrate between the marker and the matching ]
+        // (upstream hydrateFragment). The parent container is the marker's parent.
+        vnode.El = node;
+        if (!TryNode(reader.ParentNode(node), out var container))
+        {
+            return HandleMismatch(reader, node, vnode, parentComponent, isFragment: true);
+        }
+        var leftover = HydrateChildren(reader, reader.NextSibling(node), vnode, container, parentComponent, optimized);
+        if (TryNode(leftover, out var closing)
+            && reader.Kind(closing) == HydrationNodeKind.Comment
+            && string.Equals(reader.Data(closing), HydrationMarkers.FragmentEnd, StringComparison.Ordinal))
+        {
+            vnode.Anchor = closing;
+            return reader.NextSibling(closing);
+        }
+        // The server content did not close the fragment where expected: synthesize a closing anchor so
+        // later moves/unmounts still bound the fragment's range (upstream inserts a `]` comment).
+        var anchor = _options.CreateComment(HydrationMarkers.FragmentEnd);
+        vnode.Anchor = anchor;
+        if (TryNode(leftover, out var before))
+        {
+            _options.Insert(anchor, container, before);
+        }
+        else
+        {
+            _options.Insert(anchor, container, default);
+        }
+        return leftover;
+    }
+
+    private TNode? HydrateComponent(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool optimized,
+        bool isFragmentStart)
+    {
+        // Upstream component case: the subtree hydrates against the current node (mountComponent runs with
+        // vnode.el set, so componentUpdateFn adopts instead of mounts). The node that follows the component
+        // depends on its root shape — a fragment root spans [ .. ], a teleport root spans its start/end
+        // anchors, anything else is a single node.
+        if (!TryNode(reader.ParentNode(node), out var container))
+        {
+            container = node;
+        }
+        TNode? nextNode;
+        if (isFragmentStart)
+        {
+            nextNode = LocateClosingAnchor(reader, node, HydrationMarkers.FragmentStart, HydrationMarkers.FragmentEnd);
+        }
+        else if (reader.Kind(node) == HydrationNodeKind.Comment
+            && string.Equals(reader.Data(node), HydrationMarkers.TeleportStart, StringComparison.Ordinal))
+        {
+            nextNode = LocateClosingAnchor(reader, node, HydrationMarkers.TeleportStart, HydrationMarkers.TeleportEnd);
+        }
+        else
+        {
+            nextNode = reader.NextSibling(node);
+        }
+        vnode.El = node;
+        // Arm the subtree-hydration bridge, then mount: the component's render effect adopts the existing
+        // nodes (see ComponentUpdateFunction). elementNamespace is null here — the subtree elements derive
+        // their namespace from their own tags during HydrateElement.
+        _componentHydrationReader = reader;
+        MountComponent(vnode, container, default, null, parentComponent);
+        return nextNode;
+    }
+
+    private TNode? HydrateTeleport(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool optimized)
+    {
+        // The C# port of TeleportImpl.hydrate (components/Teleport.ts). The main-tree anchors are the
+        // <!--teleport start--> (El) and <!--teleport end--> (Anchor) comments; the children live in the
+        // resolved target (enabled) or between the anchors in place (disabled).
+        vnode.El = node;
+        var disabled = IsTeleportDisabled(vnode);
+        var state = new TeleportState();
+        vnode.TeleportState = state;
+        var target = ResolveTarget(vnode);
+        state.Target = target;
+
+        TNode? mainEnd;
+        if (disabled)
+        {
+            // Disabled: the children are in place between the start and end anchors — adopt them, and the
+            // node the walk stops at is the <!--teleport end--> anchor.
+            mainEnd = TryNode(reader.ParentNode(node), out var container)
+                ? HydrateChildren(reader, reader.NextSibling(node), vnode, container, parentComponent, optimized)
+                : reader.NextSibling(node);
+            vnode.Anchor = Box(mainEnd);
+            if (target is TNode inPlaceTarget)
+            {
+                // The target still carries the anchor comment; record it so a disabled->enabled toggle
+                // moves the children in front of it.
+                state.TargetAnchor = Box(LocateTeleportAnchor(inPlaceTarget));
+            }
+        }
+        else
+        {
+            // Enabled: the main tree carries only the adjacent start/end anchor pair; the children live in
+            // the resolved target. Snapshot the target subtree (one more batched crossing on the browser —
+            // a target lies outside the root's subtree) and adopt the range up to the anchor comment.
+            mainEnd = reader.NextSibling(node);
+            vnode.Anchor = Box(mainEnd);
+            if (target is TNode targetContainer && _options.CreateHydrationReader is not null)
+            {
+                var targetReader = _options.CreateHydrationReader(targetContainer);
+                var targetFirst = targetReader.FirstChild(targetContainer);
+                state.TargetStart = Box(targetFirst);
+                var leftover = HydrateChildren(targetReader, targetFirst, vnode, targetContainer, parentComponent, optimized);
+                state.TargetAnchor = TryNode(leftover, out var anchor)
+                    && targetReader.Kind(anchor) == HydrationNodeKind.Comment
+                    && string.Equals(targetReader.Data(anchor), HydrationMarkers.TeleportAnchor, StringComparison.Ordinal)
+                    ? anchor
+                    : null;
+            }
+        }
+        // The walk continues after the main-tree end anchor.
+        return TryNode(mainEnd, out var end) ? reader.NextSibling(end) : default;
+    }
+
+    // The C# port of handleMismatch: reset the vnode, discard the mismatched server node (and, for a
+    // fragment, its whole [ .. ] range), then client-render the vnode where it stood so the tree
+    // converges. Returns the server node that follows the discarded range.
+    private TNode? HandleMismatch(
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        VirtualNode vnode,
+        ComponentInstance? parentComponent,
+        bool isFragment)
+    {
+        // A node-type/structure mismatch is a CHILDREN mismatch of the container, so it is suppressible by
+        // data-allow-mismatch on the node (or its nearest element ancestor) — upstream isNodeMismatchAllowed.
+        var allowFrom = reader.Kind(node) == HydrationNodeKind.Element
+            ? node
+            : TryNode(reader.ParentNode(node), out var parentElement) ? parentElement : node;
+        if (!IsMismatchAllowed(reader, allowFrom, HydrationMismatchType.Children))
+        {
+            WarnNodeMismatch(reader, node, vnode);
+        }
+        vnode.El = null;
+        if (isFragment)
+        {
+            // Remove the excess fragment children between the [ marker and its matching ].
+            var end = LocateClosingAnchor(reader, node, HydrationMarkers.FragmentStart, HydrationMarkers.FragmentEnd);
+            while (TryNode(reader.NextSibling(node), out var following)
+                && !(TryNode(end, out var endNode) && NodeComparer.Equals(following, endNode)))
+            {
+                _options.Remove(following);
+            }
+        }
+        var next = reader.NextSibling(node);
+        if (!TryNode(reader.ParentNode(node), out var container))
+        {
+            container = node;
+        }
+        _options.Remove(node);
+        var anchor = TryNode(next, out var anchorNode) ? anchorNode : default(TNode?);
+        Patch(null, vnode, container, anchor, null, parentComponent);
+        // #12063: a mismatch may change the parent component's host element.
+        if (parentComponent is not null && ReferenceEquals(parentComponent.Subtree, vnode))
+        {
+            parentComponent.VirtualNode.El = vnode.El;
+        }
+        return next;
+    }
+
+    // The C# port of locateClosingAnchor: find the matching close comment for an open comment, honoring
+    // nesting, and return the node after it.
+    private TNode? LocateClosingAnchor(HydrationNodeReader<TNode> reader, TNode node, string open, string close)
+    {
+        var depth = 0;
+        TNode? cursor = node;
+        while (TryNode(cursor, out var current))
+        {
+            cursor = reader.NextSibling(current);
+            if (TryNode(cursor, out var candidate) && reader.Kind(candidate) == HydrationNodeKind.Comment)
+            {
+                var data = reader.Data(candidate);
+                if (string.Equals(data, open, StringComparison.Ordinal))
+                {
+                    depth++;
+                }
+                else if (string.Equals(data, close, StringComparison.Ordinal))
+                {
+                    if (depth == 0)
+                    {
+                        return reader.NextSibling(candidate);
+                    }
+                    depth--;
+                }
+            }
+        }
+        return cursor;
+    }
+
+    private static bool ShouldHydrateProperty(string name, bool forcePatch, string[]? dynamicProperties)
+    {
+        // Upstream hydrateElement prop-qualification: value-like props on input/option (forcePatch), event
+        // listeners (always attached), .-prefixed DOM properties, and the compiler's dynamic prop list.
+        if (forcePatch
+            && (name.EndsWith("value", StringComparison.Ordinal)
+                || string.Equals(name, "indeterminate", StringComparison.Ordinal)))
+        {
+            return true;
+        }
+        if (VirtualNodeFactory.IsEventListenerName(name) && !IsReservedProperty(name))
+        {
+            return true;
+        }
+        if (name.Length > 0 && name[0] == '.')
+        {
+            return true;
+        }
+        if (dynamicProperties is not null)
+        {
+            foreach (var dynamicName in dynamicProperties)
+            {
+                if (string.Equals(dynamicName, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private string ReadElementText(HydrationNodeReader<TNode> reader, TNode element)
+    {
+        // The element's text content is the concatenation of its child text nodes. SSR emits a single
+        // text child for a text-children element, so this is usually one read; a builder covers the
+        // general case without allocating for the common single-child one.
+        var child = reader.FirstChild(element);
+        if (!TryNode(child, out var first))
+        {
+            return string.Empty;
+        }
+        if (reader.Kind(first) == HydrationNodeKind.Text && !TryNode(reader.NextSibling(first), out _))
+        {
+            return reader.Data(first);
+        }
+        var builder = new StringBuilder();
+        var cursor = child;
+        while (TryNode(cursor, out var node))
+        {
+            if (reader.Kind(node) == HydrationNodeKind.Text)
+            {
+                builder.Append(reader.Data(node));
+            }
+            cursor = reader.NextSibling(node);
+        }
+        return builder.ToString();
+    }
+
+    private static string? NamespaceForTag(string? tag)
+        => string.Equals(tag, "svg", StringComparison.Ordinal) ? "svg"
+            : string.Equals(tag, "math", StringComparison.Ordinal) ? "mathml"
+            : null;
+
+    private TNode? LocateTeleportAnchor(TNode target)
+    {
+        // Best-effort scan for the <!--teleport anchor--> inside a disabled teleport's target using the
+        // write-side node-ops (the target is already resolved and its nodes registered). Rarely walked.
+        if (_options.CreateHydrationReader is null)
+        {
+            return default;
+        }
+        var reader = _options.CreateHydrationReader(target);
+        var cursor = reader.FirstChild(target);
+        while (TryNode(cursor, out var node))
+        {
+            if (reader.Kind(node) == HydrationNodeKind.Comment
+                && string.Equals(reader.Data(node), HydrationMarkers.TeleportAnchor, StringComparison.Ordinal))
+            {
+                return node;
+            }
+            cursor = reader.NextSibling(node);
+        }
+        return default;
+    }
+
+    // --- mismatch reporting + the data-allow-mismatch escape hatch -----------------------------
+
+    private void ReportPropertyMismatch(
+        HydrationNodeReader<TNode> reader,
+        TNode element,
+        string name,
+        object? clientValue,
+        VirtualNode vnode)
+    {
+        // A focused port of propHasMismatch for the class/style/attribute bindings the AC names: compare
+        // the server-rendered value against the client vnode's and warn (honoring data-allow-mismatch).
+        // Directives, event listeners, reserved props, and DOM-property (.-prefixed) bindings never carry
+        // an observable attribute mismatch and are skipped.
+        if (VirtualNodeFactory.IsEventListenerName(name)
+            || IsReservedProperty(name)
+            || (name.Length > 0 && name[0] == '.')
+            || string.Equals(name, "value", StringComparison.Ordinal)
+            || string.Equals(name, "innerHTML", StringComparison.Ordinal)
+            || string.Equals(name, "textContent", StringComparison.Ordinal))
+        {
+            return;
+        }
+        if (string.Equals(name, "class", StringComparison.Ordinal))
+        {
+            var server = reader.Attribute(element, "class");
+            if (!ClassEquivalent(server, clientValue) && !IsMismatchAllowed(reader, element, HydrationMismatchType.Class))
+            {
+                WarnMismatch(
+                    reader,
+                    element,
+                    $"Hydration class mismatch: rendered on server \"{server}\", expected on client "
+                    + $"\"{clientValue}\".");
+            }
+            return;
+        }
+        var mismatchType = string.Equals(name, "style", StringComparison.Ordinal)
+            ? HydrationMismatchType.Style
+            : HydrationMismatchType.Attribute;
+        var serverValue = reader.Attribute(element, name);
+        var clientText = clientValue?.ToString();
+        // A boolean/absent attribute: a false/null client value with an absent server attribute matches.
+        if (clientValue is null or false)
+        {
+            if (serverValue is not null && !IsMismatchAllowed(reader, element, mismatchType))
+            {
+                WarnMismatch(reader, element, $"Hydration attribute mismatch on \"{name}\": server rendered \"{serverValue}\", client expected none.");
+            }
+            return;
+        }
+        if (!string.Equals(serverValue ?? string.Empty, clientText ?? string.Empty, StringComparison.Ordinal)
+            && !IsMismatchAllowed(reader, element, mismatchType))
+        {
+            WarnMismatch(
+                reader,
+                element,
+                $"Hydration {(mismatchType == HydrationMismatchType.Style ? "style" : "attribute")} mismatch on "
+                + $"\"{name}\": rendered on server \"{serverValue}\", expected on client \"{clientText}\".");
+        }
+    }
+
+    private static bool ClassEquivalent(string? server, object? clientValue)
+    {
+        var client = clientValue as string;
+        if (server is null && string.IsNullOrEmpty(client))
+        {
+            return true;
+        }
+        // Compare as unordered token sets so attribute-order differences are not reported as mismatches.
+        var serverTokens = Tokenize(server);
+        var clientTokens = Tokenize(client);
+        if (serverTokens.Count != clientTokens.Count)
+        {
+            return false;
+        }
+        foreach (var token in clientTokens)
+        {
+            if (!serverTokens.Contains(token))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static HashSet<string> Tokenize(string? value)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(value))
+        {
+            return set;
+        }
+        foreach (var token in value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            set.Add(token);
+        }
+        return set;
+    }
+
+    private bool IsMismatchAllowed(HydrationNodeReader<TNode> reader, TNode element, HydrationMismatchType type)
+    {
+        // Upstream isMismatchAllowed: text/children mismatches consult the nearest ancestor carrying a
+        // data-allow-mismatch attribute; class/style/attribute mismatches consult only the element.
+        var target = element;
+        if (type is HydrationMismatchType.Text or HydrationMismatchType.Children)
+        {
+            var found = false;
+            var cursor = (TNode?)element;
+            while (TryNode(cursor, out var current) && reader.Kind(current) == HydrationNodeKind.Element)
+            {
+                if (reader.Attribute(current, AllowMismatchAttribute) is not null)
+                {
+                    target = current;
+                    found = true;
+                    break;
+                }
+                cursor = reader.ParentNode(current);
+            }
+            if (!found)
+            {
+                return false;
+            }
+        }
+        if (reader.Kind(target) != HydrationNodeKind.Element)
+        {
+            return false;
+        }
+        return IsMismatchAllowedByAttribute(reader.Attribute(target, AllowMismatchAttribute), type);
+    }
+
+    private static bool IsMismatchAllowedByAttribute(string? attribute, HydrationMismatchType type)
+    {
+        if (attribute is null)
+        {
+            return false;
+        }
+        if (attribute.Length == 0)
+        {
+            // A bare data-allow-mismatch allows every kind (upstream: attr === '').
+            return true;
+        }
+        var typeToken = MismatchTypeToken(type);
+        foreach (var raw in attribute.Split(','))
+        {
+            var token = raw.Trim();
+            if (string.Equals(token, typeToken, StringComparison.Ordinal))
+            {
+                return true;
+            }
+            // Allowing "attribute" also allows class and style (they are attributes) — upstream parity.
+            if ((type is HydrationMismatchType.Class or HydrationMismatchType.Style)
+                && string.Equals(token, "attribute", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string MismatchTypeToken(HydrationMismatchType type) => type switch
+    {
+        HydrationMismatchType.Text => "text",
+        HydrationMismatchType.Children => "children",
+        HydrationMismatchType.Class => "class",
+        HydrationMismatchType.Style => "style",
+        _ => "attribute",
+    };
+
+    private void WarnNodeMismatch(HydrationNodeReader<TNode> reader, TNode node, VirtualNode vnode)
+    {
+        var kind = reader.Kind(node);
+        var served = kind switch
+        {
+            HydrationNodeKind.Text => "a text node",
+            HydrationNodeKind.Comment => string.Equals(reader.Data(node), HydrationMarkers.FragmentStart, StringComparison.Ordinal)
+                ? "the start of a fragment"
+                : "a comment node",
+            HydrationNodeKind.Element => $"<{reader.ElementTag(node)}>",
+            _ => "an unknown node",
+        };
+        WarnMismatch(
+            reader,
+            node,
+            $"Hydration node mismatch: rendered on server {served}, expected on client a {DescribeVirtualNode(vnode)}.");
+    }
+
+    private void WarnMismatch(HydrationNodeReader<TNode> reader, TNode node, string message)
+        => RuntimeWarnings.Warn($"{message} (at {DescribeNodePath(reader, node)})");
+
+    private string DescribeNodePath(HydrationNodeReader<TNode> reader, TNode node)
+    {
+        // Name the offending node's path from the root: html > body > div — enough for a developer to
+        // locate the mismatch (upstream passes the element to warn(); Viu materializes the tag chain).
+        var segments = new List<string>();
+        var cursor = (TNode?)node;
+        var guard = 0;
+        while (TryNode(cursor, out var current) && guard++ < 64)
+        {
+            var kind = reader.Kind(current);
+            if (kind == HydrationNodeKind.Element)
+            {
+                segments.Add(reader.ElementTag(current).ToLowerInvariant());
+            }
+            else if (segments.Count == 0)
+            {
+                segments.Add(kind == HydrationNodeKind.Comment ? "#comment" : "#text");
+            }
+            cursor = reader.ParentNode(current);
+        }
+        segments.Reverse();
+        return segments.Count == 0 ? "root" : string.Join(" > ", segments);
+    }
+
+    private static string DescribeVirtualNode(VirtualNode vnode) => vnode.Type switch
+    {
+        VirtualNodeType.Element => $"<{vnode.ElementTag}>",
+        VirtualNodeType.Text => "text node",
+        VirtualNodeType.Comment => "comment node",
+        VirtualNodeType.Fragment => "fragment",
+        VirtualNodeType.Component => "component",
+        VirtualNodeType.Teleport => "teleport",
+        VirtualNodeType.Static => "static block",
+        _ => "node",
+    };
+
+    private static bool TryNode(TNode? candidate, out TNode node)
+    {
+        // Uniform "is this a real node" test across a reference-type TNode (null == none) and a
+        // value-type TNode (default == the "no node" sentinel, e.g. the browser's 0 handle).
+        if (candidate is not null && !NodeComparer.Equals(candidate, default!))
+        {
+            node = candidate;
+            return true;
+        }
+        node = default!;
+        return false;
+    }
+
+    // Boxes a real node for storage on the object-typed VirtualNode.El/Anchor and TeleportState handles,
+    // collapsing the "no node" sentinel (null, or a value-type default) to null so those fields stay null
+    // when absent (matching how the mount path leaves them).
+    private static object? Box(TNode? node) => TryNode(node, out var value) ? value : null;
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/Renderer.TNode.cs
@@ -27,7 +27,7 @@ namespace Assimalign.Viu.RuntimeCore;
 /// Not thread-safe (single-threaded JS event-loop model).
 /// </summary>
 /// <typeparam name="TNode">The platform node type; <c>default</c> means "no node".</typeparam>
-public sealed class Renderer<TNode>
+public sealed partial class Renderer<TNode>
     where TNode : notnull
 {
     private static readonly EqualityComparer<TNode> NodeComparer = EqualityComparer<TNode>.Default;
@@ -671,7 +671,19 @@ public sealed class Renderer<TNode>
             instance.ToggleRecurse(true);
             var subtree = RenderComponentRoot(instance);
             instance.Subtree = subtree;
-            Patch(null, subtree, container, anchor, elementNamespace, instance);
+            // Hydration bridge (upstream componentUpdateFn: the `if (el && hydrateNode)` arm). When the
+            // walker positioned this component over a server node it stamped that node onto the component
+            // vnode's El and armed _componentHydrationReader before mounting, so the first render adopts
+            // the existing DOM subtree instead of creating it. Every other mount (El null, or no active
+            // hydration) takes the normal create path.
+            if (instance.VirtualNode.El is { } hydrationNode && _componentHydrationReader is { } hydrationReader)
+            {
+                HydrateNode(hydrationReader, (TNode)hydrationNode, subtree, instance, optimized: false);
+            }
+            else
+            {
+                Patch(null, subtree, container, anchor, elementNamespace, instance);
+            }
             instance.VirtualNode.El = subtree.El;
             instance.VirtualNode.Anchor = subtree.Anchor;
             instance.IsMounted = true;

--- a/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/RendererOptions{TNode}.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/src/Rendering/RendererOptions{TNode}.cs
@@ -18,6 +18,7 @@ namespace Assimalign.Viu.RuntimeCore;
 /// </summary>
 /// <typeparam name="TNode">The platform node type.</typeparam>
 public sealed class RendererOptions<TNode>
+    where TNode : notnull
 {
     /// <summary>
     /// Inserts <c>child</c> into <c>parent</c> before <c>anchor</c>, appending when the anchor
@@ -79,4 +80,20 @@ public sealed class RendererOptions<TNode>
     /// vnodes.
     /// </summary>
     public InsertStaticContentDelegate<TNode>? InsertStaticContent { get; init; }
+
+    /// <summary>
+    /// Optional: opens a read-only view over the existing server-rendered subtree rooted at the
+    /// given node so the renderer can hydrate it instead of mounting fresh (upstream: the
+    /// <c>nodeOps</c> reads <c>createHydrationFunctions</c> closes over —
+    /// <c>packages/runtime-core/src/hydration.ts</c>). Required to hydrate through
+    /// <c>Renderer.Hydrate</c> / <c>CreateSSRApp</c>; a renderer without it can only mount.
+    /// <para>
+    /// The factory is where the interop-cost discipline lives: the browser adapter returns a reader
+    /// backed by a single batched snapshot of the whole subtree (one boundary crossing), so the walk
+    /// reads structure and node data without a marshaled call per node; the in-memory test adapter
+    /// reads the live tree directly. Called once per hydration root — and once per teleport target,
+    /// which lies outside the root's subtree — never per node.
+    /// </para>
+    /// </summary>
+    public Func<TNode, HydrationNodeReader<TNode>>? CreateHydrationReader { get; init; }
 }

--- a/libraries/Assimalign.Viu.RuntimeCore/test/HydrationSnapshotReaderTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/HydrationSnapshotReaderTests.cs
@@ -1,0 +1,164 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Shared;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.Tests;
+
+// Snapshot-safety regression coverage for the hydration walker ([V01.01.07.03]). These run against a
+// FROZEN reader (TestRenderer(snapshotSemantics: true)) that mirrors the browser's batched snapshot: an
+// immutable pre-walk that never reflects an Insert/Remove/SetText, plus a double-remove that throws like the
+// browser bridge's "unknown DOM handle". A walker that re-reads structure after mutating passes against the
+// live-tree reader but breaks here — the exact bug class the browser hits. Live-reader coverage stays in
+// HydrationTests.
+public class HydrationSnapshotReaderTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new(snapshotSemantics: true);
+    private readonly TestNodeOperationLog _log;
+
+    public HydrationSnapshotReaderTests()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        _log = _renderer.OperationLog;
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+    }
+
+    [Fact]
+    public void HandleMismatch_FragmentRange_ReadBeforeMutate_IsSnapshotSafe()
+    {
+        // Server is a multi-child fragment; the client wants a single <div>, so HandleMismatch must discard
+        // the whole [ .. ] range. With an immutable snapshot, re-reading NextSibling(node) after each Remove
+        // keeps returning the already-removed first child — the walker must collect the range first.
+        var container = TestServerMarkup.Parse("<!--[--><span>x</span><span>y</span><!--]-->");
+        var vnode = VirtualNodeFactory.Element("div", "z");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        // Pre-fix: throws on the double-remove. Post-fix: the fragment range is gone and the client <div> is
+        // mounted in its place — the tree converges.
+        warnings.Messages.ShouldContain(message => message.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+        container.Children.Count.ShouldBe(1);
+        ((TestElement)container.Children[0]).Tag.ShouldBe("div");
+        ((TestText)((TestElement)container.Children[0]).Children[0]).Text.ShouldBe("z");
+    }
+
+    [Fact]
+    public void HandleMismatch_NestedFragmentRange_IsSnapshotSafe()
+    {
+        // A nested [ .. ] inside the outer fragment: the removal range must honor nesting (locateClosingAnchor)
+        // and still read the whole chain from the snapshot before removing.
+        var container = TestServerMarkup.Parse("<!--[--><span>x</span><!--[--><i>n</i><!--]--><!--]-->");
+        var vnode = VirtualNodeFactory.Element("div", "z");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+        container.Children.Count.ShouldBe(1);
+        ((TestElement)container.Children[0]).Tag.ShouldBe("div");
+    }
+
+    [Fact]
+    public void HydrateChildren_AdjacentText_AdoptsSplitDirectly_IsSnapshotSafe()
+    {
+        // Server renders two adjacent client text vnodes as ONE text node "ab". The walker splits it and must
+        // adopt the created split node DIRECTLY (it is not in the snapshot), not resume via the frozen reader's
+        // NextSibling — otherwise the split is orphaned, the second vnode adopts the original following sibling,
+        // and the result drifts (e.g. "abb") plus a spurious mismatch warning.
+        var container = TestServerMarkup.Parse("<div>ab</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div",
+            null,
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Text("a"),
+                VirtualNodeFactory.Text("b"),
+            });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        var div = (TestElement)container.Children[0];
+        div.Children.Count.ShouldBe(2);
+        ((TestText)div.Children[0]).Text.ShouldBe("a");
+        ((TestText)div.Children[1]).Text.ShouldBe("b");
+        warnings.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void HydrateChildren_ThreeAdjacentText_PeeledInOrder_IsSnapshotSafe()
+    {
+        // Three adjacent text vnodes served as one "abc": the peel must produce "a","b","c" in order.
+        var container = TestServerMarkup.Parse("<div>abc</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div",
+            null,
+            new VirtualNode?[]
+            {
+                VirtualNodeFactory.Text("a"),
+                VirtualNodeFactory.Text("b"),
+                VirtualNodeFactory.Text("c"),
+            });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        var div = (TestElement)container.Children[0];
+        div.Children.Count.ShouldBe(3);
+        ((TestText)div.Children[0]).Text.ShouldBe("a");
+        ((TestText)div.Children[1]).Text.ShouldBe("b");
+        ((TestText)div.Children[2]).Text.ShouldBe("c");
+        warnings.Messages.ShouldBeEmpty();
+    }
+
+    // --- happy-path sanity under the frozen reader (proves frozen mode is correct for non-mutating walks) --
+
+    [Fact]
+    public void CleanElementHydration_UnderFrozenReader_AdoptsWithoutMutation()
+    {
+        var container = TestServerMarkup.Parse("<button>Click</button>");
+        var clicks = 0;
+        var vnode = VirtualNodeFactory.Element(
+            "button",
+            VirtualNodeFactory.Properties(("onClick", (Action)(() => clicks++))),
+            "Click",
+            PatchFlags.NeedHydration);
+
+        _renderer.Hydrate(vnode, container);
+
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        var button = (TestElement)container.Children[0];
+        ((Action)button.EventListeners["click"])();
+        clicks.ShouldBe(1);
+    }
+
+    [Fact]
+    public void CleanFragmentHydration_UnderFrozenReader_AdoptsAnchors()
+    {
+        var container = TestServerMarkup.Parse("<!--[--><span>a</span><span>b</span><!--]-->");
+        var vnode = VirtualNodeFactory.Fragment(
+            new VirtualNode?[] { VirtualNodeFactory.Element("span", "a"), VirtualNodeFactory.Element("span", "b") },
+            null,
+            PatchFlags.StableFragment);
+
+        _renderer.Hydrate(vnode, container);
+
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        ((TestComment)vnode.El!).Text.ShouldBe("[");
+        ((TestComment)vnode.Anchor!).Text.ShouldBe("]");
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/test/HydrationTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/HydrationTests.cs
@@ -1,0 +1,355 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.Shared;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.RuntimeCore.Tests;
+
+// Pins the hydration walker against @vue/runtime-core's createHydrationFunctions
+// (packages/runtime-core/src/hydration.ts) — https://vuejs.org/guide/scaling-up/ssr.html#client-hydration.
+// The walker adopts the server-rendered TestNode tree (built with TestServerMarkup, the DOM-free stand-in
+// for parsing SSR output) instead of creating nodes: a clean hydration performs zero structural node
+// operations, event handlers become live, PatchFlag fast paths skip static work, and a server/client
+// mismatch recovers per subtree without crashing ([V01.01.07.03]).
+public class HydrationTests : IDisposable
+{
+    private readonly TestRenderer _renderer = new();
+    private readonly TestNodeOperationLog _log;
+    private readonly TestSchedulerPump _pump;
+
+    public HydrationTests()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        _pump = TestSchedulerPump.Install();
+        _log = _renderer.OperationLog;
+    }
+
+    public void Dispose()
+    {
+        Scheduler.Reset();
+        BlockStack.Reset();
+        _pump.Dispose();
+    }
+
+    // --- adoption without mutation --------------------------------------------------------------
+
+    [Fact]
+    public void HydrateElement_MatchingServerMarkup_AdoptsWithoutStructuralMutation()
+    {
+        var container = TestServerMarkup.Parse("<div>hello</div>");
+        var serverDiv = container.Children[0];
+        var vnode = VirtualNodeFactory.Element("div", "hello");
+
+        _renderer.Hydrate(vnode, container);
+
+        AssertAdoptedWithoutMutation();
+        // The vnode adopts the existing server node rather than creating a new one.
+        vnode.El.ShouldBeSameAs(serverDiv);
+    }
+
+    [Fact]
+    public void HydrateElement_AttachesEventListener_WithoutTouchingTheDom()
+    {
+        var clicks = 0;
+        var container = TestServerMarkup.Parse("<button>Click</button>");
+        var vnode = VirtualNodeFactory.Element(
+            "button",
+            VirtualNodeFactory.Properties(("onClick", (Action)(() => clicks++))),
+            "Click",
+            PatchFlags.NeedHydration);
+
+        _renderer.Hydrate(vnode, container);
+
+        // Zero DOM mutations, yet the listener is live (upstream: event listeners are always attached).
+        AssertAdoptedWithoutMutation();
+        var button = (TestElement)container.Children[0];
+        button.EventListeners.ShouldContainKey("click");
+        ((Action)button.EventListeners["click"])();
+        clicks.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HydrateElement_CachedSubtree_AdoptedWithoutInspectingChildren()
+    {
+        // A CACHED (hoisted / v-once) element is trusted verbatim — its children are never walked
+        // (upstream hydrateElement: the `patchFlag !== CACHED` gate). Even a server/client child
+        // difference is left untouched because the fast path never inspects it.
+        var container = TestServerMarkup.Parse("<div><span>server</span></div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div",
+            null,
+            new VirtualNode?[] { VirtualNodeFactory.Element("span", "client") },
+            PatchFlags.Cached);
+
+        _renderer.Hydrate(vnode, container);
+
+        AssertAdoptedWithoutMutation();
+        // The child span vnode was never descended into, so it holds no adopted node.
+        vnode.ArrayChildren![0].El.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HydrateElement_ReconcilesOnlyDynamicProps_LeavingStaticPropsUntouched()
+    {
+        // The PatchFlag fast path: only the compiler's dynamicProps are reconciled during the walk; the
+        // static id attribute is never patched (upstream: the ShouldHydrateProperty qualification).
+        var container = TestServerMarkup.Parse("<div id=\"static\" title=\"live\">hi</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div",
+            VirtualNodeFactory.Properties(("id", "static"), ("title", "live")),
+            "hi",
+            PatchFlags.Props,
+            new[] { "title" });
+
+        _renderer.Hydrate(vnode, container);
+
+        _log.Count(TestNodeOperationType.PatchProperty).ShouldBe(1);
+        _log.OfType(TestNodeOperationType.PatchProperty)[0].PropertyName.ShouldBe("title");
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+    }
+
+    [Fact]
+    public void HydrateFragment_MatchingAnchors_AdoptsChildrenBetweenBrackets()
+    {
+        var container = TestServerMarkup.Parse("<!--[--><span>a</span><span>b</span><!--]-->");
+        var vnode = VirtualNodeFactory.Fragment(
+            new VirtualNode?[] { VirtualNodeFactory.Element("span", "a"), VirtualNodeFactory.Element("span", "b") },
+            null,
+            PatchFlags.StableFragment);
+
+        _renderer.Hydrate(vnode, container);
+
+        AssertAdoptedWithoutMutation();
+        // El/Anchor are the [ and ] comment anchors the server emitted.
+        ((TestComment)vnode.El!).Text.ShouldBe("[");
+        ((TestComment)vnode.Anchor!).Text.ShouldBe("]");
+        vnode.ArrayChildren![0].El.ShouldBeSameAs(container.Children[1]);
+    }
+
+    [Fact]
+    public void HydrateComment_MatchingComment_Adopted()
+    {
+        var container = TestServerMarkup.Parse("<!--anchor-->");
+        var vnode = VirtualNodeFactory.Comment("anchor");
+
+        _renderer.Hydrate(vnode, container);
+
+        AssertAdoptedWithoutMutation();
+        vnode.El.ShouldBeSameAs(container.Children[0]);
+    }
+
+    // --- mismatch detection + recovery ----------------------------------------------------------
+
+    [Fact]
+    public void Hydrate_TextContentMismatch_WarnsAndCorrectsInPlace()
+    {
+        var container = TestServerMarkup.Parse("<div>server</div>");
+        var vnode = VirtualNodeFactory.Element("div", "client");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("text content mismatch", StringComparison.OrdinalIgnoreCase));
+        // Recovery corrects the text to the client value, without a remount (Insert stays zero).
+        _log.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        ((TestElement)container.Children[0]).Children.Count.ShouldBe(1);
+        ((TestText)((TestElement)container.Children[0]).Children[0]).Text.ShouldBe("client");
+    }
+
+    [Fact]
+    public void Hydrate_StructuralMismatch_RecoversSubtree_WhileAdoptingTheRest()
+    {
+        // The outer <div> matches and is adopted; only the mismatched <span>-vs-<p> child is torn down and
+        // client-rendered (upstream handleMismatch). A mismatch never crashes and the tree converges.
+        var container = TestServerMarkup.Parse("<div><span>x</span></div>");
+        var serverDiv = container.Children[0];
+        var vnode = VirtualNodeFactory.Element(
+            "div", null, new VirtualNode?[] { VirtualNodeFactory.Element("p", "x") });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+        // The outer div was adopted, not recreated.
+        vnode.El.ShouldBeSameAs(serverDiv);
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(1); // just the replacement <p>
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(1);        // the stale <span>
+        // Final DOM converges to the client tree.
+        var div = (TestElement)container.Children[0];
+        div.Children.Count.ShouldBe(1);
+        ((TestElement)div.Children[0]).Tag.ShouldBe("p");
+    }
+
+    [Fact]
+    public void Hydrate_DataAllowMismatch_SuppressesTheWarning_ButStillRecovers()
+    {
+        var container = TestServerMarkup.Parse("<div data-allow-mismatch=\"children\"><span>x</span></div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div", null, new VirtualNode?[] { VirtualNodeFactory.Element("p", "x") });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        // The escape hatch suppresses the warning...
+        warnings.Messages.ShouldBeEmpty();
+        // ...but the tree still converges to the client vdom.
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(1);
+        ((TestElement)((TestElement)container.Children[0]).Children[0]).Tag.ShouldBe("p");
+    }
+
+    [Fact]
+    public void Hydrate_ClassMismatch_Warns()
+    {
+        var container = TestServerMarkup.Parse("<div class=\"a b\">hi</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div", VirtualNodeFactory.Properties(("class", "a c")), "hi");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("class mismatch", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Hydrate_ClassMismatch_SuppressedByDataAllowMismatch()
+    {
+        var container = TestServerMarkup.Parse("<div class=\"a b\" data-allow-mismatch=\"class\">hi</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div", VirtualNodeFactory.Properties(("class", "a c")), "hi");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void HydrateElement_ExcessServerChildren_RemovedWithWarning()
+    {
+        var container = TestServerMarkup.Parse("<ul><li>a</li><li>b</li></ul>");
+        var vnode = VirtualNodeFactory.Element("ul", null, new VirtualNode?[] { VirtualNodeFactory.Element("li", "a") });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("more child nodes", StringComparison.OrdinalIgnoreCase));
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(1);
+        ((TestElement)container.Children[0]).Children.Count.ShouldBe(1);
+    }
+
+    // --- components + reactive updates ----------------------------------------------------------
+
+    [Fact]
+    public void HydrateComponent_AdoptsSubtree_AndReactiveUpdatePatchesInPlace_NoRemount()
+    {
+        var message = Reactive.Reference("hello");
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Element("div", null, message.Value, PatchFlags.Text),
+        };
+        var container = TestServerMarkup.Parse("<div>hello</div>");
+        var serverDiv = container.Children[0];
+        var root = VirtualNodeFactory.Component(component);
+
+        _renderer.Hydrate(root, container);
+
+        // Clean hydration: nothing created, inserted, or removed.
+        AssertAdoptedWithoutMutation();
+
+        // A reactive change patches the adopted node in place — no remount (Insert/CreateElement stay 0).
+        _log.Reset();
+        message.Value = "world";
+        _pump.RunUntilIdle();
+
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _log.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        // The same server element carries the new text.
+        container.Children[0].ShouldBeSameAs(serverDiv);
+        ((TestText)((TestElement)serverDiv).Children[0]).Text.ShouldBe("world");
+    }
+
+    [Fact]
+    public void HydrateComponent_MultiRootFragment_AdoptsViaAnchorComments()
+    {
+        var component = new TestComponent
+        {
+            SetupFunction = (_, _) => () => VirtualNodeFactory.Fragment(
+                new VirtualNode?[] { VirtualNodeFactory.Element("span", "a"), VirtualNodeFactory.Element("span", "b") },
+                null,
+                PatchFlags.StableFragment),
+        };
+        var container = TestServerMarkup.Parse("<!--[--><span>a</span><span>b</span><!--]-->");
+        var root = VirtualNodeFactory.Component(component);
+
+        _renderer.Hydrate(root, container);
+
+        AssertAdoptedWithoutMutation();
+        var instance = (ComponentInstance)root.Component!;
+        ((TestComment)instance.Subtree!.El!).Text.ShouldBe("[");
+        ((TestComment)instance.Subtree!.Anchor!).Text.ShouldBe("]");
+    }
+
+    // --- teleport -------------------------------------------------------------------------------
+
+    [Fact]
+    public void HydrateTeleport_Enabled_AdoptsContentAtTarget()
+    {
+        var target = TestServerMarkup.Parse("<div id=\"modal\"><span>x</span><!--teleport anchor--></div>");
+        _renderer.RegisterQueryRoot(target);
+        var modal = (TestElement)target.Children[0];
+        var targetSpan = modal.Children[0];
+
+        var container = TestServerMarkup.Parse("<!--teleport start--><!--teleport end-->");
+        var teleport = VirtualNodeFactory.Teleport(
+            VirtualNodeFactory.Properties(("to", "#modal")),
+            new VirtualNode?[] { VirtualNodeFactory.Element("span", "x") });
+
+        _renderer.Hydrate(teleport, container);
+
+        AssertAdoptedWithoutMutation();
+        // The teleported child adopted the node already sitting in the target, not a fresh one.
+        teleport.ArrayChildren![0].El.ShouldBeSameAs(targetSpan);
+        // The main-tree footprint is the start anchor.
+        ((TestComment)teleport.El!).Text.ShouldBe("teleport start");
+    }
+
+    // --- root fallbacks -------------------------------------------------------------------------
+
+    [Fact]
+    public void Hydrate_EmptyContainer_FallsBackToFullMount()
+    {
+        var container = _renderer.CreateContainer();
+        var vnode = VirtualNodeFactory.Element("div", "fresh");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("container is empty", StringComparison.OrdinalIgnoreCase));
+        // A full mount creates and inserts the tree.
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(1);
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(1);
+        container.Children.Count.ShouldBe(1);
+        ((TestElement)container.Children[0]).Tag.ShouldBe("div");
+    }
+
+    private void AssertAdoptedWithoutMutation()
+    {
+        // A clean hydration issues no node-creating or structural operations — every node is adopted from
+        // the server DOM (upstream: zero DOM mutations). Property patches (listener attachment) are allowed.
+        _log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        _log.Count(TestNodeOperationType.CreateText).ShouldBe(0);
+        _log.Count(TestNodeOperationType.CreateComment).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        _log.Count(TestNodeOperationType.Remove).ShouldBe(0);
+        _log.Count(TestNodeOperationType.SetElementText).ShouldBe(0);
+        _log.Count(TestNodeOperationType.SetText).ShouldBe(0);
+        _log.Count(TestNodeOperationType.InsertStaticContent).ShouldBe(0);
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeCore/test/HydrationTests.cs
+++ b/libraries/Assimalign.Viu.RuntimeCore/test/HydrationTests.cs
@@ -94,23 +94,74 @@ public class HydrationTests : IDisposable
     }
 
     [Fact]
-    public void HydrateElement_ReconcilesOnlyDynamicProps_LeavingStaticPropsUntouched()
+    public void HydrateElement_DynamicNonListenerAttribute_NotPatchedDuringCleanHydration()
     {
-        // The PatchFlag fast path: only the compiler's dynamicProps are reconciled during the walk; the
-        // static id attribute is never patched (upstream: the ShouldHydrateProperty qualification).
+        // v3.5 hydrateElement patches only (forcePatch && value/indeterminate) || (isOn && !reserved) ||
+        // key[0]=='.' || isCustomElement — NOT dynamicProps. A dynamic `title` is left as the server rendered
+        // it; only the click listener is attached. Reconciling it would spend interop per dynamic prop and,
+        // on a mismatch, overwrite the hydrated server value.
+        var clicks = 0;
         var container = TestServerMarkup.Parse("<div id=\"static\" title=\"live\">hi</div>");
         var vnode = VirtualNodeFactory.Element(
             "div",
-            VirtualNodeFactory.Properties(("id", "static"), ("title", "live")),
+            VirtualNodeFactory.Properties(("id", "static"), ("title", "live"), ("onClick", (Action)(() => clicks++))),
             "hi",
-            PatchFlags.Props,
+            PatchFlags.Props | PatchFlags.NeedHydration,
             new[] { "title" });
 
         _renderer.Hydrate(vnode, container);
 
-        _log.Count(TestNodeOperationType.PatchProperty).ShouldBe(1);
-        _log.OfType(TestNodeOperationType.PatchProperty)[0].PropertyName.ShouldBe("title");
+        // Exactly one property patch — the click listener; the dynamic `title` attribute is not touched.
+        var patches = _log.OfType(TestNodeOperationType.PatchProperty);
+        patches.Count.ShouldBe(1);
+        patches[0].PropertyName.ShouldBe("onClick");
         _log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+    }
+
+    [Fact]
+    public void HydrateElement_DynamicAttributeMismatch_WarnsWithoutOverwriting()
+    {
+        // A dynamic attribute whose server value differs: v3.5 warns (propHasMismatch) but does NOT patch —
+        // the server value stays; the next reactive update reconciles it through the normal diff.
+        var container = TestServerMarkup.Parse("<div title=\"server\">hi</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div", VirtualNodeFactory.Properties(("title", "client")), "hi", PatchFlags.Props, new[] { "title" });
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("attribute mismatch", StringComparison.OrdinalIgnoreCase));
+        _log.Count(TestNodeOperationType.PatchProperty).ShouldBe(0);
+        ((TestElement)container.Children[0]).Properties["title"].ShouldBe("server");
+    }
+
+    [Fact]
+    public void Hydrate_TextMismatch_SuppressedByDataAllowMismatchChildren()
+    {
+        // v3.5 isMismatchAllowed: "text is a subset of children" — a text mismatch is suppressed by
+        // data-allow-mismatch="children".
+        var container = TestServerMarkup.Parse("<div data-allow-mismatch=\"children\">server</div>");
+        var vnode = VirtualNodeFactory.Element("div", "client");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Hydrate_ClassMismatch_NotSuppressedByDataAllowMismatchAttribute()
+    {
+        // v3.5 isMismatchAllowed: an "attribute" token does NOT cover class/style — each carries its own
+        // token — so a class mismatch is still reported.
+        var container = TestServerMarkup.Parse("<div class=\"a b\" data-allow-mismatch=\"attribute\">hi</div>");
+        var vnode = VirtualNodeFactory.Element(
+            "div", VirtualNodeFactory.Properties(("class", "a c")), "hi");
+        using var warnings = new WarningCapture();
+
+        _renderer.Hydrate(vnode, container);
+
+        warnings.Messages.ShouldContain(message => message.Contains("class mismatch", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.RuntimeDom/docs/DESIGN.md
@@ -300,6 +300,35 @@ The fix is to participate in the same standard mechanism rather than hand-copy a
   (captured `RuntimeWarnings` sink), the wrapper/children class channels staying separate across a FLIP
   reorder, and a reactive fallthrough-attr change patching the same wrapper element in place.
 
+## Hydration reads: one batched snapshot per root ([V01.01.07.03])
+
+Client hydration (the walker lives in `Assimalign.Viu.RuntimeCore`) reads the existing server DOM to
+decide what to adopt: node kind, tag, text/comment data, first-child/next-sibling structure, and a few
+attributes. Answering each of those with a `JSImport` call per node would make hydration the chattiest
+path in the framework — the opposite of "the boundary is the budget". So the browser answers them the
+same way it answers a FLIP measure or a history read: **one crossing that returns a flat snapshot**.
+
+- **`dom.snapshotHydration(container)`** walks the container's subtree once (`createTreeWalker`),
+  registers a bridge handle for every node (so an adopted node's `int` flows straight into the write-side
+  `patchProp`/`insert`/`remove`), and returns a compact serialization — per node: `handle parent firstChild
+  nextSibling kind`, then `tag attrCount [name value]*` for an element or `data` for text/comment. Strings
+  are length-prefixed (`<len>:<chars>`) so arbitrary content needs no escaping; the length is a UTF-16
+  code-unit count, matching `.NET` `string.Length`.
+- **`BrowserHydrationReader`** parses that once into a handle→node map and answers every
+  `HydrationNodeReader` read locally — **zero** further crossings for the whole walk. A teleport target
+  lies outside the root's subtree, so it takes one additional snapshot (teleports are rare); `registerNode`
+  dedups, so an overlapping re-snapshot is harmless.
+- **Buffered mode** treats the snapshot as a read: it commits any pending command-buffer frame first (so
+  the walk sees committed DOM), then snapshots — the same "reads force a flush" rule `parentNode`/
+  `nextSibling`/`querySelector` follow. `CreateSSRApp` uses the direct path; the buffered wrapper carries a
+  snapshot source too so a buffered renderer is not left mount-only.
+- **`BrowserRuntime.CreateSsrApp(...).Mount(...)`** does **not** clear the container (unlike a client
+  `CreateApp` mount) — the server content is precisely what hydration reuses.
+
+Over-registration is deliberate and bounded: a text node deep inside an adopted element gets a handle even
+though no vnode points at it, but the whole subtree's handles are released together when the element is
+removed (`releaseSubtree`), so a mount/unmount cycle still returns the registries to baseline.
+
 ## Non-goals (sequenced work)
 
 - App bootstrap (`CreateApp`-equivalent, container clearing) — [V01.01.04.04] (#42).

--- a/libraries/Assimalign.Viu.RuntimeDom/src/BrowserApplication.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/BrowserApplication.cs
@@ -20,11 +20,16 @@ public sealed class BrowserApplication
 {
     private readonly Application<int> _application;
     private readonly BufferedBrowserNodeOperations? _bufferedOperations;
+    private readonly bool _hydrate;
 
-    internal BrowserApplication(Application<int> application, BufferedBrowserNodeOperations? bufferedOperations = null)
+    internal BrowserApplication(
+        Application<int> application,
+        BufferedBrowserNodeOperations? bufferedOperations = null,
+        bool hydrate = false)
     {
         _application = application;
         _bufferedOperations = bufferedOperations;
+        _hydrate = hydrate;
     }
 
     /// <summary>Whether the app is currently mounted.</summary>
@@ -164,16 +169,23 @@ public sealed class BrowserApplication
     /// <returns>The root component instance.</returns>
     public ComponentInstance? Mount(int containerHandle)
     {
-        if (!_application.IsMounted)
+        if (_application.IsMounted)
         {
-            // The container is a foreign node the bridge registered (a QuerySelector result); fold its
-            // handle into the buffered handle counter so a buffered create never reuses it. Harmless
-            // in direct mode (no buffered operations).
-            _bufferedOperations?.ObserveForeignHandle(containerHandle);
-            // Non-hydrating client mount clears existing container content (upstream parity);
-            // one interop call that also releases any registered child handles.
-            BrowserRuntime.ClearContainer(containerHandle);
+            // Already mounted: delegate so the app warns and returns the existing instance (upstream parity).
+            return _application.Mount(containerHandle);
         }
+        // The container is a foreign node the bridge registered (a QuerySelector result); fold its handle
+        // into the buffered handle counter so a buffered create never reuses it. Harmless in direct mode.
+        _bufferedOperations?.ObserveForeignHandle(containerHandle);
+        if (_hydrate)
+        {
+            // An app created with CreateSsrApp adopts the existing server-rendered content — the container
+            // is NOT cleared (that content is what hydration reuses).
+            return _application.Hydrate(containerHandle);
+        }
+        // Non-hydrating client mount clears existing container content (upstream parity); one interop call
+        // that also releases any registered child handles.
+        BrowserRuntime.ClearContainer(containerHandle);
         return _application.Mount(containerHandle);
     }
 

--- a/libraries/Assimalign.Viu.RuntimeDom/src/BrowserRuntime.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/BrowserRuntime.cs
@@ -77,6 +77,30 @@ public static class BrowserRuntime
         return new BrowserApplication(renderer.CreateApplication(rootComponent, rootProperties));
     }
 
+    /// <summary>
+    /// Creates a browser application that <b>hydrates</b> existing server-rendered markup rather than
+    /// mounting fresh — the C# port of <c>createSSRApp(rootComponent)</c> in <c>@vue/runtime-dom</c>
+    /// (https://vuejs.org/guide/scaling-up/ssr.html#client-hydration). Its
+    /// <see cref="BrowserApplication.Mount(string)"/> adopts the container's server DOM (attaching event
+    /// listeners and component instances, reconciling only dynamic bindings) instead of clearing and
+    /// recreating it; a server/client mismatch recovers per subtree without crashing. The container must
+    /// already hold the markup the server renderer produced for the same root component.
+    /// </summary>
+    /// <param name="rootComponent">The root component definition (the same one rendered on the server).</param>
+    /// <param name="rootProperties">Props for the root component, or null.</param>
+    /// <returns>The hydrating app; mount it by selector or handle over the server-rendered container.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="rootComponent"/> is null.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="InitializeAsync"/> has not completed.</exception>
+    public static BrowserApplication CreateSsrApp(
+        IComponentDefinition rootComponent,
+        VirtualNodeProperties? rootProperties = null)
+    {
+        ArgumentNullException.ThrowIfNull(rootComponent);
+        EnsureInitialized();
+        var renderer = RendererFactory.CreateRenderer(BrowserNodeOperations.Create());
+        return new BrowserApplication(renderer.CreateApplication(rootComponent, rootProperties), hydrate: true);
+    }
+
     /// <summary>Clears a container's content in one interop call, releasing registered child handles.</summary>
     /// <param name="containerHandle">The container's node handle.</param>
     internal static void ClearContainer(int containerHandle)

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserDomBridge.cs
@@ -141,6 +141,18 @@ internal static partial class BrowserDomBridge
         }
     }
 
+    internal static string SnapshotHydration(int containerHandle)
+    {
+        try
+        {
+            return Imports.SnapshotHydration(containerHandle);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("snapshotHydration", containerHandle, exception);
+        }
+    }
+
     internal static int[] InsertStaticContent(string content, int parentHandle, int anchorHandle, string? namespaceName)
     {
         try
@@ -527,6 +539,9 @@ internal static partial class BrowserDomBridge
 
         [JSImport("dom.nextSibling", ModuleName)]
         internal static partial int NextSibling(int nodeHandle);
+
+        [JSImport("dom.snapshotHydration", ModuleName)]
+        internal static partial string SnapshotHydration(int containerHandle);
 
         [JSImport("dom.insertStaticContent", ModuleName)]
         internal static partial int[] InsertStaticContent(string content, int parentHandle, int anchorHandle, string? namespaceName);

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserHydrationReader.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserHydrationReader.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.RuntimeDom;
+
+/// <summary>
+/// The browser <see cref="HydrationNodeReader{TNode}"/> — decodes the single batched snapshot the JS
+/// bridge produces (<c>dom.snapshotHydration</c>) and answers every hydration read from it, so the
+/// client-side walk crosses the interop boundary once per hydration root rather than a marshaled call
+/// per <c>firstChild</c>/<c>nextSibling</c>/<c>getAttribute</c> (the JS-interop cost discipline the
+/// SSR area requires — see this package's <c>docs/DESIGN.md</c>). Node handles in the snapshot are the
+/// same int handles the write-side node-ops use, so an adopted node's <see cref="int"/> flows straight
+/// into <c>patchProp</c>/<c>insert</c>/<c>remove</c>. The "no node" sentinel is <c>0</c> (the bridge's
+/// reserved handle), matching <see cref="RendererOptions{TNode}"/>'s <c>default</c> convention.
+/// </summary>
+internal sealed class BrowserHydrationReader : HydrationNodeReader<int>
+{
+    private readonly Dictionary<int, SnapshotNode> _nodes;
+
+    internal BrowserHydrationReader(string snapshot)
+    {
+        _nodes = Parse(snapshot);
+    }
+
+    /// <inheritdoc/>
+    public override HydrationNodeKind Kind(int node)
+        => _nodes.TryGetValue(node, out var entry) ? entry.Kind : HydrationNodeKind.Other;
+
+    /// <inheritdoc/>
+    public override int FirstChild(int node) => _nodes.TryGetValue(node, out var entry) ? entry.FirstChild : 0;
+
+    /// <inheritdoc/>
+    public override int NextSibling(int node) => _nodes.TryGetValue(node, out var entry) ? entry.NextSibling : 0;
+
+    /// <inheritdoc/>
+    public override int ParentNode(int node) => _nodes.TryGetValue(node, out var entry) ? entry.Parent : 0;
+
+    /// <inheritdoc/>
+    public override string ElementTag(int node) => _nodes.TryGetValue(node, out var entry) ? entry.Tag : string.Empty;
+
+    /// <inheritdoc/>
+    public override string Data(int node) => _nodes.TryGetValue(node, out var entry) ? entry.Data : string.Empty;
+
+    /// <inheritdoc/>
+    public override string? Attribute(int node, string name)
+        => _nodes.TryGetValue(node, out var entry) && entry.Attributes is { } attributes
+            && attributes.TryGetValue(name, out var value)
+            ? value
+            : null;
+
+    private static Dictionary<int, SnapshotNode> Parse(string snapshot)
+    {
+        var cursor = 0;
+        var count = ReadInt(snapshot, ref cursor);
+        var nodes = new Dictionary<int, SnapshotNode>(count);
+        for (var index = 0; index < count; index++)
+        {
+            var handle = ReadInt(snapshot, ref cursor);
+            var parent = ReadInt(snapshot, ref cursor);
+            var firstChild = ReadInt(snapshot, ref cursor);
+            var nextSibling = ReadInt(snapshot, ref cursor);
+            var kind = ReadInt(snapshot, ref cursor);
+            string tag = string.Empty;
+            string data = string.Empty;
+            Dictionary<string, string>? attributes = null;
+            if (kind == 0)
+            {
+                tag = ReadString(snapshot, ref cursor);
+                var attributeCount = ReadInt(snapshot, ref cursor);
+                if (attributeCount > 0)
+                {
+                    attributes = new Dictionary<string, string>(attributeCount, StringComparer.Ordinal);
+                    for (var attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++)
+                    {
+                        var name = ReadString(snapshot, ref cursor);
+                        var value = ReadString(snapshot, ref cursor);
+                        attributes[name] = value;
+                    }
+                }
+            }
+            else
+            {
+                data = ReadString(snapshot, ref cursor);
+            }
+            nodes[handle] = new SnapshotNode
+            {
+                Kind = kind switch
+                {
+                    0 => HydrationNodeKind.Element,
+                    1 => HydrationNodeKind.Text,
+                    2 => HydrationNodeKind.Comment,
+                    _ => HydrationNodeKind.Other,
+                },
+                Parent = parent,
+                FirstChild = firstChild,
+                NextSibling = nextSibling,
+                Tag = tag,
+                Data = data,
+                Attributes = attributes,
+            };
+        }
+        return nodes;
+    }
+
+    private static int ReadInt(string snapshot, ref int cursor)
+    {
+        var start = cursor;
+        while (cursor < snapshot.Length && snapshot[cursor] != ' ')
+        {
+            cursor++;
+        }
+        var value = int.Parse(snapshot.AsSpan(start, cursor - start), NumberStyles.Integer, CultureInfo.InvariantCulture);
+        cursor++; // skip the terminating space
+        return value;
+    }
+
+    private static string ReadString(string snapshot, ref int cursor)
+    {
+        var lengthStart = cursor;
+        while (cursor < snapshot.Length && snapshot[cursor] != ':')
+        {
+            cursor++;
+        }
+        var length = int.Parse(snapshot.AsSpan(lengthStart, cursor - lengthStart), NumberStyles.Integer, CultureInfo.InvariantCulture);
+        cursor++; // skip ':'
+        var value = snapshot.Substring(cursor, length);
+        cursor += length + 1; // skip the content and the terminating space
+        return value;
+    }
+
+    private sealed class SnapshotNode
+    {
+        public required HydrationNodeKind Kind { get; init; }
+
+        public required int Parent { get; init; }
+
+        public required int FirstChild { get; init; }
+
+        public required int NextSibling { get; init; }
+
+        public required string Tag { get; init; }
+
+        public required string Data { get; init; }
+
+        public required Dictionary<string, string>? Attributes { get; init; }
+    }
+}

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BrowserNodeOperations.cs
@@ -111,6 +111,9 @@ internal static class BrowserNodeOperations
             var span = BrowserDomBridge.InsertStaticContent(content, parent, anchor, elementNamespace);
             return (span[0], span[1]);
         },
+        // Hydration reads are answered from a single batched snapshot of the container subtree (one interop
+        // crossing), not per-node bridge calls ([V01.01.07.03]); see the package DESIGN.md.
+        CreateHydrationReader = static container => new BrowserHydrationReader(BrowserDomBridge.SnapshotHydration(container)),
     };
 
     /// <summary>

--- a/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/Internal/BufferedBrowserNodeOperations.cs
@@ -70,6 +70,7 @@ internal sealed class BufferedBrowserNodeOperations
     private readonly Func<int, int> _parentNode;
     private readonly Func<int, int> _nextSibling;
     private readonly Func<string, int, int, string?, (int First, int Last)> _insertStaticContent;
+    private readonly Func<int, string>? _snapshotHydration;
 
     private Action? _previousFlushBoundary;
     private Func<int, bool, BrowserEvent, int>? _previousDispatcher;
@@ -83,13 +84,15 @@ internal sealed class BufferedBrowserNodeOperations
         Func<string, int> querySelector,
         Func<int, int> parentNode,
         Func<int, int> nextSibling,
-        Func<string, int, int, string?, (int First, int Last)> insertStaticContent)
+        Func<string, int, int, string?, (int First, int Last)> insertStaticContent,
+        Func<int, string>? snapshotHydration = null)
     {
         _applier = applier;
         _querySelector = querySelector;
         _parentNode = parentNode;
         _nextSibling = nextSibling;
         _insertStaticContent = insertStaticContent;
+        _snapshotHydration = snapshotHydration;
         _invokers = new BrowserEventInvokerRegistry(
             (handle, eventName, once, capture, passive) => _buffer.WriteAddEventListener(handle, eventName, once, capture, passive),
             (handle, eventName, capture) => _buffer.WriteRemoveEventListener(handle, eventName, capture));
@@ -163,6 +166,16 @@ internal sealed class BufferedBrowserNodeOperations
             _buffer.ObserveForeignHandle(last);
             return (first, last);
         },
+        // Hydration snapshot is a read: commit any pending frame first so the walk sees committed DOM, then
+        // take the single batched snapshot ([V01.01.07.03]). Null when no snapshot source is wired (the
+        // DOM-free command-buffer tests), leaving the buffered renderer mount-only.
+        CreateHydrationReader = _snapshotHydration is null
+            ? null
+            : container =>
+            {
+                FlushPending();
+                return new BrowserHydrationReader(_snapshotHydration(container));
+            },
     };
 
     /// <summary>
@@ -320,7 +333,8 @@ internal sealed class BufferedBrowserNodeOperations
             {
                 var span = BrowserDomBridge.InsertStaticContent(content, parent, anchor, elementNamespace);
                 return (span[0], span[1]);
-            });
+            },
+            static container => BrowserDomBridge.SnapshotHydration(container));
         operations.Activate();
         return operations;
     }

--- a/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
+++ b/libraries/Assimalign.Viu.RuntimeDom/src/wwwroot/viu-dom.js
@@ -29,6 +29,18 @@ function fail(operation, handle, message) {
     throw new Error(`viu-dom|${operation}|${handle}|${message}`)
 }
 
+// Hydration snapshot serializers ([V01.01.07.03]): ints are space-terminated decimals; strings are
+// length-prefixed (`<len>:<chars> `) so arbitrary content needs no escaping. The length is a UTF-16
+// code-unit count, matching .NET string.Length, so the reader takes exactly that many chars.
+function writeSnapshotInt(parts, value) {
+    parts.push(value + ' ')
+}
+
+function writeSnapshotString(parts, value) {
+    const text = value == null ? '' : String(value)
+    parts.push(text.length + ':' + text + ' ')
+}
+
 function registerNode(node) {
     const existingHandle = nodeHandles.get(node)
     if (existingHandle !== undefined) {
@@ -308,6 +320,56 @@ export const dom = {
     nextSibling: nodeHandle => {
         const sibling = getNode('nextSibling', nodeHandle).nextSibling
         return sibling ? registerNode(sibling) : 0
+    },
+
+    // Hydration snapshot ([V01.01.07.03]): ONE batched interop crossing walks the whole subtree rooted at
+    // the container, registers a handle for every node, and returns a compact serialization the .NET
+    // BrowserHydrationReader answers all subsequent structure/kind/data/attribute reads from — so the
+    // client-side hydration walk crosses the boundary once per root (and once per teleport target) instead
+    // of a marshaled call per firstChild/nextSibling/getAttribute. Per node the wire format is
+    //   handle parent firstChild nextSibling kind  (five space-terminated ints; kind 0/1/2/3)
+    // then, for an element, `tag attrCount [name value]*`, else `data` — every string written length-
+    // prefixed as `<len>:<chars> ` so arbitrary text/attribute content needs no escaping. Reads are
+    // idempotent (registerNode dedups), so re-snapshotting a target that overlaps the root is harmless.
+    snapshotHydration: containerHandle => {
+        const container = getNode('snapshotHydration', containerHandle)
+        const nodes = [container]
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_ALL)
+        let current = walker.nextNode()
+        while (current) {
+            nodes.push(current)
+            current = walker.nextNode()
+        }
+        const parts = []
+        writeSnapshotInt(parts, nodes.length)
+        for (let index = 0; index < nodes.length; index++) {
+            const node = nodes[index]
+            const isRoot = node === container
+            writeSnapshotInt(parts, registerNode(node))
+            writeSnapshotInt(parts, isRoot || !node.parentNode ? 0 : registerNode(node.parentNode))
+            writeSnapshotInt(parts, node.firstChild ? registerNode(node.firstChild) : 0)
+            writeSnapshotInt(parts, isRoot || !node.nextSibling ? 0 : registerNode(node.nextSibling))
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                writeSnapshotInt(parts, 0)
+                writeSnapshotString(parts, node.tagName)
+                const attributes = node.attributes
+                writeSnapshotInt(parts, attributes.length)
+                for (let a = 0; a < attributes.length; a++) {
+                    writeSnapshotString(parts, attributes[a].name)
+                    writeSnapshotString(parts, attributes[a].value)
+                }
+            } else if (node.nodeType === Node.TEXT_NODE) {
+                writeSnapshotInt(parts, 1)
+                writeSnapshotString(parts, node.data)
+            } else if (node.nodeType === Node.COMMENT_NODE) {
+                writeSnapshotInt(parts, 2)
+                writeSnapshotString(parts, node.data)
+            } else {
+                writeSnapshotInt(parts, 3)
+                writeSnapshotString(parts, node.data || '')
+            }
+        }
+        return parts.join('')
     },
 
     // Inserts a multi-node static HTML chunk in ONE interop call via a detached <template>,

--- a/libraries/Assimalign.Viu.ServerRenderer/test/Assimalign.Viu.ServerRenderer.Tests.csproj
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/Assimalign.Viu.ServerRenderer.Tests.csproj
@@ -13,5 +13,9 @@
     <ViuProjectReference Include="Assimalign.Viu.ServerRenderer" />
     <ViuProjectReference Include="Assimalign.Viu.RuntimeCore" />
     <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <!-- The hydration round-trip tests ([V01.01.07.03]) render with the SSR renderer, then parse the
+         output into the in-memory tree and hydrate against it — pinning that the SSR marker output is the
+         exact contract the hydration walker consumes. -->
+    <ViuProjectReference Include="Assimalign.Viu.Testing" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Viu.ServerRenderer/test/HydrationRoundTripTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/HydrationRoundTripTests.cs
@@ -1,0 +1,94 @@
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.RuntimeCore;
+using Assimalign.Viu.Shared;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.ServerRenderer.Tests;
+
+// End-to-end proof that the SSR marker output ([V01.01.07.01]) is exactly the contract the hydration
+// walker ([V01.01.07.03]) consumes: render a component to HTML with the server renderer, parse that HTML
+// into the in-memory tree, and hydrate the SAME component against it — adoption must be mutation-free and
+// reactive updates must patch the adopted nodes in place. This couples the two ends without the walker
+// taking a code dependency on the server renderer (issue #66 boundary): only the emitted byte sequences.
+public class HydrationRoundTripTests
+{
+    [Fact]
+    public async Task SingleRootComponent_ServerRenderedThenHydrated_AdoptsAndUpdatesInPlace()
+    {
+        var message = Reactive.Reference("hello");
+        InlineComponent Component() => new((_, _) => () =>
+            VirtualNodeFactory.Element(
+                "div", VirtualNodeFactory.Properties(("id", "app")), message.Value, PatchFlags.Text));
+
+        // 1. Render on the server.
+        var html = await Ssr.RenderAsync(Component());
+        html.ShouldBe("<div id=\"app\">hello</div>");
+
+        // 2. Parse the server HTML into the in-memory tree and hydrate the same component over it.
+        Scheduler.Reset();
+        using var pump = TestSchedulerPump.Install();
+        var container = TestServerMarkup.Parse(html);
+        var serverDiv = container.Children[0];
+        var renderer = new TestRenderer();
+        var root = VirtualNodeFactory.Component(Component());
+        renderer.Hydrate(root, container);
+
+        // Adoption is mutation-free — the server div is reused.
+        var log = renderer.OperationLog;
+        log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        log.Count(TestNodeOperationType.SetElementText).ShouldBe(0);
+
+        // 3. A reactive update patches the adopted node in place — no remount.
+        log.Reset();
+        message.Value = "world";
+        pump.RunUntilIdle();
+
+        log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        log.Count(TestNodeOperationType.SetElementText).ShouldBe(1);
+        container.Children[0].ShouldBeSameAs(serverDiv);
+        ((TestText)((TestElement)serverDiv).Children[0]).Text.ShouldBe("world");
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public async Task MultiRootComponent_ServerRenderedFragment_HydratesViaAnchorComments()
+    {
+        InlineComponent Component() => new((_, _) => () =>
+            VirtualNodeFactory.Fragment(
+                new VirtualNode?[]
+                {
+                    VirtualNodeFactory.Element("span", "a"),
+                    VirtualNodeFactory.Element("span", "b"),
+                },
+                null,
+                PatchFlags.StableFragment));
+
+        // The server wraps a multi-root component subtree in the fragment markers.
+        var html = await Ssr.RenderAsync(Component());
+        html.ShouldBe("<!--[--><span>a</span><span>b</span><!--]-->");
+
+        Scheduler.Reset();
+        using var pump = TestSchedulerPump.Install();
+        var container = TestServerMarkup.Parse(html);
+        var renderer = new TestRenderer();
+        var root = VirtualNodeFactory.Component(Component());
+        renderer.Hydrate(root, container);
+
+        // The fragment adopts the [ ] anchor comments with no structural mutation.
+        var log = renderer.OperationLog;
+        log.Count(TestNodeOperationType.CreateElement).ShouldBe(0);
+        log.Count(TestNodeOperationType.CreateComment).ShouldBe(0);
+        log.Count(TestNodeOperationType.Insert).ShouldBe(0);
+        var subtree = ((ComponentInstance)root.Component!).Subtree!;
+        ((TestComment)subtree.El!).Text.ShouldBe("[");
+        ((TestComment)subtree.Anchor!).Text.ShouldBe("]");
+        Scheduler.Reset();
+    }
+}

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/FrozenTestHydrationReader.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/FrozenTestHydrationReader.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Testing;
+
+/// <summary>
+/// A hydration reader that mirrors the <b>browser</b>'s snapshot semantics in-memory — the DOM-free
+/// stand-in for <c>BrowserHydrationReader</c>, not the live-tree <see cref="TestHydrationReader"/>. It
+/// takes an <b>immutable pre-walk</b> of the <see cref="TestNode"/> subtree at construction and answers
+/// every read from that frozen copy, so it <b>never</b> reflects an <c>Insert</c>/<c>Remove</c>/<c>SetText</c>
+/// the walker performs afterward — exactly like the batched JS snapshot the browser reads once per root.
+/// <para>
+/// Its purpose is regression coverage: a walker that re-reads structure after mutating (rather than
+/// reading-before-mutate) works against the live reader but breaks against a frozen snapshot — the bug
+/// class the browser hits. Wire it through <see cref="TestRenderer"/>'s snapshot-semantics mode
+/// ([V01.01.07.03]).
+/// </para>
+/// </summary>
+public sealed class FrozenTestHydrationReader : HydrationNodeReader<TestNode>
+{
+    private readonly Dictionary<TestNode, Frame> _frames = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>Pre-walks and freezes the subtree rooted at <paramref name="root"/>.</summary>
+    /// <param name="root">The subtree root (the hydration container, or a teleport target).</param>
+    public FrozenTestHydrationReader(TestNode root)
+    {
+        Capture(root, parent: null, nextSibling: null);
+    }
+
+    /// <inheritdoc/>
+    public override HydrationNodeKind Kind(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.Kind : HydrationNodeKind.Other;
+
+    /// <inheritdoc/>
+    public override TestNode? FirstChild(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.FirstChild : null;
+
+    /// <inheritdoc/>
+    public override TestNode? NextSibling(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.NextSibling : null;
+
+    /// <inheritdoc/>
+    public override TestNode? ParentNode(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.Parent : null;
+
+    /// <inheritdoc/>
+    public override string ElementTag(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.Tag : string.Empty;
+
+    /// <inheritdoc/>
+    public override string Data(TestNode node)
+        => _frames.TryGetValue(node, out var frame) ? frame.Data : string.Empty;
+
+    /// <inheritdoc/>
+    public override string? Attribute(TestNode node, string name)
+        => _frames.TryGetValue(node, out var frame) && frame.Attributes is { } attributes
+            && attributes.TryGetValue(name, out var value)
+            ? value
+            : null;
+
+    private void Capture(TestNode node, TestElement? parent, TestNode? nextSibling)
+    {
+        var element = node as TestElement;
+        _frames[node] = new Frame
+        {
+            Kind = node switch
+            {
+                TestElement => HydrationNodeKind.Element,
+                TestText => HydrationNodeKind.Text,
+                TestComment => HydrationNodeKind.Comment,
+                _ => HydrationNodeKind.Other,
+            },
+            Parent = parent,
+            FirstChild = element is { Children.Count: > 0 } ? element.Children[0] : null,
+            NextSibling = nextSibling,
+            Tag = element?.Tag ?? string.Empty,
+            Data = node switch
+            {
+                TestText text => text.Text,
+                TestComment comment => comment.Text,
+                _ => string.Empty,
+            },
+            Attributes = CaptureAttributes(element),
+        };
+        if (element is null)
+        {
+            return;
+        }
+        for (var index = 0; index < element.Children.Count; index++)
+        {
+            var child = element.Children[index];
+            var sibling = index + 1 < element.Children.Count ? element.Children[index + 1] : null;
+            Capture(child, element, sibling);
+        }
+    }
+
+    private static Dictionary<string, string?>? CaptureAttributes(TestElement? element)
+    {
+        if (element is null || element.Properties.Count == 0)
+        {
+            return null;
+        }
+        var attributes = new Dictionary<string, string?>(element.Properties.Count, System.StringComparer.Ordinal);
+        foreach (var (name, value) in element.Properties)
+        {
+            attributes[name] = value as string ?? System.Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+        return attributes;
+    }
+
+    private sealed class Frame
+    {
+        public required HydrationNodeKind Kind { get; init; }
+
+        public required TestElement? Parent { get; init; }
+
+        public required TestNode? FirstChild { get; init; }
+
+        public required TestNode? NextSibling { get; init; }
+
+        public required string Tag { get; init; }
+
+        public required string Data { get; init; }
+
+        public required Dictionary<string, string?>? Attributes { get; init; }
+    }
+}

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestHydrationReader.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestHydrationReader.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+
+using Assimalign.Viu.RuntimeCore;
+
+namespace Assimalign.Viu.Testing;
+
+/// <summary>
+/// The in-memory <see cref="HydrationNodeReader{TNode}"/> — the DOM-free stand-in for the browser's
+/// batched snapshot reader. It answers the hydration walk's reads directly off the live
+/// <see cref="TestNode"/> tree (the same tree the SSR renderer's output would be parsed into), so a
+/// green hydration test against it implies the same adoption walk against the browser DOM. Stateless
+/// and shared through <see cref="Instance"/>; reads any node in the tree, so one instance serves the
+/// hydration root and every teleport target.
+/// </summary>
+public sealed class TestHydrationReader : HydrationNodeReader<TestNode>
+{
+    /// <summary>The shared, stateless reader instance.</summary>
+    public static readonly TestHydrationReader Instance = new();
+
+    private TestHydrationReader()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override HydrationNodeKind Kind(TestNode node) => node switch
+    {
+        TestElement => HydrationNodeKind.Element,
+        TestText => HydrationNodeKind.Text,
+        TestComment => HydrationNodeKind.Comment,
+        _ => HydrationNodeKind.Other,
+    };
+
+    /// <inheritdoc/>
+    public override TestNode? FirstChild(TestNode node)
+        => node is TestElement element && element.Children.Count > 0 ? element.Children[0] : null;
+
+    /// <inheritdoc/>
+    public override TestNode? NextSibling(TestNode node)
+    {
+        if (node.Parent is null)
+        {
+            return null;
+        }
+        var siblings = node.Parent.Children;
+        var index = siblings.IndexOf(node);
+        return index >= 0 && index + 1 < siblings.Count ? siblings[index + 1] : null;
+    }
+
+    /// <inheritdoc/>
+    public override TestNode? ParentNode(TestNode node) => node.Parent;
+
+    /// <inheritdoc/>
+    public override string ElementTag(TestNode node) => ((TestElement)node).Tag;
+
+    /// <inheritdoc/>
+    public override string Data(TestNode node) => node switch
+    {
+        TestText text => text.Text,
+        TestComment comment => comment.Text,
+        _ => string.Empty,
+    };
+
+    /// <inheritdoc/>
+    public override string? Attribute(TestNode node, string name)
+    {
+        if (node is not TestElement element || !element.Properties.TryGetValue(name, out var value) || value is null)
+        {
+            return null;
+        }
+        return value as string ?? System.Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
@@ -152,6 +152,9 @@ public static class TestNodeOperations
             // wired when target roots are supplied, so a renderer built without them behaves like one
             // that declares no querySelector option (a string Teleport target then warns as unsupported).
             QuerySelector = teleportTargetRoots is null ? null : selector => ResolveTarget(teleportTargetRoots, selector),
+            // The in-memory hydration reader reads the live tree directly (no interop snapshot needed), so
+            // one stateless instance serves the hydration root and every teleport target ([V01.01.07.03]).
+            CreateHydrationReader = _ => TestHydrationReader.Instance,
         };
     }
 

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
@@ -24,12 +24,21 @@ public static class TestNodeOperations
     /// The browser adapter resolves targets through the real DOM <c>querySelector</c>; this registered-root
     /// search is the in-memory stand-in ([V01.01.03.17]).
     /// </param>
+    /// <param name="snapshotSemantics">
+    /// When true, hydration reads are answered by a <see cref="FrozenTestHydrationReader"/> (an immutable
+    /// pre-walk, like the browser's batched snapshot) instead of the live-tree
+    /// <see cref="TestHydrationReader"/>, and <c>Remove</c> throws on a double-remove (like the browser
+    /// bridge's "unknown DOM handle" on a released handle). Together they surface a walker that re-reads
+    /// structure after mutating — the snapshot-safety regression coverage for hydration ([V01.01.07.03]).
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="log"/> is null.</exception>
     public static RendererOptions<TestNode> Create(
         TestNodeOperationLog log,
-        IReadOnlyList<TestElement>? teleportTargetRoots = null)
+        IReadOnlyList<TestElement>? teleportTargetRoots = null,
+        bool snapshotSemantics = false)
     {
         ArgumentNullException.ThrowIfNull(log);
+        var removedNodes = snapshotSemantics ? new HashSet<TestNode>(ReferenceEqualityComparer.Instance) : null;
         return new RendererOptions<TestNode>
         {
             CreateElement = (tag, elementNamespace) =>
@@ -88,6 +97,16 @@ public static class TestNodeOperations
             },
             Remove = child =>
             {
+                // Snapshot-semantics mode mirrors the browser bridge: removing an already-removed node throws
+                // ("unknown DOM handle" on a released handle), so a walker that re-reads a stale sibling from
+                // an immutable snapshot and double-removes fails loudly instead of looping.
+                if (removedNodes is not null && !removedNodes.Add(child))
+                {
+                    throw new InvalidOperationException(
+                        $"Snapshot semantics: node #{child.Identifier} removed twice — the hydration walk "
+                        + "re-read a stale sibling from the immutable snapshot after mutating "
+                        + "(mirrors the browser bridge's 'unknown DOM handle' on a released handle).");
+                }
                 var parent = child.Parent;
                 Detach(child);
                 log.Add(new TestNodeOperation(TestNodeOperationType.Remove, child, parent));
@@ -153,8 +172,12 @@ public static class TestNodeOperations
             // that declares no querySelector option (a string Teleport target then warns as unsupported).
             QuerySelector = teleportTargetRoots is null ? null : selector => ResolveTarget(teleportTargetRoots, selector),
             // The in-memory hydration reader reads the live tree directly (no interop snapshot needed), so
-            // one stateless instance serves the hydration root and every teleport target ([V01.01.07.03]).
-            CreateHydrationReader = _ => TestHydrationReader.Instance,
+            // one stateless instance serves the hydration root and every teleport target. Snapshot-semantics
+            // mode instead builds an immutable FrozenTestHydrationReader per root/target, mirroring the
+            // browser's batched one-crossing snapshot ([V01.01.07.03]).
+            CreateHydrationReader = snapshotSemantics
+                ? container => new FrozenTestHydrationReader(container)
+                : _ => TestHydrationReader.Instance,
         };
     }
 

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestServerMarkup.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestServerMarkup.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Testing;
+
+/// <summary>
+/// Parses a server-rendered HTML fragment into the in-memory <see cref="TestNode"/> tree the
+/// hydration walker adopts — the DOM-free stand-in for a browser parsing SSR output into real DOM
+/// before <c>CreateSSRApp(...).Mount</c>. It understands exactly the vocabulary
+/// <c>Assimalign.Viu.ServerRenderer</c> emits: elements with double/single-quoted or bare
+/// attributes, void elements (no closing tag), text, and comments — including the hydration markers
+/// <c>&lt;!--[--&gt;</c>, <c>&lt;!--]--&gt;</c>, <c>&lt;!----&gt;</c>, and the teleport anchors. Whitespace is
+/// preserved verbatim (Vue SSR emits none between nodes), so write fragments as a single line to mirror
+/// real output. Intended for hydration tests ([V01.01.07.03]).
+/// </summary>
+public static class TestServerMarkup
+{
+    // The WHATWG void elements the SSR renderer emits with no closing tag and no children.
+    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    };
+
+    /// <summary>
+    /// Parses <paramref name="markup"/> into the children of a fresh container element and returns the
+    /// container, ready to hand to <see cref="TestRenderer.Hydrate"/>.
+    /// </summary>
+    /// <param name="markup">The server-rendered HTML fragment.</param>
+    /// <param name="containerTag">The container element's tag (default <c>"root"</c>).</param>
+    /// <returns>The container holding the parsed server tree.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="markup"/> is null.</exception>
+    /// <exception cref="FormatException">The markup is malformed (an unbalanced or unexpected close tag).</exception>
+    public static TestElement Parse(string markup, string containerTag = "root")
+    {
+        ArgumentNullException.ThrowIfNull(markup);
+        var container = new TestElement(containerTag, null);
+        var stack = new Stack<TestElement>();
+        stack.Push(container);
+        var position = 0;
+        while (position < markup.Length)
+        {
+            if (markup[position] == '<')
+            {
+                if (StartsWith(markup, position, "<!--"))
+                {
+                    position = ParseComment(markup, position, stack.Peek());
+                }
+                else if (position + 1 < markup.Length && markup[position + 1] == '/')
+                {
+                    position = ParseCloseTag(markup, position, stack);
+                }
+                else
+                {
+                    position = ParseOpenTag(markup, position, stack);
+                }
+            }
+            else
+            {
+                position = ParseText(markup, position, stack.Peek());
+            }
+        }
+        if (stack.Count != 1)
+        {
+            throw new FormatException($"Unbalanced markup: {stack.Count - 1} element(s) left open.");
+        }
+        return container;
+    }
+
+    private static int ParseComment(string markup, int position, TestElement parent)
+    {
+        var end = markup.IndexOf("-->", position + 4, StringComparison.Ordinal);
+        if (end < 0)
+        {
+            throw new FormatException("Unterminated comment.");
+        }
+        var content = markup[(position + 4)..end];
+        Append(parent, new TestComment(content));
+        return end + 3;
+    }
+
+    private static int ParseCloseTag(string markup, int position, Stack<TestElement> stack)
+    {
+        var end = markup.IndexOf('>', position);
+        if (end < 0)
+        {
+            throw new FormatException("Unterminated close tag.");
+        }
+        var tag = markup[(position + 2)..end].Trim();
+        if (stack.Count <= 1)
+        {
+            throw new FormatException($"Unexpected close tag </{tag}>.");
+        }
+        var open = stack.Pop();
+        if (!string.Equals(open.Tag, tag, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new FormatException($"Mismatched close tag: expected </{open.Tag}>, found </{tag}>.");
+        }
+        return end + 1;
+    }
+
+    private static int ParseOpenTag(string markup, int position, Stack<TestElement> stack)
+    {
+        var end = markup.IndexOf('>', position);
+        if (end < 0)
+        {
+            throw new FormatException("Unterminated open tag.");
+        }
+        var selfClosing = markup[end - 1] == '/';
+        var inner = markup[(position + 1)..(selfClosing ? end - 1 : end)].Trim();
+        var spaceIndex = IndexOfWhitespace(inner);
+        var tag = spaceIndex < 0 ? inner : inner[..spaceIndex];
+        var element = new TestElement(tag, null);
+        if (spaceIndex >= 0)
+        {
+            ParseAttributes(inner[spaceIndex..], element);
+        }
+        Append(stack.Peek(), element);
+        if (!selfClosing && !VoidElements.Contains(tag))
+        {
+            stack.Push(element);
+        }
+        return end + 1;
+    }
+
+    private static int ParseText(string markup, int position, TestElement parent)
+    {
+        var next = markup.IndexOf('<', position);
+        var end = next < 0 ? markup.Length : next;
+        Append(parent, new TestText(markup[position..end]));
+        return end;
+    }
+
+    private static void ParseAttributes(string attributes, TestElement element)
+    {
+        var position = 0;
+        while (position < attributes.Length)
+        {
+            while (position < attributes.Length && char.IsWhiteSpace(attributes[position]))
+            {
+                position++;
+            }
+            if (position >= attributes.Length)
+            {
+                break;
+            }
+            var nameStart = position;
+            while (position < attributes.Length
+                && !char.IsWhiteSpace(attributes[position])
+                && attributes[position] != '=')
+            {
+                position++;
+            }
+            var name = attributes[nameStart..position];
+            if (name.Length == 0)
+            {
+                break;
+            }
+            while (position < attributes.Length && char.IsWhiteSpace(attributes[position]))
+            {
+                position++;
+            }
+            if (position < attributes.Length && attributes[position] == '=')
+            {
+                position++;
+                while (position < attributes.Length && char.IsWhiteSpace(attributes[position]))
+                {
+                    position++;
+                }
+                element.Properties[name] = ParseAttributeValue(attributes, ref position);
+            }
+            else
+            {
+                // A bare boolean attribute (upstream renders these by presence).
+                element.Properties[name] = string.Empty;
+            }
+        }
+    }
+
+    private static string ParseAttributeValue(string attributes, ref int position)
+    {
+        if (position < attributes.Length && (attributes[position] == '"' || attributes[position] == '\''))
+        {
+            var quote = attributes[position];
+            position++;
+            var valueStart = position;
+            while (position < attributes.Length && attributes[position] != quote)
+            {
+                position++;
+            }
+            var value = attributes[valueStart..position];
+            if (position < attributes.Length)
+            {
+                position++;
+            }
+            return value;
+        }
+        var unquotedStart = position;
+        while (position < attributes.Length && !char.IsWhiteSpace(attributes[position]))
+        {
+            position++;
+        }
+        return attributes[unquotedStart..position];
+    }
+
+    private static void Append(TestElement parent, TestNode child)
+    {
+        child.Parent = parent;
+        parent.Children.Add(child);
+    }
+
+    private static int IndexOfWhitespace(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (char.IsWhiteSpace(value[index]))
+            {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static bool StartsWith(string value, int position, string token)
+        => position + token.Length <= value.Length
+            && string.CompareOrdinal(value, position, token, 0, token.Length) == 0;
+}

--- a/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
+++ b/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
@@ -63,4 +63,20 @@ public sealed class TestRenderer
         RegisterQueryRoot(container);
         Renderer.Render(node, container);
     }
+
+    /// <summary>
+    /// Hydrates <paramref name="node"/> against the existing server-rendered children already present in
+    /// <paramref name="container"/> — the DOM-free counterpart of a browser <c>CreateSSRApp(...).Mount</c>
+    /// (upstream: <c>createSSRApp</c>'s hydrating mount, https://vuejs.org/guide/scaling-up/ssr.html#client-hydration).
+    /// Populate <paramref name="container"/> with the server tree first (by hand or by parsing SSR output),
+    /// then hydrate: matching nodes are adopted with zero structural mutations, and a mismatch recovers per
+    /// subtree ([V01.01.07.03]).
+    /// </summary>
+    /// <param name="node">The client vnode tree to hydrate onto the server nodes.</param>
+    /// <param name="container">The container holding the pre-rendered server tree.</param>
+    public void Hydrate(VirtualNode node, TestElement container)
+    {
+        RegisterQueryRoot(container);
+        Renderer.Hydrate(node, container);
+    }
 }

--- a/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
+++ b/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
@@ -18,10 +18,17 @@ public sealed class TestRenderer
     private readonly List<TestElement> _teleportTargetRoots = [];
 
     /// <summary>Creates a renderer over a fresh op log.</summary>
-    public TestRenderer()
+    /// <param name="snapshotSemantics">
+    /// When true, hydration reads use an immutable <see cref="FrozenTestHydrationReader"/> and a double-remove
+    /// throws — mirroring the browser's batched snapshot reader so a hydration walk that re-reads structure
+    /// after mutating fails loudly (the snapshot-safety regression mode, [V01.01.07.03]). Default false
+    /// (live-tree reads).
+    /// </param>
+    public TestRenderer(bool snapshotSemantics = false)
     {
         OperationLog = new TestNodeOperationLog();
-        Renderer = RendererFactory.CreateRenderer(TestNodeOperations.Create(OperationLog, _teleportTargetRoots));
+        Renderer = RendererFactory.CreateRenderer(
+            TestNodeOperations.Create(OperationLog, _teleportTargetRoots, snapshotSemantics));
     }
 
     /// <summary>The underlying platform-agnostic renderer.</summary>


### PR DESCRIPTION
## Summary
- Ports vuejs/core `hydration.ts`: the client adopts server-rendered DOM instead of recreating it — elements/text/comments/fragments (via the `<!--[-->`/`<!--]-->` pairs)/components/teleports, with per-subtree mismatch fallback (a mismatch never crashes; the rest of the tree still adopts; listeners attach exactly once) and `data-allow-mismatch` gating.
- Walker lives in Core as a renderer partial per the issue's boundary (upstream's `createHydrationFunctions` shape), with **one** new node-op: `CreateHydrationReader` — the browser implementation reads a **single batched snapshot** (one interop crossing for the whole container subtree); Testing reads the live tree. Entry: `CreateSsrApp(...).Mount(...)` / `TestRenderer.Hydrate`.
- **Includes the four adversarial-review fixes** (each triple-verified, reproduce-first): snapshot-safe fragment-mismatch removal and adjacent-text split (both browser-only bugs the live-tree test reader masked — now pinned by a `FrozenTestHydrationReader` mirroring browser snapshot semantics), `ShouldHydrateProperty` ported to upstream's exact patch condition (no more redundant dynamic-prop patches or overwrite-on-mismatch), and `data-allow-mismatch` gating made character-exact (including text-allowed-by-children).
- Lazy hydration strategies (idle/visible/media/interaction) are browser-API-bound and deferred to [#229](https://github.com/assimalign/viu/issues/229); SSR→hydrate round-trip pins live in the ServerRenderer suite.

**TRAIN BASE — merge FIRST.** This PR is the base of the .NET reshape train (R1–R5 stack on it; see `docs/NET-RESHAPE-PLAN.md` arriving with the R1 PR).

## Verification
0-warning solution build · RuntimeCore 287, ServerRenderer 67 (incl. round-trips), Browser-suite + Testing green · adoption pinned with `Insert==0`/`CreateElement==0`, reactive-update-no-remount pins.

Closes #66
Refs #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)