### PR TITLE
fix(tooling): hide the compiler seam from completion [V01.01.14.02]

### DIFF
--- a/libraries/Assimalign.Viu.Browser/src/CssVariables.cs
+++ b/libraries/Assimalign.Viu.Browser/src/CssVariables.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 using Assimalign.Viu;
 using Assimalign.Viu.Components;
@@ -8,6 +9,7 @@ using Assimalign.Viu.Reactivity;
 namespace Assimalign.Viu.Browser;
 
 /// <summary>
+/// Compiler-generated code only; not part of the supported Viu API.
 /// Applies generated single-file-component <c>v-bind()</c> values as CSS custom properties.
 /// </summary>
 /// <remarks>
@@ -18,9 +20,11 @@ namespace Assimalign.Viu.Browser;
 /// reads an ambient component instance, because there is none to read in an AOT build. Specified by
 /// <c>[STY-6]</c> through <c>[STY-8]</c>.
 /// </remarks>
+[System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
 public static class CssVariables
 {
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Registers a component's generated CSS-variable getter against its current outermost browser
     /// elements.
     /// </summary>
@@ -35,6 +39,7 @@ public static class CssVariables
     /// <param name="getter">
     /// Produces hashed custom-property names without the leading <c>--</c> and their current values.
     /// </param>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static void UseCssVariables(
         IComponentContext context,
         Func<IReadOnlyDictionary<string, string>> getter)

--- a/libraries/Assimalign.Viu.Browser/src/DomRenderHelpers.cs
+++ b/libraries/Assimalign.Viu.Browser/src/DomRenderHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 using Assimalign.Viu;
@@ -7,6 +8,7 @@ using Assimalign.Viu.Components;
 namespace Assimalign.Viu.Browser;
 
 /// <summary>
+/// Compiler-generated code only; not part of the supported Viu API.
 /// Provides the browser-specific helper names emitted by the template compiler.
 /// </summary>
 /// <remarks>
@@ -16,45 +18,78 @@ namespace Assimalign.Viu.Browser;
 /// invoking a registered directive. Task-returning handler overloads preserve the returned
 /// <see cref="Task"/> so browser dispatch can observe failures.
 /// </remarks>
+[System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
 public static class DomRenderHelpers
 {
-    /// <summary>Gets the unresolved <c>v-show</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved <c>v-show</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vShow =
         new ComponentDirectiveBinding("show");
 
-    /// <summary>Gets the unresolved text <c>v-model</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved text <c>v-model</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vModelText =
         new ComponentDirectiveBinding("modelText");
 
-    /// <summary>Gets the unresolved checkbox <c>v-model</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved checkbox <c>v-model</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vModelCheckbox =
         new ComponentDirectiveBinding("modelCheckbox");
 
-    /// <summary>Gets the unresolved radio <c>v-model</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved radio <c>v-model</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vModelRadio =
         new ComponentDirectiveBinding("modelRadio");
 
-    /// <summary>Gets the unresolved select <c>v-model</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved select <c>v-model</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vModelSelect =
         new ComponentDirectiveBinding("modelSelect");
 
-    /// <summary>Gets the unresolved dynamic <c>v-model</c> directive marker.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the unresolved dynamic <c>v-model</c> directive marker.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly IComponentDirectiveBinding _vModelDynamic =
         new ComponentDirectiveBinding("modelDynamic");
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Gets the named-template marker for Browser's <c>Transition</c> built-in.
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _Transition =
         RenderHelpers._resolveComponent("Transition");
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Gets the named-template marker for the browser <c>TransitionGroup</c> built-in.
     /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _TransitionGroup =
         RenderHelpers._resolveComponent("TransitionGroup");
 
-    /// <summary>Applies event modifiers to a value-returning browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a value-returning browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withModifiers(
         Func<BrowserEvent, object?> handler,
         params string[] modifiers)
@@ -65,7 +100,11 @@ public static class DomRenderHelpers
             modifiers);
     }
 
-    /// <summary>Applies event modifiers to a synchronous browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a synchronous browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withModifiers(
         Action<BrowserEvent> handler,
         params string[] modifiers)
@@ -73,7 +112,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithModifiers(handler, modifiers);
     }
 
-    /// <summary>Applies event modifiers to a task-returning browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a task-returning browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<BrowserEvent, Task> _withModifiers(
         Func<BrowserEvent, Task> handler,
         params string[] modifiers)
@@ -81,7 +124,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithModifiers(handler, modifiers);
     }
 
-    /// <summary>Applies event modifiers to a value-returning parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a value-returning parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withModifiers(
         Func<object?> handler,
         params string[] modifiers)
@@ -95,7 +142,11 @@ public static class DomRenderHelpers
             modifiers);
     }
 
-    /// <summary>Applies event modifiers to a synchronous parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a synchronous parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withModifiers(
         Action handler,
         params string[] modifiers)
@@ -104,7 +155,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithModifiers(_ => handler(), modifiers);
     }
 
-    /// <summary>Applies event modifiers to a task-returning parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies event modifiers to a task-returning parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<BrowserEvent, Task> _withModifiers(
         Func<Task> handler,
         params string[] modifiers)
@@ -113,7 +168,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithModifiers(_ => handler(), modifiers);
     }
 
-    /// <summary>Applies key guards to a value-returning browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a value-returning browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withKeys(
         Func<BrowserEvent, object?> handler,
         params string[] keys)
@@ -124,7 +183,11 @@ public static class DomRenderHelpers
             keys);
     }
 
-    /// <summary>Applies key guards to a synchronous browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a synchronous browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withKeys(
         Action<BrowserEvent> handler,
         params string[] keys)
@@ -132,7 +195,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithKeys(handler, keys);
     }
 
-    /// <summary>Applies key guards to a task-returning browser event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a task-returning browser event handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<BrowserEvent, Task> _withKeys(
         Func<BrowserEvent, Task> handler,
         params string[] keys)
@@ -140,7 +207,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithKeys(handler, keys);
     }
 
-    /// <summary>Applies key guards to a value-returning parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a value-returning parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withKeys(
         Func<object?> handler,
         params string[] keys)
@@ -154,7 +225,11 @@ public static class DomRenderHelpers
             keys);
     }
 
-    /// <summary>Applies key guards to a synchronous parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a synchronous parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<BrowserEvent> _withKeys(
         Action handler,
         params string[] keys)
@@ -163,7 +238,11 @@ public static class DomRenderHelpers
         return BrowserEvents.WithKeys(_ => handler(), keys);
     }
 
-    /// <summary>Applies key guards to a task-returning parameterless handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Applies key guards to a task-returning parameterless handler.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<BrowserEvent, Task> _withKeys(
         Func<Task> handler,
         params string[] keys)

--- a/libraries/Assimalign.Viu.Components/src/Abstraction/IComponentHotReloadMetadata.cs
+++ b/libraries/Assimalign.Viu.Components/src/Abstraction/IComponentHotReloadMetadata.cs
@@ -1,8 +1,10 @@
 using System;
+using System.ComponentModel;
 
 namespace Assimalign.Viu.Components;
 
 /// <summary>
+/// Compiler-generated code only; not part of the supported Viu API.
 /// Supplies compiler-generated change markers for a component that participates in
 /// development-time Hot Reload.
 /// </summary>
@@ -13,17 +15,34 @@ namespace Assimalign.Viu.Components;
 /// transformed call sites can continue targeting the previous method body. Style changes remain
 /// mounted and are handled by the Viu CSS Hot Reload worker.
 /// </remarks>
+[System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
 public interface IComponentHotReloadMetadata
 {
-    /// <summary>Gets the stable compiler-generated identifier for the component source file.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the stable compiler-generated identifier for the component source file.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     string ComponentIdentifier { get; }
 
-    /// <summary>Gets the compiler-generated type whose method changes with the template block.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the compiler-generated type whose method changes with the template block.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     Type TemplateUpdateMarkerType { get; }
 
-    /// <summary>Gets the compiler-generated type whose method changes with the C# script blocks.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the compiler-generated type whose method changes with the C# script blocks.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     Type ScriptUpdateMarkerType { get; }
 
-    /// <summary>Gets the compiler-generated type whose method changes with the style blocks.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the compiler-generated type whose method changes with the style blocks.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     Type StyleUpdateMarkerType { get; }
 }

--- a/libraries/Assimalign.Viu.Components/src/Optimization/ComponentOptimization.cs
+++ b/libraries/Assimalign.Viu.Components/src/Optimization/ComponentOptimization.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 using Assimalign.Viu.Shared;
 
@@ -29,7 +30,10 @@ public sealed class ComponentOptimization
     /// <summary>Gets the metadata used by hand-authored, unoptimized tree values.</summary>
     public static ComponentOptimization None { get; } = new();
 
-    /// <summary>Creates optimization metadata.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates optimization metadata.
+    /// </summary>
     /// <param name="patchFlags">The compiler-produced patch flags.</param>
     /// <param name="dynamicProperties">
     /// The property names that may change when <paramref name="patchFlags"/> contains
@@ -41,6 +45,7 @@ public sealed class ComponentOptimization
     /// <param name="hasOnce">
     /// Whether suspended block tracking such as <c>v-once</c> occurred inside the block.
     /// </param>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public ComponentOptimization(
         PatchFlags patchFlags = default,
         IReadOnlyList<string>? dynamicProperties = null,

--- a/libraries/Assimalign.Viu.Core/src/Components/ComponentHotReload.cs
+++ b/libraries/Assimalign.Viu.Core/src/Components/ComponentHotReload.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 using Assimalign.Viu.Components;
 
 namespace Assimalign.Viu;
 
 /// <summary>
+/// Compiler-generated code only; not part of the supported Viu API.
 /// Applies compiler-generated component metadata updates to mounted development-time components.
 /// </summary>
 /// <remarks>
@@ -24,12 +26,14 @@ namespace Assimalign.Viu;
 /// This is the runtime half of [V01.01.06.05]:
 /// https://github.com/assimalign/viu/issues/61.
 /// </remarks>
+[System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
 public static class ComponentHotReload
 {
     private static readonly Dictionary<Type, List<ComponentHotReloadRegistration>>
         _registrations = [];
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Occurs once per updated component type immediately before Core resets its mounted instances
     /// for a script-block change.
     /// </summary>
@@ -38,15 +42,18 @@ public static class ComponentHotReload
     /// existing state, which would retain effects and lifecycle resources created by the previous
     /// script. A browser host may handle this event to perform a full application reload instead.
     /// </remarks>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static event ComponentScriptUpdateResetHandler? ScriptUpdateRequiresReset;
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Applies updated component method bodies to the corresponding mounted component instances.
     /// </summary>
     /// <param name="updatedTypes">
     /// The types supplied by <c>MetadataUpdateHandler.UpdateApplication</c>, or null when the
     /// runtime does not identify the changed types and every registered component must be checked.
     /// </param>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static void ApplyUpdates(Type[]? updatedTypes)
     {
         if (_registrations.Count == 0)

--- a/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
+++ b/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 using Assimalign.Viu.Components;
 using Assimalign.Viu.Reactivity;
@@ -12,6 +13,7 @@ using Assimalign.Viu.Shared;
 namespace Assimalign.Viu;
 
 /// <summary>
+/// Compiler-generated code only; not part of the supported Viu API.
 /// Implements the by-name runtime-helper contract emitted by the Viu template compiler and creates
 /// values in the unified <see cref="IComponent"/> tree.
 /// </summary>
@@ -22,44 +24,71 @@ namespace Assimalign.Viu;
 /// literally. This type is not thread-safe; Viu's runtime executes on the single-threaded host event
 /// loop.
 /// </remarks>
+[System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
 public static class RenderHelpers
 {
     private static readonly List<BlockFrame> BlockFrames = new();
     private static ConditionalWeakTable<IComponent, MemoMetadata> _memoMetadata = new();
     private static int _blockTrackingDepth = 1;
 
-    /// <summary>Gets the compiler marker for a fragment tree value.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the compiler marker for a fragment tree value.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _Fragment = new BuiltInComponentType("Fragment");
 
-    /// <summary>Gets the compiler marker for a teleport tree value.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the compiler marker for a teleport tree value.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _Teleport = new BuiltInComponentType("Teleport");
 
-    /// <summary>Gets the registered template type for the host-neutral Suspense built-in.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the registered template type for the host-neutral Suspense built-in.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _Suspense = typeof(Suspense);
 
-    /// <summary>Gets the registered template type for the host-neutral KeepAlive built-in.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the registered template type for the host-neutral KeepAlive built-in.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _KeepAlive = typeof(KeepAlive);
 
-    /// <summary>Gets the registered template type for the host-neutral BaseTransition built-in.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Gets the registered template type for the host-neutral BaseTransition built-in.
+    /// </summary>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static readonly object _BaseTransition = typeof(BaseTransition);
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Opens an optimization block and returns the token used to preserve generated evaluation order.
     /// </summary>
     /// <param name="disableTracking">
     /// Whether descendants should be excluded from the block's dynamic-child collection.
     /// </param>
     /// <returns>An opaque block token.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static BlockToken _openBlock(bool disableTracking = false)
     {
         BlockFrames.Add(new BlockFrame(disableTracking));
         return new BlockToken(0);
     }
 
-    /// <summary>Suspends or resumes block-tree collection.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Suspends or resumes block-tree collection.
+    /// </summary>
     /// <param name="value">A negative value suspends tracking; a positive value resumes it.</param>
     /// <param name="inVOnce">Whether the suspension begins a <c>v-once</c> subtree.</param>
     /// <returns>A token used by <see cref="_setCache"/> to apply the inverse change.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static BlockToken _setBlockTracking(int value, bool inVOnce = false)
     {
         _blockTrackingDepth += value;
@@ -71,7 +100,10 @@ public static class RenderHelpers
         return new BlockToken(value);
     }
 
-    /// <summary>Creates an element or fragment block.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates an element or fragment block.
+    /// </summary>
     /// <param name="block">The token returned by <see cref="_openBlock"/>.</param>
     /// <param name="tag">An element tag or <see cref="_Fragment"/>.</param>
     /// <param name="properties">The generated property bag.</param>
@@ -79,6 +111,7 @@ public static class RenderHelpers
     /// <param name="patchFlag">The compiler patch flags.</param>
     /// <param name="dynamicProperties">The selectively patchable property names.</param>
     /// <returns>The block root.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _createElementBlock(
         BlockToken block,
         object? tag,
@@ -97,7 +130,10 @@ public static class RenderHelpers
             asBlock: true);
     }
 
-    /// <summary>Creates a template, dynamic, or built-in block.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a template, dynamic, or built-in block.
+    /// </summary>
     /// <param name="block">The token returned by <see cref="_openBlock"/>.</param>
     /// <param name="tag">A template type, resolved name, element tag, or built-in marker.</param>
     /// <param name="properties">The generated property bag.</param>
@@ -105,6 +141,7 @@ public static class RenderHelpers
     /// <param name="patchFlag">The compiler patch flags.</param>
     /// <param name="dynamicProperties">The selectively patchable property names.</param>
     /// <returns>The block root.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _createBlock(
         BlockToken block,
         object? tag,
@@ -123,13 +160,17 @@ public static class RenderHelpers
             asBlock: true);
     }
 
-    /// <summary>Creates a non-block element or fragment.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a non-block element or fragment.
+    /// </summary>
     /// <param name="tag">An element tag or <see cref="_Fragment"/>.</param>
     /// <param name="properties">The generated property bag.</param>
     /// <param name="children">The generated child value or values.</param>
     /// <param name="patchFlag">The compiler patch flags.</param>
     /// <param name="dynamicProperties">The selectively patchable property names.</param>
     /// <returns>The tree value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _createElementVNode(
         object? tag,
         object? properties = null,
@@ -146,13 +187,17 @@ public static class RenderHelpers
             asBlock: false);
     }
 
-    /// <summary>Creates a non-block template, dynamic, or element value.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a non-block template, dynamic, or element value.
+    /// </summary>
     /// <param name="tag">A template type, resolved name, element tag, or built-in marker.</param>
     /// <param name="properties">The generated property bag.</param>
     /// <param name="children">Children or component slots.</param>
     /// <param name="patchFlag">The compiler patch flags.</param>
     /// <param name="dynamicProperties">The selectively patchable property names.</param>
     /// <returns>The tree value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _createVNode(
         object? tag,
         object? properties = null,
@@ -169,10 +214,14 @@ public static class RenderHelpers
             asBlock: false);
     }
 
-    /// <summary>Creates a text tree value.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a text tree value.
+    /// </summary>
     /// <param name="text">The text or value to display.</param>
     /// <param name="patchFlag">The compiler patch flags.</param>
     /// <returns>The text value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static ITextComponent _createTextVNode(object? text = null, int patchFlag = 0)
     {
         ITextComponent component = ComponentTree.Text(
@@ -182,10 +231,14 @@ public static class RenderHelpers
         return component;
     }
 
-    /// <summary>Creates a comment or empty-render placeholder.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a comment or empty-render placeholder.
+    /// </summary>
     /// <param name="text">The comment text.</param>
     /// <param name="asBlock">Whether to create a block-form comment.</param>
     /// <returns>The comment value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static ICommentComponent _createCommentVNode(string? text = "", bool asBlock = false)
     {
         if (!asBlock)
@@ -200,30 +253,42 @@ public static class RenderHelpers
             null);
     }
 
-    /// <summary>Creates a platform-specific static-content tree value.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a platform-specific static-content tree value.
+    /// </summary>
     /// <param name="content">The raw static content.</param>
     /// <param name="count">The compiler's top-level-node count hint.</param>
     /// <returns>The static tree value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IStaticComponent _createStaticVNode(string content, int count)
     {
         _ = count;
         return ComponentTree.Static(content);
     }
 
-    /// <summary>Formats an interpolation value for display.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Formats an interpolation value for display.
+    /// </summary>
     /// <param name="value">The value to format.</param>
     /// <returns>The display string.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _toDisplayString(object? value)
     {
         return DisplayStringFormatter.ToDisplayString(value);
     }
 
-    /// <summary>Renders each item in an enumerable.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders each item in an enumerable.
+    /// </summary>
     /// <typeparam name="T">The item type.</typeparam>
     /// <typeparam name="TResult">The generated result type.</typeparam>
     /// <param name="source">The source values.</param>
     /// <param name="render">The per-item renderer.</param>
     /// <returns>The rendered values.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static TResult[] _renderList<T, TResult>(
         IEnumerable<T>? source,
         Func<T, TResult> render)
@@ -244,12 +309,16 @@ public static class RenderHelpers
         return result.ToArray();
     }
 
-    /// <summary>Renders each item and its zero-based index.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders each item and its zero-based index.
+    /// </summary>
     /// <typeparam name="T">The item type.</typeparam>
     /// <typeparam name="TResult">The generated result type.</typeparam>
     /// <param name="source">The source values.</param>
     /// <param name="render">The per-item renderer.</param>
     /// <returns>The rendered values.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static TResult[] _renderList<T, TResult>(
         IEnumerable<T>? source,
         Func<T, int, TResult> render)
@@ -272,11 +341,15 @@ public static class RenderHelpers
         return result.ToArray();
     }
 
-    /// <summary>Renders a one-based numeric range.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders a one-based numeric range.
+    /// </summary>
     /// <typeparam name="TResult">The generated result type.</typeparam>
     /// <param name="count">The inclusive upper bound.</param>
     /// <param name="render">The per-number renderer.</param>
     /// <returns>The rendered values.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static TResult[] _renderList<TResult>(int count, Func<int, TResult> render)
     {
         ArgumentNullException.ThrowIfNull(render);
@@ -289,11 +362,15 @@ public static class RenderHelpers
         return result;
     }
 
-    /// <summary>Renders a one-based numeric range with a zero-based index.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders a one-based numeric range with a zero-based index.
+    /// </summary>
     /// <typeparam name="TResult">The generated result type.</typeparam>
     /// <param name="count">The inclusive upper bound.</param>
     /// <param name="render">The per-number renderer.</param>
     /// <returns>The rendered values.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static TResult[] _renderList<TResult>(
         int count,
         Func<int, int, TResult> render)
@@ -308,13 +385,17 @@ public static class RenderHelpers
         return result;
     }
 
-    /// <summary>Renders key/value entries with their zero-based index.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders key/value entries with their zero-based index.
+    /// </summary>
     /// <typeparam name="TKey">The entry key type.</typeparam>
     /// <typeparam name="TValue">The entry value type.</typeparam>
     /// <typeparam name="TResult">The generated result type.</typeparam>
     /// <param name="source">The entry source.</param>
     /// <param name="render">The per-entry renderer.</param>
     /// <returns>The rendered values.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static TResult[] _renderList<TKey, TValue, TResult>(
         IEnumerable<KeyValuePair<TKey, TValue>>? source,
         Func<TValue, TKey, int, TResult> render)
@@ -339,30 +420,42 @@ public static class RenderHelpers
         return result.ToArray();
     }
 
-    /// <summary>Wraps an unscoped generated slot function.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Wraps an unscoped generated slot function.
+    /// </summary>
     /// <param name="render">The generated slot renderer.</param>
     /// <returns>The component-slot delegate.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static ComponentSlot _withCtx(Func<object?[]?> render)
     {
         ArgumentNullException.ThrowIfNull(render);
         return _ => NormalizeSlotResult(render());
     }
 
-    /// <summary>Wraps a scoped generated slot function.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Wraps a scoped generated slot function.
+    /// </summary>
     /// <param name="render">The generated slot renderer.</param>
     /// <returns>The component-slot delegate.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static ComponentSlot _withCtx(Func<object?, object?[]?> render)
     {
         ArgumentNullException.ThrowIfNull(render);
         return arguments => NormalizeSlotResult(render(arguments));
     }
 
-    /// <summary>Renders a named slot or its fallback content.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Renders a named slot or its fallback content.
+    /// </summary>
     /// <param name="slots">The current component's slots.</param>
     /// <param name="name">The slot name.</param>
     /// <param name="properties">The scoped-slot arguments.</param>
     /// <param name="fallback">The optional fallback renderer.</param>
     /// <returns>The rendered slot subtree.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _renderSlot(
         IReadOnlyDictionary<string, ComponentSlot>? slots,
         string name,
@@ -384,10 +477,14 @@ public static class RenderHelpers
             : NormalizeSlotResult(fallback()) ?? ComponentTree.Comment();
     }
 
-    /// <summary>Merges static and compiler-produced dynamic slots.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Merges static and compiler-produced dynamic slots.
+    /// </summary>
     /// <param name="slots">The statically named slot property bag.</param>
     /// <param name="dynamicSlots">Dynamic slot descriptors and rendered descriptor arrays.</param>
     /// <returns>A merged slot property bag.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IReadOnlyDictionary<string, object?> _createSlots(
         object? slots,
         object?[] dynamicSlots)
@@ -403,19 +500,25 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Creates a deferred named-template reference without resolving or activating a template.
     /// </summary>
     /// <param name="name">The registered template name.</param>
     /// <returns>An opaque name reference consumed by the tree factories.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object _resolveComponent(string name)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         return new NamedTemplateType(name);
     }
 
-    /// <summary>Creates a deferred directive-name reference.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates a deferred directive-name reference.
+    /// </summary>
     /// <param name="name">The registered directive name.</param>
     /// <returns>An opaque directive reference.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object _resolveDirective(string name)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
@@ -423,6 +526,7 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Preserves a dynamic component selector until the tree request is created.
     /// </summary>
     /// <param name="value">
@@ -431,15 +535,20 @@ public static class RenderHelpers
     /// the application component factory intentionally has no probing API.
     /// </param>
     /// <returns>The unchanged selector.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _resolveDynamicComponent(object? value)
     {
         return DynamicComponents.ResolveDynamicComponent(value);
     }
 
-    /// <summary>Attaches generated directive metadata to an element or template request.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Attaches generated directive metadata to an element or template request.
+    /// </summary>
     /// <param name="component">The component tree value.</param>
     /// <param name="directives">The generated directive tuples.</param>
     /// <returns>A copy carrying the directive bindings.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _withDirectives(IComponent component, object?[] directives)
     {
         ArgumentNullException.ThrowIfNull(component);
@@ -503,12 +612,14 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Merges generated property sources: <c>class</c> and <c>style</c> values from every source are
     /// normalized and combined rather than overwritten, event handlers for the same name accumulate
     /// into a list, and any other repeated name takes the last source's value.
     /// </summary>
     /// <param name="sources">The property sources.</param>
     /// <returns>The merged property bag.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IReadOnlyDictionary<string, object?> _mergeProps(params object?[] sources)
     {
         ArgumentNullException.ThrowIfNull(sources);
@@ -550,25 +661,37 @@ public static class RenderHelpers
         return new ReadOnlyDictionary<string, object?>(merged);
     }
 
-    /// <summary>Normalizes a dynamic class binding.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Normalizes a dynamic class binding.
+    /// </summary>
     /// <param name="value">The class binding.</param>
     /// <returns>The normalized class string.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _normalizeClass(object? value)
     {
         return StyleAndClassNormalization.NormalizeClass(value);
     }
 
-    /// <summary>Normalizes a dynamic style binding.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Normalizes a dynamic style binding.
+    /// </summary>
     /// <param name="value">The style binding.</param>
     /// <returns>The normalized style representation.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _normalizeStyle(object? value)
     {
         return StyleAndClassNormalization.NormalizeStyle(value);
     }
 
-    /// <summary>Normalizes the class and style entries in a generated property bag.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Normalizes the class and style entries in a generated property bag.
+    /// </summary>
     /// <param name="properties">The property source.</param>
     /// <returns>A normalized snapshot of the source, or the original non-property value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _normalizeProps(object? properties)
     {
         if (!CanReadProperties(properties))
@@ -590,17 +713,25 @@ public static class RenderHelpers
         return new ReadOnlyDictionary<string, object?>(normalized);
     }
 
-    /// <summary>Returns a property source unchanged because Viu does not use identity-swapping proxies.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Returns a property source unchanged because Viu does not use identity-swapping proxies.
+    /// </summary>
     /// <param name="properties">The property source.</param>
     /// <returns><paramref name="properties"/>.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _guardReactiveProps(object? properties)
     {
         return properties;
     }
 
-    /// <summary>Prefixes a generated event map's keys with <c>on</c>.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Prefixes a generated event map's keys with <c>on</c>.
+    /// </summary>
     /// <param name="value">The unprefixed event property source.</param>
     /// <returns>The prefixed event property bag.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IReadOnlyDictionary<string, object?> _toHandlers(object? value)
     {
         Dictionary<string, object?> handlers = new(StringComparer.Ordinal);
@@ -612,9 +743,13 @@ public static class RenderHelpers
         return new ReadOnlyDictionary<string, object?>(handlers);
     }
 
-    /// <summary>Converts a hyphenated name to camel case.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Converts a hyphenated name to camel case.
+    /// </summary>
     /// <param name="value">The input name.</param>
     /// <returns>The camel-cased name.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _camelize(string value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -644,9 +779,13 @@ public static class RenderHelpers
         return new string(buffer, 0, length);
     }
 
-    /// <summary>Capitalizes the first character of a string.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Capitalizes the first character of a string.
+    /// </summary>
     /// <param name="value">The input string.</param>
     /// <returns>The capitalized string.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _capitalize(string value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -655,34 +794,50 @@ public static class RenderHelpers
             : char.ToUpperInvariant(value[0]) + value[1..];
     }
 
-    /// <summary>Builds an <c>onEvent</c> property name.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Builds an <c>onEvent</c> property name.
+    /// </summary>
     /// <param name="value">The event name.</param>
     /// <returns>The handler property name.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _toHandlerKey(object? value)
     {
         string name = value as string ?? DisplayStringFormatter.ToDisplayString(value);
         return name.Length == 0 ? string.Empty : "on" + _capitalize(_camelize(name));
     }
 
-    /// <summary>Unwraps a reactive reference or returns a non-reference unchanged.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Unwraps a reactive reference or returns a non-reference unchanged.
+    /// </summary>
     /// <param name="value">The value to inspect.</param>
     /// <returns>The current reference value or the original value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _unref(object? value)
     {
         return value is IReactiveReference reference ? reference.Value : value;
     }
 
-    /// <summary>Determines whether a value is a reactive reference.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Determines whether a value is a reactive reference.
+    /// </summary>
     /// <param name="value">The value to inspect.</param>
     /// <returns>True when the value is a reactive reference.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static bool _isRef(object? value)
     {
         return Reactive.IsRef(value);
     }
 
-    /// <summary>Creates the generated property-bag representation.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Creates the generated property-bag representation.
+    /// </summary>
     /// <param name="entries">The ordered name/value entries.</param>
     /// <returns>An immutable property snapshot.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IReadOnlyDictionary<string, object?> _createProps(
         params (string Name, object? Value)[] entries)
     {
@@ -699,6 +854,7 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Creates the generated directive-modifier bag — the fourth slot of a
     /// <see cref="_withDirectives(IComponent, object?[])"/> tuple.
     /// </summary>
@@ -712,6 +868,7 @@ public static class RenderHelpers
     /// </remarks>
     /// <param name="entries">The ordered modifier name/state entries.</param>
     /// <returns>An immutable modifier snapshot.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IReadOnlyDictionary<string, bool> _createModifiers(
         params (string Name, bool Value)[] entries)
     {
@@ -727,54 +884,78 @@ public static class RenderHelpers
         return new ReadOnlyDictionary<string, bool>(modifiers);
     }
 
-    /// <summary>Target-types a value-returning event handler with a payload.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a value-returning event handler with a payload.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<object?, object?> _withHandler(Func<object?, object?> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Target-types a synchronous event handler with a payload.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a synchronous event handler with a payload.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<object?> _withHandler(Action<object?> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Target-types a parameterless synchronous event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a parameterless synchronous event handler.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action _withHandler(Action handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Target-types a parameterless value-returning event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a parameterless value-returning event handler.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<object?> _withHandler(Func<object?> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Target-types a parameterless task-returning event handler.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a parameterless task-returning event handler.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged task-returning handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<Task> _withHandler(Func<Task> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Target-types a task-returning event handler with an object payload.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a task-returning event handler with an object payload.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged task-returning handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<object?, Task> _withHandler(Func<object?, Task> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
@@ -782,11 +963,13 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Adapts a task-returning handler with a strongly typed payload to the component event contract.
     /// </summary>
     /// <typeparam name="TEvent">The payload type.</typeparam>
     /// <param name="handler">The strongly typed handler.</param>
     /// <returns>An object-payload task-returning handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Func<object?, Task> _withHandler<TEvent>(Func<TEvent, Task> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
@@ -794,31 +977,41 @@ public static class RenderHelpers
     }
 
     /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
     /// Adapts a synchronous handler with a strongly typed payload to the component event contract.
     /// </summary>
     /// <typeparam name="TEvent">The payload type.</typeparam>
     /// <param name="handler">The strongly typed handler.</param>
     /// <returns>An object-payload synchronous handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Action<object?> _withHandler<TEvent>(Action<TEvent> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return value => handler((TEvent)value!);
     }
 
-    /// <summary>Target-types a delegate shape not covered by a more specific overload.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Target-types a delegate shape not covered by a more specific overload.
+    /// </summary>
     /// <param name="handler">The handler.</param>
     /// <returns>The unchanged handler.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static Delegate _withHandler(Delegate handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
         return handler;
     }
 
-    /// <summary>Resumes block tracking after writing a generated cache slot.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Resumes block tracking after writing a generated cache slot.
+    /// </summary>
     /// <param name="index">The cache slot index.</param>
     /// <param name="tracking">The suspension token.</param>
     /// <param name="value">The cached value.</param>
     /// <returns><paramref name="value"/>.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _setCache(int index, BlockToken tracking, object? value)
     {
         _ = index;
@@ -826,20 +1019,28 @@ public static class RenderHelpers
         return value;
     }
 
-    /// <summary>Clones a cached array before it is reused as generated children.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Clones a cached array before it is reused as generated children.
+    /// </summary>
     /// <param name="value">The cached value.</param>
     /// <returns>A shallow array clone, or the original non-array value.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static object? _spreadCache(object? value)
     {
         return value is Array array ? array.Clone() : value;
     }
 
-    /// <summary>Memoizes a generated subtree against a dependency array.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Memoizes a generated subtree against a dependency array.
+    /// </summary>
     /// <param name="dependencies">The current memo dependencies.</param>
     /// <param name="render">The subtree factory.</param>
     /// <param name="cache">The component instance's render cache.</param>
     /// <param name="index">The cache slot index.</param>
     /// <returns>The cached or newly rendered subtree.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent _withMemo(
         object?[] dependencies,
         Func<object?> render,
@@ -867,10 +1068,14 @@ public static class RenderHelpers
         return component;
     }
 
-    /// <summary>Compares a cached tree value's memo dependencies with the current dependencies.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Compares a cached tree value's memo dependencies with the current dependencies.
+    /// </summary>
     /// <param name="cached">The cached value.</param>
     /// <param name="dependencies">The current dependencies.</param>
     /// <returns>True when every dependency is unchanged.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static bool _isMemoSame(object? cached, object?[] dependencies)
     {
         ArgumentNullException.ThrowIfNull(dependencies);
@@ -893,9 +1098,13 @@ public static class RenderHelpers
         return true;
     }
 
-    /// <summary>Normalizes a generated render result into one component-tree root.</summary>
+    /// <summary>
+    /// Compiler-generated code only; not part of the supported Viu API.
+    /// Normalizes a generated render result into one component-tree root.
+    /// </summary>
     /// <param name="renderResult">The generated render result.</param>
     /// <returns>The normalized tree root.</returns>
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static IComponent NormalizeRoot(object? renderResult)
     {
         return NormalizeChild(renderResult);

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/ScriptSemanticEngine.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/src/Internal/ScriptSemanticEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -377,7 +378,9 @@ internal sealed class ScriptSemanticEngine
     {
         if (target is null)
         {
-            return semanticModel.LookupSymbols(position);
+            return FilterEditorBrowsableSymbols(
+                semanticModel.LookupSymbols(position),
+                semanticModel.Compilation);
         }
 
         var symbolInfo = semanticModel.GetSymbolInfo(target, cancellationToken);
@@ -405,18 +408,20 @@ internal sealed class ScriptSemanticEngine
 
         if (targetSymbol is INamespaceSymbol namespaceSymbol)
         {
-            return semanticModel.LookupSymbols(position, namespaceSymbol)
-                .Where(symbol => symbol.Kind is SymbolKind.NamedType or SymbolKind.Namespace)
-                .ToArray();
+            return FilterEditorBrowsableSymbols(
+                semanticModel.LookupSymbols(position, namespaceSymbol)
+                    .Where(symbol => symbol.Kind is SymbolKind.NamedType or SymbolKind.Namespace),
+                semanticModel.Compilation);
         }
 
         if (targetSymbol is ITypeSymbol typeReference)
         {
             // The target names a type (Reactive., String.): static members and nested types.
-            return semanticModel.LookupStaticMembers(position, typeReference)
-                .Where(symbol => symbol.Kind is SymbolKind.Field or SymbolKind.Property
-                    or SymbolKind.Method or SymbolKind.Event or SymbolKind.NamedType)
-                .ToArray();
+            return FilterEditorBrowsableSymbols(
+                semanticModel.LookupStaticMembers(position, typeReference)
+                    .Where(symbol => symbol.Kind is SymbolKind.Field or SymbolKind.Property
+                        or SymbolKind.Method or SymbolKind.Event or SymbolKind.NamedType),
+                semanticModel.Compilation);
         }
 
         var expressionType = semanticModel.GetTypeInfo(target, cancellationToken).Type;
@@ -439,13 +444,54 @@ internal sealed class ScriptSemanticEngine
             return null;
         }
 
-        return semanticModel
-            .LookupSymbols(position, expressionType, includeReducedExtensionMethods: true)
-            .Where(symbol => symbol.Kind is SymbolKind.Field or SymbolKind.Property
-                or SymbolKind.Method or SymbolKind.Event)
-            .Where(symbol => !symbol.IsStatic ||
-                symbol is IMethodSymbol { MethodKind: MethodKind.ReducedExtension })
+        return FilterEditorBrowsableSymbols(
+            semanticModel
+                .LookupSymbols(position, expressionType, includeReducedExtensionMethods: true)
+                .Where(symbol => symbol.Kind is SymbolKind.Field or SymbolKind.Property
+                    or SymbolKind.Method or SymbolKind.Event)
+                .Where(symbol => !symbol.IsStatic ||
+                    symbol is IMethodSymbol { MethodKind: MethodKind.ReducedExtension }),
+            semanticModel.Compilation);
+    }
+
+    // The referenced Microsoft.CodeAnalysis.CSharp 5.3.0 surface exposes no public
+    // ISymbol.IsEditorBrowsable API. LookupSymbols therefore needs this metadata-level filter so
+    // the compiler-only seam stays out of .viu completion ([V01.01.14.02]).
+    private static IReadOnlyList<ISymbol> FilterEditorBrowsableSymbols(
+        IEnumerable<ISymbol> symbols,
+        Compilation compilation)
+    {
+        var editorBrowsableAttribute = compilation.GetTypeByMetadataName(
+            "System.ComponentModel.EditorBrowsableAttribute");
+        if (editorBrowsableAttribute is null)
+        {
+            return symbols.ToArray();
+        }
+
+        return symbols
+            .Where(symbol => !IsEditorBrowsableNever(symbol, editorBrowsableAttribute))
             .ToArray();
+    }
+
+    private static bool IsEditorBrowsableNever(
+        ISymbol symbol,
+        INamedTypeSymbol editorBrowsableAttribute)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(
+                    attribute.AttributeClass,
+                    editorBrowsableAttribute) ||
+                attribute.ConstructorArguments.Length != 1)
+            {
+                continue;
+            }
+
+            return attribute.ConstructorArguments[0].Value is int state &&
+                state == (int)EditorBrowsableState.Never;
+        }
+
+        return false;
     }
 
     private List<LanguageCompletionItem> CreateCompletionItems(

--- a/tooling/Assimalign.Viu.Tooling.LanguageService/test/ScriptSemanticCompletionTests.cs
+++ b/tooling/Assimalign.Viu.Tooling.LanguageService/test/ScriptSemanticCompletionTests.cs
@@ -97,6 +97,47 @@ public class ScriptSemanticCompletionTests
     }
 
     [Fact]
+    public void GetCompletions_EditorBrowsableNeverRenderHelperMembers_OmitsCompilerSeam()
+    {
+        const string source =
+            "<template>\n  <div>x</div>\n</template>\n" +
+            "@script {\n" +
+            "public int Count { get; set; }\n" +
+            "    \n" +
+            "}\n";
+        var renderHelpers = new LanguageProjectSourceDocument(
+            "C:\\workspace\\App\\RenderHelpers.cs",
+            "namespace Assimalign.Viu;\n" +
+            "\n" +
+            "public static class RenderHelpers\n" +
+            "{\n" +
+            "    [System.ComponentModel.EditorBrowsable(" +
+            "System.ComponentModel.EditorBrowsableState.Never)]\n" +
+            "    public static readonly object _Fragment = new();\n" +
+            "\n" +
+            "    [System.ComponentModel.EditorBrowsable(" +
+            "System.ComponentModel.EditorBrowsableState.Never)]\n" +
+            "    public static object _createVNode() => new();\n" +
+            "\n" +
+            "    public static object CompletionControl => new();\n" +
+            "}\n",
+            IsComponent: false);
+        var service = CreateService(
+            source,
+            ScriptSemanticFixture.CreateContext(renderHelpers));
+
+        var completions = service.GetCompletions(
+            DocumentUri,
+            PositionAfter(source, "set; }\n    "));
+
+        // [V01.01.14.02] RenderHelpers is statically imported into the generated unit containing
+        // @script, so filtering must honor EditorBrowsable on each imported member.
+        completions.ShouldContain(completion => completion.Label == "CompletionControl");
+        completions.ShouldNotContain(
+            completion => completion.Label.StartsWith("_", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void GetCompletions_WithoutProjectContext_IsByteIdenticalToSyntaxOnlyPath()
     {
         var position = PositionAfter(ComponentSource, "set; }\n    ");


### PR DESCRIPTION
## Summary

The template compiler emits calls into public runtime helpers from the **consumer's own** assembly, so those helpers cannot become `internal`. There are ~90 such members and none was hidden — the repository had **zero** uses of `[EditorBrowsable]` before this.

The exposure was not hypothetical: `SingleFileComponentSourceEmitter` writes `using static global::Assimalign.Viu.RenderHelpers;` into the *same generated compilation unit* that carries the author's `@script` members, so a developer typing inside a `.viu` script block was offered the entire code-generation contract by simple name.

## Changes

`[EditorBrowsable(EditorBrowsableState.Never)]` on the type **and every public member** of:

| Type | Members |
|---|---|
| `RenderHelpers` | 56 |
| `DomRenderHelpers` | 20 |
| `IComponentHotReloadMetadata` | 4 |
| `ComponentHotReload` | 2 |
| `CssVariables` | 1 |

Plus `ComponentOptimization`'s **public constructor only** — never its type, since `[RND-BLOCK-1]` makes `ComponentOptimization.None` hand-authorable.

Member-level application is required, not cosmetic: Roslyn filters `EditorBrowsable` per symbol, so the attribute on the type alone does not hide members already in scope through `using static`.

The language service now drops `EditorBrowsableState.Never` symbols from completion, applied at all four symbol-lookup sites. **Without this the attribute is inert for `.viu` authors**, because `SemanticModel.LookupSymbols` does not filter on it — this is the half that delivers the benefit.

## What deliberately did not change

- **No renames.** The leading-underscore prefix is load-bearing collision hygiene: these members bind *unqualified* via `using static` into a user-authored partial class, so PascalCase spellings (`Fragment`, `Suspense`, `Capitalize`, `RenderList`) would be shadowed by any same-named user member. The names are also pinned normatively by `[SFC-CG-2]`, `[SFC-CG-6]`, `[SFC-CG-7]`.
- **No accessibility changes.** Generated code in the consumer's assembly binds these by name.
- **Untouched extension points:** `Dependency`, `Subscriber`, `SubscriberLink`, `ReactiveTraversal`, `ViuModelBinding`, `ApplicationWatchScheduler`, `Reactive.Track`/`Trigger` — `[RCT-9]` requires several to stay publicly readable.

`[EditorBrowsable]` has no compile-time or runtime effect; this changes IntelliSense presentation only.

## Verification

- `dotnet build Assimalign.Viu.slnx -c Release -warnaserror` — 0 warnings, 0 errors
- Language-service tests 142/142
- The new test asserts no `_`-prefixed member appears in `@script` completion **and** that a browsable member still does, so it cannot pass by filtering everything away
- Filter confirmed invoked at all four lookup sites, not merely defined

## Work items resolved by this PR

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)