### PR TITLE
fix(build): stop stamping every shipped assembly as preview [V01.01.14.03]

### DIFF
--- a/.claude/rules/build-system.md
+++ b/.claude/rules/build-system.md
@@ -55,8 +55,14 @@ test, or example csproj. Use the by-name item groups the build system resolves:
 - Opt a project into its TFM via the central alias, never a hardcoded string:
   `<TargetFramework>$(TargetFrameworkForLibraries)</TargetFramework>` (net10.0). Analyzers use
   `$(TargetFrameworkForAnalyzers)` (netstandard2.0).
-- `Nullable`, `LangVersion=preview`, `EnablePreviewFeatures=true`, and `EnforceCodeStyleInBuild` flow
+- `Nullable`, `LangVersion=preview`, `EnablePreviewFeatures=false`, and `EnforceCodeStyleInBuild` flow
   centrally from `build/Targets/` — do **not** set them per-csproj.
+- **C# preview *language* features are on; runtime preview *APIs* are off.** `LangVersion=Preview` and
+  `EnablePreviewFeatures` are independent switches. Shipped assemblies must not emit
+  `[assembly: RequiresPreviewFeatures]` — it is viral, forcing every consumer to opt in
+  ([V01.01.14.07]). A project needing a runtime preview API (`static abstract` interface members,
+  `INumber<T>`, `IParsable<T>`) has to justify making that requirement viral for consumers; it is not
+  a per-csproj convenience.
 
 ## csproj shapes
 

--- a/analyzers/Assimalign.Viu.Generators.Reactive/src/Assimalign.Viu.Generators.Reactivity.csproj
+++ b/analyzers/Assimalign.Viu.Generators.Reactive/src/Assimalign.Viu.Generators.Reactivity.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source generators must target the stable analyzer surface: opt out of the repo-wide preview
-         features switch (see build/Targets/Build.TargetFramework.props) so no [RequiresPreviewFeatures]
-         leaks into the netstandard2.0 analyzer. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- The analyzer DLL is packed into consuming libraries' nupkgs by

--- a/analyzers/Assimalign.Viu.Generators.Syntax/src/Assimalign.Viu.Generators.Syntax.csproj
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/src/Assimalign.Viu.Generators.Syntax.csproj
@@ -5,10 +5,6 @@
          load in the consumer's analyzer context; this flows their outputs through GetTargetPath (see
          build/Targets/Build.References.Analyzers.targets). -->
     <ViuAnalyzerBundlesProjectReferenceOutputs>true</ViuAnalyzerBundlesProjectReferenceOutputs>
-    <!-- Source generators must target the stable analyzer surface: opt out of the repo-wide preview
-         features switch (see build/Targets/Build.TargetFramework.props) so no [RequiresPreviewFeatures]
-         leaks into the netstandard2.0 analyzer. Mirrors the sibling Reactivity.Generators csproj. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- The analyzer DLL is packed into consuming libraries' nupkgs by

--- a/build/Targets/Build.TargetFramework.props
+++ b/build/Targets/Build.TargetFramework.props
@@ -23,12 +23,11 @@
     <PropertyGroup>
         <LangVersion>Preview</LangVersion>
         <!--
-            Repo-wide opt-in to runtime preview APIs (emits [assembly: RequiresPreviewFeatures]).
-            This is the documented default (see .claude/rules/general-rules.md). It must live here because the attribute
-            is viral: any assembly that requires preview features forces every consumer to opt in,
-            so a single central switch is the only coherent place for it. Projects that must target
-            the stable surface (source generators, build tasks) override this with <EnablePreviewFeatures>false</EnablePreviewFeatures>.
+            C# preview language features are controlled independently by LangVersion. Keep runtime
+            preview APIs disabled repo-wide so shipped assemblies do not emit
+            [assembly: RequiresPreviewFeatures]. The attribute is viral: any assembly that requires
+            preview features forces every consumer to opt in.
         -->
-        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <EnablePreviewFeatures>false</EnablePreviewFeatures>
     </PropertyGroup>
 </Project>

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
@@ -28,9 +28,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForVisualStudioClassicExtensions)</TargetFramework>
-    <!-- The repository default emits [assembly: RequiresPreviewFeatures], whose attribute does not
-         exist on the .NET Framework surface every classic VSIX compiles against. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <IsPackable>false</IsPackable>
     <NeutralLanguage>en-US</NeutralLanguage>
 

--- a/libraries/Assimalign.Viu.Syntax.Css/src/Assimalign.Viu.Syntax.Css.csproj
+++ b/libraries/Assimalign.Viu.Syntax.Css/src/Assimalign.Viu.Syntax.Css.csproj
@@ -7,10 +7,6 @@
          alias — the same central property the other Assimalign.Viu.Syntax.* projects use — never a
          hardcoded string. Its net10.0 test project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set here: the AOT analyzers require net8.0+, so the central
          libraries targets clear the inherited IsAotCompatible=true for this netstandard2.0 TFM. The
          assembly is consumed at build time by generators, never shipped into the WASM app. -->

--- a/libraries/Assimalign.Viu.Syntax.Html/src/Assimalign.Viu.Syntax.Html.csproj
+++ b/libraries/Assimalign.Viu.Syntax.Html/src/Assimalign.Viu.Syntax.Html.csproj
@@ -7,10 +7,6 @@
          Assimalign.Viu.Syntax.* projects use — never a hardcoded string. Its net10.0 test project
          references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set here: the AOT analyzers require net8.0+, so the central
          libraries targets clear the inherited IsAotCompatible=true for this netstandard2.0 TFM. The
          assembly is consumed at build time by generators, never shipped into the WASM app. -->

--- a/libraries/Assimalign.Viu.Syntax.JavaScript/src/Assimalign.Viu.Syntax.JavaScript.csproj
+++ b/libraries/Assimalign.Viu.Syntax.JavaScript/src/Assimalign.Viu.Syntax.JavaScript.csproj
@@ -7,10 +7,6 @@
          property the other Assimalign.Viu.Syntax.* projects use — never a hardcoded string. Its net10.0
          test project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set here: the AOT analyzers require net8.0+, so the central
          libraries targets clear the inherited IsAotCompatible=true for this netstandard2.0 TFM. The
          assembly is consumed at build time by generators, never shipped into the WASM app. -->

--- a/libraries/Assimalign.Viu.Syntax.SingleFileComponent/src/Assimalign.Viu.Syntax.SingleFileComponent.csproj
+++ b/libraries/Assimalign.Viu.Syntax.SingleFileComponent/src/Assimalign.Viu.Syntax.SingleFileComponent.csproj
@@ -6,10 +6,6 @@
          analyzer TFM alias — the same central property the template compiler and generators projects use
          — never a hardcoded string. Its net10.0 test project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- Deviates from the checklist rule "shipping libraries set IsAotCompatible=true": the AOT analyzers
          require net7.0+, so the switch is inert on netstandard2.0. The central libraries targets
          (libraries/Directory.Build.targets) clear the inherited IsAotCompatible=true once this

--- a/libraries/Assimalign.Viu.Syntax.Templates/src/Assimalign.Viu.Syntax.Templates.csproj
+++ b/libraries/Assimalign.Viu.Syntax.Templates/src/Assimalign.Viu.Syntax.Templates.csproj
@@ -6,10 +6,6 @@
          the analyzer TFM alias — the same central property the generators project uses — never a hardcoded
          string. Its net10.0 test project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the generators csproj. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- Deviates from the checklist rule "shipping libraries set IsAotCompatible=true": the AOT analyzers
          require net7.0+, so the switch is inert on netstandard2.0. The central libraries targets
          (libraries/Directory.Build.targets) clear the inherited IsAotCompatible=true once this

--- a/libraries/Assimalign.Viu.Syntax/src/Assimalign.Viu.Syntax.csproj
+++ b/libraries/Assimalign.Viu.Syntax/src/Assimalign.Viu.Syntax.csproj
@@ -8,10 +8,6 @@
          derived parsers and the generators projects use — never a hardcoded string. Its net10.0 test
          project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Source-generator-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the derived parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set here: the AOT analyzers require net7.0+, so the switch is
          inert on netstandard2.0. The central libraries targets (libraries/Directory.Build.targets) clear
          the inherited IsAotCompatible=true once the netstandard2.0 TFM is known, so no per-project value

--- a/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.Common.props
+++ b/sdks/Assimalign.Viu.Sdk/Targets/Assimalign.Viu.Sdk.Common.props
@@ -39,14 +39,6 @@
         -->
         <MetadataUpdaterSupport Condition="'$(MetadataUpdaterSupport)' == '' and '$(Configuration)' == 'Debug' and '$(WasmEnableHotReload)' != 'false'">true</MetadataUpdaterSupport>
 
-        <!--
-            The Assimalign.Viu.App framework libraries opt into runtime preview
-            APIs ([assembly: RequiresPreviewFeatures] - see the repo's
-            build/Targets/Build.TargetFramework.props). The attribute is viral,
-            so consumers referencing the framework must opt in too; default it
-            here (overridable in the consumer csproj body).
-        -->
-        <EnablePreviewFeatures Condition="'$(EnablePreviewFeatures)' == ''">true</EnablePreviewFeatures>
         <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
         <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
     </PropertyGroup>

--- a/sdks/Directory.Build.props
+++ b/sdks/Directory.Build.props
@@ -14,8 +14,6 @@
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<IsPackable>true</IsPackable>
 		<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
-		<!-- Build-task code targets the stable surface (see Build.TargetFramework.props). -->
-		<EnablePreviewFeatures>false</EnablePreviewFeatures>
 	</PropertyGroup>
 	<!-- Package metadata -->
 	<PropertyGroup>

--- a/tooling/Assimalign.Viu.Tooling.Css/src/Assimalign.Viu.Tooling.Css.csproj
+++ b/tooling/Assimalign.Viu.Tooling.Css/src/Assimalign.Viu.Tooling.Css.csproj
@@ -7,10 +7,6 @@
          TFM alias, the same central property the Assimalign.Viu.Syntax.* parsers use, never a hardcoded
          string. Its net10.0 test project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Build-time-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set: the AOT analyzers require net8.0+, so the central
          libraries targets clear the inherited IsAotCompatible=true for this netstandard2.0 TFM. This
          assembly is consumed at build time by the generator and the bundling task, never shipped into the

--- a/tooling/Assimalign.Viu.Tooling.SingleFileComponent/src/Assimalign.Viu.Tooling.SingleFileComponent.csproj
+++ b/tooling/Assimalign.Viu.Tooling.SingleFileComponent/src/Assimalign.Viu.Tooling.SingleFileComponent.csproj
@@ -8,10 +8,6 @@
          Assimalign.Viu.Tooling.Css core use, never a hardcoded string. Its net10.0 test project
          references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Build-time-hosted code must target the stable analyzer surface: opt out of the repo-wide
-         preview-features switch (see build/Targets/Build.TargetFramework.props) so no
-         [RequiresPreviewFeatures] leaks into the netstandard2.0 assembly. Mirrors the sibling parsers. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- The projection core was extracted from the generator project, whose
          EnforceExtendedAnalyzerRules=true kept the RS1035 no-I/O guard on this code (the name resolver's
          string-only design relies on it). Keep the guard here so the extraction cannot silently start

--- a/tooling/Assimalign.Viu.Tooling.UtilityCss/src/Assimalign.Viu.Tooling.UtilityCss.csproj
+++ b/tooling/Assimalign.Viu.Tooling.UtilityCss/src/Assimalign.Viu.Tooling.UtilityCss.csproj
@@ -7,9 +7,6 @@
          never a hardcoded framework, exactly like Assimalign.Viu.Tooling.Css. The net10.0 test
          project references it normally. -->
     <TargetFramework>$(TargetFrameworkForAnalyzers)</TargetFramework>
-    <!-- Build-time-hosted code uses the stable analyzer surface. This avoids leaking the
-         repository-wide preview-features marker into the netstandard2.0 assembly. -->
-    <EnablePreviewFeatures>false</EnablePreviewFeatures>
     <!-- IsAotCompatible is intentionally not set: its analyzers require net8.0 or later. This
          assembly runs only at build/editor time and emits no runtime code. Its implementation
          remains reflection-free, deterministic, and I/O-free. -->


### PR DESCRIPTION
## Summary

`build/Targets/Build.TargetFramework.props` set `EnablePreviewFeatures=true` **repo-wide**, and the comment above it already acknowledged the consequence — *"it is viral: any assembly that requires preview features forces every consumer to opt in."* The attribute was genuinely emitted into every shipped assembly.

**No library needed it.** Verified: `libraries/**/*.cs` contains zero uses of `static abstract`, `virtual static`, `INumber<`, or `IParsable`. Meanwhile **13** projects were already overriding it back to `false` — the six `Syntax*` libraries, both generators, three `tooling/` projects, `sdks/Directory.Build.props`, and the VS extension.

This flips the central default to `false`, deletes all 13 redundant overrides, and removes the SDK's consumer-side `EnablePreviewFeatures=true` default, which existed only to compensate for the libraries requiring it.

`LangVersion=Preview` is untouched. C# preview **language** features stay on; runtime preview **APIs** stay off. These are independent switches — a distinction `.claude/rules/build-system.md` never drew, and which it now documents. That rules file also still asserted `EnablePreviewFeatures=true` as binding convention, so it is corrected in the same change rather than left contradicting the build.

## This supersedes #280

#280 proposed a **consumer-side workaround** — defaulting `GenerateRequiresPreviewFeaturesAttribute=true` in the SDK so a pristine consumer stops failing `CA2252` beside a newer preview .NET SDK. Removing the requirement eliminates the root cause.

Verified rather than assumed, under #280's exact trigger condition:

- Packed the full SDK + framework chain via `scripts/Install-Local.ps1` (22 packages)
- Pruned the showcase's repo-local package cache so the new builds were genuinely re-extracted
- Built `viu-examples/examples/Assimalign.Viu.Showcase` against them on a machine carrying **`11.0.100-preview.4.26230.115`** alongside the app's `net10.0` target — the `NETCoreAppMaximumVersion > app TFM` condition #280 describes
- **Build succeeded: 0 errors, 0 CA2252.** The only warnings were two pre-existing `CS8618` in the showcase's own `FeatureCard.viu`, unrelated to this change and already failing the budget gate on `main`
- Confirmed the showcase's generated `AssemblyInfo.cs` carries no `[RequiresPreviewFeatures]`

## Verification

- `dotnet build Assimalign.Viu.slnx -c Release -warnaserror -p:EnablePreviewFeatures=false` clean — this is the gate that matters, since `CA2252` becomes an **error** rather than a warning for any still-referenced preview API
- Normal `-warnaserror` Release build clean
- `EnablePreviewFeatures` now appears exactly once repo-wide
- No Release `AssemblyInfo.cs` emits the attribute

## Note

The original analysis said the SDK change must ship a release *after* the libraries, because the packaged SDK is version-pinned in consumer lock folders. That constraint does not apply: nothing has shipped publicly yet, so both halves release together and are done here in one change.

## Work items resolved by this PR

Closes #292
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)