### PR TITLE
fix(build): exclude the compile-time-only Roslyn closure from the SDK Tasks payload [V01.01.12.19.04]

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -236,11 +236,10 @@ jobs:
               'Tasks/Microsoft.Build.Utilities.Core.dll',
               'Tasks/Microsoft.NET.StringTools.dll',
               # The shared .viu -> C# projection core ([V01.01.06.11]) belongs to the generator +
-              # language-service graph only. If it (or its Roslyn dependency) ever appears here, a
-              # reference leaked into the Sdk.Tasks/Tooling.Css graph, whose whole OutDir sweeps
-              # into the SDK package's Tasks/ payload.
+              # language-service graph only. If it ever appears here, a reference leaked into the
+              # Sdk.Tasks/Tooling.Css graph, whose whole OutDir sweeps into the SDK package's
+              # Tasks/ payload.
               'Tasks/Assimalign.Viu.Tooling.SingleFileComponent.dll',
-              'Tasks/Microsoft.CodeAnalysis.CSharp.dll',
               'Targets/Assimalign.Viu.Syntax.Generators.props',
               'Targets/Assimalign.Viu.Syntax.Generators.targets'
             )
@@ -248,6 +247,23 @@ jobs:
               if ($null -ne $sdkArchive.GetEntry($entryName)) {
                 throw "$($sdkPackage[0].Name) must not contain stale or host-provided entry $entryName"
               }
+            }
+
+            # Roslyn IS legitimately in the task host's reference graph — Sdk.Tasks -> Tooling.Css ->
+            # Syntax.Templates parses template expressions with the real C# parser — but it is
+            # compile-time-only there ([V01.01.12.19.04]): the ViuBundleCss task composes the style-only parsers and
+            # never dispatches template content (Roslyn-backed expression compilation runs only in
+            # the source generator, where the compiler host supplies Roslyn), so the Tasks csproj
+            # re-declares the whole Roslyn closure with ExcludeAssets=runtime. Any
+            # Microsoft.CodeAnalysis assembly under Tasks/ — satellites included — means that
+            # compile-only pin regressed and the ~26 MB compiler set is back in the SDK package.
+            $taskRoslynEntries = @(
+              $sdkArchive.Entries |
+                Where-Object { $_.FullName.StartsWith('Tasks/', [System.StringComparison]::Ordinal) -and $_.Name -like 'Microsoft.CodeAnalysis*.dll' } |
+                ForEach-Object FullName
+            )
+            if ($taskRoslynEntries.Count -ne 0) {
+              throw "$($sdkPackage[0].Name) must not carry the compile-time-only Roslyn closure under Tasks/: $($taskRoslynEntries -join ', ')"
             }
 
             $nuspecEntry = @($sdkArchive.Entries | Where-Object { $_.FullName.EndsWith('.nuspec', [System.StringComparison]::OrdinalIgnoreCase) })

--- a/build/Targets/Build.References.Packages.targets
+++ b/build/Targets/Build.References.Packages.targets
@@ -7,6 +7,23 @@
              ([V01.01.12.07.04], #261): its assets must stay unrestricted so they flow into the
              self-contained Assimalign.Viu.Tooling.LanguageServer publish. Do not add PrivateAssets here. -->
         <_ViuPackage Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+        <!-- The transitive netstandard2.0 closure of Microsoft.CodeAnalysis.CSharp 5.3.0, pinned at
+             exactly the versions NuGet resolves for that line so the resolution is explicit rather
+             than approximate (the Imaging.Interop precedent below). Consumed only by the SDK task
+             host (sdks/Assimalign.Viu.Sdk/Tasks), which re-declares each member compile-only so the
+             compiler-host closure never sweeps into the packaged Tasks/ payload — asset stance stays
+             project-local there; do NOT add PrivateAssets/ExcludeAssets here, for the same
+             language-server reason as the CSharp entry above. Bumping Microsoft.CodeAnalysis.CSharp
+             re-derives this list (a stale floor fails loudly as an NU1605 downgrade). -->
+        <_ViuPackage Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
+        <_ViuPackage Include="System.Buffers" Version="4.6.1" />
+        <_ViuPackage Include="System.Collections.Immutable" Version="9.0.0" />
+        <_ViuPackage Include="System.Memory" Version="4.6.3" />
+        <_ViuPackage Include="System.Numerics.Vectors" Version="4.6.1" />
+        <_ViuPackage Include="System.Reflection.Metadata" Version="9.0.0" />
+        <_ViuPackage Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+        <_ViuPackage Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+        <_ViuPackage Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
         <!-- Removed ([V01.01.12.23], #259): Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0 and
              Microsoft.CodeAnalysis.Workspaces.MSBuild 5.0.0 had zero consumers, and the semantic
              IntelliSense increment deliberately ships without a workspace (SemanticModel over an

--- a/sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj
+++ b/sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj
@@ -45,4 +45,30 @@
     <ViuPackageReference Include="Microsoft.Build.Utilities.Core" />
     <ViuPackageReference Include="Microsoft.Build.Framework" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- The Roslyn closure that rides the parser graph (Tooling.Css -> Syntax.Templates, whose
+         template expressions are parsed with the real C# parser) is compile-time-only for THIS host:
+         the bundling task composes the style-only parsers
+         (SingleFileComponentParserFactory.CreateForStyleExtraction), which never dispatch template
+         content, and the v-bind()/module/scoped rewrites live in Assimalign.Viu.Syntax.Css with no
+         Roslyn dependency — Roslyn-backed expression compilation of the recorded bindings runs only
+         in the source generator, where the compiler host supplies Roslyn. Re-declaring the closure
+         with ExcludeAssets=runtime (each member, because asset exclusion is not transitive) keeps
+         CopyLocalLockFileAssemblies from sweeping the ~26 MB compiler set (satellites included) into
+         the packaged Tasks/ payload and keeps the deps.json truthful; the packaging lane asserts the
+         resulting shape ([V01.01.12.19.04]). PrivateAssets=all keeps the SDK nuspec
+         dependency-free, the same stance as the Microsoft.Build references above. Versions are
+         central; this list tracks the Microsoft.CodeAnalysis.CSharp closure pinned in
+         Build.References.Packages.targets. -->
+    <ViuPackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Buffers" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Collections.Immutable" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Memory" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Numerics.Vectors" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Reflection.Metadata" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Runtime.CompilerServices.Unsafe" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Text.Encoding.CodePages" PrivateAssets="all" ExcludeAssets="runtime" />
+    <ViuPackageReference Include="System.Threading.Tasks.Extensions" PrivateAssets="all" ExcludeAssets="runtime" />
+  </ItemGroup>
 </Project>

--- a/tooling/Assimalign.Viu.Tooling.Css/docs/DESIGN.md
+++ b/tooling/Assimalign.Viu.Tooling.Css/docs/DESIGN.md
@@ -42,6 +42,14 @@ dependency arrows point toward the base and the language libraries, never sidewa
   `Shims/` — it loads in Roslyn analyzer hosts alongside the rest of the syntax cluster.
 - **No I/O.** The core never touches the filesystem; the `ViuBundleCss` task (outside the sandbox) reads and
   writes. This is how the engine respects RS1035 while still landing a physical stylesheet.
+- **Roslyn never ships beside the task** (decision [V01.01.12.19.04], #279). The Roslyn dependency this
+  library carries transitively (via `Assimalign.Viu.Syntax.Templates`, whose template expressions are parsed
+  with the real C# parser) is compile-time-only for the SDK task host: the style-extraction parsers above
+  never dispatch template content, and the `v-bind()`/`module`/`scoped` rewrites live in
+  `Assimalign.Viu.Syntax.Css` with no Roslyn dependency — Roslyn-backed expression compilation of the
+  recorded bindings runs only in the source generator, where the compiler host supplies Roslyn. The SDK
+  Tasks csproj therefore re-declares the Roslyn closure `ExcludeAssets=runtime`, and the packaging lane
+  asserts no `Microsoft.CodeAnalysis*` assembly under the SDK package's `Tasks/`.
 - **No reflection, no dynamic codegen.** Recoverable: a malformed `v-bind()` surfaces as a diagnostic carried
   back to the host (`SingleFileComponentStyleDiagnostic`), never thrown; the only expected exception is
   `OperationCanceledException`.


### PR DESCRIPTION
## Summary

The packaging lane's "Assert package shapes" step failed on `Tasks/Microsoft.CodeAnalysis.CSharp.dll` in the packed `Assimalign.Viu.Sdk` — the last red in that lane after the [V01.01.12.19.02] pack-path fix (#275, `fix/ci-red-lanes`). This PR resolves the decision framed by #279 as **option (b): Roslyn must not ship beside the task**, because the task never executes it. No restructuring was needed — the style-only/template split already existed; only the restore graph was wrong.

## Investigation

Roslyn is in the task host's reference graph legitimately (`Sdk.Tasks` → `Tooling.Css` → `Syntax.Templates`, whose template expressions are parsed with the real C# parser), but the `ViuBundleCss` execution path never reaches it:

- The bundler composes the style-only parsers (`SingleFileComponentParserFactory.CreateForStyleExtraction` / `CreateVueForStyleExtraction`), which register no template parser, so template content is never dispatched — documented on the factory as the design intent ("keeps the task from ever loading the template compiler (and its Roslyn dependency)").
- The `v-bind()`/`module`/`scoped` rewrites live in `Assimalign.Viu.Syntax.Css`, which has no `Microsoft.CodeAnalysis` reference; `CssBindingRewriter` records the raw expression text and its hash. Roslyn-backed expression compilation of the recorded bindings runs only in the source generator, where the compiler host supplies Roslyn.
- `CopyLocalLockFileAssemblies=true` swept the full lock-file runtime closure into `$(OutDir)`, and the deps.json edges show every swept non-Viu assembly (`Microsoft.CodeAnalysis[.CSharp].dll`, 13 satellite locales, 8 `System.*` facades — **~26 MB**) arrives exclusively through the transitive `Microsoft.CodeAnalysis.CSharp` reference.

Note #279's Summary states the parse happens "at task run time (ExpressionProcessor)" — the investigation disproved that premise for the bundling task; `ExpressionProcessor` runs only under the generator.

## Fix

- **`sdks/Assimalign.Viu.Sdk/Tasks/Assimalign.Viu.Sdk.Tasks.csproj`** re-declares the Roslyn closure with `PrivateAssets=all; ExcludeAssets=runtime` — each of the 10 members, because asset exclusion is not transitive — the same host-provides-it stance as its `Microsoft.Build` references. The swept payload and the generated deps.json now carry only the Viu parser closure, so nothing stale can mis-resolve at task load.
- **`build/Targets/Build.References.Packages.targets`** pins the closure's versions centrally at exactly what NuGet resolves for `Microsoft.CodeAnalysis.CSharp` 5.3.0; a Roslyn bump that outruns the pins fails loudly as NU1605. The catalog's `Microsoft.CodeAnalysis.CSharp` entry stays unrestricted for the language-server publish, per its existing comment.
- **`.github/workflows/packaging.yml`** replaces the single forbidden entry with a family-wide `Tasks/Microsoft.CodeAnalysis*.dll` scan (satellites included) and corrects the comment that framed Roslyn's presence in the reference graph as a leak.
- **`tooling/Assimalign.Viu.Tooling.Css/docs/DESIGN.md`** records the decision (per #279's acceptance criteria).

## Verification

- The extracted "Assert package shapes" step, `Test-UtilityCssIndependence.ps1`, and `Test-UtilityCssArtifactShape.ps1` all pass against a fresh `Install-Local.ps1` feed; solution builds 0W/0E; CssHotReload tests 6/6.
- A pristine external consumer (`<Project Sdk="Assimalign.Viu.Sdk">`, one `.viu` with a template C# expression and `<style scoped>` containing `v-bind(AccentColor)`) built against the packed feed: the restored SDK's `Tasks/` contains no `Microsoft.CodeAnalysis` assembly, and `ViuBundleCss` wrote `obj/Release/net10.0/viu/App.viu.css` with the scoped selector (`.card[data-v-0e7c3b3e]`) and the binding rewritten to `var(--4d35184d)`.

## Notes

- This branch does **not** contain the #275 fix (`ac33e21` on `fix/ci-red-lanes`); the packaging lane needs both branches merged (either order) to go fully green.
- #280 ([V01.01.12.19.05], `GenerateRequiresPreviewFeaturesAttribute` consumer default) was discovered while building the proof consumer and is filed, not implemented here — it must stay open.

## Work items resolved by this PR
Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)