### PR TITLE
feat(visual-studio): auto-close paired delimiters and elements in .viu documents [V01.01.12.07.08]

### DIFF
--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
@@ -193,6 +193,134 @@ in process. Whole-document lexing is a property of the container format and surv
 change; the version watermarking and requested-range bookkeeping that made the round trips bearable
 did not, and is gone.
 
+## Auto-closing
+
+Typing an opening delimiter closes it ([V01.01.12.07.08]). Two mechanisms carry that, chosen because
+the editor offers exactly two shapes and they answer different questions.
+
+**Character pairs ride the editor's brace-completion engine.** The engine already owns everything a
+pair needs after it opens — inserting the closer, tracking the span, typing through the closer, and
+deleting both halves on one backspace — so Viu contributes only which characters pair and where.
+`{ }`, `( )`, and `[ ]` are registered on an `IBraceCompletionDefaultProvider`
+(`ViuBraceCompletionDefaults`), which is metadata with no code, because those pairs need no gating:
+they are balanced constructs in template markup, in C#, and in CSS alike. Interpolation falls out of
+that rather than needing a rule — typing `{` twice yields `{{}}` with the caret in the middle, which
+is the authoring path for `{{ Count }}`.
+
+The quotes do need gating, and that decides their registration. The editor's aggregator asks the
+providers registered for a character in order — session, dynamic session, context, then default — and
+takes the first that agrees to start; a default provider always agrees, so a pair registered on one
+can never be declined. The quotes are therefore registered on an `IBraceCompletionContextProvider`
+(`ViuQuoteBraceCompletionContextProvider`) and **only** there, making its `TryCreateContext` the gate.
+Adding them to the default provider as well would hand the aggregator an unconditional fallback and
+defeat the gate entirely.
+
+**Element and comment closing rides a typed-character command handler**, because there is no
+"pair" to register: what gets inserted depends on the tag name the user just typed.
+`ViuAutoClosingCommandHandler` is an `ICommandHandler<TypeCharCommandArgs>` filtered on the `viu`
+content type.
+
+**All the decisions are pure.** `ViuAutoClosingLogic` answers both questions from document text and a
+caret position alone — no editor type appears in it — and it takes its section attribution from
+`ViuSectionScanner` and its void-element list from the repository's shared `DomKnowledgeData`. The
+MEF parts and the command handler are thin adapters: they convert a snapshot into lines, ask, and
+apply. That is why the behavior below is unit-tested through the source-linked test project while the
+composition and the buffer edit are honestly runtime-verified only.
+
+`ViuSectionScanner` is the single definition of the container grammar in this extension. It owns the
+patterns that open and close a section and the `@`-block and tag-delimited state machines;
+`ViuLexicalClassifier` drives its per-line passes from the same primitives, so colorization and
+auto-closing cannot disagree about where a section starts. Attribution is per line, which is what the
+format supports: every section boundary is line-anchored. A line that opens or closes a section
+belongs to it, because content may sit on the same line; the column-0 `}` that ends a legacy
+`@`-block does not, because it is structure rather than content.
+
+### What pairs, and where
+
+| Typed | Template | `@script` / `<script>` | `<style>` | Between containers |
+| --- | --- | --- | --- | --- |
+| `{` `(` `[` | pairs | pairs | pairs | pairs |
+| `"` | pairs **only in attribute-value position** | pairs | — | — |
+| `'` | — | pairs | — | — |
+| `>` after an open tag | inserts `</name>` | — | — | — |
+| `/` immediately after `<` | completes the nearest unclosed element | — | — | — |
+| `-` completing `<!--` | inserts ` -->` | — | — | — |
+
+Attribute-value position means: inside an open tag header, with `=` as the last non-whitespace
+character before the caret, and not already inside a quoted value. A tag header spanning several
+lines is walked back through. Everything else in a template is text content, where a double quote is
+punctuation rather than a delimiter and an apostrophe is part of ordinary prose — which is the whole
+reason the single quote is script-only.
+
+The three element behaviors each have exclusions, and they are what keeps the feature from being
+intrusive:
+
+- `>` inserts nothing after a **void** element (`<br>`, `<input>`, … — matched case-insensitively
+  against the shared WHATWG table), after a tag the user **self-closed** (`<Component />`), when the
+  matching end tag **already follows the caret**, when the `>` is **inside an attribute value**, and
+  when the caret is not in a tag header at all — template text and interpolation interiors reach a
+  `>` from the enclosing tag first, so they never qualify. Framework tags are ordinary elements here:
+  `<template>` and `<slot>` auto-close like any other.
+- `/` completes only when it is typed **immediately after `<`**, and only when something is still
+  open. The ancestor scan starts at the top of the template run and skips void elements,
+  self-closed elements, comments, and tags written inside attribute values. In a tag-delimited
+  section the container tag is itself an unclosed element, so `</` at the top of a hand-authored
+  `<template>` completes `</template>`.
+- `-` completes only the third hyphen of `<!--`, and not when a `-` already follows.
+
+**Section awareness is the load-bearing part.** A `>` in `@script` closes a generic argument list or
+a lambda arrow, and a `>` in `<style>` is the CSS child combinator; a script or style section that
+grew an end tag on every `>` would be unusable. That is why the element behaviors are template-only,
+and why the top-level `<style>`/`<script>` opening tags do not auto-close either — their own line is
+already attributed to the section they open.
+
+### Recorded decisions
+
+- **The comment shape is `<!-- | -->`.** Typing the third `-` inserts `-  -->` with the caret between
+  the two spaces, so the comment reads `<!-- text -->` the moment the user types. Parking the caret
+  hard against the opener instead would produce `<!--text -->`.
+- **The typed character is part of the insertion.** The handler reports the command as handled and
+  writes the character itself, so the completion is one buffer change inside one transaction: a
+  single `Ctrl+Z` removes the end tag and the character that triggered it together, matching the
+  editor's own brace completion and Visual Studio's HTML editor.
+- **The handler is ordered after the completion and brace-completion handlers.** Both are chained
+  handlers that pass the character along, so they see it first and this one still runs; the order
+  matters because a handled command stops the chain, and running first would hide the keystroke from
+  an open completion session. The two names are written as literals — one of them has no published
+  constant, so a package reference for the other would buy nothing, and an unrecognized ordering name
+  is simply ignored.
+- **The Automatic Brace Completion option is the editor's, and is left alone.** The editor's
+  brace-completion manager reads `DefaultTextViewOptions.BraceCompletionEnabledOptionId` and returns
+  before it consults any provider, so turning the option off turns the Viu pairs off with it and no
+  Viu code needs to read it. Element auto-close has no editor-owned option and ships **always on**;
+  inventing a Viu options page for one toggle was rejected. Revisit if it proves intrusive.
+- **Auto-surround is ungated.** Selecting text and typing a quote wraps the selection wherever the
+  pair is registered, because the editor answers that from the `[BracePair]` metadata alone and never
+  consults the context provider. Accepted rather than worked around: surrounding happens only with an
+  active selection, where the alternative — replacing the selection with the typed character — is the
+  more destructive outcome.
+- **No new package pins were needed.** `Microsoft.VisualStudio.Text.BraceCompletion`,
+  `Microsoft.VisualStudio.Commanding`, `TypeCharCommandArgs`, and the undo history registry all live
+  in the editor packages this project already references compile-only.
+
+### Out of scope, recorded rather than half-built
+
+- **`=` inserting `=""`.** Auto-quoting an attribute the moment `=` is typed is a separate behavior
+  from pairing a quote the user typed, and it interacts with attribute-name completion — a directive
+  such as `v-else` takes no value at all. Deferred as its own decision.
+- **Element auto-close in Visual Studio Code.** That client gets its character pairs from
+  `language-configuration.json` already. Element auto-close there has no declarative form: it needs a
+  custom protocol request between the extension and the language server, which is a protocol change
+  this work item deliberately does not make. Recorded as a follow-up candidate.
+- **An options page for element auto-close.** See the recorded decision above: always on for now.
+- **Moving a paired `}` onto its own line on Return.** Observed while verifying the brace engine, and
+  left as it is. The editor's default session only reformats on Return when a brace-completion
+  *context* is present, so pressing Return inside a freshly paired `@script {}` leaves the `}` on the
+  caret's new line rather than pushing it down one further. That is the same thing every language
+  without a context does, and it does not break the container: the closer stays at column 0, which is
+  where the `@`-block grammar needs it. Giving `{` a context purely to reformat would be a
+  runtime-only, untestable addition, so it is recorded here rather than built.
+
 ## Activation, and where `.vue` stands in Visual Studio
 
 `ViuLanguageClient` is a MEF `[Export(typeof(ILanguageClient))]` filtered on the `viu` content type,

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
@@ -102,6 +102,12 @@
          as the netstandard2.0 parser projects link it; its path is frozen. -->
     <Compile Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.Syntax\src\Shims\IsExternalInit.cs"
              Link="Shims\IsExternalInit.cs" />
+    <!-- The WHATWG void-element table ViuAutoClosingLogic excludes from element auto-close, taken
+         from the repository's single authoritative DOM knowledge definition rather than retyped for
+         the editor. It is written to the lowest-common-denominator language surface precisely so
+         hosts like this one can link it; its path is frozen. -->
+    <Compile Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.Shared\src\Internal\DomKnowledgeData.cs"
+             Link="Internal\DomKnowledgeData.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuAutoClosingCommandHandler.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuAutoClosingCommandHandler.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Closes elements and comments as they are typed in a <c>.viu</c> template ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A thin adapter over <see cref="ViuAutoClosingLogic.GetTypedCharacterCompletion"/>: it converts
+/// the caret into a line and offset, asks what — if anything — should be inserted, and applies that
+/// answer to the buffer. Every rule about <em>what</em> to insert, and every rule about where an
+/// insertion is forbidden, lives in that pure decision class and is unit-tested there.
+/// </para>
+/// <para>
+/// <b>Element auto-close has no user option, deliberately.</b> Character pairs ride the editor's
+/// Automatic Brace Completion option; this behavior has no editor-owned equivalent, and inventing a
+/// Viu options page for one toggle was rejected in favor of shipping it always on. Recorded in
+/// <c>docs/DESIGN.md</c>; revisit if it proves intrusive in practice.
+/// </para>
+/// <para>
+/// <b>Ordering.</b> The handler runs after the editor's completion and brace-completion handlers.
+/// Both of those are chained handlers that pass the character along, so they see it first and this
+/// one still runs; the order matters because this handler reports the command as handled when it
+/// acts, and a handled command stops the chain — running first would hide the keystroke from an open
+/// completion session. The two names are written as literals rather than imported: one of them
+/// (<c>BraceCompletionCommandHandler</c>) has no published constant at all, so a package reference
+/// for the other would buy nothing, and an ordering name the composition does not recognize is
+/// simply ignored.
+/// </para>
+/// <para>
+/// <b>Undo.</b> The typed character is part of the inserted text rather than being left to the
+/// editor, so the completion is a single buffer change inside a single transaction: one
+/// <c>Ctrl+Z</c> removes the end tag and the character that triggered it together, which is how the
+/// editor's own brace completion and Visual Studio's HTML editor behave.
+/// </para>
+/// <para>
+/// Runtime-only surface: the MEF export, the buffer edit, and the caret move below are verified by
+/// running the extension, not by a unit test.
+/// </para>
+/// </remarks>
+[Export(typeof(ICommandHandler))]
+[Name(nameof(ViuAutoClosingCommandHandler))]
+[ContentType(ViuContentTypes.Viu)]
+[TextViewRole(PredefinedTextViewRoles.Editable)]
+[Order(After = "CompletionCommandHandler")]
+[Order(After = "BraceCompletionCommandHandler")]
+internal sealed class ViuAutoClosingCommandHandler : ICommandHandler<TypeCharCommandArgs>
+{
+    private readonly ITextUndoHistoryRegistry undoHistoryRegistry;
+
+    /// <summary>
+    /// Initializes the handler with the registry it takes the buffer's undo history from.
+    /// </summary>
+    /// <param name="undoHistoryRegistry">The editor's undo history registry.</param>
+    [ImportingConstructor]
+    public ViuAutoClosingCommandHandler(ITextUndoHistoryRegistry undoHistoryRegistry) =>
+        this.undoHistoryRegistry = undoHistoryRegistry;
+
+    /// <inheritdoc />
+    public string DisplayName => "Viu automatic element closing";
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Unspecified rather than available: this handler contributes no command of its own to any menu
+    /// and only ever reacts to ordinary typing, so it must not influence the state the rest of the
+    /// chain reports.
+    /// </remarks>
+    public CommandState GetCommandState(TypeCharCommandArgs args) => CommandState.Unspecified;
+
+    /// <inheritdoc />
+    public bool ExecuteCommand(TypeCharCommandArgs args, CommandExecutionContext executionContext)
+    {
+        if (!ViuAutoClosingLogic.IsCompletionTriggerCharacter(args.TypedChar))
+        {
+            return false;
+        }
+
+        ITextView textView = args.TextView;
+        ITextBuffer subjectBuffer = args.SubjectBuffer;
+
+        // Typing over a selection replaces it; that is the editor's job, and an auto-closed end tag
+        // around a replacement would be guesswork.
+        if (!textView.Selection.IsEmpty)
+        {
+            return false;
+        }
+
+        SnapshotPoint? caretPoint = textView.Caret.Position.Point.GetPoint(
+            subjectBuffer,
+            PositionAffinity.Successor);
+        if (caretPoint is null)
+        {
+            return false;
+        }
+
+        ITextSnapshot snapshot = caretPoint.Value.Snapshot;
+        ITextSnapshotLine line = snapshot.GetLineFromPosition(caretPoint.Value.Position);
+
+        ViuAutoClosingEdit? completion = ViuAutoClosingLogic.GetTypedCharacterCompletion(
+            ViuSnapshotLines.Read(snapshot),
+            line.LineNumber,
+            caretPoint.Value.Position - line.Start.Position,
+            args.TypedChar);
+        if (completion is not { } autoClosingEdit)
+        {
+            return false;
+        }
+
+        this.ApplyCompletion(textView, subjectBuffer, caretPoint.Value.Position, autoClosingEdit);
+        return true;
+    }
+
+    private void ApplyCompletion(
+        ITextView textView,
+        ITextBuffer subjectBuffer,
+        int insertPosition,
+        ViuAutoClosingEdit autoClosingEdit)
+    {
+        this.undoHistoryRegistry.TryGetHistory(subjectBuffer, out ITextUndoHistory undoHistory);
+        ITextUndoTransaction? transaction = undoHistory?.CreateTransaction(this.DisplayName);
+
+        try
+        {
+            using (ITextEdit edit = subjectBuffer.CreateEdit())
+            {
+                edit.Insert(insertPosition, autoClosingEdit.InsertedText);
+                edit.Apply();
+            }
+
+            MoveCaret(
+                textView,
+                subjectBuffer,
+                insertPosition + autoClosingEdit.CaretOffset);
+            transaction?.Complete();
+        }
+        finally
+        {
+            transaction?.Dispose();
+        }
+    }
+
+    // The caret is placed explicitly because an insertion at the caret otherwise carries it to the
+    // end of the inserted text, which is the wrong end for every completion but the closing tag.
+    private static void MoveCaret(ITextView textView, ITextBuffer subjectBuffer, int position)
+    {
+        ITextSnapshot snapshot = subjectBuffer.CurrentSnapshot;
+        if (position > snapshot.Length)
+        {
+            return;
+        }
+
+        SnapshotPoint subjectPoint = new(snapshot, position);
+        SnapshotPoint? viewPoint = ReferenceEquals(subjectBuffer, textView.TextBuffer)
+            ? subjectPoint
+            : textView.BufferGraph.MapUpToBuffer(
+                subjectPoint,
+                PointTrackingMode.Positive,
+                PositionAffinity.Successor,
+                textView.TextBuffer);
+
+        if (viewPoint is { } caretPoint)
+        {
+            textView.Caret.MoveTo(caretPoint);
+        }
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuBraceCompletionContext.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuBraceCompletionContext.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.Text.BraceCompletion;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// The language-specific half of a Viu quote-completion session: nothing beyond the editor's default
+/// behavior ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A context exists at all only because the decision to <em>start</em> a quote session is
+/// position-dependent, and <see cref="IBraceCompletionContextProvider"/> is the extension point that
+/// can decline. Once a session has started there is nothing Viu wants to add: the editor already
+/// inserts the pair, tracks the span, types through the closing quote, and deletes the pair on
+/// backspace, and none of that is language-specific for a quoted string.
+/// </para>
+/// <para>
+/// One instance serves every session because the type holds no state; the session it is handed is
+/// passed in on each call.
+/// </para>
+/// </remarks>
+internal sealed class ViuBraceCompletionContext : IBraceCompletionContext
+{
+    /// <summary>The single shared, stateless context.</summary>
+    public static readonly ViuBraceCompletionContext Instance = new();
+
+    private ViuBraceCompletionContext()
+    {
+    }
+
+    /// <inheritdoc />
+    public void Start(IBraceCompletionSession session)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Finish(IBraceCompletionSession session)
+    {
+    }
+
+    /// <inheritdoc />
+    public void OnReturn(IBraceCompletionSession session)
+    {
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Typing the closing quote inside the session always moves through it rather than inserting a
+    /// second one: the editor only asks when there is nothing but whitespace between the caret and
+    /// the closing quote, so the only way to reach this question is for the user to be finishing the
+    /// string the session opened.
+    /// </remarks>
+    public bool AllowOverType(IBraceCompletionSession session) => true;
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuBraceCompletionDefaults.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuBraceCompletionDefaults.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Text.BraceCompletion;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Registers the bracket pairs a <c>.viu</c> document completes in every section
+/// ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IBraceCompletionDefaultProvider"/> is metadata only: the part contributes no code, and
+/// the editor's own brace-completion session handles insertion, type-through of the closing
+/// character, and paired deletion on backspace. That is the right shape for these three pairs
+/// precisely because they need no gating — braces, parentheses, and square brackets are balanced
+/// constructs in template markup, in C#, and in CSS alike, so no position in a Viu container wants
+/// them treated differently. Quotes do want that, and are registered separately by
+/// <see cref="ViuQuoteBraceCompletionContextProvider"/>.
+/// </para>
+/// <para>
+/// Interpolation falls out of the brace pair rather than needing a rule of its own: typing <c>{</c>
+/// twice yields <c>{{}}</c> with the caret in the middle, which is the authoring path for
+/// <c>{{ Count }}</c>.
+/// </para>
+/// <para>
+/// The editor consults the user's Automatic Brace Completion option
+/// (<c>DefaultTextViewOptions.BraceCompletionEnabledOptionId</c>) before it starts any session, so
+/// this part neither reads nor overrides it: turning the option off turns these pairs off with it.
+/// </para>
+/// <para>
+/// Runtime-only surface — this is MEF metadata that exists to be composed inside
+/// <c>devenv.exe</c>, and it is verified by running the extension rather than by a unit test.
+/// </para>
+/// </remarks>
+[Export(typeof(IBraceCompletionDefaultProvider))]
+[BracePair('{', '}')]
+[BracePair('(', ')')]
+[BracePair('[', ']')]
+[ContentType(ViuContentTypes.Viu)]
+internal sealed class ViuBraceCompletionDefaults : IBraceCompletionDefaultProvider
+{
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuQuoteBraceCompletionContextProvider.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/AutoClosing/ViuQuoteBraceCompletionContextProvider.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.BraceCompletion;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Starts a quote-completion session only where a quote means a string ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a context provider rather than a default one.</b> The editor's brace-completion aggregator
+/// asks the providers registered for a character in order — session, dynamic session, context, then
+/// default — and takes the first one that agrees to start. A default provider always agrees, so a
+/// pair registered on one could not be declined; registering the quotes on an
+/// <see cref="IBraceCompletionContextProvider"/> instead makes
+/// <see cref="TryCreateContext"/> the gate. That is also why the quotes are registered <em>here</em>
+/// and nowhere else: adding them to <see cref="ViuBraceCompletionDefaults"/> as well would give the
+/// aggregator an unconditional fallback and defeat the gate entirely.
+/// </para>
+/// <para>
+/// <b>The gate itself</b> is <see cref="ViuAutoClosingLogic.AllowsQuotePair"/> — pure, section-aware,
+/// and unit-tested. This part only converts the editor's snapshot and point into the line-and-offset
+/// form that decision takes, so the interesting behavior is covered without the editor in the way.
+/// </para>
+/// <para>
+/// <b>Auto-surround is metadata-driven and therefore ungated.</b> Selecting text and typing a quote
+/// wraps the selection wherever the pair is registered, because the editor answers that from the
+/// <see cref="BracePairAttribute"/> alone and never consults this provider. That is accepted rather
+/// than worked around: surrounding only happens with an active selection, where the alternative — the
+/// editor replacing the selection with the typed character — is the more destructive outcome.
+/// </para>
+/// <para>
+/// Runtime-only surface: the MEF composition and the snapshot conversion below are verified by
+/// running the extension, not by a unit test.
+/// </para>
+/// </remarks>
+[Export(typeof(IBraceCompletionContextProvider))]
+[BracePair('"', '"')]
+[BracePair('\'', '\'')]
+[ContentType(ViuContentTypes.Viu)]
+internal sealed class ViuQuoteBraceCompletionContextProvider : IBraceCompletionContextProvider
+{
+    /// <inheritdoc />
+    public bool TryCreateContext(
+        ITextView textView,
+        SnapshotPoint openingPoint,
+        char openingBrace,
+        char closingBrace,
+        out IBraceCompletionContext context)
+    {
+        ITextSnapshot snapshot = openingPoint.Snapshot;
+        ITextSnapshotLine line = snapshot.GetLineFromPosition(openingPoint.Position);
+
+        if (ViuAutoClosingLogic.AllowsQuotePair(
+                ViuSnapshotLines.Read(snapshot),
+                line.LineNumber,
+                openingPoint.Position - line.Start.Position,
+                openingBrace))
+        {
+            context = ViuBraceCompletionContext.Instance;
+            return true;
+        }
+
+        context = null!;
+        return false;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifier.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifier.cs
@@ -121,14 +121,8 @@ internal sealed class ViuClassifier : IClassifier
 
     private IReadOnlyList<ClassificationSpan> ClassifySnapshot(ITextSnapshot snapshot)
     {
-        int lineCount = snapshot.LineCount;
-        List<string> lines = new(lineCount);
-        for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
-        {
-            lines.Add(snapshot.GetLineFromLineNumber(lineNumber).GetText());
-        }
-
-        IReadOnlyList<ViuLexicalSpan> lexicalSpans = ViuLexicalClassifier.Classify(lines);
+        IReadOnlyList<ViuLexicalSpan> lexicalSpans =
+            ViuLexicalClassifier.Classify(ViuSnapshotLines.Read(snapshot));
         List<ClassificationSpan> snapshotSpans = new(lexicalSpans.Count);
 
         foreach (ViuLexicalSpan lexicalSpan in lexicalSpans)

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/README.md
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/README.md
@@ -4,7 +4,8 @@ This project is the thin, **in-process** Visual Studio client for Viu single-fil
 classic VSSDK package targeting `net48`, because the editor surfaces it contributes exist only as MEF
 exports inside `devenv.exe`. It ships the `viu` content type, the `.pkgdef` claiming the `.viu` file
 extension, the Viu classification types and their format definitions, the lexical classifier that
-colors a buffer with no round trip, and `ViuLanguageClient`.
+colors a buffer with no round trip, the section-aware auto-closing of delimiters and elements, and
+`ViuLanguageClient`.
 
 Nothing semantic runs here. Semantic completion, diagnostics, navigation, and every future editor
 feature belong to the standalone language server the client starts, so the Viu parsers and Roslyn

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuAutoClosingEdit.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuAutoClosingEdit.cs
@@ -1,0 +1,19 @@
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// One auto-closing insertion: the text to place at the caret and where the caret lands inside it.
+/// </summary>
+/// <param name="InsertedText">
+/// Everything the edit writes at the caret, the character the user typed included. The typed
+/// character is part of the insertion rather than left to the editor so the whole completion is one
+/// buffer change and therefore one undo unit.
+/// </param>
+/// <param name="CaretOffset">
+/// The caret's position after the edit, as an offset into <paramref name="InsertedText"/>. Zero
+/// leaves the caret before the insertion; <see cref="string.Length"/> leaves it after.
+/// </param>
+/// <remarks>
+/// A value type with no editor dependency, so the decisions that produce it stay unit-testable
+/// ([V01.01.12.07.08]).
+/// </remarks>
+internal readonly record struct ViuAutoClosingEdit(string InsertedText, int CaretOffset);

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuAutoClosingLogic.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuAutoClosingLogic.cs
@@ -1,0 +1,583 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Assimalign.Viu.Shared;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Decides, from document text and a caret position alone, what a <c>.viu</c> document should
+/// auto-close ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two questions, one for each mechanism the extension uses. <see cref="AllowsQuotePair"/> answers
+/// the editor's brace-completion engine — may a quote pair start here — and
+/// <see cref="GetTypedCharacterCompletion"/> answers the typed-character command handler — what text
+/// completes the element or comment the user just opened.
+/// </para>
+/// <para>
+/// Both answers are section-aware and take their section attribution from
+/// <see cref="ViuSectionScanner"/> rather than re-scanning the container grammar, and the void
+/// element list comes from <see cref="DomKnowledgeData.VoidTags"/> — the same WHATWG table the
+/// template compiler and the runtime use — rather than from a table written for the editor. Nothing
+/// here touches a Visual Studio type, which is what lets the whole decision surface be unit-tested
+/// through the source-linked test project while the MEF and commanding glue stays a thin adapter.
+/// </para>
+/// <para>
+/// Scanning is whole-document per keystroke, which is affordable because it happens only on the five
+/// characters that can trigger anything (<c>&gt;</c>, <c>/</c>, <c>-</c>, and the two quotes) and
+/// only in a <c>.viu</c> buffer: two regular expressions per line, no allocation per line beyond the
+/// result array.
+/// </para>
+/// </remarks>
+internal static class ViuAutoClosingLogic
+{
+    private static readonly HashSet<string> VoidTagSet = BuildVoidTagSet();
+
+    /// <summary>
+    /// Determines whether a typed character can trigger an auto-closing completion at all.
+    /// </summary>
+    /// <param name="typedCharacter">The character the user typed.</param>
+    /// <returns>
+    /// <see langword="true"/> for the three characters
+    /// <see cref="GetTypedCharacterCompletion"/> can act on, so the command handler can decline
+    /// every other keystroke without reading the buffer.
+    /// </returns>
+    public static bool IsCompletionTriggerCharacter(char typedCharacter) =>
+        typedCharacter is '>' or '/' or '-';
+
+    /// <summary>
+    /// Determines whether a quote typed at the given position means the start of a string, and may
+    /// therefore be paired.
+    /// </summary>
+    /// <param name="lines">The document's lines, without their line breaks.</param>
+    /// <param name="lineNumber">Zero-based line the quote is being typed on.</param>
+    /// <param name="characterIndex">Zero-based offset within that line where the quote goes.</param>
+    /// <param name="quoteCharacter">The quote character: <c>"</c> or <c>'</c>.</param>
+    /// <returns><see langword="true"/> when the pair may be completed.</returns>
+    /// <remarks>
+    /// The gating exists because a quote is only sometimes a delimiter. In a script section every
+    /// quote opens a C# string or character literal, so both forms pair. In a template only the
+    /// attribute-value position is a string position: pairing a double quote in template text would
+    /// interrupt ordinary prose, and pairing an apostrophe there would corrupt it outright, which is
+    /// why the single quote never pairs outside script. Style sections and the text between
+    /// containers pair neither.
+    /// </remarks>
+    public static bool AllowsQuotePair(
+        IReadOnlyList<string> lines,
+        int lineNumber,
+        int characterIndex,
+        char quoteCharacter)
+    {
+        if (quoteCharacter is not ('"' or '\'') ||
+            !IsPositionInRange(lines, lineNumber, characterIndex))
+        {
+            return false;
+        }
+
+        ViuSectionKind[] lineSections = ViuSectionScanner.ScanLineSections(lines);
+
+        return lineSections[lineNumber] switch
+        {
+            // Every quote in a script section delimits a C# string or character literal.
+            ViuSectionKind.Script => true,
+
+            // In a template only an attribute value is a string, and only the double quote spells
+            // one in the form Viu's own lexer recognizes.
+            ViuSectionKind.Template => quoteCharacter == '"' &&
+                IsAttributeValuePosition(lines, lineSections, lineNumber, characterIndex),
+
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Computes the completion a typed character should produce, or <see langword="null"/> when it
+    /// should be typed as an ordinary character.
+    /// </summary>
+    /// <param name="lines">The document's lines, without their line breaks.</param>
+    /// <param name="lineNumber">Zero-based line the character is being typed on.</param>
+    /// <param name="characterIndex">Zero-based offset within that line where the character goes.</param>
+    /// <param name="typedCharacter">The character the user typed.</param>
+    /// <returns>The insertion and caret placement, or <see langword="null"/> for no completion.</returns>
+    /// <remarks>
+    /// <para>
+    /// Three completions, all confined to template sections. <c>&gt;</c> after an open tag inserts
+    /// that tag's end tag and leaves the caret between the two. <c>/</c> immediately after <c>&lt;</c>
+    /// completes the nearest unclosed ancestor element, closing brace included. <c>-</c> completing
+    /// <c>&lt;!--</c> inserts the comment terminator.
+    /// </para>
+    /// <para>
+    /// The template restriction is the whole reason this is section-aware: <c>&gt;</c> in a
+    /// <c>@script</c> block closes a generic argument list or a lambda arrow, and a script or style
+    /// section that grew an end tag on every <c>&gt;</c> would be unusable.
+    /// </para>
+    /// </remarks>
+    public static ViuAutoClosingEdit? GetTypedCharacterCompletion(
+        IReadOnlyList<string> lines,
+        int lineNumber,
+        int characterIndex,
+        char typedCharacter)
+    {
+        if (!IsCompletionTriggerCharacter(typedCharacter) ||
+            !IsPositionInRange(lines, lineNumber, characterIndex))
+        {
+            return null;
+        }
+
+        ViuSectionKind[] lineSections = ViuSectionScanner.ScanLineSections(lines);
+        if (lineSections[lineNumber] != ViuSectionKind.Template)
+        {
+            return null;
+        }
+
+        return typedCharacter switch
+        {
+            '>' => GetEndTagCompletion(lines, lineSections, lineNumber, characterIndex),
+            '/' => GetClosingTagCompletion(lines, lineSections, lineNumber, characterIndex),
+            '-' => GetCommentCompletion(lines, lineNumber, characterIndex),
+            _ => null,
+        };
+    }
+
+    // '>' finishing an open tag: insert the matching end tag and keep the caret between the two.
+    private static ViuAutoClosingEdit? GetEndTagCompletion(
+        IReadOnlyList<string> lines,
+        ViuSectionKind[] lineSections,
+        int lineNumber,
+        int characterIndex)
+    {
+        if (!TryFindOpenTagStart(
+                lines,
+                lineSections,
+                lineNumber,
+                characterIndex,
+                out int tagLineNumber,
+                out int tagCharacterIndex))
+        {
+            return null;
+        }
+
+        string tagHeader = ReadTagHeaderText(
+            lines,
+            tagLineNumber,
+            tagCharacterIndex,
+            lineNumber,
+            characterIndex);
+
+        // '</', '<!', '<?', and a bare '<' name nothing to close.
+        int tagNameLength = ReadTagNameLength(tagHeader, 1);
+        if (tagNameLength == 0)
+        {
+            return null;
+        }
+
+        // A '>' inside an attribute value is content, not the end of the header.
+        if (FindUnterminatedQuote(tagHeader) != '\0')
+        {
+            return null;
+        }
+
+        // A tag the user closed themselves takes no end tag.
+        if (EndsWithSolidus(tagHeader))
+        {
+            return null;
+        }
+
+        string tagName = tagHeader.Substring(1, tagNameLength);
+        if (VoidTagSet.Contains(tagName))
+        {
+            return null;
+        }
+
+        // Already closed: the end tag sits immediately after the caret, which is what re-typing the
+        // '>' of an existing tag looks like.
+        string endTag = "</" + tagName + ">";
+        if (StartsWithAt(lines[lineNumber], characterIndex, endTag))
+        {
+            return null;
+        }
+
+        return new ViuAutoClosingEdit(">" + endTag, 1);
+    }
+
+    // '/' immediately after '<': complete the nearest unclosed ancestor element, '>' included.
+    private static ViuAutoClosingEdit? GetClosingTagCompletion(
+        IReadOnlyList<string> lines,
+        ViuSectionKind[] lineSections,
+        int lineNumber,
+        int characterIndex)
+    {
+        string line = lines[lineNumber];
+        if (characterIndex == 0 || line[characterIndex - 1] != '<')
+        {
+            return null;
+        }
+
+        string? ancestorName = FindNearestUnclosedElementName(
+            lines,
+            lineSections,
+            lineNumber,
+            characterIndex - 1);
+        if (ancestorName is null)
+        {
+            return null;
+        }
+
+        string insertedText = "/" + ancestorName + ">";
+        return new ViuAutoClosingEdit(insertedText, insertedText.Length);
+    }
+
+    // '-' completing '<!--': insert the terminator and park the caret in the middle of the comment.
+    private static ViuAutoClosingEdit? GetCommentCompletion(
+        IReadOnlyList<string> lines,
+        int lineNumber,
+        int characterIndex)
+    {
+        string line = lines[lineNumber];
+        if (characterIndex < 3 ||
+            line[characterIndex - 3] != '<' ||
+            line[characterIndex - 2] != '!' ||
+            line[characterIndex - 1] != '-')
+        {
+            return null;
+        }
+
+        // A '-' already follows, so the user is editing an existing delimiter rather than opening a
+        // comment; completing here would produce '<!--  ---->'.
+        if (characterIndex < line.Length && line[characterIndex] == '-')
+        {
+            return null;
+        }
+
+        // Recorded shape ([V01.01.12.07.08]): the insertion is "-  -->" with the caret between the
+        // two spaces, so the comment reads "<!-- text -->" the moment the user types - the spaced
+        // form WHATWG comments are conventionally written in. Placing the caret hard against the
+        // opener instead would leave "<!--text -->".
+        return new ViuAutoClosingEdit("-  -->", 2);
+    }
+
+    // True when the caret sits where an attribute's value belongs: inside an open tag header, with
+    // '=' as the last non-whitespace character before it, and not already inside a quoted value.
+    private static bool IsAttributeValuePosition(
+        IReadOnlyList<string> lines,
+        ViuSectionKind[] lineSections,
+        int lineNumber,
+        int characterIndex)
+    {
+        if (!TryFindOpenTagStart(
+                lines,
+                lineSections,
+                lineNumber,
+                characterIndex,
+                out int tagLineNumber,
+                out int tagCharacterIndex))
+        {
+            return false;
+        }
+
+        string tagHeader = ReadTagHeaderText(
+            lines,
+            tagLineNumber,
+            tagCharacterIndex,
+            lineNumber,
+            characterIndex);
+
+        if (FindUnterminatedQuote(tagHeader) != '\0')
+        {
+            return false;
+        }
+
+        for (int index = tagHeader.Length - 1; index >= 0; index--)
+        {
+            char character = tagHeader[index];
+            if (!char.IsWhiteSpace(character))
+            {
+                return character == '=';
+            }
+        }
+
+        return false;
+    }
+
+    // Walks backwards for the '<' that opens the tag header the caret is inside, staying within the
+    // template run the caret line belongs to. A '>' encountered first means the caret is in content
+    // rather than in a header, which is what keeps template text and interpolation interiors out.
+    private static bool TryFindOpenTagStart(
+        IReadOnlyList<string> lines,
+        ViuSectionKind[] lineSections,
+        int lineNumber,
+        int characterIndex,
+        out int tagLineNumber,
+        out int tagCharacterIndex)
+    {
+        for (int line = lineNumber; line >= 0 && lineSections[line] == ViuSectionKind.Template; line--)
+        {
+            string text = lines[line];
+            int start = line == lineNumber ? characterIndex - 1 : text.Length - 1;
+            for (int index = start; index >= 0; index--)
+            {
+                if (text[index] == '>')
+                {
+                    tagLineNumber = -1;
+                    tagCharacterIndex = -1;
+                    return false;
+                }
+
+                if (text[index] == '<')
+                {
+                    tagLineNumber = line;
+                    tagCharacterIndex = index;
+                    return true;
+                }
+            }
+        }
+
+        tagLineNumber = -1;
+        tagCharacterIndex = -1;
+        return false;
+    }
+
+    // The text of a tag header from its '<' up to (but excluding) the caret, with line breaks
+    // normalized to '\n' - only the characters matter to the callers, never the offsets.
+    private static string ReadTagHeaderText(
+        IReadOnlyList<string> lines,
+        int tagLineNumber,
+        int tagCharacterIndex,
+        int lineNumber,
+        int characterIndex)
+    {
+        if (tagLineNumber == lineNumber)
+        {
+            return lines[lineNumber].Substring(
+                tagCharacterIndex,
+                characterIndex - tagCharacterIndex);
+        }
+
+        StringBuilder builder = new();
+        string firstLine = lines[tagLineNumber];
+        builder.Append(firstLine, tagCharacterIndex, firstLine.Length - tagCharacterIndex);
+        for (int line = tagLineNumber + 1; line < lineNumber; line++)
+        {
+            builder.Append('\n').Append(lines[line]);
+        }
+
+        builder.Append('\n').Append(lines[lineNumber], 0, characterIndex);
+        return builder.ToString();
+    }
+
+    // The nearest element still open at the given position, or null when nothing is open. The scan
+    // starts at the top of the contiguous template run so nesting is counted from the section's own
+    // beginning rather than from an arbitrary window.
+    private static string? FindNearestUnclosedElementName(
+        IReadOnlyList<string> lines,
+        ViuSectionKind[] lineSections,
+        int lineNumber,
+        int characterIndex)
+    {
+        int runStart = lineNumber;
+        while (runStart > 0 && lineSections[runStart - 1] == ViuSectionKind.Template)
+        {
+            runStart--;
+        }
+
+        StringBuilder builder = new();
+        for (int line = runStart; line < lineNumber; line++)
+        {
+            builder.Append(lines[line]).Append('\n');
+        }
+
+        builder.Append(lines[lineNumber], 0, characterIndex);
+        return ScanForNearestUnclosedElement(builder.ToString());
+    }
+
+    private static string? ScanForNearestUnclosedElement(string text)
+    {
+        List<string> openElements = [];
+        int index = 0;
+
+        while (index < text.Length)
+        {
+            if (text[index] != '<')
+            {
+                index++;
+                continue;
+            }
+
+            if (StartsWithAt(text, index, "<!--"))
+            {
+                int commentEnd = text.IndexOf("-->", index + 4, StringComparison.Ordinal);
+                index = commentEnd < 0 ? text.Length : commentEnd + 3;
+                continue;
+            }
+
+            if (index + 1 < text.Length && text[index + 1] == '/')
+            {
+                int closingNameLength = ReadTagNameLength(text, index + 2);
+                if (closingNameLength > 0)
+                {
+                    // Ordinal, because Viu resolves a tag name by its authored spelling
+                    // (specified by [CMP-6]). An end tag that matches an ancestor closes it and
+                    // everything opened since; one that matches nothing is left alone.
+                    string closingName = text.Substring(index + 2, closingNameLength);
+                    int matchIndex = openElements.LastIndexOf(closingName);
+                    if (matchIndex >= 0)
+                    {
+                        openElements.RemoveRange(matchIndex, openElements.Count - matchIndex);
+                    }
+                }
+
+                index = SkipTagHeader(text, index, out _);
+                continue;
+            }
+
+            int tagNameLength = ReadTagNameLength(text, index + 1);
+            if (tagNameLength == 0)
+            {
+                index++;
+                continue;
+            }
+
+            string tagName = text.Substring(index + 1, tagNameLength);
+            index = SkipTagHeader(text, index, out bool isSelfClosing);
+            if (!isSelfClosing && !VoidTagSet.Contains(tagName))
+            {
+                openElements.Add(tagName);
+            }
+        }
+
+        return openElements.Count > 0 ? openElements[openElements.Count - 1] : null;
+    }
+
+    // Advances past a tag header that starts at '<', treating quoted attribute values as opaque.
+    // Returns the index just past the header's '>', or the end of the text for an unterminated one.
+    private static int SkipTagHeader(string text, int start, out bool isSelfClosing)
+    {
+        isSelfClosing = false;
+        char openQuote = '\0';
+
+        for (int index = start + 1; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (openQuote != '\0')
+            {
+                if (character == openQuote)
+                {
+                    openQuote = '\0';
+                }
+
+                continue;
+            }
+
+            if (character is '"' or '\'')
+            {
+                openQuote = character;
+                continue;
+            }
+
+            if (character == '>')
+            {
+                int previous = index - 1;
+                while (previous > start && char.IsWhiteSpace(text[previous]))
+                {
+                    previous--;
+                }
+
+                isSelfClosing = previous > start && text[previous] == '/';
+                return index + 1;
+            }
+        }
+
+        return text.Length;
+    }
+
+    // The quote character an attribute value opened with and never closed, or '\0' when every quote
+    // in the text is balanced. A quote of the other form inside an open value is content, which is
+    // what keeps :title="it's fine" from reading as an unterminated value.
+    private static char FindUnterminatedQuote(string text)
+    {
+        char openQuote = '\0';
+        foreach (char character in text)
+        {
+            if (openQuote == '\0')
+            {
+                if (character is '"' or '\'')
+                {
+                    openQuote = character;
+                }
+            }
+            else if (character == openQuote)
+            {
+                openQuote = '\0';
+            }
+        }
+
+        return openQuote;
+    }
+
+    private static bool EndsWithSolidus(string text)
+    {
+        for (int index = text.Length - 1; index >= 0; index--)
+        {
+            char character = text[index];
+            if (!char.IsWhiteSpace(character))
+            {
+                return character == '/';
+            }
+        }
+
+        return false;
+    }
+
+    private static int ReadTagNameLength(string text, int start)
+    {
+        if (start >= text.Length || !IsTagNameStartCharacter(text[start]))
+        {
+            return 0;
+        }
+
+        int end = start + 1;
+        while (end < text.Length && IsTagNameCharacter(text[end]))
+        {
+            end++;
+        }
+
+        return end - start;
+    }
+
+    private static bool IsTagNameStartCharacter(char character)
+        => character is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z');
+
+    private static bool IsTagNameCharacter(char character)
+        => character is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9')
+            or '_' or '.' or ':' or '-';
+
+    private static bool StartsWithAt(string text, int index, string value)
+        => index >= 0 &&
+           index + value.Length <= text.Length &&
+           string.CompareOrdinal(text, index, value, 0, value.Length) == 0;
+
+    private static bool IsPositionInRange(
+        IReadOnlyList<string> lines,
+        int lineNumber,
+        int characterIndex)
+        => lineNumber >= 0 &&
+           lineNumber < lines.Count &&
+           characterIndex >= 0 &&
+           characterIndex <= lines[lineNumber].Length;
+
+    // The WHATWG void elements, from the repository's single authoritative DOM knowledge table.
+    // Case-insensitive to match how the template compiler and the runtime resolve them.
+    private static HashSet<string> BuildVoidTagSet()
+    {
+        HashSet<string> voidTags = new(StringComparer.OrdinalIgnoreCase);
+        foreach (string voidTag in DomKnowledgeData.VoidTags.Split(','))
+        {
+            voidTags.Add(voidTag);
+        }
+
+        return voidTags;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuLexicalClassifier.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuLexicalClassifier.cs
@@ -26,21 +26,10 @@ namespace Assimalign.Viu.VisualStudio;
 /// </remarks>
 internal static class ViuLexicalClassifier
 {
-    // The hybrid .viu container ([V01.01.06.10], Assimalign.Viu.Syntax.SingleFileComponent
-    // docs/FORMAT.md): <template> and <style> are top-level tags, @script keeps the @-block grammar,
-    // and the legacy @template/@style blocks keep highlighting during the migration window.
-    private static readonly Regex SectionHeaderExpression = new(
-        @"^\s*@(?<name>template|script|style)\b[^{]*(?<brace>\{)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex TagSectionOpenExpression = new(
-        @"^\s*<(?<name>template|style|script)\b",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex TemplateSectionTagExpression = new(
-        @"</?template\b",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
+    // The container grammar itself - which line opens a section, which line closes it, and what a
+    // container name means - lives in ViuSectionScanner, so this classifier and the auto-closing
+    // decisions share one definition of the hybrid .viu sections ([V01.01.06.10]) instead of each
+    // carrying a copy.
     private static readonly Regex TagHeaderAttributeExpression = new(
         @"(?<name>[A-Za-z_][A-Za-z0-9_.:-]*)(?:\s*=\s*(?<value>""[^""]*""|'[^']*'))?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -149,7 +138,7 @@ internal static class ViuLexicalClassifier
                         if (ClassifyTagDelimitedRawLine(
                                 line,
                                 lineNumber,
-                                "</style>",
+                                ViuSectionScanner.StyleClosingTag,
                                 0,
                                 ref isInStyleComment,
                                 ClassifyStyleLine,
@@ -166,7 +155,7 @@ internal static class ViuLexicalClassifier
                         if (ClassifyTagDelimitedRawLine(
                                 line,
                                 lineNumber,
-                                "</script>",
+                                ViuSectionScanner.ScriptClosingTag,
                                 0,
                                 ref isInScriptComment,
                                 ClassifyScriptLine,
@@ -183,20 +172,13 @@ internal static class ViuLexicalClassifier
                 continue;
             }
 
-            Match sectionMatch = SectionHeaderExpression.Match(line);
+            Match sectionMatch = ViuSectionScanner.MatchSectionHeader(line);
 
             if (sectionMatch.Success)
             {
-                string sectionName = sectionMatch.Groups["name"].Value;
-                sectionKind = sectionName switch
-                {
-                    "template" => ViuSectionKind.Template,
-                    "script" => ViuSectionKind.Script,
-                    "style" => ViuSectionKind.Style,
-                    _ => ViuSectionKind.None,
-                };
-
                 Group nameGroup = sectionMatch.Groups["name"];
+                sectionKind = ViuSectionScanner.GetSectionKind(nameGroup.Value);
+
                 // The legacy @template/@style headers name the same containers their tag-delimited
                 // successors do, so they carry the framework-tag color. @script is the C# container's
                 // own header and keeps the keyword classification, which puts it in the same color as
@@ -222,7 +204,7 @@ internal static class ViuLexicalClassifier
             }
             else if (sectionKind == ViuSectionKind.None)
             {
-                Match tagMatch = TagSectionOpenExpression.Match(line);
+                Match tagMatch = ViuSectionScanner.MatchTagSectionOpen(line);
                 if (tagMatch.Success)
                 {
                     ClassifyTagSectionOpenLine(
@@ -317,9 +299,9 @@ internal static class ViuLexicalClassifier
             return;
         }
 
-        switch (nameGroup.Value)
+        switch (ViuSectionScanner.GetSectionKind(nameGroup.Value))
         {
-            case "template":
+            case ViuSectionKind.Template:
                 sectionKind = ViuSectionKind.Template;
                 isTagDelimitedSection = true;
                 templateTagDepth = 0;
@@ -337,13 +319,13 @@ internal static class ViuLexicalClassifier
 
                 break;
 
-            case "style":
+            case ViuSectionKind.Style:
                 sectionKind = ViuSectionKind.Style;
                 isTagDelimitedSection = true;
                 if (ClassifyTagDelimitedRawLine(
                         line,
                         lineNumber,
-                        "</style>",
+                        ViuSectionScanner.StyleClosingTag,
                         headerEnd,
                         ref isInStyleComment,
                         ClassifyStyleLine,
@@ -356,7 +338,7 @@ internal static class ViuLexicalClassifier
 
                 break;
 
-            case "script":
+            case ViuSectionKind.Script:
                 // The container parser rejects a top-level <script> tag (VIU1017); the lexer still
                 // colors it as a script section so the misplaced code stays readable while the
                 // diagnostic points at the fix.
@@ -365,7 +347,7 @@ internal static class ViuLexicalClassifier
                 if (ClassifyTagDelimitedRawLine(
                         line,
                         lineNumber,
-                        "</script>",
+                        ViuSectionScanner.ScriptClosingTag,
                         headerEnd,
                         ref isInScriptComment,
                         ClassifyScriptLine,
@@ -391,7 +373,7 @@ internal static class ViuLexicalClassifier
         bool[] occupiedCharacters,
         List<ViuLexicalSpan> spans)
     {
-        int closerEnd = ScanTemplateTagDepth(line, ref templateTagDepth);
+        int closerEnd = ViuSectionScanner.ScanTemplateTagDepth(line, ref templateTagDepth);
         if (closerEnd >= 0 && closerEnd < line.Length)
         {
             // Occupy everything past the true closer without emitting spans; whatever follows the
@@ -439,33 +421,6 @@ internal static class ViuLexicalClassifier
         ref bool isInComment,
         bool[] occupiedCharacters,
         List<ViuLexicalSpan> spans);
-
-    // Walks the <template>/</template> boundaries on a line, updating the nesting depth. Returns the
-    // exclusive end offset of the closer that brings the depth back to zero, or -1 when the section
-    // stays open past this line. Self-closing <template /> tags do not change the depth.
-    private static int ScanTemplateTagDepth(string line, ref int depth)
-    {
-        foreach (Match match in TemplateSectionTagExpression.Matches(line))
-        {
-            bool isClosing = line[match.Index + 1] == '/';
-            int tagClose = line.IndexOf('>', match.Index + match.Length);
-
-            if (isClosing)
-            {
-                depth--;
-                if (depth <= 0)
-                {
-                    return tagClose < 0 ? line.Length : tagClose + 1;
-                }
-            }
-            else if (tagClose < 0 || line[tagClose - 1] != '/')
-            {
-                depth++;
-            }
-        }
-
-        return -1;
-    }
 
     // Classifies a top-level container tag header: the tag punctuation as delimiters, the tag name as
     // the framework tag it always is at this position, and attributes (valueless ones such as

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuSectionScanner.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuSectionScanner.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// The container-section state machine of the hybrid <c>.viu</c> format: it owns the patterns that
+/// open and close a section and answers which section each line of a document belongs to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the single definition of "where does a section start and stop" in the extension.
+/// <see cref="ViuLexicalClassifier"/> drives its own per-line classification from these primitives,
+/// and <see cref="ViuAutoClosingLogic"/> drives auto-closing from <see cref="ScanLineSections"/>, so
+/// neither carries its own copy of the container grammar ([V01.01.12.07.08]).
+/// </para>
+/// <para>
+/// Attribution is per line, which is what both consumers need and what the format supports: a
+/// section boundary is a line-anchored construct in every container form — the legacy
+/// <c>@template {</c> header and its column-0 <c>}</c>, and the top-level <c>&lt;template&gt;</c> /
+/// <c>&lt;style&gt;</c> / <c>&lt;script&gt;</c> tags the hybrid container introduced
+/// ([V01.01.06.10]). A line that opens a section is attributed to that section, because content may
+/// follow the opener on the same line; a line that closes one is attributed to it for the same
+/// reason. The one exception mirrors the classifier: the column-0 <c>}</c> that ends a legacy
+/// <c>@</c>-block is structure rather than content, so its line is attributed to no section.
+/// </para>
+/// <para>
+/// Purely lexical and editor-free — no Visual Studio type appears here, which is what lets the same
+/// source be compiled into the extension assembly and, through <c>&lt;Compile Include&gt;</c> links,
+/// into a <c>dotnet test</c> project. The language surface is the .NET Framework one the extension
+/// compiles against.
+/// </para>
+/// </remarks>
+internal static class ViuSectionScanner
+{
+    /// <summary>The tag that closes a top-level <c>&lt;style&gt;</c> section.</summary>
+    internal const string StyleClosingTag = "</style>";
+
+    /// <summary>The tag that closes a top-level <c>&lt;script&gt;</c> section.</summary>
+    internal const string ScriptClosingTag = "</script>";
+
+    // The hybrid .viu container ([V01.01.06.10], Assimalign.Viu.Syntax.SingleFileComponent
+    // docs/FORMAT.md): <template> and <style> are top-level tags, @script keeps the @-block grammar,
+    // and the legacy @template/@style blocks keep highlighting during the migration window.
+    private static readonly Regex SectionHeaderExpression = new(
+        @"^\s*@(?<name>template|script|style)\b[^{]*(?<brace>\{)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TagSectionOpenExpression = new(
+        @"^\s*<(?<name>template|style|script)\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TemplateSectionTagExpression = new(
+        @"</?template\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Matches a legacy <c>@template</c> / <c>@script</c> / <c>@style</c> block header, capturing the
+    /// section name in <c>name</c> and its opening brace in <c>brace</c>.
+    /// </summary>
+    /// <param name="line">The line to match, without its line break.</param>
+    /// <returns>The match; <see cref="Group.Success"/> is false when the line is not a header.</returns>
+    internal static Match MatchSectionHeader(string line) => SectionHeaderExpression.Match(line);
+
+    /// <summary>
+    /// Matches a top-level <c>&lt;template&gt;</c> / <c>&lt;style&gt;</c> / <c>&lt;script&gt;</c>
+    /// opening tag, capturing the tag name in <c>name</c>.
+    /// </summary>
+    /// <param name="line">The line to match, without its line break.</param>
+    /// <returns>The match; <see cref="Group.Success"/> is false when the line opens no section.</returns>
+    internal static Match MatchTagSectionOpen(string line) => TagSectionOpenExpression.Match(line);
+
+    /// <summary>
+    /// Maps a container name — from either header form — onto the section it opens.
+    /// </summary>
+    /// <param name="sectionName">The captured container name.</param>
+    /// <returns>The section kind, or <see cref="ViuSectionKind.None"/> for an unknown name.</returns>
+    internal static ViuSectionKind GetSectionKind(string sectionName) => sectionName switch
+    {
+        "template" => ViuSectionKind.Template,
+        "script" => ViuSectionKind.Script,
+        "style" => ViuSectionKind.Style,
+        _ => ViuSectionKind.None,
+    };
+
+    /// <summary>
+    /// Walks the <c>&lt;template&gt;</c>/<c>&lt;/template&gt;</c> boundaries on a line, updating the
+    /// nesting depth.
+    /// </summary>
+    /// <param name="line">The line to walk.</param>
+    /// <param name="depth">The nesting depth on entry, updated in place.</param>
+    /// <returns>
+    /// The exclusive end offset of the closer that brings the depth back to zero, or <c>-1</c> when
+    /// the section stays open past this line. Self-closing <c>&lt;template /&gt;</c> tags do not
+    /// change the depth, so a slot fragment such as <c>&lt;template #header&gt;</c> never ends the
+    /// section.
+    /// </returns>
+    internal static int ScanTemplateTagDepth(string line, ref int depth)
+    {
+        foreach (Match match in TemplateSectionTagExpression.Matches(line))
+        {
+            bool isClosing = line[match.Index + 1] == '/';
+            int tagClose = line.IndexOf('>', match.Index + match.Length);
+
+            if (isClosing)
+            {
+                depth--;
+                if (depth <= 0)
+                {
+                    return tagClose < 0 ? line.Length : tagClose + 1;
+                }
+            }
+            else if (tagClose < 0 || line[tagClose - 1] != '/')
+            {
+                depth++;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Attributes every line of a document to the container section that encloses it.
+    /// </summary>
+    /// <param name="lines">The document's lines, without their line breaks.</param>
+    /// <returns>
+    /// One <see cref="ViuSectionKind"/> per line, in document order. Lines outside every section —
+    /// text between containers and the column-0 <c>}</c> that closes a legacy <c>@</c>-block — are
+    /// <see cref="ViuSectionKind.None"/>.
+    /// </returns>
+    public static ViuSectionKind[] ScanLineSections(IReadOnlyList<string> lines)
+    {
+        ViuSectionKind[] lineSections = new ViuSectionKind[lines.Count];
+        ViuSectionKind sectionKind = ViuSectionKind.None;
+        bool isTagDelimitedSection = false;
+        int templateTagDepth = 0;
+
+        for (int lineNumber = 0; lineNumber < lines.Count; lineNumber++)
+        {
+            string line = lines[lineNumber];
+
+            // Tag-delimited sections close at their matching end tag, never at an @-header or a
+            // column-0 '}' — the closer alone decides where the section ends.
+            if (isTagDelimitedSection)
+            {
+                lineSections[lineNumber] = sectionKind;
+                if (ClosesTagDelimitedSection(line, sectionKind, 0, ref templateTagDepth))
+                {
+                    sectionKind = ViuSectionKind.None;
+                    isTagDelimitedSection = false;
+                }
+
+                continue;
+            }
+
+            Match sectionMatch = MatchSectionHeader(line);
+            if (sectionMatch.Success)
+            {
+                sectionKind = GetSectionKind(sectionMatch.Groups["name"].Value);
+                lineSections[lineNumber] = sectionKind;
+                continue;
+            }
+
+            if (sectionKind == ViuSectionKind.None)
+            {
+                Match tagMatch = MatchTagSectionOpen(line);
+                if (tagMatch.Success)
+                {
+                    lineSections[lineNumber] = OpenTagDelimitedSection(
+                        line,
+                        tagMatch,
+                        ref sectionKind,
+                        ref isTagDelimitedSection,
+                        ref templateTagDepth);
+                    continue;
+                }
+            }
+            else if (line.Length > 0 && line[0] == '}')
+            {
+                // Column 0 is structural in the hybrid format: this '}' closes the open @-block, and
+                // is no more part of the section than the header that opened it.
+                sectionKind = ViuSectionKind.None;
+                lineSections[lineNumber] = ViuSectionKind.None;
+                continue;
+            }
+
+            lineSections[lineNumber] = sectionKind;
+        }
+
+        return lineSections;
+    }
+
+    // Opens a tag-delimited section on its opening-tag line and returns the section that line's
+    // content belongs to. A self-closing top-level tag carries no content, so no section opens; a
+    // section whose closer sits on the same line opens and closes here.
+    private static ViuSectionKind OpenTagDelimitedSection(
+        string line,
+        Match tagMatch,
+        ref ViuSectionKind sectionKind,
+        ref bool isTagDelimitedSection,
+        ref int templateTagDepth)
+    {
+        Group nameGroup = tagMatch.Groups["name"];
+        int headerClose = line.IndexOf('>', nameGroup.Index + nameGroup.Length);
+        if (headerClose > 0 && line[headerClose - 1] == '/')
+        {
+            return ViuSectionKind.None;
+        }
+
+        ViuSectionKind openedKind = GetSectionKind(nameGroup.Value);
+        sectionKind = openedKind;
+        isTagDelimitedSection = true;
+        templateTagDepth = 0;
+
+        // A template's depth scan reads the whole line, opening tag included; a raw-text section's
+        // closer search starts past its own header so "<style></style>" is recognized as one line.
+        int searchStart = openedKind == ViuSectionKind.Template
+            ? 0
+            : headerClose < 0 ? line.Length : headerClose + 1;
+
+        if (ClosesTagDelimitedSection(line, openedKind, searchStart, ref templateTagDepth))
+        {
+            sectionKind = ViuSectionKind.None;
+            isTagDelimitedSection = false;
+        }
+
+        return openedKind;
+    }
+
+    private static bool ClosesTagDelimitedSection(
+        string line,
+        ViuSectionKind sectionKind,
+        int searchStart,
+        ref int templateTagDepth)
+    {
+        switch (sectionKind)
+        {
+            case ViuSectionKind.Template:
+                return ScanTemplateTagDepth(line, ref templateTagDepth) >= 0;
+
+            case ViuSectionKind.Style:
+                return FindClosingTag(line, StyleClosingTag, searchStart) >= 0;
+
+            case ViuSectionKind.Script:
+                return FindClosingTag(line, ScriptClosingTag, searchStart) >= 0;
+
+            default:
+                return false;
+        }
+    }
+
+    private static int FindClosingTag(string line, string closingTag, int searchStart) =>
+        searchStart <= line.Length
+            ? line.IndexOf(closingTag, searchStart, StringComparison.Ordinal)
+            : -1;
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuSnapshotLines.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuSnapshotLines.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.Text;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Reads a text snapshot into the line list the editor-free Viu analyses take as input.
+/// </summary>
+/// <remarks>
+/// The lexer, the section scanner, and the auto-closing decisions all work on lines without their
+/// line breaks and know nothing of <see cref="ITextSnapshot"/>; this is the single place the editor's
+/// buffer model is converted into that shape.
+/// </remarks>
+internal static class ViuSnapshotLines
+{
+    /// <summary>
+    /// Copies a snapshot's text into one string per line, in document order.
+    /// </summary>
+    /// <param name="snapshot">The snapshot to read.</param>
+    /// <returns>The snapshot's lines, without their line breaks.</returns>
+    public static IReadOnlyList<string> Read(ITextSnapshot snapshot)
+    {
+        int lineCount = snapshot.LineCount;
+        List<string> lines = new(lineCount);
+        for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
+        {
+            lines.Add(snapshot.GetLineFromLineNumber(lineNumber).GetText());
+        }
+
+        return lines;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/Assimalign.Viu.VisualStudio.Tests.csproj
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/Assimalign.Viu.VisualStudio.Tests.csproj
@@ -28,10 +28,17 @@
 
   <ItemGroup>
     <Compile Include="..\src\ViuLexicalClassifier.cs" Link="ViuLexicalClassifier.cs" />
+    <Compile Include="..\src\ViuSectionScanner.cs" Link="ViuSectionScanner.cs" />
+    <Compile Include="..\src\ViuAutoClosingLogic.cs" Link="ViuAutoClosingLogic.cs" />
+    <Compile Include="..\src\ViuAutoClosingEdit.cs" Link="ViuAutoClosingEdit.cs" />
     <Compile Include="..\src\ViuClassificationKind.cs" Link="ViuClassificationKind.cs" />
     <Compile Include="..\src\ViuClassificationTypeNames.cs" Link="ViuClassificationTypeNames.cs" />
     <Compile Include="..\src\ViuLexicalSpan.cs" Link="ViuLexicalSpan.cs" />
     <Compile Include="..\src\ViuSectionKind.cs" Link="ViuSectionKind.cs" />
     <Compile Include="..\src\ViuLanguageServerConfiguration.cs" Link="ViuLanguageServerConfiguration.cs" />
+    <!-- The same frozen-path link the extension takes, so the void-element table the auto-closing
+         tests exercise is the repository's authoritative one and not a test fixture. -->
+    <Compile Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.Shared\src\Internal\DomKnowledgeData.cs"
+             Link="Internal\DomKnowledgeData.cs" />
   </ItemGroup>
 </Project>

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuAutoClosingLogicTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuAutoClosingLogicTests.cs
@@ -1,0 +1,476 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Pins every auto-closing decision a <c>.viu</c> document makes ([V01.01.12.07.08]).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The caret is written into the test text as a <c>|</c>, which the helpers strip before handing the
+/// document to the decision logic. Assertions on a completion re-render the affected line with the
+/// insertion applied and the caret marked, so a single expected string pins the inserted text and
+/// the caret offset together and a wrong offset cannot pass.
+/// </para>
+/// <para>
+/// Only the decisions are covered here, because only the decisions are testable outside
+/// <c>devenv.exe</c>: the MEF exports, the brace-completion session, and the buffer edit are
+/// runtime-verified.
+/// </para>
+/// </remarks>
+public class ViuAutoClosingLogicTests
+{
+    // ---- Character-pair gating -------------------------------------------------------------
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInTemplateAttributeValuePosition_Pairs()
+    {
+        AllowsQuote('"', "<template>", "    <div class=|", "</template>").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInDirectiveValuePosition_Pairs()
+    {
+        AllowsQuote('"', "<template>", "    <button @click=|", "</template>").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInAttributeValuePositionOnAContinuationLine_Pairs()
+    {
+        // A tag header may span lines, so the attribute-value test walks back through them.
+        AllowsQuote(
+            '"',
+            "<template>",
+            "    <div",
+            "        class=|",
+            "</template>").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInTemplateTextContent_DoesNotPair()
+    {
+        // Pairing here would interrupt ordinary prose: the quote is punctuation, not a delimiter.
+        AllowsQuote('"', "<template>", "    <p>He said |", "</template>").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInsideAnOpenAttributeValue_DoesNotPair()
+    {
+        AllowsQuote('"', "<template>", "    <div class=\"card |", "</template>").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_DoubleQuoteInTagHeaderWithoutAnEquals_DoesNotPair()
+    {
+        AllowsQuote('"', "<template>", "    <div |", "</template>").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_SingleQuoteInTemplate_NeverPairs()
+    {
+        // The apostrophe is the reason the single quote is script-only: pairing it in template prose
+        // would corrupt ordinary text, and the attribute-value position is already served by the
+        // double quote Viu's own lexer recognizes.
+        AllowsQuote('\'', "<template>", "    <div class=|", "</template>").ShouldBeFalse();
+        AllowsQuote('\'', "<template>", "    <p>it|", "</template>").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_BothQuotesInTheScriptBlock_Pair()
+    {
+        AllowsQuote('"', "@script {", "    var text = |", "}").ShouldBeTrue();
+        AllowsQuote('\'', "@script {", "    var letter = |", "}").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_BothQuotesInATopLevelScriptTag_Pair()
+    {
+        AllowsQuote('"', "<script>", "    var text = |", "</script>").ShouldBeTrue();
+        AllowsQuote('\'', "<script>", "    var letter = |", "</script>").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_NeitherQuoteInAStyleSection_Pairs()
+    {
+        AllowsQuote('"', "<style>", "    div { content: |", "</style>").ShouldBeFalse();
+        AllowsQuote('\'', "<style>", "    div { content: |", "</style>").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_NeitherQuoteBetweenContainers_Pairs()
+    {
+        AllowsQuote('"', "<template></template>", "|", "@script {", "}").ShouldBeFalse();
+        AllowsQuote('\'', "<template></template>", "|", "@script {", "}").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AllowsQuotePair_ACharacterThatIsNotAQuote_DoesNotPair()
+    {
+        AllowsQuote('`', "@script {", "    var text = |", "}").ShouldBeFalse();
+    }
+
+    // ---- Element auto-close: '>' finishing an open tag ------------------------------------
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAnElementTag_InsertsTheEndTag()
+    {
+        Complete('>', "<template>", "    <div|", "</template>")
+            .ShouldBe("    <div>|</div>");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterATagWithAttributes_InsertsTheEndTag()
+    {
+        Complete('>', "<template>", "    <div class=\"card\" @click=\"Save\"|", "</template>")
+            .ShouldBe("    <div class=\"card\" @click=\"Save\">|</div>");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAComponentTag_InsertsTheEndTag()
+    {
+        // Casing is the only component signal a lexical decision has, and it needs none: the end tag
+        // repeats the authored spelling ordinally, which is how Viu resolves names ([CMP-6]).
+        Complete('>', "<template>", "    <TodoItem|", "</template>")
+            .ShouldBe("    <TodoItem>|</TodoItem>");
+        Complete('>', "<template>", "    <Layout.Header|", "</template>")
+            .ShouldBe("    <Layout.Header>|</Layout.Header>");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAFrameworkTag_InsertsTheEndTag()
+    {
+        // The framework tags auto-close like any other element: <template> is what a new component
+        // starts with, and <slot> is what a layout component is built from.
+        Complete('>', "<template|").ShouldBe("<template>|</template>");
+        Complete('>', "<template>", "    <slot|", "</template>")
+            .ShouldBe("    <slot>|</slot>");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterATagHeaderSpanningLines_InsertsTheEndTag()
+    {
+        Complete(
+            '>',
+            "<template>",
+            "    <div",
+            "        class=\"card\"|",
+            "</template>").ShouldBe("        class=\"card\">|</div>");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAVoidElement_InsertsNothing()
+    {
+        // The WHATWG void elements take no end tag, and the list comes from the repository's shared
+        // DOM knowledge rather than from a table written for the editor.
+        Completion('>', "<template>", "    <br|", "</template>").ShouldBeNull();
+        Completion('>', "<template>", "    <input type=\"text\"|", "</template>").ShouldBeNull();
+        Completion('>', "<template>", "    <img src=\"a.png\"|", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAVoidElementInAnyCasing_InsertsNothing()
+    {
+        // Void elements are matched case-insensitively, the same way the template compiler and the
+        // runtime resolve them.
+        Completion('>', "<template>", "    <BR|", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterASelfClosedTag_InsertsNothing()
+    {
+        Completion('>', "<template>", "    <div /|", "</template>").ShouldBeNull();
+        Completion('>', "<template>", "    <TodoItem :item=\"Item\"/|", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanBeforeAnExistingEndTag_InsertsNothing()
+    {
+        // Re-typing the '>' of a tag that already has its end tag must not add a second one.
+        Completion('>', "<template>", "    <div|</div>", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInsideAnAttributeValue_InsertsNothing()
+    {
+        // The '>' is content inside the value, not the end of the tag header.
+        Completion('>', "<template>", "    <div :title=\"a |", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInTemplateTextContent_InsertsNothing()
+    {
+        Completion('>', "<template>", "    <p>a |", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInsideAnInterpolation_InsertsNothing()
+    {
+        Completion('>', "<template>", "    <p>{{ Left |", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanAfterAnEndTagName_InsertsNothing()
+    {
+        Completion('>', "<template>", "    <div>text</div|", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInTheScriptBlock_InsertsNothing()
+    {
+        // A '>' in C# closes a generic argument list or a lambda arrow. This is the whole reason the
+        // decision is section-aware.
+        Completion('>', "@script {", "    var value = Context.Get<string|", "}").ShouldBeNull();
+        Completion('>', "@script {", "    Items.Select(item =|", "}").ShouldBeNull();
+        Completion('>', "@script {", "    if (Count |", "}").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInATopLevelScriptTag_InsertsNothing()
+    {
+        Completion('>', "<script>", "    var value = Read<string|", "</script>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanInAStyleSection_InsertsNothing()
+    {
+        // '>' is the CSS child combinator.
+        Completion('>', "<style>", "    div |", "</style>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_GreaterThanBetweenContainers_InsertsNothing()
+    {
+        Completion('>', "<template></template>", "<div|").ShouldBeNull();
+    }
+
+    // ---- Element auto-close: '/' completing the nearest unclosed element -------------------
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAfterAngleBracket_CompletesTheNearestUnclosedElement()
+    {
+        Complete('/', "<template>", "    <div>", "        <|", "</template>")
+            .ShouldBe("        </div>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAfterAngleBracket_CompletesTheInnermostOfNestedElements()
+    {
+        Complete(
+            '/',
+            "<template>",
+            "    <div>",
+            "        <section>",
+            "            <|",
+            "</template>").ShouldBe("            </section>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAfterAngleBracket_SkipsElementsAlreadyClosed()
+    {
+        Complete(
+            '/',
+            "<template>",
+            "    <div>",
+            "        <section>Done</section>",
+            "        <|",
+            "</template>").ShouldBe("        </div>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAfterAngleBracket_SkipsVoidAndSelfClosedChildren()
+    {
+        Complete(
+            '/',
+            "<template>",
+            "    <div>",
+            "        <br>",
+            "        <TodoItem :item=\"Item\" />",
+            "        <|",
+            "</template>").ShouldBe("        </div>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAfterAngleBracket_IgnoresTagsInsideCommentsAndAttributeValues()
+    {
+        Complete(
+            '/',
+            "<template>",
+            "    <div title=\"<b>\">",
+            "        <!-- <section> -->",
+            "        <|",
+            "</template>").ShouldBe("        </div>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusAtTheTopOfATagDelimitedTemplate_CompletesTheContainer()
+    {
+        // The container tag is an unclosed element like any other, so this is how a hand-authored
+        // <template> gets its closer.
+        Complete('/', "<template>", "    <|").ShouldBe("    </template>|");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusWithNothingUnclosed_InsertsNothing()
+    {
+        Completion('/', "@template {", "    <|", "}").ShouldBeNull();
+        Completion('/', "@template {", "    <p>Done</p>", "    <|", "}").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusNotImmediatelyAfterAngleBracket_InsertsNothing()
+    {
+        Completion('/', "<template>", "    <div>text |", "</template>").ShouldBeNull();
+        Completion('/', "<template>", "    <div |", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusInTheScriptBlock_InsertsNothing()
+    {
+        // Division, comments, and a generic type argument all put a '/' next to a '<' in C#.
+        Completion('/', "@script {", "    var value = Read<|", "}").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_SolidusInAStyleSection_InsertsNothing()
+    {
+        Completion('/', "<style>", "    div { width: calc(100% <|", "</style>").ShouldBeNull();
+    }
+
+    // ---- Comment auto-close ---------------------------------------------------------------
+
+    [Fact]
+    public void GetTypedCharacterCompletion_HyphenCompletingACommentOpener_InsertsTheTerminator()
+    {
+        // Recorded shape: the caret lands between two spaces, so the comment reads "<!-- text -->"
+        // as soon as the user types - the spaced form comments are conventionally written in.
+        Complete('-', "<template>", "    <!-|", "</template>")
+            .ShouldBe("    <!-- | -->");
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_HyphenWithATrailingHyphenAlreadyPresent_InsertsNothing()
+    {
+        Completion('-', "<template>", "    <!-|->", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_HyphenNotCompletingACommentOpener_InsertsNothing()
+    {
+        Completion('-', "<template>", "    <!|", "</template>").ShouldBeNull();
+        Completion('-', "<template>", "    <p>a |", "</template>").ShouldBeNull();
+        Completion('-', "<template>", "    <div class=\"top|", "</template>").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_HyphenOutsideATemplate_InsertsNothing()
+    {
+        Completion('-', "@script {", "    var value = Count -|", "}").ShouldBeNull();
+        Completion('-', "<style>", "    <!-|", "</style>").ShouldBeNull();
+    }
+
+    // ---- Trigger characters and bounds ------------------------------------------------------
+
+    [Theory]
+    [InlineData('>', true)]
+    [InlineData('/', true)]
+    [InlineData('-', true)]
+    [InlineData('<', false)]
+    [InlineData('"', false)]
+    [InlineData('a', false)]
+    public void IsCompletionTriggerCharacter_ReportsOnlyTheThreeActingCharacters(
+        char typedCharacter,
+        bool expected)
+    {
+        ViuAutoClosingLogic.IsCompletionTriggerCharacter(typedCharacter).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_APositionOutsideTheDocument_InsertsNothing()
+    {
+        string[] lines = ["<template>", "    <div", "</template>"];
+
+        ViuAutoClosingLogic.GetTypedCharacterCompletion(lines, -1, 0, '>').ShouldBeNull();
+        ViuAutoClosingLogic.GetTypedCharacterCompletion(lines, 3, 0, '>').ShouldBeNull();
+        ViuAutoClosingLogic.GetTypedCharacterCompletion(lines, 1, 99, '>').ShouldBeNull();
+        ViuAutoClosingLogic.AllowsQuotePair(lines, 9, 0, '"').ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetTypedCharacterCompletion_ANonTriggerCharacter_InsertsNothing()
+    {
+        Completion('<', "<template>", "    <div|", "</template>").ShouldBeNull();
+    }
+
+    // ---- Helpers ----------------------------------------------------------------------------
+
+    // Applies the completion the given keystroke produces and re-renders the caret line with the
+    // caret marked, so one expected string pins the inserted text and the caret offset together.
+    private static string Complete(char typedCharacter, params string[] markedLines)
+    {
+        (IReadOnlyList<string> lines, int lineNumber, int characterIndex) = ReadCaret(markedLines);
+        ViuAutoClosingEdit? completion = ViuAutoClosingLogic.GetTypedCharacterCompletion(
+            lines,
+            lineNumber,
+            characterIndex,
+            typedCharacter);
+
+        completion.ShouldNotBeNull();
+        ViuAutoClosingEdit autoClosingEdit = completion.Value;
+        autoClosingEdit.CaretOffset.ShouldBeInRange(0, autoClosingEdit.InsertedText.Length);
+        autoClosingEdit.InsertedText[0].ShouldBe(typedCharacter);
+
+        return lines[lineNumber]
+            .Insert(characterIndex, autoClosingEdit.InsertedText)
+            .Insert(characterIndex + autoClosingEdit.CaretOffset, "|");
+    }
+
+    private static ViuAutoClosingEdit? Completion(char typedCharacter, params string[] markedLines)
+    {
+        (IReadOnlyList<string> lines, int lineNumber, int characterIndex) = ReadCaret(markedLines);
+        return ViuAutoClosingLogic.GetTypedCharacterCompletion(
+            lines,
+            lineNumber,
+            characterIndex,
+            typedCharacter);
+    }
+
+    private static bool AllowsQuote(char quoteCharacter, params string[] markedLines)
+    {
+        (IReadOnlyList<string> lines, int lineNumber, int characterIndex) = ReadCaret(markedLines);
+        return ViuAutoClosingLogic.AllowsQuotePair(
+            lines,
+            lineNumber,
+            characterIndex,
+            quoteCharacter);
+    }
+
+    // Strips the '|' caret marker out of the document and reports where it was.
+    private static (IReadOnlyList<string> Lines, int LineNumber, int CharacterIndex) ReadCaret(
+        string[] markedLines)
+    {
+        List<string> lines = new(markedLines.Length);
+        int caretLineNumber = -1;
+        int caretCharacterIndex = -1;
+
+        for (int lineNumber = 0; lineNumber < markedLines.Length; lineNumber++)
+        {
+            int markerIndex = markedLines[lineNumber].IndexOf('|');
+            if (markerIndex < 0)
+            {
+                lines.Add(markedLines[lineNumber]);
+                continue;
+            }
+
+            caretLineNumber = lineNumber;
+            caretCharacterIndex = markerIndex;
+            lines.Add(markedLines[lineNumber].Remove(markerIndex, 1));
+        }
+
+        caretLineNumber.ShouldBeGreaterThanOrEqualTo(0, "the test document needs one '|' caret");
+        return (lines, caretLineNumber, caretCharacterIndex);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSectionScannerTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSectionScannerTests.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Pins the container-section attribution both the classifier and the auto-closing decisions read
+/// ([V01.01.12.07.08]).
+/// </summary>
+public class ViuSectionScannerTests
+{
+    [Fact]
+    public void ScanLineSections_HybridContainer_AttributesEveryLineToItsSection()
+    {
+        // The hybrid .viu container ([V01.01.06.10]): tag-delimited <template>/<style> plus the
+        // @script @-block. A line that opens or closes a tag section belongs to it, because content
+        // may sit on the same line; the column-0 '}' that ends an @-block does not, because it is
+        // structure rather than content.
+        string[] lines =
+        [
+            "<template>",
+            "    <div>Hello</div>",
+            "</template>",
+            "",
+            "@script {",
+            "    public int Count { get; set; }",
+            "}",
+            "",
+            "<style scoped>",
+            "    div { color: red; }",
+            "</style>",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+        [
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.None,
+            ViuSectionKind.Script,
+            ViuSectionKind.Script,
+            ViuSectionKind.None,
+            ViuSectionKind.None,
+            ViuSectionKind.Style,
+            ViuSectionKind.Style,
+            ViuSectionKind.Style,
+        ]);
+    }
+
+    [Fact]
+    public void ScanLineSections_LegacyAtBlocks_AttributesEveryLineToItsSection()
+    {
+        // Transition-window pin ([V01.01.06.10]): the legacy @template/@style containers stay
+        // recognized until they are removed.
+        string[] lines =
+        [
+            "@template {",
+            "    <div>Hello</div>",
+            "}",
+            "@style scoped {",
+            "    div { color: red; }",
+            "}",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+        [
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.None,
+            ViuSectionKind.Style,
+            ViuSectionKind.Style,
+            ViuSectionKind.None,
+        ]);
+    }
+
+    [Fact]
+    public void ScanLineSections_NestedTemplateSlotFragment_DoesNotEndTheSection()
+    {
+        // A <template #header> slot fragment nests inside the container tag of the same name, so
+        // only the closer that brings the depth back to zero ends the section.
+        string[] lines =
+        [
+            "<template>",
+            "    <template #header>",
+            "        <h1>Title</h1>",
+            "    </template>",
+            "    <p>Body</p>",
+            "</template>",
+            "trailing",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+        [
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.Template,
+            ViuSectionKind.None,
+        ]);
+    }
+
+    [Fact]
+    public void ScanLineSections_UnterminatedOpeningTag_StillOpensTheSection()
+    {
+        // The state a container is in mid-keystroke: the user has typed "<template" and not yet the
+        // '>'. Auto-closing depends on this, because that is exactly when it must decide whether to
+        // insert the end tag.
+        string[] lines =
+        [
+            "<template",
+            "    <div>",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+            [ViuSectionKind.Template, ViuSectionKind.Template]);
+    }
+
+    [Fact]
+    public void ScanLineSections_SelfClosingTopLevelTag_OpensNoSection()
+    {
+        string[] lines =
+        [
+            "<template />",
+            "after",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+            [ViuSectionKind.None, ViuSectionKind.None]);
+    }
+
+    [Fact]
+    public void ScanLineSections_SectionOpenedAndClosedOnOneLine_ClaimsOnlyThatLine()
+    {
+        string[] lines =
+        [
+            "<style>div { color: red; }</style>",
+            "after",
+            "<template><p>Hello</p></template>",
+            "after",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+        [
+            ViuSectionKind.Style,
+            ViuSectionKind.None,
+            ViuSectionKind.Template,
+            ViuSectionKind.None,
+        ]);
+    }
+
+    [Fact]
+    public void ScanLineSections_TopLevelScriptTag_IsAttributedToTheScriptSection()
+    {
+        // The container parser rejects a top-level <script> tag (VIU1017); the editor still treats
+        // its body as script so the misplaced code keeps its behavior while the diagnostic points at
+        // the fix.
+        string[] lines =
+        [
+            "<script>",
+            "    var value = 1;",
+            "</script>",
+        ];
+
+        ViuSectionScanner.ScanLineSections(lines).ShouldBe(
+            [ViuSectionKind.Script, ViuSectionKind.Script, ViuSectionKind.Script]);
+    }
+
+    [Fact]
+    public void ScanLineSections_EmptyDocument_ReturnsNoSections()
+    {
+        ViuSectionScanner.ScanLineSections([]).ShouldBeEmpty();
+        ViuSectionScanner.ScanLineSections([""]).ShouldBe([ViuSectionKind.None]);
+    }
+
+    [Fact]
+    public void ScanLineSections_AgreesWithTheClassifiersOwnSectionHandling()
+    {
+        // The scanner owns the container grammar and the classifier drives its per-line passes from
+        // the same primitives; this pins that the two stay in agreement about which section a line
+        // is in, read through the classifications only that section can produce.
+        string[] lines =
+        [
+            "<template>",
+            "    <div :title=\"Label\">{{ Count }}</div>",
+            "</template>",
+            "",
+            "@script {",
+            "    public int Count { get; set; }",
+            "}",
+            "",
+            "<style>",
+            "    div { color: red; }",
+            "</style>",
+        ];
+
+        ViuSectionKind[] sections = ViuSectionScanner.ScanLineSections(lines);
+        IReadOnlyList<ViuLexicalSpan> spans = ViuLexicalClassifier.Classify(lines);
+
+        sections[1].ShouldBe(ViuSectionKind.Template);
+        ClassificationsOnLine(spans, 1).ShouldContain(ViuClassificationKind.MarkupNode);
+
+        sections[5].ShouldBe(ViuSectionKind.Script);
+        ClassificationsOnLine(spans, 5).ShouldContain(ViuClassificationKind.Keyword);
+
+        sections[9].ShouldBe(ViuSectionKind.Style);
+        ClassificationsOnLine(spans, 9).ShouldContain(ViuClassificationKind.StyleSelector);
+    }
+
+    private static IReadOnlyList<ViuClassificationKind> ClassificationsOnLine(
+        IReadOnlyList<ViuLexicalSpan> spans,
+        int lineNumber) =>
+        spans.Where(span => span.LineNumber == lineNumber)
+            .Select(span => span.ClassificationKind)
+            .ToList();
+}

--- a/extensions/VisualStudio/Marketplace.md
+++ b/extensions/VisualStudio/Marketplace.md
@@ -15,6 +15,12 @@ One package: the `.viu` file association, the Viu color theme, and the Viu langu
   the C# in the file next to it
 - **`.viu` opens in the right editor automatically.** The package registers the file extension, so
   there is no per-file Open With step
+- **Auto-closing that knows which section you are in.** `{`, `(`, and `[` pair everywhere — typing
+  `{` twice gives you `{{}}` for an interpolation. Quotes pair only where they mean a string, so an
+  apostrophe in template prose stays an apostrophe. Typing `>` after an open tag inserts its end tag
+  with the caret between them, `</` completes the nearest unclosed element, and `<!--` completes to
+  `<!-- | -->`. Nothing fires inside `@script` or `<style>`, where `>` is a generic argument or a CSS
+  child combinator, and void elements such as `<br>` insert nothing
 - Diagnostics for malformed single-file-component block structure
 - Completion for block headers and options, common template elements, directives, events, CSS
   properties, `Context.*`, and `Reactive.*`

--- a/extensions/VisualStudio/README.md
+++ b/extensions/VisualStudio/README.md
@@ -119,6 +119,14 @@ The complete repository and Marketplace setup is documented in
 - Embedded C# — the `@script` block, interpolation interiors, and binding-expression interiors —
   colors with the editor's and Roslyn's own classification types, so it inherits whatever theme you
   chose for C#. A `class` value is deliberately one uninterrupted attribute-value color
+- **Auto-closing** as you type. `{`, `(`, and `[` pair in every section — typing `{` twice gives you
+  `{{}}` for an interpolation. Quotes pair only where they mean a string: `"` in attribute-value
+  position and in script, `'` in script only, so an apostrophe in template prose stays an apostrophe.
+  Typing `>` after an open tag inserts its end tag with the caret between them, `</` completes the
+  nearest unclosed element, and `<!--` completes to `<!-- | -->`; none of that fires inside `@script`
+  or `<style>`, where `>` is a generic argument or a CSS child combinator. Void elements
+  (`<br>`, `<input>`, …) and tags you self-closed insert nothing. Pairs follow the editor's
+  Automatic Brace Completion option in Tools > Options; element closing is always on
 - Parser diagnostics for malformed single-file-component block structure
 - Full and incremental document synchronization
 - Completion for block headers and options, common template tags/directives/events, CSS properties,


### PR DESCRIPTION
## Summary

Typing an opening delimiter in a `.viu` document now pairs, through two mechanisms in the in-process extension:

- **Character pairs** via the editor's brace-completion engine: `{ }`, `( )`, `[ ]` in every section (typing `{` twice yields `{{}}` — the interpolation authoring path); `"` only where it means a string (attribute-value position and script blocks); `'` in script blocks only, so an apostrophe in template prose stays an apostrophe. Type-through and backspace-pair-deletion come from the editor's sessions, and the editor's own Automatic Brace Completion option is respected — verified from the shipping `BraceCompletionManager`, which checks it before consulting any provider. The quote gating lives exclusively on a context provider, because the aggregator takes the first provider that agrees and a default provider always agrees — registering quotes on both would silently defeat the gate.
- **Element auto-close** via a typed-character command handler, template sections only: `>` after an open tag inserts its end tag with the caret between (declining void elements from the shared WHATWG table, self-closed tags, and already-closed tags); `</` completes the nearest unclosed element; `<!--` completes to `<!-- | -->`. Nothing fires inside `@script` (generics, lambdas) or `<style>` (`div > p`).

The section grammar was consolidated into one `ViuSectionScanner` that both the classifier and the auto-closing logic drive, so the two features cannot drift. All decision logic is pure and source-linked into the test project; the MEF/commanding glue is runtime-verified only, as documented.

Out of scope, recorded in DESIGN.md: `=` → `=""` attribute quotes, VS Code element auto-close (needs a custom protocol request), an options page for element auto-close.

## Tests

Extension tests 62 → 122 (+60): full gating matrix (section × character), tag-close decisions, `</` completion, comment completion, caret offsets pinned exactly, and a classifier-agreement pin on the shared section scanner. Solution 0 warnings / 0 errors; VSIX 11-entry shape intact; LanguageService/LanguageServer tests unchanged.

## Work items resolved by this PR

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)