### PR TITLE
fix(ci): unblock beta publishing and pin LF checkout for UtilityCss tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,12 @@
 # Windows) would otherwise yield a different fingerprint than a LF checkout (Linux/CI) for
 # identical source — breaking the bundler's byte-stable-across-machines contract. Pin LF.
 *.viu text eol=lf
+
+# The Viu Utilities emitters normalize their output to LF unconditionally
+# (UtilityDirectiveEmitter and UtilityCssLayerEmitter both collapse CRLF and lone CR to LF;
+# the layer emitter documents "LF line endings" as its contract). Its tests assert that
+# canonical output against C# raw string literals, so the literal's line endings are part of
+# the expected value — a CRLF checkout (autocrlf on Windows) makes the expected value CRLF
+# while the emitter still produces LF, failing 7 tests that pass on a LF checkout (Linux/CI).
+# Pin LF so a fresh clone or worktree is green on every platform ([V01.01.12.24]).
+tooling/Assimalign.Viu.Tooling.UtilityCss/test/**/*.cs text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
+      package-count: ${{ steps.package-count.outputs.count }}
     steps:
       - name: Checkout
         # actions/checkout v4
@@ -159,6 +160,27 @@ jobs:
           VIU_PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: ./scripts/Pack-Release.ps1 -Version $env:VIU_PACKAGE_VERSION
 
+      # The publish jobs assert the artifact they download still carries every
+      # package this job produced. They cannot compute that themselves - they
+      # only download the artifact and never check out the repository - so the
+      # producer publishes the number. Deriving it here is what keeps it from
+      # drifting: Pack-Release.ps1 writes package-order.txt from the same
+      # authoritative id list it validates the pack against, so adding a package
+      # updates this automatically.
+      - name: Record package count
+        id: package-count
+        shell: pwsh
+        run: |
+          $packageOrderPath = '_out/release/packages/package-order.txt'
+          $packageCount = @(Get-Content -LiteralPath $packageOrderPath).Count
+          if ($packageCount -lt 1) {
+            throw "Pack-Release.ps1 produced no packages in $packageOrderPath."
+          }
+
+          "count=$packageCount" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Release package count: $packageCount"
+
       - name: Verify utility release artifacts
         shell: pwsh
         env:
@@ -223,11 +245,13 @@ jobs:
         env:
           GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           VIU_PACKAGE_VERSION: ${{ needs.pack-packages.outputs.version }}
+          VIU_PACKAGE_COUNT: ${{ needs.pack-packages.outputs.package-count }}
         run: |
           $packageDirectory = '_release/packages'
           $packageFiles = @(Get-Content -LiteralPath "$packageDirectory/package-order.txt")
-          if ($packageFiles.Count -ne 21) {
-            throw "Expected 21 release packages, found $($packageFiles.Count)."
+          $expectedPackageCount = [int]$env:VIU_PACKAGE_COUNT
+          if ($packageFiles.Count -ne $expectedPackageCount) {
+            throw "Expected $expectedPackageCount release packages, found $($packageFiles.Count)."
           }
 
           foreach ($packageFile in $packageFiles) {
@@ -248,7 +272,7 @@ jobs:
           @"
           ## Published beta packages
 
-          Published all 21 Viu packages at version ``$($env:VIU_PACKAGE_VERSION)`` to the
+          Published all $($packageFiles.Count) Viu packages at version ``$($env:VIU_PACKAGE_VERSION)`` to the
           Assimalign GitHub Packages feed.
           "@ |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
@@ -292,11 +316,13 @@ jobs:
         env:
           NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
           VIU_PACKAGE_VERSION: ${{ needs.pack-packages.outputs.version }}
+          VIU_PACKAGE_COUNT: ${{ needs.pack-packages.outputs.package-count }}
         run: |
           $packageDirectory = '_release/packages'
           $packageFiles = @(Get-Content -LiteralPath "$packageDirectory/package-order.txt")
-          if ($packageFiles.Count -ne 21) {
-            throw "Expected 21 release packages, found $($packageFiles.Count)."
+          $expectedPackageCount = [int]$env:VIU_PACKAGE_COUNT
+          if ($packageFiles.Count -ne $expectedPackageCount) {
+            throw "Expected $expectedPackageCount release packages, found $($packageFiles.Count)."
           }
 
           foreach ($packageFile in $packageFiles) {
@@ -317,7 +343,7 @@ jobs:
           @"
           ## Published stable packages
 
-          Published all 21 Viu packages at version ``$($env:VIU_PACKAGE_VERSION)`` to
+          Published all $($packageFiles.Count) Viu packages at version ``$($env:VIU_PACKAGE_VERSION)`` to
           [nuget.org](https://www.nuget.org/profiles/Assimalign).
           "@ |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -63,35 +63,40 @@ taking `Browser` and its `browser-wasm` runtime pin.
 
 ## State
 
-| Unit | Theme | Wave | Status |
-|---|---|---|---|
-| `V01.01.14.01` | T01 ship XML documentation + T15 derivative doc phrasing | 1 | **IN PROGRESS** |
-| `V01.01.14.02` | T04 compiler-seam hardening (`[EditorBrowsable]` + language-service filter) | 1 | Not started |
-| `V01.01.14.03` | T03 unship build-time packages | 1 | Not started |
-| `V01.01.14.04` | T02 public-API baseline and hardening-attribute conventions | 1 | Not started |
-| `V01.01.14.22` | **Application lifetime: middleware pipeline, delete `IApplicationPlugin`** | 2A | Not started |
-| `V01.01.14.23` | **Composition surface: drop public `IApplicationBuilder`, self-returning builders, frozen options** | 2A | Not started |
-| `V01.01.14.24` | **Separate SSR: `ServerApplication` → `ServerRenderApplication`, off `IApplication`** | 2A | Not started |
-| `V01.01.14.25` | **Host facade: `Application.CreateBuilder()` in Browser/SDK** | 2A | Not started |
-| `V01.01.14.26` | **Router bootstrap: `UseRouter`, `ReadyAsync` cancellation, lazy history init** | 2A | Not started |
-| `V01.01.14.27` | **Specification: replace `[CMP-25]` with application lifecycle clauses; lifetime test suite** | 2A | Not started |
-| `V01.01.14.05` | T05 internalize friend-only publics (~120 types) | 2 | Not started |
-| `V01.01.14.06` | T13 single source of truth for the helper-name contract | 2 | Not started |
-| `V01.01.14.07` | T16 drop the viral `RequiresPreviewFeatures` stamp | 2 | Not started |
-| `V01.01.14.08` | T06 namespace segmentation (`Assimalign.Viu.Hosting`) | 3 | Not started — decide after `.02` lands |
-| `V01.01.14.09` | T07 product-prefix and duplicate facades | 3 | Not started |
-| `V01.01.14.10` | T08 naming-rule compliance | 3 | Not started |
-| `V01.01.14.11` | T09 mutable state and encapsulation | 4 | Not started |
-| `V01.01.14.12` | T10 compiler-seam typing | 4 | Not started |
-| `V01.01.14.13` | T11 async conventions | 4 | Not started |
-| `V01.01.14.14` | T12 close open hierarchies | 5 | Not started |
-| `V01.01.14.15` | T14 dead and speculative surface | 5 | Not started |
-| `V01.01.14.16` | T17 debugger presentation + untracked `Peek()` | 5 | Not started |
-| `V01.01.14.17` | G1 `PackageOverrides.txt` (see D2) | 1 or 2 | Not started |
-| `V01.01.14.18` | G2 `IApplication` disposal contract | — | **Absorbed by `.22`/`.24`** |
-| `V01.01.14.19` | G3 `SlotFlags` is not a bitmask | 3 | Not started |
-| `V01.01.14.20` | G4 equality operators on app-visible `IEquatable<T>` | 4 | Not started |
-| `V01.01.14.21` | G5 covariant read-only reactive reference | 4 | Not started |
+**Theme id is the stable key, not the WBS code.** Do not pre-assign WBS codes here. The
+`viu-work-items` script derives the next free child of `V01.01.14` at creation time, so a code
+reserved in advance will not match the one the item actually receives. Fill the WBS and Issue columns
+in as each item is created.
+
+| Theme | Description | Wave | WBS | Issue | Status |
+|---|---|---|---|---|---|
+| T01 + T15 | Ship XML documentation; sweep derivative doc phrasing | 1 | `.01` | #285 | **MERGED** (PR #288) |
+| T04 | Compiler-seam hardening (`[EditorBrowsable]` + language-service filter) | 1 | `.02` | #287 | **IN REVIEW** (PR #289) |
+| T16 | Drop the viral `RequiresPreviewFeatures` stamp | 1 | `.03` | #292 | **IN REVIEW** — supersedes #280 |
+| T03 | Unship build-time packages; delete `Syntax.JavaScript` (keep `Syntax.Html`, see D3) | 1 | — | — | Not started — must follow T16 (both edit the Syntax csprojs) |
+| T02 | Public-API baseline and hardening-attribute conventions | 1 | — | — | Not started — must be **last** in Wave 1 |
+| D5-A | Application lifetime: middleware pipeline, delete `IApplicationPlugin` | 2A | — | — | Not started |
+| D5-B | Composition surface: drop public `IApplicationBuilder`, self-returning builders, frozen options | 2A | — | — | Not started |
+| D5-C | Separate SSR: `ServerApplication` → `ServerRenderApplication`, off `IApplication` | 2A | — | — | Not started |
+| D5-D | Host facade: `Application.CreateBuilder()` in Browser/SDK | 2A | — | — | Not started |
+| D5-E | Router bootstrap: `UseRouter`, `ReadyAsync` cancellation, lazy history init | 2A | — | — | Not started |
+| D5-F | Specification: replace `[CMP-25]` with application lifecycle clauses; lifetime test suite | 2A | — | — | Not started |
+| T05 | Internalize friend-only publics (~120 types) | 2 | — | — | Not started |
+| T13 | Single source of truth for the helper-name contract | 2 | — | — | Not started |
+| T06 | Namespace segmentation (`Assimalign.Viu.Hosting`) | 3 | — | — | Not started — decide after T04 lands |
+| T07 | Product-prefix stutter and duplicate facades | 3 | — | — | Not started |
+| T08 | Naming-rule compliance | 3 | — | — | Not started |
+| G3 | `SlotFlags` is named `*Flags` but is not a bitmask | 3 | — | — | Not started |
+| T09 | Mutable state and encapsulation | 4 | — | — | Not started |
+| T10 | Compiler-seam typing | 4 | — | — | Not started |
+| T11 | Async conventions | 4 | — | — | Not started |
+| G4 | Equality operators on app-visible `IEquatable<T>` | 4 | — | — | Not started |
+| G5 | Covariant read-only reactive reference | 4 | — | — | Not started |
+| T12 | Close open inheritance hierarchies | 5 | — | — | Not started |
+| T14 | Dead and speculative surface | 5 | — | — | Not started |
+| T17 | Debugger presentation + untracked `Peek()` | 5 | — | — | Not started |
+| G1 | `PackageOverrides.txt` (see D2) | 1 or 2 | — | — | Not started |
+| G2 | `IApplication` disposal contract | — | — | — | **Absorbed by D5-A / D5-C** |
 
 ### Units the D5 redesign absorbs
 
@@ -100,12 +105,12 @@ types that are about to be deleted:
 
 | Absorbed | Into | Why |
 |---|---|---|
-| G2 `IApplication` declares no disposal; `ServerApplication` implements neither | `.22`, `.24` | The new `IApplication : IAsyncDisposable` closes the contract, and `ServerApplication` leaves the interface entirely rather than growing a teardown path it has no use for. |
-| G6 `Application<TNode>` non-virtual `Dispose` with a private flag | `.22` | The state machine replaces the single `IsMounted` Boolean, and disposal is defined by it. |
-| T09 — `IApplicationContext.ErrorHandler`/`WarnHandler`/`Performance` are `{ get; set; }` on the interface while three docs call the context immutable | `.23` | Diagnostics move into builder options and freeze at `Build()`, which makes the documentation true instead of restating the mutation. |
-| T12 — `ApplicationBuilder`'s configuration methods return `IApplicationBuilder`, collapsing the covariant `Build()` on `BrowserApplicationBuilder` | `.23` | Concrete builders return themselves; the erasing interface is removed. |
-| T14 — `Performance` has no production reader; `BrowserApplication.CreateServerRendererBuilder` has zero callers | `.23`, `.25` | Both are deleted rather than renamed or documented. |
-| T11 — `Router.ReadyAsync` takes no `CancellationToken` | `.26` | Cancellation is required for the middleware pipeline to be cancellable at all. |
+| G2 `IApplication` declares no disposal; `ServerApplication` implements neither | D5-A, D5-C | The new `IApplication : IAsyncDisposable` closes the contract, and `ServerApplication` leaves the interface entirely rather than growing a teardown path it has no use for. |
+| G6 `Application<TNode>` non-virtual `Dispose` with a private flag | D5-A | The state machine replaces the single `IsMounted` Boolean, and disposal is defined by it. |
+| T09 — `IApplicationContext.ErrorHandler`/`WarnHandler`/`Performance` are `{ get; set; }` on the interface while three docs call the context immutable | D5-B | Diagnostics move into builder options and freeze at `Build()`, which makes the documentation true instead of restating the mutation. |
+| T12 — `ApplicationBuilder`'s configuration methods return `IApplicationBuilder`, collapsing the covariant `Build()` on `BrowserApplicationBuilder` | D5-B | Concrete builders return themselves; the erasing interface is removed. |
+| T14 — `Performance` has no production reader; `BrowserApplication.CreateServerRendererBuilder` has zero callers | D5-B, D5-D | Both are deleted rather than renamed or documented. |
+| T11 — `Router.ReadyAsync` takes no `CancellationToken` | D5-E | Cancellation is required for the middleware pipeline to be cancellable at all. |
 
 ## D5 — application lifetime redesign
 

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -358,8 +358,12 @@ spec-discoverable choice is the wrong one for component code. Resolution is a re
 
 Recorded here because they are unrelated to API surface but were confirmed:
 
-- `.github/workflows/release.yml:230,299` and `docs/RELEASING.md:10-11` assert 21 packages while
-  `scripts/Pack-Release.ps1:158-162` produces 22 — **the publish lane throws today.**
+- ~~`.github/workflows/release.yml:230,299` and `docs/RELEASING.md:10-11` assert 21 packages while
+  `scripts/Pack-Release.ps1:158-162` produces 22 — **the publish lane throws today.**~~
+  **FIXED** — confirmed live on the `[V01.01.14.01]` merge (`Expected 21 release packages, found 22.`),
+  which was the sixth consecutive `release.yml` failure. The count is now published by the
+  `pack-packages` job and consumed by both publish jobs, so it derives from the same authoritative
+  id list `Pack-Release.ps1` validates against and cannot drift again.
 - `HelperNames.ResolveFilter` names `_resolveFilter`, which exists on no runtime surface.
 - `SingleFileComponentSourceEmitter`'s `DomRenderHelperNames` array substring-scans the emitted body
   to decide whether to write the DOM `using static`; adding an 11th DOM helper without updating it

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,8 +7,8 @@ Area workflows only build and test their part of the repository; they never publ
 
 | Event | NuGet packages | Visual Studio extension |
 | --- | --- | --- |
-| Merged pull request into `main` | All 21 packages publish to the Assimalign GitHub Packages feed as `X.Y.Z-beta.<run-number>` | Publishes the next numeric VSIX version when the extension or an embedded language-engine dependency changed |
-| Published stable GitHub Release | All 21 packages publish to nuget.org as the stable release version | No publication |
+| Merged pull request into `main` | Every package listed in `package-order.txt` publishes to the Assimalign GitHub Packages feed as `X.Y.Z-beta.<run-number>` | Publishes the next numeric VSIX version when the extension or an embedded language-engine dependency changed |
+| Published stable GitHub Release | Every package listed in `package-order.txt` publishes to nuget.org as the stable release version | No publication |
 | Draft or prerelease GitHub Release | No publication | No publication |
 
 The two source generators remain embedded in the SDK and targeting pack. Their projects are

--- a/tooling/Assimalign.Viu.Tooling.UtilityCss/docs/DESIGN.md
+++ b/tooling/Assimalign.Viu.Tooling.UtilityCss/docs/DESIGN.md
@@ -163,3 +163,18 @@ The remaining boundaries are explicit:
 
 `UtilityDirectiveEmitter` remains the canonical directive-only projection for cache keys. It does
 not duplicate the project compiler or pretend that a projection is transformed application CSS.
+
+## Line endings are part of the emitted contract
+
+Every emitter normalizes its output to LF regardless of the source stylesheet's line endings —
+`UtilityDirectiveEmitter` and `UtilityCssLayerEmitter` both collapse CRLF and lone CR to LF before
+returning. That is deliberate: emitted CSS feeds cache keys and content fingerprints, so identical
+input must produce byte-identical output on every platform, not merely equivalent text.
+
+The tests pin that contract by asserting emitter output against C# raw string literals, which makes
+each literal's line endings part of the expected value. So the test sources themselves must check
+out LF — `.gitattributes` pins `tooling/Assimalign.Viu.Tooling.UtilityCss/test/**/*.cs` to
+`eol=lf` ([V01.01.12.24]); without it a Windows checkout under `core.autocrlf=true` turns the
+expected values into CRLF and the assertions fail against correct LF output. Keep new expected-CSS
+assertions in that directory, and do not relax them to be line-ending agnostic — the canonical LF
+output *is* the specified behavior.


### PR DESCRIPTION
## Summary

Two small, independent CI fixes bundled by request. Both are red today; neither touches product code.

### 1. The beta publish lane has been broken for six merges

Both publish jobs asserted a literal **21** release packages while `scripts/Pack-Release.ps1` produces **22**. `release.yml` has failed on its **last six runs**, so no beta package has published to GitHub Packages since the 22nd package was added. Reproduced exactly on the `[V01.01.14.01]` merge:

```
Expected 21 release packages, found 22.
```

This could not be fixed by counting locally: **neither publish job checks out the repository** — each only downloads the package artifact — so neither has access to `$script:ViuLibraryPackageIds`. The `pack-packages` job now publishes the count as a job output and both consumers read it, mirroring how they already consume the resolved version.

The number is **derived, not restated**: `Pack-Release.ps1` writes `package-order.txt` from the same expected-set array it validates the pack against with `Compare-Object`, so adding a package updates the assertion automatically.

Worth noting the assertion was already redundant for correctness — `Pack-Release.ps1` enforces exact set membership, and the publish jobs independently verify checksums and per-file existence. It is kept only as a producer-to-consumer transfer check, now one that cannot drift.

### 2. Fresh Windows checkouts fail 7 UtilityCss tests

A fresh clone or `git worktree add` on Windows with `core.autocrlf=true` failed 7 tests in `tooling/Assimalign.Viu.Tooling.UtilityCss/test/`. The emitters normalize output to LF unconditionally, but the tests assert against C# raw string literals, so a CRLF checkout turned the *expected* values into CRLF while the emitters still produced LF. CI runs `ubuntu-24.04` only, so the platform gap was invisible there.

Pins those test sources to `eol=lf`, following the pattern and rationale already documented in `.gitattributes` for `*.viu`. The stored blobs are already LF, so this changes **checkout conversion only — no renormalization**, and therefore does not conflict with open branches.

Found independently by two agents working in fresh worktrees, and reproduced directly.

## Process note

These are two unrelated fixes in one PR, which departs from the usual one-item-per-PR convention. Bundled deliberately at the maintainer's request given both are small, both are CI-only, and both are currently red.

## Verification

- `release.yml` parses; the `package-count` job output resolves through both consumers
- No hardcoded package count remains in the workflow or `docs/RELEASING.md`
- The 7 UtilityCss failures reproduce in a fresh worktree before the change
- Full solution build clean under `-warnaserror`

The beta-publish path itself is only verifiable post-merge, since `release.yml` runs on merged `pull_request_target`.

## Work items resolved by this PR

Closes #290
Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)