### PR TITLE
fix(compiler): correct native v-model binding carriers in generated render functions [V01.01.05.03.01]

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1003,6 +1003,35 @@ into it. The hash reads only the component's own path, so a discriminated name i
 build and in any order MSBuild presents the files; a component that collides with nothing keeps its
 readable hint name unchanged [V01.01.06.10.01].
 
+`[SFC-CG-6]` **The runtime-directive tuple.** `_withDirectives` receives one `object?[]` per
+directive, positional: `[0]` the directive reference, `[1]` its bound value, `[2]` its string
+argument or null, `[3]` its modifier bag. Slot `[3]` is `IReadOnlyDictionary<string, bool>` and is
+built by `_createModifiers`, **not** by the `_createProps` property helper — the two bags differ in
+value type (`bool` versus `object?`), and a property bag in the modifier slot type-checks yet reads
+back as *no modifiers at all*. Core therefore rejects any other non-null shape in slot `[3]` rather
+than degrading silently. Slots `[2]` and `[3]` are emitted only when the directive has an argument or
+modifiers; an absent leading slot is filled with `null` so the positions never shift.
+
+`[SFC-CG-7]` **Native `v-model` carriers.** On a native control the compiler selects the runtime
+directive from the element and its `type` — `input`/`textarea` → `_vModelText`, `type="checkbox"` →
+`_vModelCheckbox`, `type="radio"` → `_vModelRadio`, `select` → `_vModelSelect`, and a dynamic
+`:type` (or a dynamically keyed `v-bind`) → `_vModelDynamic`, which re-resolves per render from the
+element's current tag and type. `type="file"` is an error. Each directive reflects the model through
+the DOM property that carries it and commits user edits from the event that carries them: `value` +
+`input` for text-like inputs and `textarea`, `checked` + `change` for checkbox and radio, and option
+`selected` + `change` for `select` — matching the events those controls fire per
+[WHATWG HTML](https://html.spec.whatwg.org/multipage/input.html#common-input-element-events).
+Modifiers shift them: `.lazy` moves the text-input commit from `input` to `change`, `.trim` trims the
+committed value and re-syncs the element on change, and `.number` (implied by `type="number"`)
+coerces it numerically.
+
+Because Viu has no `this`-proxy and no reflection, a native `v-model` cannot recover its setter from
+the `onUpdate:modelValue` prop the way a component `v-model` does. Slot `[1]` therefore carries a
+`ViuModelBinding` holding **both** the current value and the generated write-back delegate; the
+`onUpdate:modelValue` prop is still emitted for uniformity but is inert on a native element, which
+the DOM patcher skips rather than binding as a listener. The `modelValue` prop is not emitted at all
+on a native element.
+
 `[SFC-8]` **Source mapping.** Each expression-bearing render line carries a C# `#line` **span**
 directive — `#line (line,column)-(line,column) offset "file"` — anchored to that line's leftmost
 expression and closed with `#line default`. The span form is required because a render expression is

--- a/libraries/Assimalign.Viu.Browser/src/Directives/ViuModelBinding.cs
+++ b/libraries/Assimalign.Viu.Browser/src/Directives/ViuModelBinding.cs
@@ -7,7 +7,7 @@ namespace Assimalign.Viu.Browser;
 /// with the setter that writes it back. Viu has no <c>this</c>-proxy and no reflection, so a
 /// directive cannot recover the write-back path from a magically named property on the render node;
 /// the value and its setter are passed explicitly instead. The
-/// <c>v-model</c> transform ([V01.01.05.03]) emits, per render,
+/// <c>v-model</c> transform ([V01.01.05.03], specified by <c>[SFC-CG-7]</c>) emits, per render,
 /// <c>new object?[] { _vModelText, new ViuModelBinding(model, value =&gt; model = value) }</c> inside
 /// the generated <c>withDirectives</c> tuple. Core resolves the directive marker through the
 /// application directive resolver. The getter is the value already read into <see cref="Value"/>

--- a/libraries/Assimalign.Viu.Browser/test/Assimalign.Viu.Browser.CompiledRenderTests/DomCompiledRenderTests.cs
+++ b/libraries/Assimalign.Viu.Browser/test/Assimalign.Viu.Browser.CompiledRenderTests/DomCompiledRenderTests.cs
@@ -166,6 +166,70 @@ public sealed class DomCompiledRenderTests
         type.GetProperty("model")!.GetValue(instance).ShouldBe("updated");
     }
 
+    [Theory]
+    // The native control matrix, each with the modifiers that shift its carriers.
+    [InlineData("<input v-model.trim.number=\"model\" />", "trim", "number")]
+    [InlineData("<input type=\"text\" v-model.lazy=\"model\" />", "lazy", null)]
+    [InlineData("<textarea v-model.lazy.trim=\"model\"></textarea>", "lazy", "trim")]
+    [InlineData("<input type=\"checkbox\" v-model.number=\"model\" />", "number", null)]
+    [InlineData("<input type=\"radio\" value=\"a\" v-model.number=\"model\" />", "number", null)]
+    [InlineData("<select v-model.number=\"model\"></select>", "number", null)]
+    [InlineData("<input :type=\"kind\" v-model.lazy.number=\"model\" />", "lazy", "number")]
+    public void NativeVModel_CompiledRenderCarriesItsModifiers_AcrossTheControlMatrix(
+        string element,
+        string firstModifier,
+        string? secondModifier)
+    {
+        // The directive tuple's fourth slot must reach DirectiveBinding.Modifiers, which is typed
+        // IReadOnlyDictionary<string, bool>. Emitting it as a property bag (name -> object?) type-checks
+        // but reads back as NO modifiers, so `.lazy` never shifted the update carrier from `input` to
+        // `change`, and `.trim`/`.number` never transformed the read — on every native control, in every
+        // compiled component. The runtime v-model tests missed it because they construct
+        // ComponentDirectiveBinding directly and so never cross the generated _withDirectives seam
+        // ([SFC-CG-6], [V01.01.05.03.01]).
+        var template = "<template>\n" + element + "\n</template>\n";
+        const string handWritten =
+            "#nullable enable\n" +
+            "namespace Demo\n" +
+            "{\n" +
+            "    partial class ModifierModelWidget\n" +
+            "    {\n" +
+            "        public object? model { get; set; } = \"initial\";\n" +
+            "        public string kind => \"text\";\n" +
+            "    }\n" +
+            "}\n";
+
+        var generated = CompiledRenderSupport.Generate("ModifierModelWidget", template);
+        var type = Assembly.Load(CompiledRenderSupport.CompileToAssembly(generated, handWritten))
+            .GetType("Demo.ModifierModelWidget")
+            ?? throw new InvalidOperationException(
+                "The compiled assembly did not contain Demo.ModifierModelWidget.");
+        var instance = Activator.CreateInstance(type, nonPublic: true)!;
+        var cacheSize = (int)type.GetField(
+            "RenderCacheSize",
+            BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+        var render = type.GetMethod("Render", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        object rendered =
+            render.Invoke(null, new object?[] { instance, new object?[cacheSize] })
+            ?? throw new InvalidOperationException("The generated render returned null.");
+        var binding = rendered.ShouldBeAssignableTo<IElementComponent>()!.Directives.Single();
+
+        // The carrier itself still rides slot 2, unchanged by the modifier slot.
+        binding.Value.ShouldBeOfType<ViuModelBinding>().Value.ShouldBe("initial");
+        binding.Modifiers[firstModifier].ShouldBeTrue();
+        if (secondModifier is null)
+        {
+            binding.Modifiers.Count.ShouldBe(1);
+        }
+        else
+        {
+            binding.Modifiers.Count.ShouldBe(2);
+            binding.Modifiers[secondModifier].ShouldBeTrue();
+        }
+    }
+
     // A template using the <Transition> built-in around a v-if element — the compiled-render proof for
     // [V01.01.04.07]: the compiler resolves <Transition> to the _Transition helper (DomRenderHelpers), and
     // the generated render binds and compiles against the real component.

--- a/libraries/Assimalign.Viu.Browser/test/DomRenderHelpersTests.cs
+++ b/libraries/Assimalign.Viu.Browser/test/DomRenderHelpersTests.cs
@@ -40,6 +40,60 @@ public sealed class DomRenderHelpersTests
     }
 
     [Fact]
+    public void WithDirectives_CarriesTheModifierBag_SoLazyShiftsTheUpdateCarrierToChange()
+    {
+        // The end-to-end proof of the generated v-model seam: an element assembled exactly the way a
+        // compiled render assembles it — the ViuModelBinding carrier in slot 2 and the _createModifiers
+        // bag in slot 4 — mounts, and `.lazy` moves the update carrier from `input` to `change`
+        // (WHATWG HTML fires `input` per keystroke and `change` on commit:
+        // https://html.spec.whatwg.org/multipage/input.html#common-input-element-events). Before
+        // [V01.01.05.03.01] the modifier slot was emitted as a property bag, which reads back as no
+        // modifiers, so this committed on `input` and the user edit reached the model at the wrong time.
+        object? model = "initial";
+        using BrowserDirectiveTestHarness harness = new();
+
+        harness.Render(
+            RenderHelpers._withDirectives(
+                ComponentTree.Element("input"),
+                [
+                    new object?[]
+                    {
+                        DomRenderHelpers._vModelText,
+                        new ViuModelBinding(model, value => model = value),
+                        null,
+                        RenderHelpers._createModifiers(("lazy", true)),
+                    },
+                ]));
+        int input = harness.FindElement("input");
+
+        harness.FireInput(input, "typed");
+        model.ShouldBe("initial");     // .lazy does not commit on input
+
+        harness.FireChange(input, "typed");
+        model.ShouldBe("typed");       // it commits on change
+    }
+
+    [Fact]
+    public void WithDirectives_PropertyBagInTheModifierSlot_FailsLoudly()
+    {
+        // The modifier slot is typed name -> bool. A property bag there is a compiler/runtime contract
+        // break, and silently reading it as "no modifiers" is exactly what hid [V01.01.05.03.01], so the
+        // seam now rejects it instead ([SFC-CG-6]).
+        Should.Throw<NotSupportedException>(() =>
+            RenderHelpers._withDirectives(
+                ComponentTree.Element("input"),
+                [
+                    new object?[]
+                    {
+                        DomRenderHelpers._vModelText,
+                        new ViuModelBinding("v", _ => { }),
+                        null,
+                        RenderHelpers._createProps(("lazy", true)),
+                    },
+                ]));
+    }
+
+    [Fact]
     public void TransitionHelpers_LowerToNamedTemplateRequests()
     {
         ITemplateComponent transition =

--- a/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
+++ b/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
@@ -698,6 +698,35 @@ public static class RenderHelpers
         return new ReadOnlyDictionary<string, object?>(properties);
     }
 
+    /// <summary>
+    /// Creates the generated directive-modifier bag — the fourth slot of a
+    /// <see cref="_withDirectives(IComponent, object?[])"/> tuple.
+    /// </summary>
+    /// <remarks>
+    /// A modifier bag is <c>name → bool</c>, not the <c>name → object?</c> of
+    /// <see cref="_createProps(ValueTuple{string, object}[])"/>, and the two are deliberately
+    /// separate spellings: <see cref="DirectiveBinding.Modifiers"/> is typed
+    /// <c>IReadOnlyDictionary&lt;string, bool&gt;</c>, so a property bag in the modifier slot reads
+    /// back as no modifiers at all rather than as a type error. Emitting modifiers through their own
+    /// helper makes that mismatch unrepresentable. Specified by <c>[SFC-CG-6]</c> ([V01.01.05.03.01]).
+    /// </remarks>
+    /// <param name="entries">The ordered modifier name/state entries.</param>
+    /// <returns>An immutable modifier snapshot.</returns>
+    public static IReadOnlyDictionary<string, bool> _createModifiers(
+        params (string Name, bool Value)[] entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        Dictionary<string, bool> modifiers =
+            new(entries.Length, StringComparer.Ordinal);
+        foreach ((string name, bool value) in entries)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            modifiers[name] = value;
+        }
+
+        return new ReadOnlyDictionary<string, bool>(modifiers);
+    }
+
     /// <summary>Target-types a value-returning event handler with a payload.</summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
@@ -1578,10 +1607,23 @@ public static class RenderHelpers
         string? argument = tuple.Length > 2 ? tuple[2] as string : existing?.Argument;
         IReadOnlyDictionary<string, bool>? modifiers =
             tuple.Length > 3
-                ? tuple[3] as IReadOnlyDictionary<string, bool>
+                ? ReadModifiers(tuple[3])
                 : existing?.Modifiers;
         return new ComponentDirectiveBinding(name, value, argument, modifiers);
     }
+
+    // The modifier slot of a directive tuple carries the name -> bool bag _createModifiers builds
+    // ([SFC-CG-6]). Any other non-null shape is a compiler/runtime contract break and fails loudly:
+    // reading it as "no modifiers" is what silently disabled .lazy/.trim/.number on compiled
+    // v-model before [V01.01.05.03.01].
+    private static IReadOnlyDictionary<string, bool>? ReadModifiers(object? source) => source switch
+    {
+        null => null,
+        IReadOnlyDictionary<string, bool> modifiers => modifiers,
+        _ => throw new NotSupportedException(
+            $"Directive modifier bag type '{source.GetType().Name}' is not supported; "
+            + "generated code must build it with _createModifiers."),
+    };
 
     private static Dictionary<string, object?> CopyProperties(object? source)
     {

--- a/libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
@@ -200,6 +200,7 @@ pinned by a snapshot test in `RenderFunctionEmitterTests`.
 | `$slots` / `$event` | `_ctx.__slots` / `__event` | `$` is not legal in C# identifiers; `__event` is the [V01.01.05.04] event-variable contract and `__slots` follows the same spelling rule. |
 | `undefined` / `void 0` | `null` | No `undefined` in C#. |
 | `{}` (renderSlot's empty-props placeholder) | `_createProps()` | Same object-literal rule as props. |
+| `{ trim: true }` directive-modifier bag (`withDirectives` tuple slot 3) | `_createModifiers(("trim", true))` | Same object-literal rule as props, but a **different helper**: a directive binding types its modifiers `IReadOnlyDictionary<string, bool>`, while `_createProps` yields `IReadOnlyDictionary<string, object?>`. The property helper in this slot type-checks and then reads back as *no modifiers*, silently disabling `.lazy`/`.trim`/`.number` on native `v-model` ([SFC-CG-6], [V01.01.05.03.01]). |
 | `const` statements, ` === `/` !== ` (v-memo bodies) | `var`, ` == `/` != ` | Lexical bridging of the JavaScript statement spellings the v-memo transform authors as raw strings. |
 | `JSON.stringify(text)` | C# string literal (`SymbolDisplay.FormatLiteral`) | Same role, C# escaping rules. |
 | 2-space indent | 4-space indent | Repository C# convention; cosmetic. |
@@ -249,8 +250,8 @@ deviation from the repository C# naming rule, because these names ARE the by-nam
 - `_unref(object?) : object?` / `_isRef(object?) : bool` — bridge to `Assimalign.Viu.Core`
   references.
 - Emitter-contract helpers, per the serialization table above: `_createProps(params (string, object?)[] entries)`,
-  `_withHandler(handler)` (delegate-typed overloads), `_setCache(int index, BlockToken tracking, object? value)`,
-  `_spreadCache(object?)`.
+  `_createModifiers(params (string, bool)[] entries)`, `_withHandler(handler)` (delegate-typed overloads),
+  `_setCache(int index, BlockToken tracking, object? value)`, `_spreadCache(object?)`.
 
 ### The DOM render-helper surface (`DomRenderHelpers`, [V01.01.04.09])
 

--- a/libraries/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/ObjectExpression.cs
+++ b/libraries/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/ObjectExpression.cs
@@ -8,6 +8,15 @@ public sealed record ObjectExpression : TemplateSyntaxNode
     /// <summary>The object's properties, in source/emit order.</summary>
     public required SyntaxList<Property> Properties { get; init; }
 
+    /// <summary>
+    /// Whether this literal is a directive-modifier bag (<c>name → true</c>) rather than a property
+    /// bag. The two emit through different runtime helpers because a directive binding types its
+    /// modifiers <c>IReadOnlyDictionary&lt;string, bool&gt;</c> while a property bag is
+    /// <c>IReadOnlyDictionary&lt;string, object?&gt;</c>; emitting the property helper into the
+    /// modifier slot loses every modifier at run time. Specified by <c>[SFC-CG-6]</c>.
+    /// </summary>
+    public bool IsDirectiveModifiers { get; init; }
+
     /// <inheritdoc />
     public override NodeType NodeType => NodeType.JsObjectExpression;
 }

--- a/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/RenderCodeWriter.cs
+++ b/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/RenderCodeWriter.cs
@@ -24,6 +24,12 @@ internal sealed class RenderCodeWriter
     // An untyped object literal has no C# equivalent, so props/slots objects emit through this helper.
     private const string CreatePropsHelper = "_createProps";
 
+    // A directive-modifier bag is name -> bool, not the name -> object? of a property bag, and the
+    // directive binding that receives it is typed that way. It therefore has its own helper: the
+    // props helper in the modifier slot type-checks yet reads back as no modifiers at all
+    // ([SFC-CG-6]).
+    private const string CreateModifiersHelper = "_createModifiers";
+
     // C# lambdas and method groups have no natural type in an object-typed position, so event-handler
     // property values emit through this delegate-typed helper.
     private const string WithHandlerHelper = "_withHandler";
@@ -274,7 +280,7 @@ internal sealed class RenderCodeWriter
 
     private void EmitObjectExpression(ObjectExpression node)
     {
-        Push(CreatePropsHelper);
+        Push(node.IsDirectiveModifiers ? CreateModifiersHelper : CreatePropsHelper);
         Push("(");
         var properties = node.Properties;
         if (properties.Count == 0)

--- a/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/TransformElement.cs
+++ b/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/TransformElement.cs
@@ -549,7 +549,12 @@ internal static class TransformElement
                 modifierProperties.Add(Ir.ObjectProperty(modifier, trueExpression));
             }
 
-            arguments.Add(Ir.ObjectExpression(modifierProperties, directive.Location));
+            // The modifier slot is a name -> bool bag, so it emits through the modifier helper rather
+            // than the property helper: the runtime reads this slot as
+            // IReadOnlyDictionary<string, bool> ([SFC-CG-6]).
+            arguments.Add(
+                Ir.ObjectExpression(modifierProperties, directive.Location)
+                    with { IsDirectiveModifiers = true });
         }
 
         return Ir.ArrayExpression(arguments, directive.Location);

--- a/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/VModelTransform.cs
+++ b/libraries/Assimalign.Viu.Syntax.Templates/src/Internal/VModelTransform.cs
@@ -188,9 +188,9 @@ internal static class VModelTransform
         => Ir.CompoundExpression("$event => { ", expression, " = $event; }");
 
     /// <summary>
-    /// Builds the Browser runtime carrier for a native <c>v-model</c>. Unlike JavaScript, Viu cannot
-    /// recover a setter from a virtual node property through reflection, so generated code carries the
-    /// current value and its assignment lambda together.
+    /// Builds the Browser runtime carrier for a native <c>v-model</c>. Viu cannot recover a setter
+    /// from a virtual node property through reflection, so generated code carries the current value
+    /// and its assignment lambda together. Specified by <c>[SFC-CG-7]</c>.
     /// </summary>
     /// <param name="expression">The writable model expression.</param>
     /// <returns>The generated <c>ViuModelBinding</c> construction.</returns>

--- a/libraries/Assimalign.Viu.Syntax.Templates/test/RenderFunctionEmitterTests.cs
+++ b/libraries/Assimalign.Viu.Syntax.Templates/test/RenderFunctionEmitterTests.cs
@@ -299,6 +299,30 @@ return _withDirectives(_createElementBlock(_openBlock(), "input", _createProps((
 """);
     }
 
+    [Fact]
+    public void VModelWithModifiers_EmitsTheModifierBagThroughTheModifierHelper()
+    {
+        // The fourth directive-tuple slot is a name -> bool modifier bag, so it emits through
+        // _createModifiers, NOT the _createProps property helper: a directive binding types its
+        // modifiers IReadOnlyDictionary<string, bool>, so a property bag (name -> object?) in that
+        // slot type-checks yet reads back as NO modifiers, silently disabling .lazy (which shifts the
+        // update carrier from `input` to `change`), .trim, and .number on every compiled native
+        // v-model ([SFC-CG-6], [V01.01.05.03.01]). The third slot stays the null directive argument.
+        EmitPrefixed("<input v-model.trim.number=\"name\" />").Code.ShouldBeCode(
+"""
+return _withDirectives(_createElementBlock(_openBlock(), "input", _createProps(("onUpdate:modelValue", _withHandler(__event => ((_ctx.name) = __event)))), null, 8 /* PROPS */, ["onUpdate:modelValue"]), new object?[] { new object?[] {
+    _vModelText,
+    new global::Assimalign.Viu.Browser.ViuModelBinding(_ctx.name, __event => { _ctx.name = __event; }),
+    null,
+    _createModifiers(
+        ("trim", true),
+        ("number", true)
+    )
+} });
+
+""");
+    }
+
     // ---- runtime directives ----
 
     [Fact]


### PR DESCRIPTION
## Summary

The issue's headline defect (native v-model carrying no setter) was already fixed by `ee5680e` — verified empirically, not assumed. What was still live is the issue's third acceptance criterion, broken by a different link in the same carrier chain: the generated directive tuple emitted its modifier slot through the generic property helper (`IReadOnlyDictionary<string, object?>`), while the runtime read it with `as IReadOnlyDictionary<string, bool>` — a cast that never matches, silently yielding null. **Every compiled directive reached the runtime with an empty modifier bag**, so `.lazy` (the modifier that shifts the update carrier from `input` to `change`), `.trim`, and `.number` were dead on every native control in every compiled component. The 211 runtime tests stayed green because they construct bindings by hand and never cross the generated `_withDirectives` seam.

Fix: a typed `_createModifiers(params (string, bool)[])` render helper; the runtime now throws on any other non-null shape instead of degrading to "no modifiers" — the silent-null failure mode is structurally gone. Reproduced first as a failing compiled-render test (`v-model.trim.number` → 0 modifiers observed, 2 expected).

The carrier matrix itself was verified correct and unchanged: `value`+`input` for text-likes/textarea (`.lazy`→`change`), `checked`+`change` for checkbox/radio, option `selected`+`change` for select, dynamic `:type` re-resolved per render — event choices per WHATWG HTML. Spec was silent on both contracts; new clauses `[SFC-CG-6]` (typed modifier slot) and `[SFC-CG-7]` (native carriers) added and cited from tests. Audit note: the inert `onUpdate:modelValue` prop on native elements is deliberate (component v-model's carrier; the browser patcher skips it) and left alone.

## Tests

Syntax.Templates 495→496, Browser 211→213, Browser.CompiledRenderTests 9→16, Testing.CompiledComponentTests 11, Core 177, Generators.Syntax 171 — all pass. Solution 0 warnings / 0 errors. Install-Local + showcase build green; FormsView's generated output now carries `_createModifiers(("lazy", true))` et al. on all 15 bindings.

## Work items resolved by this PR

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)