### PR TITLE
fix: clear the three CI-unmasked defects behind the red lanes

### DIFF
--- a/analyzers/Assimalign.Viu.Generators.Syntax/src/Internal/SingleFileComponentFileSet.cs
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/src/Internal/SingleFileComponentFileSet.cs
@@ -1,0 +1,73 @@
+using System;
+
+using Assimalign.Viu.Tooling.Css;
+using Assimalign.Viu.Tooling.SingleFileComponent;
+
+namespace Assimalign.Viu.Generators.Syntax;
+
+/// <summary>
+/// The two cross-file facts a single component's projection needs but cannot see from its own path:
+/// which canonical <c>.viu</c> base paths exist (so a same-base <c>.vue</c> peer knows it is shadowed,
+/// [VUE-7]) and which components must carry the hint-name case discriminator ([SFC-CG-5],
+/// [V01.01.06.10.01]). Both are value-equatable arrays, so this record is a legal incremental-pipeline
+/// value: it changes only when component files are added, removed, or renamed — never when one is
+/// edited — and every per-file step stays cached across an ordinary edit.
+/// </summary>
+/// <param name="CanonicalBasePaths">
+/// Every <c>.viu</c> file's path with its extension removed, ordinally sorted.
+/// </param>
+/// <param name="CaseDiscriminatedPaths">
+/// The exact paths of the components whose readable hint names collide with another component's by case
+/// alone, ordinally sorted. Empty in every compilation with no such collision, which is the norm.
+/// </param>
+internal readonly record struct SingleFileComponentFileSet(
+    EquatableArray<string> CanonicalBasePaths,
+    EquatableArray<string> CaseDiscriminatedPaths)
+{
+    /// <summary>The set for a compilation with no component files.</summary>
+    public static readonly SingleFileComponentFileSet Empty =
+        new(EquatableArray<string>.Empty, EquatableArray<string>.Empty);
+
+    /// <summary>
+    /// Whether a canonical <c>.viu</c> component shadows the compatibility <c>.vue</c> file at
+    /// <paramref name="componentBasePath"/>. Path identity follows the host operating system [VUE-7].
+    /// </summary>
+    /// <param name="componentBasePath">The extension-stripped, forward-slash-normalized component path.</param>
+    /// <returns><see langword="true"/> when a same-directory, same-base <c>.viu</c> file exists.</returns>
+    public bool ContainsCanonicalBasePath(string componentBasePath)
+    {
+        foreach (var canonicalBasePath in CanonicalBasePaths)
+        {
+            if (string.Equals(
+                    componentBasePath,
+                    canonicalBasePath,
+                    SingleFileComponentPathComparison.Comparison))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="filePath"/> must take the hint-name case discriminator because another
+    /// emitted component's readable hint name differs from its own only by case ([SFC-CG-5]).
+    /// </summary>
+    /// <param name="filePath">The component's path exactly as MSBuild supplied it.</param>
+    /// <returns><see langword="true"/> when the discriminator is required.</returns>
+    public bool RequiresCaseDiscriminator(string filePath)
+    {
+        foreach (var discriminatedPath in CaseDiscriminatedPaths)
+        {
+            // Ordinal: the entries are the very paths the additional texts carry, and a case-differing
+            // path is a DIFFERENT component here - the collision is exactly what is being resolved.
+            if (string.Equals(filePath, discriminatedPath, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/analyzers/Assimalign.Viu.Generators.Syntax/src/SingleFileComponentGenerator.cs
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/src/SingleFileComponentGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
@@ -24,6 +25,15 @@ namespace Assimalign.Viu.Generators.Syntax;
 /// tests pin. This project owns only the host concerns: the incremental pipeline, file reads, hot-reload
 /// gating, <c>.vue</c>-shadowing (a multi-file MSBuild concern), and the Roslyn materialization of the
 /// projection's neutral diagnostics (<see cref="SingleFileComponentDiagnosticAdapter"/>).
+/// </para>
+/// <para>
+/// Hint-name identity is the other multi-file concern ([SFC-CG-5], [V01.01.06.10.01]). Roslyn compares
+/// <c>AddSource</c> hint names case-insensitively and kills the whole generator run on a duplicate, so
+/// wherever path identity is ordinal — every non-Windows filesystem [VUE-7] — two components whose base
+/// names differ only by case would otherwise claim one hint name. <see cref="SingleFileComponentFileSet"/>
+/// resolves those groups once per file set and each member takes the resolver's path-hash discriminator;
+/// a component that collides with nothing keeps its readable hint name byte for byte, so no existing
+/// generated-file identity moves.
 /// </para>
 /// <para>
 /// For Debug builds, or when explicitly enabled by <c>ViuEmitHotReloadMetadata</c>, the generator also
@@ -65,15 +75,21 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
                 ShouldEmitHotReloadMetadata(configuration, emitHotReloadMetadata));
         });
 
-        var canonicalFileKeys = context.AdditionalTextsProvider
-            .Where(static text => IsViuFile(text.Path))
-            .Select(static (text, _) => ComponentBasePath(text.Path))
-            .Collect();
+        // The multi-file view: .vue shadowing [VUE-7] and hint-name case collisions [SFC-CG-5] are both
+        // facts about the SET of component files, so they are resolved once per set — keyed on the
+        // project directory alone, never on the whole option record, so an unrelated property change
+        // cannot invalidate it.
+        var fileSet = context.AdditionalTextsProvider
+            .Where(static text => IsSingleFileComponentFile(text.Path))
+            .Select(static (text, _) => text.Path)
+            .Collect()
+            .Combine(projectOptions.Select(static (options, _) => options.ProjectDirectory))
+            .Select(static (pair, _) => CreateFileSet(pair.Left, pair.Right));
 
         var files = context.AdditionalTextsProvider
             .Where(static text => IsSingleFileComponentFile(text.Path))
             .Combine(projectOptions)
-            .Combine(canonicalFileKeys)
+            .Combine(fileSet)
             .Select(static (pair, cancellationToken) => ReadFile(
                 pair.Left.Left,
                 pair.Left.Right,
@@ -148,12 +164,16 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
     private static SingleFileComponentProjectionInput ReadFile(
         AdditionalText additionalText,
         ProjectOptions options,
-        ImmutableArray<string> canonicalFileKeys,
+        SingleFileComponentFileSet fileSet,
         System.Threading.CancellationToken cancellationToken)
     {
         var text = additionalText.GetText(cancellationToken);
         var content = text?.ToString() ?? string.Empty;
-        var names = SingleFileComponentNameResolver.Resolve(additionalText.Path, options.ProjectDirectory, options.RootNamespace);
+        var names = SingleFileComponentNameResolver.Resolve(
+            additionalText.Path,
+            options.ProjectDirectory,
+            options.RootNamespace,
+            fileSet.RequiresCaseDiscriminator(additionalText.Path));
         var scopeId = StyleScopeId.Resolve(additionalText.Path, options.ProjectDirectory);
         var format = IsVueFile(additionalText.Path)
             ? SingleFileComponentFormat.Vue
@@ -172,7 +192,7 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
                     additionalText.Path,
                     options.ProjectDirectory)
                 : null,
-            HasCanonicalPeer(format, additionalText.Path, canonicalFileKeys));
+            HasCanonicalPeer(format, additionalText.Path, fileSet));
     }
 
     private static bool ShouldEmitHotReloadMetadata(
@@ -187,30 +207,59 @@ public sealed class SingleFileComponentGenerator : IIncrementalGenerator
         return string.Equals(configuration, "Debug", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool HasCanonicalPeer(
-        SingleFileComponentFormat format,
-        string filePath,
-        ImmutableArray<string> canonicalFileKeys)
+    // Resolves the two cross-file facts for one compilation's component files: the canonical .viu base
+    // paths a .vue peer is shadowed by [VUE-7], and the components whose readable hint names would
+    // collide under Roslyn's case-insensitive AddSource comparison [SFC-CG-5]. Shadowed .vue files are
+    // excluded from the collision input because they emit nothing — counting one would discriminate the
+    // canonical .viu component that suppressed it, churning an identity that never collided.
+    private static SingleFileComponentFileSet CreateFileSet(
+        ImmutableArray<string> componentPaths,
+        string? projectDirectory)
     {
-        if (format != SingleFileComponentFormat.Vue)
+        if (componentPaths.IsDefaultOrEmpty)
         {
-            return false;
+            return SingleFileComponentFileSet.Empty;
         }
 
-        var key = ComponentBasePath(filePath);
-        foreach (var canonicalKey in canonicalFileKeys)
+        var orderedPaths = new string[componentPaths.Length];
+        componentPaths.CopyTo(orderedPaths);
+        Array.Sort(orderedPaths, StringComparer.Ordinal);
+
+        var canonicalBasePaths = new List<string>();
+        foreach (var path in orderedPaths)
         {
-            if (string.Equals(
-                    key,
-                    canonicalKey,
-                    SingleFileComponentPathComparison.Comparison))
+            if (IsViuFile(path))
             {
-                return true;
+                canonicalBasePaths.Add(ComponentBasePath(path));
             }
         }
 
-        return false;
+        var canonicalSet = new SingleFileComponentFileSet(
+            new EquatableArray<string>(canonicalBasePaths.ToArray()),
+            EquatableArray<string>.Empty);
+
+        var emittedPaths = new List<string>(orderedPaths.Length);
+        foreach (var path in orderedPaths)
+        {
+            var format = IsVueFile(path) ? SingleFileComponentFormat.Vue : SingleFileComponentFormat.Viu;
+            if (!HasCanonicalPeer(format, path, canonicalSet))
+            {
+                emittedPaths.Add(path);
+            }
+        }
+
+        return new SingleFileComponentFileSet(
+            canonicalSet.CanonicalBasePaths,
+            new EquatableArray<string>(
+                SingleFileComponentNameResolver.SelectCaseCollidingPaths(emittedPaths, projectDirectory)));
     }
+
+    private static bool HasCanonicalPeer(
+        SingleFileComponentFormat format,
+        string filePath,
+        SingleFileComponentFileSet fileSet)
+        => format == SingleFileComponentFormat.Vue &&
+            fileSet.ContainsCanonicalBasePath(ComponentBasePath(filePath));
 
     private static string ComponentBasePath(string path)
     {

--- a/analyzers/Assimalign.Viu.Generators.Syntax/test/HintNameCollisionTests.cs
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/test/HintNameCollisionTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -49,6 +51,89 @@ public sealed class HintNameCollisionTests
 
         result.Exception.ShouldBeNull();
         result.GeneratedSources.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void TwoFilesWhoseBaseNamesDifferOnlyByCase_BothEmit()
+    {
+        // [SFC-CG-5] Roslyn compares hint names with OrdinalIgnoreCase, so Choice and choice are ONE
+        // name to AddSource even though the two files are two distinct components. Two canonical .viu
+        // files are never merged by .vue shadowing [VUE-7], so this collision forms on every operating
+        // system - including Windows, where the case-insensitive path identity that hides the .viu/.vue
+        // form of the collision does not apply ([V01.01.06.10.01]).
+        var fileA = new InMemoryAdditionalText("C:/proj/Components/Choice.viu", Source);
+        var fileB = new InMemoryAdditionalText("C:/proj/Components/choice.viu", Source);
+        var driver = GeneratorTestHarness.CreateDriver(
+            ImmutableArray.Create<AdditionalText>(fileA, fileB), "Demo", "C:/proj");
+
+        driver = driver.RunGenerators(GeneratorTestHarness.CreateCompilation());
+        var result = driver.GetRunResult().Results[0];
+
+        result.Exception.ShouldBeNull();
+        result.GeneratedSources.Length.ShouldBe(2);
+        result.GeneratedSources
+            .Select(source => source.HintName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count()
+            .ShouldBe(2);
+    }
+
+    [Fact]
+    public void CaseCollidingFiles_InEitherEnumerationOrder_TakeTheSameHintNames()
+    {
+        // [SFC-CG-5] The discriminator is a hash of the file's own exact-cased path, so it is a pure
+        // function of the input set: reversing the order MSBuild presents the files in cannot move a
+        // single generated-file identity.
+        var fileA = new InMemoryAdditionalText("C:/proj/Components/Choice.viu", Source);
+        var fileB = new InMemoryAdditionalText("C:/proj/Components/choice.viu", Source);
+
+        var forward = HintNames(ImmutableArray.Create<AdditionalText>(fileA, fileB));
+        var reversed = HintNames(ImmutableArray.Create<AdditionalText>(fileB, fileA));
+
+        forward.ShouldBe(reversed);
+        forward.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ComponentsThatCollideWithNothing_KeepTheirReadableHintNames()
+    {
+        // [SFC-CG-5] The identity-preservation bar: the discriminator appears ONLY inside a colliding
+        // group. Counter and Views/Admin/Panel keep the exact hint names the derivation produced before
+        // the collision rule existed, while the two Choice components - and only they - take the
+        // 8-hex-digit path hash ([V01.01.06.10.01]).
+        var files = ImmutableArray.Create<AdditionalText>(
+            new InMemoryAdditionalText("C:/proj/Counter.viu", Source),
+            new InMemoryAdditionalText("C:/proj/Views/Admin/Panel.viu", Source),
+            new InMemoryAdditionalText("C:/proj/Components/Choice.viu", Source),
+            new InMemoryAdditionalText("C:/proj/Components/choice.viu", Source));
+
+        var hintNames = HintNames(files);
+
+        hintNames.ShouldContain("Counter.SingleFileComponent.g.cs");
+        hintNames.ShouldContain("Views.Admin.Panel.SingleFileComponent.g.cs");
+        hintNames.ShouldNotContain("Components.Choice.SingleFileComponent.g.cs");
+        hintNames.ShouldNotContain("Components.choice.SingleFileComponent.g.cs");
+        hintNames.Count(name => name.StartsWith("Components.", StringComparison.Ordinal)).ShouldBe(2);
+        foreach (var name in hintNames.Where(name => name.StartsWith("Components.", StringComparison.Ordinal)))
+        {
+            // Components.<Base>.<8 hex digits>.SingleFileComponent.g.cs
+            var discriminator = name.Split('.')[2];
+            discriminator.Length.ShouldBe(8);
+            discriminator.ShouldAllBe(character => Uri.IsHexDigit(character));
+        }
+    }
+
+    private static IReadOnlyList<string> HintNames(ImmutableArray<AdditionalText> files)
+    {
+        var driver = GeneratorTestHarness.CreateDriver(files, "Demo", "C:/proj")
+            .RunGenerators(GeneratorTestHarness.CreateCompilation());
+        var result = driver.GetRunResult().Results[0];
+
+        result.Exception.ShouldBeNull();
+        return result.GeneratedSources
+            .Select(source => source.HintName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
     }
 
     [Fact]

--- a/analyzers/Assimalign.Viu.Generators.Syntax/test/SingleFileComponentPathIdentityTests.cs
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/test/SingleFileComponentPathIdentityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -25,6 +26,14 @@ public sealed class SingleFileComponentPathIdentityTests
     [Fact]
     public void Generate_BaseNamesDifferOnlyByCase_ShadowingFollowsOperatingSystemPathIdentity()
     {
+        // [VUE-7] decides how many components exist here, and it is deliberately operating-system
+        // dependent: on Windows the two files are one path identity, so the .vue peer is shadowed and a
+        // single component is emitted; everywhere else they are two components. The two-component branch
+        // is where [SFC-CG-5] earns its keep - Choice and choice are ONE hint name to Roslyn's
+        // case-insensitive AddSource comparison, and before [V01.01.06.10.01] the second AddSource threw
+        // and killed the run. The platform-independent pin for that rule is
+        // HintNameCollisionTests.TwoFilesWhoseBaseNamesDifferOnlyByCase_BothEmit, which uses two .viu
+        // files - a pair no shadowing rule can ever merge - so the collision forms on every host.
         var canonical = new InMemoryAdditionalText(
             "C:/project/Components/Choice.viu",
             ViuSource);
@@ -48,6 +57,11 @@ public sealed class SingleFileComponentPathIdentityTests
         {
             result.GeneratedSources.Length.ShouldBe(2);
             result.Diagnostics.ShouldBeEmpty();
+            result.GeneratedSources
+                .Select(source => source.HintName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count()
+                .ShouldBe(2);
         }
     }
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -989,6 +989,20 @@ declared by the generated partial, **no other partial declaration of the compone
 different base class**. A component with no template block stays a plain partial class with neither
 [V01.01.06.07].
 
+`[SFC-CG-5]` **Generated-file identity.** Each emitted component occupies exactly one `AddSource` hint
+name, derived from its path alone as
+`<relative.directory.>.<BaseName>[.<hash>].SingleFileComponent.g.cs` — the project-relative directory
+segments and the file's base name, each sanitized to a C# identifier. Roslyn compares hint names
+**case-insensitively** and fails the whole generator run on a duplicate, so the derivation appends a
+short stable hash of the exact-cased normalized path whenever the readable form is not unique on its
+own: the file lies outside the project directory, sanitizing was lossy (`Foo-Bar` and `Foo_Bar` both
+sanitize to `Foo_Bar`), **or another component the same compilation emits resolves to a hint name that
+differs from it only by case**. That last group exists wherever path identity is ordinal — every
+non-Windows filesystem [VUE-7] — and a shadowed `.vue` peer, which emits nothing, is never counted
+into it. The hash reads only the component's own path, so a discriminated name is identical on every
+build and in any order MSBuild presents the files; a component that collides with nothing keeps its
+readable hint name unchanged [V01.01.06.10.01].
+
 `[SFC-8]` **Source mapping.** Each expression-bearing render line carries a C# `#line` **span**
 directive — `#line (line,column)-(line,column) offset "file"` — anchored to that line's leftmost
 expression and closed with `#line default`. The span form is required because a render expression is

--- a/sdks/Directory.Build.targets
+++ b/sdks/Directory.Build.targets
@@ -6,10 +6,14 @@
     <ItemGroup>
         <!-- The SDK-shaped nupkg layout: Sdk/ and Targets/ at package root -
              exactly what NuGet's MSBuild SDK resolver expects. -->
-        <None Include="$(MSBuildProjectDirectory)\..\Sdk\**\*" Pack="true" PackagePath="Sdk\%(RecursiveDir)%(Filename)%(Extension)">
+        <!-- Every PackagePath in this file uses '/'. A package path is not a filesystem
+             path: pack only recognises '/' as its separator on every host, and a
+             backslash silently produces malformed entries off Windows (see
+             CollectSdkTaskFiles). -->
+        <None Include="$(MSBuildProjectDirectory)\..\Sdk\**\*" Pack="true" PackagePath="Sdk/%(RecursiveDir)%(Filename)%(Extension)">
             <Visible>false</Visible>
         </None>
-        <None Include="$(MSBuildProjectDirectory)\..\Targets\**\*" Pack="true" PackagePath="Targets\%(RecursiveDir)%(Filename)%(Extension)">
+        <None Include="$(MSBuildProjectDirectory)\..\Targets\**\*" Pack="true" PackagePath="Targets/%(RecursiveDir)%(Filename)%(Extension)">
             <Visible>false</Visible>
         </None>
 
@@ -28,11 +32,11 @@
             and dogfooded consumers share one authoritative source.
         -->
         <None Include="$(ViuRepositoryDirectory)build\Targets\Build.Css.Bundling.targets"
-              Pack="true" PackagePath="Targets\Assimalign.Viu.Sdk.Css.Bundling.targets" Visible="false" />
+              Pack="true" PackagePath="Targets/Assimalign.Viu.Sdk.Css.Bundling.targets" Visible="false" />
         <None Include="$(ViuRepositoryDirectory)build\Targets\Build.UtilityCss.targets"
-              Pack="true" PackagePath="Targets\Assimalign.Viu.Sdk.UtilityCss.targets" Visible="false" />
+              Pack="true" PackagePath="Targets/Assimalign.Viu.Sdk.UtilityCss.targets" Visible="false" />
         <None Include="$(ViuRepositoryDirectory)build\Targets\Build.Css.HotReload.targets"
-              Pack="true" PackagePath="Targets\Assimalign.Viu.Sdk.Css.HotReload.targets" Visible="false" />
+              Pack="true" PackagePath="Targets/Assimalign.Viu.Sdk.Css.HotReload.targets" Visible="false" />
 
         <!--
             Framework static web assets. A FrameworkReference delivers DLLs
@@ -43,7 +47,7 @@
             build/Targets/Build.StaticWebAssets.targets produces).
         -->
         <None Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.Browser\src\wwwroot\**\*"
-              Pack="true" PackagePath="assets\Assimalign.Viu.Browser\%(RecursiveDir)%(Filename)%(Extension)" Visible="false" />
+              Pack="true" PackagePath="assets/Assimalign.Viu.Browser/%(RecursiveDir)%(Filename)%(Extension)" Visible="false" />
 
         <None Include="$(ViuRepositoryDirectory)sdks\README.md" Pack="true" PackagePath="README.md" Visible="false" />
     </ItemGroup>
@@ -114,19 +118,43 @@
     <Target Name="CollectShippedVersionProps" DependsOnTargets="GenerateShippedVersionProps">
         <ItemGroup>
             <TfmSpecificPackageFile Include="$(IntermediateOutputPath)Build.Version.props">
-                <PackagePath>Targets\Build.Version.props</PackagePath>
+                <PackagePath>Targets/Build.Version.props</PackagePath>
             </TfmSpecificPackageFile>
         </ItemGroup>
     </Target>
     <!-- #endregion -->
 
+    <!--
+        The Tasks/ payload is the complete output closure of the task assembly, swept
+        straight out of $(OutDir) so the shipped task can load its parser dependencies.
+
+        PackagePath names the destination FOLDER only, and must stay that way. NuGet
+        carries a wildcard item's %(RecursiveDir) itself, through the NuGetRecursiveDir
+        metadata its _GetTfmSpecificContentForPackage target copies (the documented
+        msbuild#3121 workaround), and appends it under this folder. Hand-composing
+        "Tasks\%(RecursiveDir)%(Filename)%(Extension)" instead is host-OS dependent: pack
+        running on a non-Windows host does not treat the backslash as a separator, and
+        every swept file lands at the malformed entry "Tasks//<name>" rather than
+        "Tasks/<name>". The package still builds and still validates, so the damage only
+        surfaces at restore time - a consumer finds no Tasks/Assimalign.Viu.Sdk.Tasks.dll
+        where Sdk.props points $(ViuBundleCssTaskAssembly), and every Viu build fails to
+        load the ViuBundleCss task. Folder-only PackagePath is the same form the analyzer
+        and shared-framework packs use (build/Targets/Build.References.Analyzers.targets,
+        frameworks/Assimalign.Viu.App.targets).
+    -->
     <Target Name="CollectSdkTaskFiles">
         <ItemGroup>
             <TfmSpecificPackageFile Include="$(OutDir)**\*"
                                     Exclude="$(OutDir)**\*.nupkg;$(OutDir)**\*.snupkg;$(OutDir)**\*.nuspec;$(OutDir)Assimalign.Viu.Sdk.CssHotReload.*">
-                <PackagePath>Tasks\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+                <PackagePath>Tasks</PackagePath>
             </TfmSpecificPackageFile>
+            <!-- Filtered out of the collected set itself, not probed on disk: this is the
+                 payload that is actually about to be packed. -->
+            <_ViuSdkPrimaryTaskFile Include="@(TfmSpecificPackageFile)"
+                                    Condition="'%(Filename)%(Extension)' == '$(TargetFileName)'" />
         </ItemGroup>
+        <Error Condition="'@(_ViuSdkPrimaryTaskFile)' == ''"
+               Text="CollectSdkTaskFiles swept $(OutDir) but the SDK's primary task assembly $(TargetFileName) is not in the collected set, so the package would ship a Tasks/ payload that cannot load. CopyFilesToOutputDirectory is the target that places it there, and it must run before Pack collects the payload: build before packing (do not pass --no-build or -p:NoBuild=true) and do not clean $(OutDir) in between." />
     </Target>
 
     <Target Name="CollectSdkWatchFiles">
@@ -138,7 +166,7 @@
             <_ViuSdkWatchFile Include="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Watch\Assimalign.Viu.Sdk.CssHotReload.deps.json" />
             <_ViuSdkWatchFile Include="$(ViuOutputPathForSdk)\$(NETCoreSdkVersion)\sdks\$(PackageId)\Watch\Assimalign.Viu.Sdk.CssHotReload.runtimeconfig.json" />
             <TfmSpecificPackageFile Include="@(_ViuSdkWatchFile)">
-                <PackagePath>Watch\%(_ViuSdkWatchFile.RecursiveDir)%(_ViuSdkWatchFile.Filename)%(_ViuSdkWatchFile.Extension)</PackagePath>
+                <PackagePath>Watch/%(_ViuSdkWatchFile.RecursiveDir)%(_ViuSdkWatchFile.Filename)%(_ViuSdkWatchFile.Extension)</PackagePath>
             </TfmSpecificPackageFile>
         </ItemGroup>
     </Target>

--- a/sdks/Directory.Build.targets
+++ b/sdks/Directory.Build.targets
@@ -172,19 +172,65 @@
     </Target>
 
     <!-- Optional: pack every shipping library into the local feed alongside the
-         SDK (dotnet pack -p:PackViuProjects=true on the Tasks csproj). -->
+         SDK (dotnet pack -p:PackViuProjects=true on the Tasks csproj).
+
+         The fan-out reaches projects OUTSIDE this csproj's ProjectReference closure
+         (Assimalign.Viu.Syntax.Html and .JavaScript are the only two netstandard2.0
+         libraries nothing in the SDK task graph references), so the outer `dotnet pack`
+         implicit restore never covers them: on a clean CI checkout they reach the fan-out
+         with an empty obj/.
+
+         That makes the restore/build split load-bearing, and it must be spelled the way
+         MSBuild's own -restore switch spells it: two invocations whose GLOBAL PROPERTIES
+         DIFFER. A single Targets="Restore;Pack" call - or two calls sharing one property
+         set - runs both targets against ONE BuildRequestConfiguration, so the project is
+         evaluated once, BEFORE restore writes obj\*.nuget.g.props. $(ProjectAssetsFile)
+         stays empty for the whole invocation and ResolvePackageAssets silently contributes
+         nothing (the NETSDK1004 guard only fires when the property is set). net10.0
+         projects survive on the SDK's targeting pack; netstandard2.0 gets its reference
+         assemblies solely from the NETStandard.Library package via the assets file, so it
+         compiles against zero references - CS0518/CS0246 on System.Object ([V01.01.12.19.03]).
+
+         MSBuildIsRestoring=true is that differentiator, and is not a marker property:
+         Microsoft.Common.props keys ImportProjectExtensionProps off it to skip the obj/
+         NuGet imports during a restore pass, which is precisely why the restore pass and
+         the build pass must be separate configurations. Setting it here gives the Pack
+         invocation its own configuration, evaluated after restore has written obj/.
+         Restore deliberately carries no ContinueOnError: a swallowed restore failure
+         reproduces exactly the reference-less compile above.
+
+         The restore pass is also NOT parallel. Every entry project's restore walks and
+         writes the assets for its WHOLE ProjectReference closure itself, outside MSBuild's
+         per-project scheduling, so MSBuild cannot dedupe the overlap the way it dedupes a
+         build: run the fan-out entries concurrently and the shared nodes (Assimalign.Viu.Shared
+         sits in nearly every closure) get restored several times at once, racing on the same
+         obj\ files - "Cannot create a file when that file already exists" out of
+         NuGet.targets on a clean checkout. Sequential restore costs a few seconds because
+         each already-restored closure no-ops through obj\project.nuget.cache. The Pack pass
+         stays parallel: that IS one MSBuild graph, so the scheduler dedupes shared nodes. -->
     <Target Name="PackViuProjects" BeforeTargets="GenerateNuspec" Condition="'$(PackViuProjects)' == 'true'">
         <ItemGroup>
             <ViuSdkPackProject Include="$(ViuRepositoryDirectory)libraries\**\src\*.csproj"
                 Exclude="**\bin\**;**\obj\**;**\test\**;**\*.Tests.csproj;**\*Tests.csproj" />
         </ItemGroup>
+        <PropertyGroup>
+            <_ViuSdkPackProperties>Configuration=$(Configuration);PackageOutputPath=$(ViuOutputPathForLibraries)</_ViuSdkPackProperties>
+            <_ViuSdkPackRemoveProperties>OutDir;PackageId;TargetFramework;TargetFrameworks;IncludeBuildOutput;GenerateDependencyFile;CopyLocalLockFileAssemblies</_ViuSdkPackRemoveProperties>
+        </PropertyGroup>
+        <Message Text="Restoring Viu libraries for the pack fan-out" Importance="High" />
+        <MSBuild
+            Projects="@(ViuSdkPackProject)"
+            Targets="Restore"
+            BuildInParallel="false"
+            Properties="$(_ViuSdkPackProperties);MSBuildIsRestoring=true"
+            RemoveProperties="$(_ViuSdkPackRemoveProperties)" />
         <Message Text="Packing Viu libraries into $(ViuOutputPathForLibraries)" Importance="High" />
         <MSBuild
             Projects="@(ViuSdkPackProject)"
-            Targets="Restore;Pack"
+            Targets="Pack"
             BuildInParallel="true"
-            Properties="Configuration=$(Configuration);PackageOutputPath=$(ViuOutputPathForLibraries)"
-            RemoveProperties="OutDir;PackageId;TargetFramework;TargetFrameworks;IncludeBuildOutput;GenerateDependencyFile;CopyLocalLockFileAssemblies"
+            Properties="$(_ViuSdkPackProperties)"
+            RemoveProperties="$(_ViuSdkPackRemoveProperties)"
             ContinueOnError="WarnAndContinue" />
     </Target>
 

--- a/tooling/Assimalign.Viu.Tooling.SingleFileComponent/docs/OVERVIEW.md
+++ b/tooling/Assimalign.Viu.Tooling.SingleFileComponent/docs/OVERVIEW.md
@@ -27,7 +27,10 @@ The library is deliberately **all-internal**; the sanctioned consumers are decla
   build path) and `DescribeMembers` (the editor path — declared-member names, kinds, details, doc
   summaries, block-relative locations).
 - **`SingleFileComponentNameResolver`** / **`SingleFileComponentHotReloadMetadataFactory`** — the
-  shared name/namespace/hint-name resolution and the path-stable hot-reload identity.
+  shared name/namespace/hint-name resolution and the path-stable hot-reload identity. Hint names are
+  path-derived and readable; `SelectCaseCollidingPaths` takes the whole emitted set and reports which
+  components must add the path-hash discriminator, because Roslyn's `AddSource` treats hint names
+  differing only by case as one name (`[SFC-CG-5]`, [V01.01.06.10.01]).
 - **`SingleFileComponentDiagnostics`** — the host-neutral VIU diagnostic catalog (`VIU1001` …
   `VIU1303`) and the block-to-file position composition; each host materializes at its own edge (the
   generator's Roslyn adapter, the language service's LSP mapping).

--- a/tooling/Assimalign.Viu.Tooling.SingleFileComponent/src/Internal/SingleFileComponentNameResolver.cs
+++ b/tooling/Assimalign.Viu.Tooling.SingleFileComponent/src/Internal/SingleFileComponentNameResolver.cs
@@ -14,6 +14,13 @@ namespace Assimalign.Viu.Tooling.SingleFileComponent;
 /// files in different folders never collide). Uses only string operations — no <c>System.IO</c> — so it
 /// stays inside the analyzer API surface (RS1035). Path containment follows the host operating system:
 /// ordinal-ignore-case on Windows and ordinal elsewhere.
+/// <para>
+/// Hint-name identity is specified by <c>[SFC-CG-5]</c>. Roslyn compares hint names
+/// case-insensitively, so a readable hint name is unique only while no other component in the same
+/// compilation resolves to one that differs from it by case alone; <see cref="SelectCaseCollidingPaths"/>
+/// selects those components and <see cref="Resolve(string, string?, string?, bool)"/> gives each of them
+/// the path-hash discriminator ([V01.01.06.10.01]).
+/// </para>
 /// </summary>
 internal static class SingleFileComponentNameResolver
 {
@@ -21,13 +28,33 @@ internal static class SingleFileComponentNameResolver
     private const string VueExtension = ".vue";
 
     /// <summary>
-    /// Resolves the namespace, class name, and hint name for <paramref name="filePath"/>.
+    /// Resolves the namespace, class name, and hint name for <paramref name="filePath"/>, taking the
+    /// readable hint name (no case discriminator).
     /// </summary>
     /// <param name="filePath">The absolute <c>.viu</c> or <c>.vue</c> file path.</param>
     /// <param name="projectDirectory">The consuming project's directory, or <see langword="null"/> when unknown.</param>
     /// <param name="rootNamespace">The consuming project's root namespace, or <see langword="null"/> when unknown.</param>
     /// <returns>The resolved names.</returns>
     public static SingleFileComponentName Resolve(string filePath, string? projectDirectory, string? rootNamespace)
+        => Resolve(filePath, projectDirectory, rootNamespace, requiresCaseDiscriminator: false);
+
+    /// <summary>
+    /// Resolves the namespace, class name, and hint name for <paramref name="filePath"/>.
+    /// </summary>
+    /// <param name="filePath">The absolute <c>.viu</c> or <c>.vue</c> file path.</param>
+    /// <param name="projectDirectory">The consuming project's directory, or <see langword="null"/> when unknown.</param>
+    /// <param name="rootNamespace">The consuming project's root namespace, or <see langword="null"/> when unknown.</param>
+    /// <param name="requiresCaseDiscriminator">
+    /// <see langword="true"/> when another component in the same compilation resolves to a hint name
+    /// that differs from this one only by case, as reported by <see cref="SelectCaseCollidingPaths"/>.
+    /// The namespace and class name never depend on it — only the hint name does.
+    /// </param>
+    /// <returns>The resolved names.</returns>
+    public static SingleFileComponentName Resolve(
+        string filePath,
+        string? projectDirectory,
+        string? rootNamespace,
+        bool requiresCaseDiscriminator)
     {
         var normalizedPath = filePath.Replace('\\', '/');
 
@@ -39,9 +66,69 @@ internal static class SingleFileComponentNameResolver
         var relativeDirectory = ResolveRelativeDirectory(normalizedPath, projectDirectory);
 
         var namespaceValue = BuildNamespace(rootNamespace, relativeDirectory);
-        var hintName = BuildHintName(relativeDirectory, baseName, normalizedPath);
+        var hintName = BuildHintName(relativeDirectory, baseName, normalizedPath, requiresCaseDiscriminator);
 
         return new SingleFileComponentName(namespaceValue, className, hintName);
+    }
+
+    /// <summary>
+    /// Selects, out of every component a single compilation emits, the ones whose readable hint names
+    /// are equal ignoring case — the set Roslyn's <c>AddSource</c> would reject as duplicates, because it
+    /// compares hint names with <see cref="StringComparison.OrdinalIgnoreCase"/>. Only members of such a
+    /// colliding group take the discriminator; every other component keeps its readable hint name
+    /// verbatim, so this rule never churns an existing generated-file identity ([V01.01.06.10.01],
+    /// <c>[SFC-CG-5]</c>).
+    /// </summary>
+    /// <param name="componentPaths">
+    /// The paths of the components the compilation actually emits — a shadowed <c>.vue</c> peer
+    /// ([VUE-7]) emits nothing and must not be offered here, or it would discriminate the canonical
+    /// <c>.viu</c> component that suppressed it.
+    /// </param>
+    /// <param name="projectDirectory">The consuming project's directory, or <see langword="null"/> when unknown.</param>
+    /// <returns>
+    /// The colliding paths, ordinally sorted so the result is a pure function of the input set and never
+    /// of the order MSBuild presented the files in. Empty when no two components collide.
+    /// </returns>
+    public static string[] SelectCaseCollidingPaths(
+        IReadOnlyList<string> componentPaths,
+        string? projectDirectory)
+    {
+        if (componentPaths.Count < 2)
+        {
+            return Array.Empty<string>();
+        }
+
+        var groups = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in componentPaths)
+        {
+            var hintName = Resolve(path, projectDirectory, rootNamespace: null).HintName;
+            if (!groups.TryGetValue(hintName, out var members))
+            {
+                members = new List<string>();
+                groups.Add(hintName, members);
+            }
+
+            members.Add(path);
+        }
+
+        List<string>? colliding = null;
+        foreach (var group in groups)
+        {
+            if (group.Value.Count > 1)
+            {
+                colliding ??= new List<string>();
+                colliding.AddRange(group.Value);
+            }
+        }
+
+        if (colliding is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        var result = colliding.ToArray();
+        Array.Sort(result, StringComparer.Ordinal);
+        return result;
     }
 
     // Returns null (not empty) when the directory is unknown or the file sits outside it, so hint
@@ -88,13 +175,21 @@ internal static class SingleFileComponentNameResolver
         return parts.Count == 0 ? null : string.Join(".", parts);
     }
 
-    private static string BuildHintName(string? relativeDirectory, string baseName, string normalizedPath)
+    private static string BuildHintName(
+        string? relativeDirectory,
+        string baseName,
+        string normalizedPath,
+        bool requiresCaseDiscriminator)
     {
         // Roslyn's AddSource throws on a duplicate hint name and the exception kills the entire
         // generator run, so hint names must be unique BY CONSTRUCTION: whenever the relative directory
-        // is unknown (linked/out-of-project files) or sanitizing was lossy (distinct names collapsing
-        // to one identifier, e.g. Foo-Bar and Foo_Bar), a short stable hash of the full normalized path
-        // disambiguates. Files properly under the project with clean names keep readable hints.
+        // is unknown (linked/out-of-project files), sanitizing was lossy (distinct names collapsing
+        // to one identifier, e.g. Foo-Bar and Foo_Bar), or a sibling component's hint name differs from
+        // this one only by case (Roslyn compares hint names case-INSENSITIVELY, so Choice and choice are
+        // one name to it), a short stable hash of the full normalized path disambiguates. Because that
+        // hash reads only this file's own exact-cased path, the discriminated name is the same on every
+        // build and in any file order. Files properly under the project with clean, non-colliding names
+        // keep readable hints.
         var lossy = false;
         var builder = new StringBuilder();
         foreach (var segment in (relativeDirectory ?? string.Empty).Split('/'))
@@ -106,7 +201,7 @@ internal static class SingleFileComponentNameResolver
         }
 
         builder.Append(SanitizeTracked(baseName, ref lossy));
-        if (relativeDirectory is null || lossy)
+        if (relativeDirectory is null || lossy || requiresCaseDiscriminator)
         {
             builder.Append('.').Append(HashPath(normalizedPath));
         }
@@ -182,5 +277,5 @@ internal static class SingleFileComponentNameResolver
 /// <summary>The resolved names for a generated component: its namespace (or <see langword="null"/>), class, and hint name.</summary>
 /// <param name="Namespace">The containing namespace, or <see langword="null"/> for the global namespace.</param>
 /// <param name="ClassName">The generated partial class name.</param>
-/// <param name="HintName">The stable <c>AddSource</c> hint name, unique by construction (a path hash disambiguates out-of-project files and lossy sanitizations).</param>
+/// <param name="HintName">The stable <c>AddSource</c> hint name, unique by construction (a path hash disambiguates out-of-project files, lossy sanitizations, and names that collide with a sibling component's only by case).</param>
 internal readonly record struct SingleFileComponentName(string? Namespace, string ClassName, string HintName);


### PR DESCRIPTION
## Summary

Three fixes, one branch, one shared lesson: every ticket's hypothesized root cause was wrong, and each fix was preceded by a reproduction.

**#275 — SDK package "loses" its Tasks assembly.** Not clean-then-pack sequencing: the assembly was always in the package, unaddressable. `CollectSdkTaskFiles` composed `PackagePath` with a backslash prefix on a wildcard item; NuGet treats only `/` as the package separator, so on Linux the entry became `Tasks//Assimalign.Viu.Sdk.Tasks.dll`. Reproduced in a Linux container, invisible on Windows. Fixed with a folder-only `PackagePath` (NuGet appends `RecursiveDir` itself), the file's other separators normalized, and a loud backstop that fails the pack if the primary assembly leaves the payload — sabotage-tested on both OSes. `Pack-Release.ps1`/release were silently affected and are fixed by the same change.

**#274 — case-colliding hint names.** Not a fixture or dictionary bug: Roslyn compares hint names with `OrdinalIgnoreCase`, while `[VUE-7]` path identity is deliberately OS-aware — on Windows the case-differing pair merges under the shadowing rule before a collision can form; on Linux both emit and the second `AddSource` throws. Fixed by extending the existing FNV-1a path-hash discriminator with a case-collision trigger: colliding groups (ordinally sorted — enumeration-order independent) get an 8-hex exact-cased-path suffix; every non-colliding name stays byte-identical. New spec clause `[SFC-CG-5]` records generated-file identity. Fail-before/pass-after proven on Windows (new platform-independent test) and in a Linux container.

**#276 — CS0518 in the `PackViuProjects` fan-out.** Not a property mismatch: an evaluation-ordering fault. The fan-out ran `Targets="Restore;Pack"` in one MSBuild invocation, so the project evaluated once — before restore wrote `obj/*.nuget.g.props` — leaving `ProjectAssetsFile` empty for the whole build. netstandard2.0 draws its reference assemblies solely from the assets file, hence "Predefined type 'System.Object' is not defined" on exactly the two projects outside the entry closure. Fixed by splitting Restore and Pack into invocations whose property sets differ by `MSBuildIsRestoring=true` (how MSBuild's own `-restore` separates the passes; verified load-bearing — same-property split still fails). A second in-scope defect fell out: the fan-out's restore raced on shared closure nodes from a clean tree; restore is now sequential, pack stays parallel. Note: pre-fix, the net10.0 projects packed against an empty assets file without erroring — dependency groups computed from nothing — so this also corrects silently wrong package metadata.

## Expected lanes on this PR

`analyzers (Generators.Syntax)` and `publish-size + trimming gate` should go green for the first time. `packaging (SDK + framework)` clears the double-slash failure but remains red on one pre-existing assertion — `Tasks/Microsoft.CodeAnalysis.CSharp.dll` is forbidden by the workflow while being present by documented architecture (template expressions parse with the real C# parser at task run time). That is a product decision, tracked as #279, deliberately not bundled here.

## Work items resolved by this PR

Closes #275
Closes #274
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)