### PR TITLE
feat(tooling): fold nested template elements in single-file components [V01.01.12.07.07]

### DIFF
--- a/tooling/Assimalign.Viu.Tooling.LanguageServer/test/LanguageServerFoldingRangeTests.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageServer/test/LanguageServerFoldingRangeTests.cs
@@ -11,8 +11,10 @@ using Xunit;
 namespace Assimalign.Viu.Tooling.LanguageServer;
 
 /// <summary>
-/// Pins textDocument/foldingRange serialization: one line-only fold per multi-line block, ending
-/// one line above the closing delimiter.
+/// Pins textDocument/foldingRange serialization: one line-only fold per multi-line block and per
+/// multi-line template element ([V01.01.12.07.07]), each ending one line above its closing delimiter.
+/// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange">
+/// Language Server Protocol 3.17 — textDocument/foldingRange</see>.
 /// </summary>
 public class LanguageServerFoldingRangeTests
 {
@@ -47,6 +49,48 @@ public class LanguageServerFoldingRangeTests
         ranges[0].GetProperty("endLine").GetInt32().ShouldBe(1);
         ranges[1].GetProperty("startLine").GetInt32().ShouldBe(3);
         ranges[1].GetProperty("endLine").GetInt32().ShouldBe(4);
+
+        foreach (var message in messages)
+        {
+            message.Dispose();
+        }
+    }
+
+    // The nested elements travel over the wire as plain line-only ranges alongside the block ranges,
+    // in document order: <template> (0-3), <article> (1-2), then the @script block (5-6).
+    [Fact]
+    public async Task RunAsync_FoldingRangeRequest_ReturnsNestedTemplateElementRanges()
+    {
+        var inputBytes = Encoding.UTF8.GetBytes(
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Panel.viu","languageId":"viu","version":1,"text":"<template>\n    <article>\n        <h1>Title</h1>\n    </article>\n</template>\n@script {\n    public int Count;\n}\n"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","id":"folding","method":"textDocument/foldingRange","params":{"textDocument":{"uri":"file:///Panel.viu"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """));
+
+        await using var input = new MemoryStream(inputBytes);
+        await using var output = new MemoryStream();
+        var host = new LanguageServerHost();
+
+        await host.RunAsync(input, output);
+
+        output.Position = 0;
+        var messages = await ReadAllMessagesAsync(output);
+        var ranges = messages[1].RootElement.GetProperty("result");
+        ranges.GetArrayLength().ShouldBe(3);
+        ranges[0].GetProperty("startLine").GetInt32().ShouldBe(0);
+        ranges[0].GetProperty("endLine").GetInt32().ShouldBe(3);
+        ranges[1].GetProperty("startLine").GetInt32().ShouldBe(1);
+        ranges[1].GetProperty("endLine").GetInt32().ShouldBe(2);
+        ranges[2].GetProperty("startLine").GetInt32().ShouldBe(5);
+        ranges[2].GetProperty("endLine").GetInt32().ShouldBe(6);
 
         foreach (var message in messages)
         {

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Abstraction/IViuLanguageService.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Abstraction/IViuLanguageService.cs
@@ -100,13 +100,22 @@ public interface IViuLanguageService
         string documentUri,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Gets the foldable block-content ranges for an open document.</summary>
+    /// <summary>
+    /// Gets the foldable ranges for an open document: one range per multi-line block container, plus
+    /// one per multi-line element inside the template block ([V01.01.12.07.07]) — nested elements and
+    /// nested <c>&lt;template&gt;</c> fragments included. A single-line element and a self-closing
+    /// element fold nothing, and neither does an element the parse had to recover from missing markup.
+    /// </summary>
     /// <param name="documentUri">The document URI used by the editor.</param>
     /// <param name="cancellationToken">
     /// The token that cancels the computation. Cancellation is cooperative; a canceled call throws
     /// <see cref="System.OperationCanceledException"/> and leaves no service state modified.
     /// </param>
-    /// <returns>The folding ranges, or an empty list when the document is not open.</returns>
+    /// <returns>
+    /// The folding ranges in document order — a container's range ahead of the ranges nested inside
+    /// it — or an empty list when the document is not open. The result is not truncated: a document
+    /// contributes one range per foldable construct, however many that is.
+    /// </returns>
     IReadOnlyList<LanguageFoldingRange> GetFoldingRanges(
         string documentUri,
         CancellationToken cancellationToken = default);

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Assimalign.Viu.Tooling.LanguageService.csproj
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Assimalign.Viu.Tooling.LanguageService.csproj
@@ -14,6 +14,11 @@
          exact scope id the build's source generator derives, so the editor-built generated document
          is identical to the generator's by construction. -->
     <ViuProjectReference Include="Assimalign.Viu.Tooling.Css" />
+    <!-- Template element folding ([V01.01.12.07.07]) parses the template block's markup with the same
+         recoverable template parser the build compiles templates with, so the elements the editor folds
+         are exactly the elements the build sees. Already in the closure transitively; declared here
+         because this project now compiles against it. -->
+    <ViuProjectReference Include="Assimalign.Viu.Syntax.Templates" />
     <!-- Viu Utilities IntelliSense ([V01.01.12.07.01], #247) consumes the same candidate grammar,
          variant registry, and eventual design-system catalog as build-time CSS generation. Keeping the
          engine out of this project would force an editor-only catalog that can drift from emitted CSS. -->

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/LanguageDocument.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/LanguageDocument.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 using Assimalign.Viu.Syntax.SingleFileComponent;
 
@@ -7,6 +9,13 @@ namespace Assimalign.Viu.Tooling.LanguageService;
 
 internal sealed class LanguageDocument
 {
+    // Template element folding ([V01.01.12.07.07]) needs the block's markup parsed, which the
+    // container parse deliberately does not do. The document snapshot is immutable and replaced
+    // whole on every edit, so computing the ranges once here keeps the per-request contract: an
+    // unedited document answers every folding request from one template parse. Publication is
+    // thread-safe because reads run outside the service's synchronization lock.
+    private readonly Lazy<IReadOnlyList<LanguageFoldingRange>> templateElementFoldingRanges;
+
     private LanguageDocument(
         string documentUri,
         string text,
@@ -17,6 +26,9 @@ internal sealed class LanguageDocument
         Text = text;
         Version = version;
         Syntax = syntax;
+        templateElementFoldingRanges = new Lazy<IReadOnlyList<LanguageFoldingRange>>(
+            () => TemplateFoldingRangeCollector.Collect(syntax.Template),
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     internal string DocumentUri { get; }
@@ -26,6 +38,14 @@ internal sealed class LanguageDocument
     internal int? Version { get; }
 
     internal LanguageDocumentSyntax Syntax { get; }
+
+    /// <summary>
+    /// The folding ranges for the multi-line elements inside this document's template block, in
+    /// document order and in the document's own line coordinates. Computed on first use and cached
+    /// for the life of the snapshot.
+    /// </summary>
+    internal IReadOnlyList<LanguageFoldingRange> TemplateElementFoldingRanges
+        => templateElementFoldingRanges.Value;
 
     internal static LanguageDocument Create(string documentUri, string text, int? version)
     {

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/TemplateFoldingRangeCollector.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/TemplateFoldingRangeCollector.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.Syntax;
+using Assimalign.Viu.Syntax.SingleFileComponent;
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.Tooling.LanguageService;
+
+/// <summary>
+/// Computes the element-level folding ranges inside a template block ([V01.01.12.07.07]): one range
+/// per multi-line element that carries its own end tag, in document order, addressed in the
+/// document's zero-based line coordinates so the ranges compose with the section ranges the service
+/// emits for the block containers themselves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The container parse slices a template block but never parses its markup, so the elements come from
+/// a template parse of the block content. That parse is per document, not per request: the service
+/// caches the computed ranges on the immutable open-document snapshot, so an unedited document answers
+/// every folding request from the first parse.
+/// </para>
+/// <para>
+/// The markup is parsed with the DOM host's options so void elements (<c>&lt;br&gt;</c>,
+/// <c>&lt;img&gt;</c>) and raw-text elements behave as they do in a browser: a void element is not a
+/// container and therefore never opens a fold that would otherwise swallow its following siblings.
+/// </para>
+/// <para>
+/// Ranges follow the Language Server Protocol folding-range contract — the folded region runs from the
+/// end of <c>startLine</c> through the end of <c>endLine</c>, so an element's fold stops one line above
+/// its end tag and the end tag stays visible while the element is collapsed, matching the convention
+/// the block-container ranges already use.
+/// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange">
+/// Language Server Protocol 3.17 — textDocument/foldingRange</see>.
+/// </para>
+/// </remarks>
+internal static class TemplateFoldingRangeCollector
+{
+    /// <summary>
+    /// Collects the folding ranges for the multi-line elements inside <paramref name="template"/>.
+    /// Returns an empty list when there is no template block, when its content is empty, and for a
+    /// block whose elements all fold to nothing.
+    /// </summary>
+    /// <param name="template">The container parse's template block, or <see langword="null"/>.</param>
+    /// <returns>The element ranges in document order.</returns>
+    internal static IReadOnlyList<LanguageFoldingRange> Collect(
+        SingleFileComponentTemplateBlock? template)
+    {
+        if (template is null || template.Content.Length == 0)
+        {
+            return Array.Empty<LanguageFoldingRange>();
+        }
+
+        // Elements the parser recovered rather than matched: an unclosed element is reported at the
+        // offset of its open tag, and gets no range at all — its recovered span ends wherever the
+        // recovery landed, which is not a place a fold may end.
+        var unclosedOffsets = new HashSet<int>();
+        var options = ParserOptions.CreateHtml();
+        options.OnError = error =>
+        {
+            if (error.Code == CompilerErrorCode.XMissingEndTag)
+            {
+                unclosedOffsets.Add(error.Location.Start.Offset);
+            }
+        };
+
+        // Recoverable by contract: malformed markup is reported through OnError and never throws.
+        var root = TemplateParser.Parse(template.Content, options);
+        var lineStarts = GetLineStarts(template.Content);
+        // Content line 0 sits on the document line the content starts on — the block's own open-tag
+        // line for a tag container, the line after the header for an @-block container.
+        var documentLineOffset = Math.Max(template.ContentLocation.Start.Line - 1, 0);
+
+        var ranges = new List<LanguageFoldingRange>();
+        var pending = new Stack<ElementNode>();
+        PushElements(root.Children, pending);
+        while (pending.Count > 0)
+        {
+            var element = pending.Pop();
+            var range = CreateRange(
+                element,
+                template.Content.Length,
+                lineStarts,
+                documentLineOffset,
+                unclosedOffsets);
+            if (range is not null)
+            {
+                ranges.Add(range);
+            }
+
+            PushElements(element.Children, pending);
+        }
+
+        return ranges;
+    }
+
+    // Depth-first in document order: children are pushed in reverse so the first child pops first,
+    // which puts a parent's range ahead of its descendants' and siblings' in source order.
+    private static void PushElements(
+        SyntaxList<TemplateChildNode> children,
+        Stack<ElementNode> pending)
+    {
+        for (var index = children.Count - 1; index >= 0; index--)
+        {
+            if (children[index] is ElementNode element)
+            {
+                pending.Push(element);
+            }
+        }
+    }
+
+    private static LanguageFoldingRange? CreateRange(
+        ElementNode element,
+        int contentLength,
+        int[] lineStarts,
+        int documentLineOffset,
+        HashSet<int> unclosedOffsets)
+    {
+        // A self-closing element has no end tag to keep visible, and neither does an element the
+        // parser had to recover; both fold to nothing rather than to a span the author never wrote.
+        if (element.IsSelfClosing ||
+            unclosedOffsets.Contains(element.Location.Start.Offset) ||
+            !EndsWithMatchingCloseTag(element.Location.Source, element.Tag))
+        {
+            return null;
+        }
+
+        var startOffset = element.Location.Start.Offset;
+        // The span end is exclusive, so the last character of the end tag is the offset before it —
+        // asking for the end tag's own line rather than for whatever follows the '>'.
+        var closeTagOffset = element.Location.End.Offset - 1;
+        if (startOffset < 0 || closeTagOffset <= startOffset || closeTagOffset >= contentLength)
+        {
+            return null;
+        }
+
+        var startLine = documentLineOffset + GetLineIndex(lineStarts, startOffset);
+        var endLine = documentLineOffset + GetLineIndex(lineStarts, closeTagOffset) - 1;
+        // A single-line element, and an element whose end tag opens the line right after its open
+        // tag, fold nothing — and a range can never invert, whatever span the parse produced.
+        return endLine > startLine
+            ? new LanguageFoldingRange(startLine, endLine)
+            : null;
+    }
+
+    // Whether the element's own source ends with its end tag. This is what separates a matched
+    // element from a void element, a self-closing element, and an element the parse closed
+    // implicitly at an ancestor's end tag: only a matched element's span ends with '</tag>'.
+    private static bool EndsWithMatchingCloseTag(string source, string tag)
+    {
+        var index = source.Length - 1;
+        if (index < 0 || source[index] != '>')
+        {
+            return false;
+        }
+
+        index--;
+        while (index >= 0 && char.IsWhiteSpace(source[index]))
+        {
+            index--;
+        }
+
+        var nameStart = index + 1 - tag.Length;
+        // '</' has to precede the name, so the name cannot start before offset 2.
+        if (nameStart < 2 ||
+            string.Compare(source, nameStart, tag, 0, tag.Length, StringComparison.OrdinalIgnoreCase) != 0)
+        {
+            return false;
+        }
+
+        return source[nameStart - 1] == '/' && source[nameStart - 2] == '<';
+    }
+
+    // The start offset of each line in the block content. '\n', '\r\n', and a lone '\r' each end one
+    // line, matching how the container parse numbers the document's lines.
+    private static int[] GetLineStarts(string content)
+    {
+        var starts = new List<int> { 0 };
+        for (var index = 0; index < content.Length; index++)
+        {
+            var character = content[index];
+            if (character == '\r')
+            {
+                if (index + 1 < content.Length && content[index + 1] == '\n')
+                {
+                    index++;
+                }
+            }
+            else if (character != '\n')
+            {
+                continue;
+            }
+
+            starts.Add(index + 1);
+        }
+
+        return starts.ToArray();
+    }
+
+    // The index of the line containing offset (binary search over the line starts).
+    private static int GetLineIndex(int[] lineStarts, int offset)
+    {
+        var low = 0;
+        var high = lineStarts.Length - 1;
+        while (low < high)
+        {
+            var middle = (low + high + 1) >> 1;
+            if (lineStarts[middle] <= offset)
+            {
+                low = middle;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        return low;
+    }
+}

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/ViuLanguageService.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/ViuLanguageService.cs
@@ -369,6 +369,8 @@ internal sealed class ViuLanguageService :
         var ranges = new List<LanguageFoldingRange>();
         foreach (var block in CollectBlocks(document.Syntax))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // The fold stops one line short of the block end so the closing delimiter ('}' or
             // '</template>') stays visible while the block is collapsed.
             var startLine = ToLanguagePosition(block.Location.Start).Line;
@@ -376,6 +378,14 @@ internal sealed class ViuLanguageService :
             if (endLine > startLine)
             {
                 ranges.Add(new LanguageFoldingRange(startLine, endLine));
+            }
+
+            // Element folding ([V01.01.12.07.07]) is additive: the section range above is unchanged
+            // and each multi-line element inside the template contributes a nested range, emitted
+            // right after its section so the whole result stays in document order.
+            if (ReferenceEquals(block, document.Syntax.Template))
+            {
+                ranges.AddRange(document.TemplateElementFoldingRanges);
             }
         }
 

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/test/FoldingRangeTests.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/test/FoldingRangeTests.cs
@@ -5,12 +5,19 @@ using Xunit;
 namespace Assimalign.Viu.Tooling.LanguageService;
 
 /// <summary>
-/// Pins block-content folding: a fold covers the block content while the closing delimiter line
-/// stays visible, and single-line blocks fold nothing.
+/// Pins folding: a block-container fold covers the block content while the closing delimiter line
+/// stays visible, and every multi-line element inside the template block adds a nested fold under the
+/// same convention ([V01.01.12.07.07]). Ranges follow the Language Server Protocol folding-range
+/// contract — the folded region runs from the end of <c>startLine</c> through the end of
+/// <c>endLine</c>:
+/// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange">
+/// Language Server Protocol 3.17 — textDocument/foldingRange</see>.
 /// </summary>
 public class FoldingRangeTests
 {
     private const string DocumentUri = "file:///workspace/Counter.viu";
+
+    private const string VueDocumentUri = "file:///workspace/Counter.vue";
 
     [Fact]
     public void GetFoldingRanges_BlockContent_KeepsClosingDelimiterVisible()
@@ -40,5 +47,258 @@ public class FoldingRangeTests
         service.OpenDocument(DocumentUri, "<template><div /></template>\n", 1);
 
         service.GetFoldingRanges(DocumentUri).ShouldBeEmpty();
+    }
+
+    // The section range and the element ranges coexist: the template's own fold is unchanged and each
+    // nested multi-line element adds its own, parent before child, in document order.
+    [Fact]
+    public void GetFoldingRanges_NestedElements_ComposesSectionAndElementRanges()
+    {
+        const string source =
+            "<template>\n" +                     // 0
+            "    <article class=\"card\">\n" +   // 1
+            "        <header>\n" +               // 2
+            "            <h1>\n" +               // 3
+            "                Title\n" +          // 4
+            "            </h1>\n" +              // 5
+            "        </header>\n" +              // 6
+            "        <slot name=\"badge\" />\n" + // 7
+            "    </article>\n" +                 // 8
+            "</template>\n" +                    // 9
+            "@script {\n" +                      // 10
+            "    public int Count;\n" +          // 11
+            "}\n";                               // 12
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(5);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 8));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 7));
+        ranges[2].ShouldBe(new LanguageFoldingRange(StartLine: 2, EndLine: 5));
+        ranges[3].ShouldBe(new LanguageFoldingRange(StartLine: 3, EndLine: 4));
+        ranges[4].ShouldBe(new LanguageFoldingRange(StartLine: 10, EndLine: 11));
+    }
+
+    [Fact]
+    public void GetFoldingRanges_SiblingElements_FoldsEachSibling()
+    {
+        const string source =
+            "<template>\n" +      // 0
+            "    <div>\n" +       // 1
+            "        one\n" +     // 2
+            "    </div>\n" +      // 3
+            "    <div>\n" +       // 4
+            "        two\n" +     // 5
+            "    </div>\n" +      // 6
+            "</template>\n";      // 7
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(3);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 6));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 2));
+        ranges[2].ShouldBe(new LanguageFoldingRange(StartLine: 4, EndLine: 5));
+    }
+
+    // A single-line element folds nothing: there is no line between its open and close tags to hide.
+    [Fact]
+    public void GetFoldingRanges_SingleLineElement_ReturnsNoElementRange()
+    {
+        const string source =
+            "<template>\n" +                        // 0
+            "    <div><span>text</span></div>\n" +  // 1
+            "</template>\n";                        // 2
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(1);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 1));
+    }
+
+    // A self-closing element folds nothing even when its open tag wraps across lines: it has no end
+    // tag, so there is no closing delimiter for the fold to leave visible.
+    [Fact]
+    public void GetFoldingRanges_SelfClosingElement_ReturnsNoElementRange()
+    {
+        const string source =
+            "<template>\n" +               // 0
+            "    <slot\n" +                // 1
+            "        name=\"badge\" />\n" + // 2
+            "</template>\n";               // 3
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(1);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 2));
+    }
+
+    // A nested <template> slot fragment is an element like any other and folds like one.
+    [Fact]
+    public void GetFoldingRanges_NestedTemplateFragment_FoldsLikeAnyElement()
+    {
+        const string source =
+            "<template>\n" +                     // 0
+            "    <MyCard>\n" +                   // 1
+            "        <template #badge>\n" +      // 2
+            "            <span>New</span>\n" +   // 3
+            "        </template>\n" +            // 4
+            "    </MyCard>\n" +                  // 5
+            "</template>\n";                     // 6
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(3);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 5));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 4));
+        ranges[2].ShouldBe(new LanguageFoldingRange(StartLine: 2, EndLine: 3));
+    }
+
+    // The legacy @template container ([V01.01.06.10]) holds the same markup, and its content starts on
+    // the line after the header — the element lines are still the document's own lines.
+    [Fact]
+    public void GetFoldingRanges_LegacyTemplateContainer_FoldsElements()
+    {
+        const string source =
+            "@template {\n" +     // 0
+            "    <div>\n" +       // 1
+            "        text\n" +    // 2
+            "    </div>\n" +      // 3
+            "}\n";                // 4
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(2);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 3));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 2));
+    }
+
+    // The .vue compatibility container ([V01.01.06.09]) projects into the same block hierarchy, so its
+    // template elements fold identically.
+    [Fact]
+    public void GetFoldingRanges_VueContainer_FoldsElements()
+    {
+        const string source =
+            "<template>\n" +                  // 0
+            "    <div class=\"card\">\n" +    // 1
+            "        <p>Hello</p>\n" +        // 2
+            "    </div>\n" +                  // 3
+            "</template>\n";                  // 4
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(VueDocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(VueDocumentUri);
+
+        ranges.Count.ShouldBe(2);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 3));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 2));
+    }
+
+    // An element the parse recovered rather than matched gets no range: its recovered span ends
+    // wherever recovery landed, which is not a place a fold may end. The document still folds
+    // everything that is well formed, and nothing throws.
+    [Fact]
+    public void GetFoldingRanges_UnclosedElement_ReturnsNoRangeForTheUnclosedElement()
+    {
+        const string source =
+            "<template>\n" +      // 0
+            "    <div>\n" +       // 1
+            "        text\n" +    // 2
+            "</template>\n";      // 3
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(1);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 2));
+    }
+
+    // The element closed by an ancestor's end tag is the recovered one; the ancestor that does carry
+    // its own end tag still folds, and no range inverts.
+    [Fact]
+    public void GetFoldingRanges_ElementClosedByAncestorEndTag_FoldsOnlyTheMatchedAncestor()
+    {
+        const string source =
+            "<template>\n" +                 // 0
+            "    <article>\n" +              // 1
+            "        <header>\n" +           // 2
+            "            <h1>Title</h1>\n" + // 3
+            "    </article>\n" +             // 4
+            "</template>\n";                 // 5
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(2);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 4));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 3));
+        foreach (var range in ranges)
+        {
+            range.EndLine.ShouldBeGreaterThan(range.StartLine);
+        }
+    }
+
+    // A void element is not a container: it opens no fold, and the sibling that follows it folds on
+    // its own lines rather than on a span that swallowed the void element's line.
+    [Fact]
+    public void GetFoldingRanges_VoidElement_ReturnsNoRangeAndLeavesSiblingsIntact()
+    {
+        const string source =
+            "<template>\n" +        // 0
+            "    <div>\n" +         // 1
+            "        one<br>\n" +   // 2
+            "        two\n" +       // 3
+            "    </div>\n" +        // 4
+            "</template>\n";        // 5
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var ranges = service.GetFoldingRanges(DocumentUri);
+
+        ranges.Count.ShouldBe(2);
+        ranges[0].ShouldBe(new LanguageFoldingRange(StartLine: 0, EndLine: 4));
+        ranges[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 3));
+    }
+
+    // The document snapshot caches the element ranges, so repeated requests answer identically; an
+    // edit replaces the snapshot and the ranges move with the edited text.
+    [Fact]
+    public void GetFoldingRanges_AfterEdit_RecomputesAgainstTheEditedDocument()
+    {
+        const string source =
+            "<template>\n" +      // 0
+            "    <div>\n" +       // 1
+            "        text\n" +    // 2
+            "    </div>\n" +      // 3
+            "</template>\n";      // 4
+        var service = ViuLanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var first = service.GetFoldingRanges(DocumentUri);
+        var second = service.GetFoldingRanges(DocumentUri);
+        service.ChangeDocument(
+            DocumentUri,
+            2,
+            [new LanguageDocumentChange(null, "<template>\n    <div>\n        one\n        two\n    </div>\n</template>\n")]);
+        var third = service.GetFoldingRanges(DocumentUri);
+
+        second.ShouldBe(first);
+        first.Count.ShouldBe(2);
+        first[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 2));
+        third.Count.ShouldBe(2);
+        third[1].ShouldBe(new LanguageFoldingRange(StartLine: 1, EndLine: 3));
     }
 }


### PR DESCRIPTION
## Summary

Template sections previously exposed exactly one folding range each, so the whole `<template>` block collapsed as a unit while nested multi-line elements showed no collapse control. The language server's `textDocument/foldingRange` computation now walks the cached container parse and additionally emits a range for every multi-line matched element in template sections — nested slot `<template>` fragments included — for both the `.viu` and the tag-based `.vue` containers. The fix is server-side and editor-neutral: Visual Studio renders it through the in-process LSP client and Visual Studio Code through `vscode-languageclient`, from the same binary.

- `endLine` stops one line above the end tag, matching the existing section convention, so section and element folds compose instead of fighting over the closing line.
- No range for single-line, self-closing, void, or parser-recovered (unclosed or ancestor-closed) elements; inversion-guarded; never throws on recovered ASTs.
- Element ranges are computed once per immutable document snapshot (`Lazy`, `ExecutionAndPublication`) — no re-parsing per request.

## Tests

Tooling.LanguageService 113 → 124, Tooling.LanguageServer 58 → 59; deep nesting, siblings, exclusions, nested fragments, legacy `@template { }`, `.vue`, unclosed recovery, and cache/edit movement all pin exact line numbers. Solution builds 0 warnings / 0 errors.

## Work items resolved by this PR

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)