### PR TITLE
fix(build): isolate the nested language-server publish outputs

### DIFF
--- a/build/Targets/Build.Global.props
+++ b/build/Targets/Build.Global.props
@@ -12,6 +12,37 @@
 		<ViuOutputPathForDevScripts>$(ViuRepositoryDirectory)scripts\modules</ViuOutputPathForDevScripts>
 	</PropertyGroup>
 
+	<!--
+	  The ViuPublishLanguageServer target (build\Targets\Build.LanguageServer.targets) publishes the
+	  language server through a NESTED `dotnet publish` process while the rest of the solution keeps
+	  building in parallel on other MSBuild nodes. That publish carries publish-only global properties
+	  the ordinary build does not (in Debug, DebugType=embedded so symbols live inside the single
+	  file), and global properties flow into every ProjectReference — so without isolation the nested
+	  process re-compiles the shared netstandard2.0 libraries into the SAME bin\ and obj\ folders the
+	  solution build is using. The embedded-symbol variant produces no standalone .pdb, its
+	  IncrementalClean pass then deletes the .pdb recorded in the previous build's
+	  FileListAbsolute.txt, and any test project copying those references locally fails with MSB3030
+	  "Could not copy ...pdb" — intermittently, because it depends on node scheduling. Redirecting the
+	  nested publish's entire project graph into sibling bin\language-server\ and obj\language-server\
+	  roots removes every such collision by construction, while keeping DebugType global so ALL
+	  assemblies in the single file still carry embedded symbols in Debug.
+
+	  These two properties must be set here, in the Directory.Build.props chain, because
+	  Microsoft.Common.props derives MSBuildProjectExtensionsPath (where NuGet restore writes its
+	  assets) from BaseIntermediateOutputPath immediately after importing Directory.Build.props —
+	  a .targets file is far too late.
+
+	  DefaultItemExcludes must re-exclude the ordinary bin\ and obj\ explicitly: the SDK only
+	  excludes $(BaseOutputPath) and $(BaseIntermediateOutputPath) from the default item globs, so
+	  once those are redirected the outer build's obj\Debug\...\AssemblyInfo.cs would fall into this
+	  evaluation's **\*.cs compile glob and fail with CS0579 duplicate-attribute errors.
+	-->
+	<PropertyGroup Condition="'$(ViuLanguageServerNestedPublish)' == 'true'">
+		<BaseOutputPath>$(MSBuildProjectDirectory)\bin\language-server\</BaseOutputPath>
+		<BaseIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\language-server\</BaseIntermediateOutputPath>
+		<DefaultItemExcludes>$(DefaultItemExcludes);bin/**;obj/**</DefaultItemExcludes>
+	</PropertyGroup>
+
 	<!-- TODO: Need to verify if this is the correct way for generating the Intermediate path  -->
 	<PropertyGroup>
         <_ViuIntermediateOutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(MSBuildProjectDirectory)\obj$(IntermediateOutputPath)$(Configuration)\</_ViuIntermediateOutputPath>

--- a/build/Targets/Build.LanguageServer.targets
+++ b/build/Targets/Build.LanguageServer.targets
@@ -13,6 +13,13 @@
       * the extension build itself        -> ViuIncludeLanguageServerPayload depends on it
 
     Everything here is inert unless a project opts in with ViuLanguageServerPublishEnabled=true.
+
+    The nested `dotnet publish` always runs with ViuLanguageServerNestedPublish=true, which
+    build\Targets\Build.Global.props turns into isolated bin\language-server\ and
+    obj\language-server\ output roots for every project in the publish graph. The publish runs
+    concurrently with the rest of the solution build, and its publish-only global properties
+    (DebugType in Debug) must never rewrite the bin\obj folders that build is reading — see the
+    comment on the Exec below.
   -->
 
   <PropertyGroup>
@@ -174,7 +181,16 @@
          Studio's own MSBuild. Left inherited, the nested dotnet CLI resolves the wrong SDK and the
          net10.0 server fails to build. Only those two are unset: clearing the MSBuildExtensionsPath
          family as well breaks Microsoft.NET.Sdk resolution outright. -->
-    <Exec Command="dotnet publish &quot;$(ViuLanguageServerProjectPath)&quot; --nologo --configuration $(Configuration) --runtime %(ViuLanguageServerRuntimeIdentifier.Identity) --self-contained true --output &quot;$(ViuLanguageServerPublishPath)\%(ViuLanguageServerRuntimeIdentifier.Identity)&quot; -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=$(ViuLanguageServerPublishDebugType)$(_ViuLanguageServerVersionArguments)"
+    <!-- ViuLanguageServerNestedPublish=true makes build\Targets\Build.Global.props redirect this
+         nested build's ENTIRE project graph into sibling bin\language-server\ and
+         obj\language-server\ roots. The publish-only global properties on this command line —
+         DebugType above all — flow into every ProjectReference, so without the redirect the nested
+         process rewrites the shared libraries' ordinary bin\obj folders (deleting their standalone
+         .pdb files in Debug) while the rest of the solution builds against them in parallel: the
+         intermittent MSB3030 missing-.pdb failures. Keeping DebugType on the command line, rather
+         than scoping it to the server csproj, is deliberate — it is what embeds symbols for every
+         assembly in the single file, not just the server's own. -->
+    <Exec Command="dotnet publish &quot;$(ViuLanguageServerProjectPath)&quot; --nologo --configuration $(Configuration) --runtime %(ViuLanguageServerRuntimeIdentifier.Identity) --self-contained true --output &quot;$(ViuLanguageServerPublishPath)\%(ViuLanguageServerRuntimeIdentifier.Identity)&quot; -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:ViuLanguageServerNestedPublish=true -p:DebugType=$(ViuLanguageServerPublishDebugType)$(_ViuLanguageServerVersionArguments)"
           WorkingDirectory="$(ViuRepositoryDirectory)" />
 
     <Touch Files="$(ViuLanguageServerPublishStampFile)" AlwaysCreate="true" />

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
@@ -389,8 +389,14 @@ no-install fallback in [`extensions/VisualStudio/README.md`](../../README.md).
 The shared `ViuPublishLanguageServer` target in `build/Targets/Build.LanguageServer.targets`
 publishes self-contained, single-file .NET language-server executables for `win-x64` and
 `win-arm64`; `Build.ps1` and the extension build both drive that one target, so an in-IDE build can
-never package a stale server. The extension selects the executable matching
-`RuntimeInformation.ProcessArchitecture`.
+never package a stale server. The publish is a nested `dotnet publish` process that runs while the
+rest of the solution keeps building, so it stamps `ViuLanguageServerNestedPublish=true` on itself
+and `build/Targets/Build.Global.props` redirects its entire project graph into isolated
+`bin/language-server/` and `obj/language-server/` output roots. Without that isolation the
+publish-only global properties (embedded symbols in Debug) rebuilt the shared libraries into the
+same `bin`/`obj` folders the solution build was reading, deleting their standalone `.pdb` files and
+causing intermittent MSB3030 failures in the test projects that copy those references. The
+extension selects the executable matching `RuntimeInformation.ProcessArchitecture`.
 
 Self-contained packaging is the current implementation, **not an invariant**. Recorded decision
 (2026-08-02, [V01.01.12.23] #259): the fully shipped product is expected to require a locally


### PR DESCRIPTION
## Problem

`dotnet build Assimalign.Viu.slnx` failed intermittently with MSB3030 "Could not copy the file ...\bin\Debug\netstandard2.0\<Lib>.pdb because it was not found" for the shared netstandard2.0 libraries (`Assimalign.Viu.Syntax`, `Assimalign.Viu.Syntax.Css`, `Assimalign.Viu.Syntax.Templates`, `Assimalign.Viu.Syntax.SingleFileComponent`, `Assimalign.Viu.Tooling.Css`, `Assimalign.Viu.Tooling.SingleFileComponent`), reported by dependent test projects. A second build always succeeded.

Deterministic repro (before this fix):

```powershell
Remove-Item -Recurse -Force _out\extensions\VisualStudio\Debug\LanguageServer
dotnet build Assimalign.Viu.slnx   # fails with MSB3030
dotnet build Assimalign.Viu.slnx   # succeeds
```

## Root cause

The `ViuPublishLanguageServer` target runs a nested `dotnet publish` with `-p:DebugType=embedded` (Debug) on the command line, in parallel with the rest of the solution build. Global properties flow into every `ProjectReference`, so the nested publish rebuilt the shared netstandard2.0 libraries into the **same** `bin\Debug\netstandard2.0` folders the solution build was reading. The embedded-symbol variant produces no standalone `.pdb`, its `IncrementalClean` deleted the `.pdb` recorded in the previous `FileListAbsolute.txt`, and whichever test project copied those references next hit MSB3030 — intermittently, because it depended on MSBuild node scheduling.

## Fix

The nested publish now stamps `ViuLanguageServerNestedPublish=true` on itself, and `build/Targets/Build.Global.props` redirects its entire project graph into sibling `bin\language-server\` and `obj\language-server\` output roots, so it can never rewrite the folders the solution build is using:

- `build/Targets/Build.LanguageServer.targets` — the publish `Exec` passes the marker; header and Exec-site comments document the decision. `DebugType` deliberately stays global so **all** assemblies in the single file keep embedded symbols in Debug (scoping it to the server csproj would have dropped the referenced libraries' symbols and leaked loose `.pdb` files into the VSIX payload). `Build.ps1` and the in-IDE F5 path still drive the same target, so both callers get the fix.
- `build/Targets/Build.Global.props` — the marker redirects `BaseOutputPath`/`BaseIntermediateOutputPath` (set in the props chain because NuGet derives `MSBuildProjectExtensionsPath` from it before any `.targets` loads) and re-adds the ordinary `bin/**;obj/**` to `DefaultItemExcludes`, since the SDK derives the default item excludes from the redirected base paths and the outer build's generated `AssemblyInfo.cs` would otherwise fall into the compile glob (CS0579).
- `extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md` § Packaging — records the isolation decision.

## Verification

- Repro above: after the fix, the build after deleting the payload passes **first try** at 0 warnings / 0 errors, with both `win-x64` and `win-arm64` publishes confirmed re-running.
- All six libraries keep their standalone `.pdb` files in `bin\Debug\netstandard2.0` after the publish; the isolated `bin\language-server\` output carries the dll with no `.pdb` (symbols embedded, unchanged behavior).
- Clean-tree first build and a follow-up incremental build both finish 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
