### PR TITLE
refactor(compiler): centralize the helper-name contract [V01.01.14.07]

### DIFF
--- a/Assimalign.Viu.slnx
+++ b/Assimalign.Viu.slnx
@@ -259,6 +259,7 @@
 		<Project Path="tooling/Assimalign.Viu.Syntax.Templates/src/Assimalign.Viu.Syntax.Templates.csproj" />
 	</Folder>
 	<Folder Name="/viu/tooling/Assimalign.Viu.Syntax.Templates/test/">
+		<Project Path="tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.HelperContractTests/Assimalign.Viu.Syntax.Templates.HelperContractTests.csproj" />
 		<Project Path="tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.Tests.csproj" />
 	</Folder>
 	<Folder Name="/viu/tooling/Assimalign.Viu.Syntax.Templates/tools/">

--- a/libraries/Assimalign.Viu.Components/src/Activation/ComponentFactory.cs
+++ b/libraries/Assimalign.Viu.Components/src/Activation/ComponentFactory.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
+using Assimalign.Viu.Shared;
+
 namespace Assimalign.Viu.Components;
 
 /// <summary>
@@ -89,14 +91,14 @@ public sealed class ComponentFactory : IComponentFactory
             return true;
         }
 
-        string camelizedName = Camelize(name);
+        string camelizedName = NameNormalization.Camelize(name);
         if (!string.Equals(camelizedName, name, StringComparison.Ordinal)
             && _componentsByName.TryGetValue(camelizedName, out activator))
         {
             return true;
         }
 
-        string pascalizedName = Capitalize(camelizedName);
+        string pascalizedName = NameNormalization.Capitalize(camelizedName);
         if (!string.Equals(
                 pascalizedName,
                 camelizedName,
@@ -108,40 +110,5 @@ public sealed class ComponentFactory : IComponentFactory
 
         activator = null;
         return false;
-    }
-
-    private static string Camelize(string name)
-    {
-        if (name.IndexOf('-', StringComparison.Ordinal) < 0)
-        {
-            return name;
-        }
-
-        char[] buffer = new char[name.Length];
-        int length = 0;
-        bool capitalizeNext = false;
-        foreach (char character in name)
-        {
-            if (character == '-')
-            {
-                capitalizeNext = true;
-                continue;
-            }
-
-            buffer[length] = capitalizeNext
-                ? char.ToUpperInvariant(character)
-                : character;
-            length++;
-            capitalizeNext = false;
-        }
-
-        return new string(buffer, 0, length);
-    }
-
-    private static string Capitalize(string name)
-    {
-        return name.Length == 0
-            ? name
-            : char.ToUpperInvariant(name[0]) + name[1..];
     }
 }

--- a/libraries/Assimalign.Viu.Core/src/Directives/DirectiveRegistry.cs
+++ b/libraries/Assimalign.Viu.Core/src/Directives/DirectiveRegistry.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Assimalign.Viu.Shared;
+
 namespace Assimalign.Viu;
 
 /// <summary>
@@ -47,14 +49,14 @@ public sealed class DirectiveRegistry : IDirectiveResolver
             return directive;
         }
 
-        string camelizedName = Camelize(name);
+        string camelizedName = NameNormalization.Camelize(name);
         if (!string.Equals(camelizedName, name, StringComparison.Ordinal)
             && _directives.TryGetValue(camelizedName, out directive))
         {
             return directive;
         }
 
-        string pascalizedName = Capitalize(camelizedName);
+        string pascalizedName = NameNormalization.Capitalize(camelizedName);
         return !string.Equals(
                    pascalizedName,
                    camelizedName,
@@ -62,40 +64,5 @@ public sealed class DirectiveRegistry : IDirectiveResolver
                && _directives.TryGetValue(pascalizedName, out directive)
             ? directive
             : null;
-    }
-
-    private static string Camelize(string name)
-    {
-        if (name.IndexOf('-', StringComparison.Ordinal) < 0)
-        {
-            return name;
-        }
-
-        char[] buffer = new char[name.Length];
-        int length = 0;
-        bool capitalizeNext = false;
-        foreach (char character in name)
-        {
-            if (character == '-')
-            {
-                capitalizeNext = true;
-                continue;
-            }
-
-            buffer[length] = capitalizeNext
-                ? char.ToUpperInvariant(character)
-                : character;
-            length++;
-            capitalizeNext = false;
-        }
-
-        return new string(buffer, 0, length);
-    }
-
-    private static string Capitalize(string name)
-    {
-        return name.Length == 0
-            ? name
-            : char.ToUpperInvariant(name[0]) + name[1..];
     }
 }

--- a/libraries/Assimalign.Viu.Core/src/Internal/ComponentContext.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/ComponentContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
 using System.Threading.Tasks;
 
 using Assimalign.Viu.Components;
@@ -67,7 +66,7 @@ internal sealed class ComponentContext :
                 AddAlias(_parameterAliases, parameter.Name, parameter, "parameter");
                 AddAlias(
                     _parameterAliases,
-                    Camelize(parameter.Name),
+                    NameNormalization.Camelize(parameter.Name),
                     parameter,
                     "parameter");
                 AddAlias(
@@ -88,7 +87,7 @@ internal sealed class ComponentContext :
                 AddAlias(_eventAliases, componentEvent.Name, componentEvent, "event");
                 AddAlias(
                     _eventAliases,
-                    Camelize(componentEvent.Name),
+                    NameNormalization.Camelize(componentEvent.Name),
                     componentEvent,
                     "event");
             }
@@ -303,7 +302,7 @@ internal sealed class ComponentContext :
             return declaration;
         }
 
-        _eventAliases.TryGetValue(Camelize(eventName), out declaration);
+        _eventAliases.TryGetValue(NameNormalization.Camelize(eventName), out declaration);
         return declaration;
     }
 
@@ -338,7 +337,7 @@ internal sealed class ComponentContext :
             return true;
         }
 
-        string camelizedName = Camelize(eventName) + suffix;
+        string camelizedName = NameNormalization.Camelize(eventName) + suffix;
         if (!string.Equals(camelizedName, exactName, StringComparison.Ordinal)
             && _listeners.TryGetValue(camelizedName, out listener!))
         {
@@ -458,34 +457,6 @@ internal sealed class ComponentContext :
     {
         string name = listenerName[2..];
         return char.ToLowerInvariant(name[0]) + name[1..];
-    }
-
-    private static string Camelize(string name)
-    {
-        int firstHyphen = name.IndexOf('-', StringComparison.Ordinal);
-        if (firstHyphen < 0)
-        {
-            return name;
-        }
-
-        StringBuilder result = new(name.Length);
-        bool uppercaseNext = false;
-        foreach (char character in name)
-        {
-            if (character == '-')
-            {
-                uppercaseNext = true;
-                continue;
-            }
-
-            result.Append(
-                uppercaseNext
-                    ? char.ToUpperInvariant(character)
-                    : character);
-            uppercaseNext = false;
-        }
-
-        return result.ToString();
     }
 
     private static void AddAlias<T>(

--- a/libraries/Assimalign.Viu.Core/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Core/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+#nullable enable
+*REMOVED*static Assimalign.Viu.RenderHelpers._isRef(object? value) -> bool

--- a/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
+++ b/libraries/Assimalign.Viu.Core/src/RenderHelpers.cs
@@ -752,31 +752,7 @@ public static class RenderHelpers
     [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _camelize(string value)
     {
-        ArgumentNullException.ThrowIfNull(value);
-        if (value.IndexOf('-', StringComparison.Ordinal) < 0)
-        {
-            return value;
-        }
-
-        char[] buffer = new char[value.Length];
-        int length = 0;
-        bool capitalizeNext = false;
-        foreach (char character in value)
-        {
-            if (character == '-')
-            {
-                capitalizeNext = true;
-                continue;
-            }
-
-            buffer[length] = capitalizeNext
-                ? char.ToUpperInvariant(character)
-                : character;
-            length++;
-            capitalizeNext = false;
-        }
-
-        return new string(buffer, 0, length);
+        return NameNormalization.Camelize(value);
     }
 
     /// <summary>
@@ -788,10 +764,7 @@ public static class RenderHelpers
     [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
     public static string _capitalize(string value)
     {
-        ArgumentNullException.ThrowIfNull(value);
-        return value.Length == 0
-            ? value
-            : char.ToUpperInvariant(value[0]) + value[1..];
+        return NameNormalization.Capitalize(value);
     }
 
     /// <summary>
@@ -817,18 +790,6 @@ public static class RenderHelpers
     public static object? _unref(object? value)
     {
         return value is IReactiveReference reference ? reference.Value : value;
-    }
-
-    /// <summary>
-    /// Compiler-generated code only; not part of the supported Viu API.
-    /// Determines whether a value is a reactive reference.
-    /// </summary>
-    /// <param name="value">The value to inspect.</param>
-    /// <returns>True when the value is a reactive reference.</returns>
-    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]
-    public static bool _isRef(object? value)
-    {
-        return Reactive.IsRef(value);
     }
 
     /// <summary>

--- a/libraries/Assimalign.Viu.Shared/src/Normalization/NameNormalization.cs
+++ b/libraries/Assimalign.Viu.Shared/src/Normalization/NameNormalization.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Assimalign.Viu.Shared;
+
+/// <summary>
+/// Provides the culture-invariant name casing used by component, directive, event, and generated-property
+/// lookup throughout the Viu runtime.
+/// </summary>
+/// <remarks>
+/// The operations are ordinal and deterministic. Keeping them on one shared surface prevents runtime
+/// registries and compiler-generated helper calls from assigning different aliases to the same name.
+/// Specified by <c>[V01.01.14.08]</c>.
+/// </remarks>
+public static class NameNormalization
+{
+    /// <summary>
+    /// Converts a hyphenated name to camel case by removing each hyphen and invariant-capitalizing the
+    /// next non-hyphen character.
+    /// </summary>
+    /// <param name="value">The name to normalize.</param>
+    /// <returns>
+    /// The camel-case name. A value without a hyphen is returned unchanged and without an allocation.
+    /// </returns>
+    public static string Camelize(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (value.IndexOf('-', StringComparison.Ordinal) < 0)
+        {
+            return value;
+        }
+
+        char[] buffer = new char[value.Length];
+        int length = 0;
+        bool capitalizeNext = false;
+        foreach (char character in value)
+        {
+            if (character == '-')
+            {
+                capitalizeNext = true;
+                continue;
+            }
+
+            buffer[length] = capitalizeNext
+                ? char.ToUpperInvariant(character)
+                : character;
+            length++;
+            capitalizeNext = false;
+        }
+
+        return new string(buffer, 0, length);
+    }
+
+    /// <summary>Invariant-capitalizes the first character of a name.</summary>
+    /// <param name="value">The name to normalize.</param>
+    /// <returns>The capitalized name, or the original empty string when <paramref name="value"/> is empty.</returns>
+    public static string Capitalize(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value.Length == 0
+            ? value
+            : char.ToUpperInvariant(value[0]) + value[1..];
+    }
+}

--- a/libraries/Assimalign.Viu.Shared/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Shared/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Assimalign.Viu.Shared.NameNormalization
+static Assimalign.Viu.Shared.NameNormalization.Camelize(string! value) -> string!
+static Assimalign.Viu.Shared.NameNormalization.Capitalize(string! value) -> string!

--- a/libraries/Assimalign.Viu.Shared/test/NameNormalizationTests.cs
+++ b/libraries/Assimalign.Viu.Shared/test/NameNormalizationTests.cs
@@ -1,0 +1,52 @@
+using System;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.Shared.Tests;
+
+// [V01.01.14.08] Runtime registries and generated helper calls share these exact, culture-invariant
+// name aliases instead of carrying private implementations that can drift.
+public sealed class NameNormalizationTests
+{
+    [Theory]
+    [InlineData("my-widget", "myWidget")]
+    [InlineData("-my-widget", "MyWidget")]
+    [InlineData("my--widget", "myWidget")]
+    [InlineData("my-widget-", "myWidget")]
+    [InlineData("alreadyCamel", "alreadyCamel")]
+    [InlineData("", "")]
+    public void Camelize_Name_ReturnsInvariantCamelCase(string value, string expected)
+    {
+        NameNormalization.Camelize(value).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Camelize_NameWithoutHyphen_ReturnsOriginalInstance()
+    {
+        string value = new(new[] { 'n', 'a', 'm', 'e' });
+
+        NameNormalization.Camelize(value).ShouldBeSameAs(value);
+    }
+
+    [Theory]
+    [InlineData("widget", "Widget")]
+    [InlineData("Widget", "Widget")]
+    [InlineData("", "")]
+    public void Capitalize_Name_ReturnsInvariantInitialCapital(string value, string expected)
+    {
+        NameNormalization.Capitalize(value).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Camelize_NullValue_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => NameNormalization.Camelize(null!));
+    }
+
+    [Fact]
+    public void Capitalize_NullValue_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => NameNormalization.Capitalize(null!));
+    }
+}

--- a/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Internal/SingleFileComponentSourceEmitter.cs
+++ b/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Internal/SingleFileComponentSourceEmitter.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
+using Assimalign.Viu.Syntax.Templates;
+
 namespace Assimalign.Viu.Compiler.SingleFileComponent;
 
 /// <summary>
@@ -48,20 +50,6 @@ internal static class SingleFileComponentSourceEmitter
     /// binds these types by name and therefore does not reference the runtime assembly itself.
     /// </summary>
     private const string ComponentsNamespace = "global::Assimalign.Viu.Components";
-
-    private static readonly string[] DomRenderHelperNames =
-    {
-        "_vModelRadio",
-        "_vModelCheckbox",
-        "_vModelText",
-        "_vModelSelect",
-        "_vModelDynamic",
-        "_withModifiers",
-        "_withKeys",
-        "_vShow",
-        "_Transition",
-        "_TransitionGroup",
-    };
 
     /// <summary>Emits the full generated source for <paramref name="model"/>.</summary>
     /// <param name="model">The scaffold to render.</param>
@@ -504,6 +492,9 @@ internal static class SingleFileComponentSourceEmitter
         }
 
         var cacheExpression = model.HotReloadMetadata is null ? "_cache" : "_hotReloadRenderCache";
+        // NormalizeRoot remains a qualified PascalCase call rather than a HelperNames entry. Both helper
+        // prefixing sites represent names only as "_" + helper.Name, so they cannot express this deliberately
+        // unprefixed runtime member without changing the helper-name model.
         if (model.Declarations.Parameters.Count == 0)
         {
             AppendIndent(builder, indent + 1);
@@ -1114,8 +1105,9 @@ internal static class SingleFileComponentSourceEmitter
 
     private static bool UsesDomRenderHelpers(string renderBody)
     {
-        foreach (var helperName in DomRenderHelperNames)
+        foreach (var helper in HelperNames.DomHelpers)
         {
+            var helperName = "_" + helper.Name;
             if (renderBody.IndexOf(helperName, StringComparison.Ordinal) >= 0)
             {
                 return true;

--- a/tooling/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
+++ b/tooling/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
@@ -215,7 +215,10 @@ The emitted code compiles against `global::Assimalign.Viu.RenderHelpers` (import
 `using static` by the generator) — a static surface the runtime area provides ([V01.01.03.22], issue
 #136). Members carry the underscore-prefixed alias names on purpose — a deliberate, generated-code-only
 deviation from the repository C# naming rule, because these names ARE the by-name binding contract
-(`[SFC-CG-2]`). What code generation requires of each member:
+(`[SFC-CG-2]`). `HelperNames` is the single name table: transforms register its ordinary entries,
+`RenderCodeWriter` reads its fenced writer-only entries without adding them to `TransformResult.Helpers`,
+and its derived `DomHelpers` array drives the generator's conditional DOM import. What code generation
+requires of each member:
 
 - `_openBlock(bool disableTracking = false) : BlockToken` — opens a block, returns an opaque
   `BlockToken`; every `_createBlock`/`_createElementBlock` takes it as the first argument
@@ -247,8 +250,7 @@ deviation from the repository C# naming rule, because these names ARE the by-nam
 - Built-in tags as values (runtime-core): `_Fragment`, `_Teleport`, `_Suspense`, `_KeepAlive`,
   `_BaseTransition`. `_Fragment` is fully realized; the component-like built-ins are surface markers
   whose renderer support lands with their own work items.
-- `_unref(object?) : object?` / `_isRef(object?) : bool` — bridge to `Assimalign.Viu.Core`
-  references.
+- `_unref(object?) : object?` — unwraps a reactive reference and leaves a non-reference unchanged.
 - Emitter-contract helpers, per the serialization table above: `_createProps(params (string, object?)[] entries)`,
   `_createModifiers(params (string, bool)[] entries)`, `_withHandler(handler)` (delegate-typed overloads),
   `_setCache(int index, BlockToken tracking, object? value)`, `_spreadCache(object?)`.
@@ -263,13 +265,15 @@ platform-agnostic runtime-core layer must not reference (keeping runtime-core DO
 directive from ever mis-binding onto a runtime-core marker). They ship instead as
 `global::Assimalign.Viu.Browser.DomRenderHelpers`, and the composition-root generator ([V01.01.06.02])
 emits a **second** file-level `using static global::Assimalign.Viu.Browser.DomRenderHelpers;` alongside the
-runtime-core one whenever a render body is present. A browser `.viu` always has Browser available (it is the
-DOM renderer), so both imports are unconditional — DOM-directive templates (`v-show`, `v-model`,
-`@click.prevent`, `@keyup.enter`) are now end-to-end compilable. `DomRenderHelpers` references only Browser's
-own machinery and Core's `IDirective`, never any `Assimalign.Viu.Syntax.*` assembly; the by-name contract
-still flows one way. Pinned by `Assimalign.Viu.Browser.CompiledRenderTests` (a `.viu` using every spelling
-below compiles against both facades) and `Assimalign.Viu.Browser.Tests.DomRenderHelpersTests` (facade
-mapping + v-show / `.prevent` execution through the in-memory adapter).
+runtime-core one whenever the render body contains an entry from `HelperNames.DomHelpers`. The array is
+derived as each DOM helper is declared in the canonical table, so a new DOM helper cannot leave this import
+decision behind. DOM-directive templates (`v-show`, `v-model`, `@click.prevent`, `@keyup.enter`) are therefore
+end-to-end compilable without making an ordinary component depend on the Browser host. `DomRenderHelpers`
+references only Browser's own machinery and Core's `IDirective`, never any
+`Assimalign.Viu.Syntax.*` assembly; the by-name contract still flows one way. Pinned by the helper-contract
+conformance tests, `Assimalign.Viu.Browser.CompiledRenderTests` (a `.viu` using every spelling below compiles
+against both facades), and `Assimalign.Viu.Browser.Tests.DomRenderHelpersTests` (facade mapping + v-show /
+`.prevent` execution through the in-memory adapter).
 
 What code generation requires of each DOM member, mapped to the runtime machinery it forwards to:
 

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/HelperNames.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/HelperNames.cs
@@ -1,15 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Assimalign.Viu.Syntax.Templates;
 
 /// <summary>
-/// The canonical table of runtime helper references the transform pipeline can emit. Each field is a
-/// <see cref="RuntimeHelper"/> whose <see cref="RuntimeHelper.Name"/> equals the member name generated
-/// code binds against on <c>Assimalign.Viu.RenderHelpers</c> (and <c>DomRenderHelpers</c> for the DOM
-/// helpers below). The binding is <b>by name</b>: no <c>Assimalign.Viu.Syntax.*</c> assembly references
-/// any runtime assembly, so the name in this table is a one-way contract that a rename on either side
-/// breaks (<c>[SFC-CG-2]</c>).
+/// The canonical table of runtime helper references emitted by the transform pipeline or its render-code
+/// writer. Each field is a <see cref="RuntimeHelper"/> whose <see cref="RuntimeHelper.Name"/> equals the
+/// member name generated code binds against on <c>Assimalign.Viu.RenderHelpers</c> (and
+/// <c>DomRenderHelpers</c> for the DOM helpers below). The binding is <b>by name</b>: no
+/// <c>Assimalign.Viu.Syntax.*</c> assembly references any runtime assembly, so the name in this table is
+/// a one-way contract that a rename on either side breaks (<c>[SFC-CG-2]</c>).
 /// </summary>
 public static class HelperNames
 {
+    private static readonly List<RuntimeHelper> domHelpers = new();
+
     /// <summary>The <c>Fragment</c> block type.</summary>
     public static readonly RuntimeHelper Fragment = new("Fragment");
 
@@ -58,9 +63,6 @@ public static class HelperNames
     /// <summary>Resolves a directive by name.</summary>
     public static readonly RuntimeHelper ResolveDirective = new("resolveDirective");
 
-    /// <summary>Resolves a filter by name.</summary>
-    public static readonly RuntimeHelper ResolveFilter = new("resolveFilter");
-
     /// <summary>Applies runtime directives to a vnode.</summary>
     public static readonly RuntimeHelper WithDirectives = new("withDirectives");
 
@@ -97,9 +99,6 @@ public static class HelperNames
     /// <summary>Camel-cases a dynamic argument.</summary>
     public static readonly RuntimeHelper Camelize = new("camelize");
 
-    /// <summary>Capitalizes a string.</summary>
-    public static readonly RuntimeHelper Capitalize = new("capitalize");
-
     /// <summary>Builds an <c>onXxx</c> handler key.</summary>
     public static readonly RuntimeHelper ToHandlerKey = new("toHandlerKey");
 
@@ -112,44 +111,67 @@ public static class HelperNames
     /// <summary>Unwraps a ref.</summary>
     public static readonly RuntimeHelper Unref = new("unref");
 
-    /// <summary>Tests whether a value is a ref.</summary>
-    public static readonly RuntimeHelper IsRef = new("isRef");
-
     /// <summary>Memoizes a subtree for <c>v-memo</c>.</summary>
     public static readonly RuntimeHelper WithMemo = new("withMemo");
 
     /// <summary>Compares two memo dependency arrays.</summary>
     public static readonly RuntimeHelper IsMemoSame = new("isMemoSame");
 
+    // ---- Writer-only helpers: bound against Assimalign.Viu.RenderHelpers. ----
+    // These names are serialized directly by RenderCodeWriter after transformation. Do not route them
+    // through TransformContext.Helper or HelperString: doing so would add them to TransformResult.Helpers
+    // and change that observable transform contract.
+
+    internal static readonly RuntimeHelper CreateProps = new("createProps");
+
+    internal static readonly RuntimeHelper CreateModifiers = new("createModifiers");
+
+    internal static readonly RuntimeHelper WithHandler = new("withHandler");
+
+    internal static readonly RuntimeHelper SetCache = new("setCache");
+
+    internal static readonly RuntimeHelper SpreadCache = new("spreadCache");
+
     // ---- DOM helpers: bound against Assimalign.Viu.Browser.DomRenderHelpers ----
+    // Register every DOM helper through RegisterDomHelper. DomHelpers is derived from these declarations,
+    // so the source emitter's conditional using-static import cannot drift from the canonical names.
 
     /// <summary>The <c>v-model</c> directive for radio inputs.</summary>
-    public static readonly RuntimeHelper VModelRadio = new("vModelRadio");
+    public static readonly RuntimeHelper VModelRadio = RegisterDomHelper("vModelRadio");
 
     /// <summary>The <c>v-model</c> directive for checkbox inputs.</summary>
-    public static readonly RuntimeHelper VModelCheckbox = new("vModelCheckbox");
+    public static readonly RuntimeHelper VModelCheckbox = RegisterDomHelper("vModelCheckbox");
 
     /// <summary>The <c>v-model</c> directive for text inputs.</summary>
-    public static readonly RuntimeHelper VModelText = new("vModelText");
+    public static readonly RuntimeHelper VModelText = RegisterDomHelper("vModelText");
 
     /// <summary>The <c>v-model</c> directive for select elements.</summary>
-    public static readonly RuntimeHelper VModelSelect = new("vModelSelect");
+    public static readonly RuntimeHelper VModelSelect = RegisterDomHelper("vModelSelect");
 
     /// <summary>The <c>v-model</c> directive for dynamic input types.</summary>
-    public static readonly RuntimeHelper VModelDynamic = new("vModelDynamic");
+    public static readonly RuntimeHelper VModelDynamic = RegisterDomHelper("vModelDynamic");
 
     /// <summary>The <c>v-on</c> modifier guard wrapper.</summary>
-    public static readonly RuntimeHelper WithModifiers = new("withModifiers");
+    public static readonly RuntimeHelper WithModifiers = RegisterDomHelper("withModifiers");
 
     /// <summary>The <c>v-on</c> key guard wrapper.</summary>
-    public static readonly RuntimeHelper WithKeys = new("withKeys");
+    public static readonly RuntimeHelper WithKeys = RegisterDomHelper("withKeys");
 
     /// <summary>The <c>v-show</c> directive.</summary>
-    public static readonly RuntimeHelper VShow = new("vShow");
+    public static readonly RuntimeHelper VShow = RegisterDomHelper("vShow");
 
     /// <summary>The <c>Transition</c> DOM built-in.</summary>
-    public static readonly RuntimeHelper Transition = new("Transition");
+    public static readonly RuntimeHelper Transition = RegisterDomHelper("Transition");
 
     /// <summary>The <c>TransitionGroup</c> DOM built-in.</summary>
-    public static readonly RuntimeHelper TransitionGroup = new("TransitionGroup");
+    public static readonly RuntimeHelper TransitionGroup = RegisterDomHelper("TransitionGroup");
+
+    internal static readonly RuntimeHelper[] DomHelpers = domHelpers.ToArray();
+
+    private static RuntimeHelper RegisterDomHelper(string name)
+    {
+        var helper = new RuntimeHelper(name);
+        domHelpers.Add(helper);
+        return helper;
+    }
 }

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/RenderCodeWriter.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/RenderCodeWriter.cs
@@ -22,26 +22,26 @@ internal sealed class RenderCodeWriter
     // ---- Contract helper names bound by name on the runtime helper surface (see docs/DESIGN.md). ----
 
     // An untyped object literal has no C# equivalent, so props/slots objects emit through this helper.
-    private const string CreatePropsHelper = "_createProps";
+    private static readonly string CreatePropsHelper = "_" + HelperNames.CreateProps.Name;
 
     // A directive-modifier bag is name -> bool, not the name -> object? of a property bag, and the
     // directive binding that receives it is typed that way. It therefore has its own helper: the
     // props helper in the modifier slot type-checks yet reads back as no modifiers at all
     // ([SFC-CG-6]).
-    private const string CreateModifiersHelper = "_createModifiers";
+    private static readonly string CreateModifiersHelper = "_" + HelperNames.CreateModifiers.Name;
 
     // C# lambdas and method groups have no natural type in an object-typed position, so event-handler
     // property values emit through this delegate-typed helper.
-    private const string WithHandlerHelper = "_withHandler";
+    private static readonly string WithHandlerHelper = "_" + HelperNames.WithHandler.Name;
 
     // Pausing block tracking, creating the value, stamping its cache index, resuming, and yielding the
     // slot must happen in that order. C# has no comma operator, so the sequence collapses into this
     // helper and rides on guaranteed left-to-right argument evaluation.
-    private const string SetCacheHelper = "_setCache";
+    private static readonly string SetCacheHelper = "_" + HelperNames.SetCache.Name;
 
     // A cached array must be copied before use, so a consumer cannot mutate the cached instance;
     // C# has no spread in this position, so a cloning helper call takes its place.
-    private const string SpreadCacheHelper = "_spreadCache";
+    private static readonly string SpreadCacheHelper = "_" + HelperNames.SpreadCache.Name;
 
     private readonly TransformResult result;
     private readonly StringBuilder builder = new();

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/Properties/AssemblyInfo.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assimalign.Viu.Syntax.Templates.Tests")]
+[assembly: InternalsVisibleTo("Assimalign.Viu.Syntax.Templates.HelperContractTests")]
 
 // The shared .viu -> C# projection core is a build-time HOST of this compiler ([V01.01.06.11]); its
 // component-usage validation ([SFC-USE-2]) asks the same DOM knowledge table the compiler itself uses to

--- a/tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.HelperContractTests/Assimalign.Viu.Syntax.Templates.HelperContractTests.csproj
+++ b/tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.HelperContractTests/Assimalign.Viu.Syntax.Templates.HelperContractTests.csproj
@@ -4,13 +4,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <!-- The helper-contract conformance project references the runtime assemblies beside Syntax.Templates.
-         Keep its sources out of this project's implicit globs so the linked PatchFlags/SlotFlags copies do
-         not collide with the definitions in Assimalign.Viu.Shared. -->
-    <Compile Remove="Assimalign.Viu.Syntax.Templates.HelperContractTests/**" />
-    <None Remove="Assimalign.Viu.Syntax.Templates.HelperContractTests/**" />
-  </ItemGroup>
-  <ItemGroup>
     <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
     <ViuPackageReference Include="xunit" />
     <ViuPackageReference Include="xunit.runner.visualstudio" />
@@ -18,5 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ViuProjectReference Include="Assimalign.Viu.Syntax.Templates" />
+    <ViuProjectReference Include="Assimalign.Viu.Core" />
+    <ViuProjectReference Include="Assimalign.Viu.Browser" />
   </ItemGroup>
 </Project>

--- a/tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.HelperContractTests/HelperNameContractTests.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/test/Assimalign.Viu.Syntax.Templates.HelperContractTests/HelperNameContractTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Browser;
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.Syntax.Templates.HelperContractTests;
+
+// [V01.01.14.08] Every canonical compiler spelling must bind to the designated public runtime facade;
+// this catches a broken by-name contract in Viu's own build instead of a consuming application's build.
+public sealed class HelperNameContractTests
+{
+    [Fact]
+    public void HelperNames_EveryEntryResolvesToItsPublicRuntimeSurface()
+    {
+        var helperEntries = typeof(HelperNames)
+            .GetFields(
+                BindingFlags.Public |
+                BindingFlags.NonPublic |
+                BindingFlags.Static |
+                BindingFlags.DeclaredOnly)
+            .Where(field => field.FieldType == typeof(RuntimeHelper))
+            .Select(field => new
+            {
+                FieldName = field.Name,
+                Helper = field.GetValue(null).ShouldBeOfType<RuntimeHelper>(),
+            })
+            .OrderBy(entry => entry.FieldName, StringComparer.Ordinal)
+            .ToArray();
+        HashSet<RuntimeHelper> tableEntries = helperEntries
+            .Select(entry => entry.Helper)
+            .ToHashSet();
+        HashSet<RuntimeHelper> domHelpers = HelperNames.DomHelpers.ToHashSet();
+
+        HelperNames.DomHelpers.ShouldAllBe(helper => tableEntries.Contains(helper));
+
+        var missingMembers = new List<string>();
+        foreach (var entry in helperEntries)
+        {
+            Type surface = domHelpers.Contains(entry.Helper)
+                ? typeof(DomRenderHelpers)
+                : typeof(RenderHelpers);
+            string memberName = "_" + entry.Helper.Name;
+            if (surface.GetMember(
+                    memberName,
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly).Length == 0)
+            {
+                missingMembers.Add($"{entry.FieldName} -> {surface.FullName}.{memberName}");
+            }
+        }
+
+        missingMembers.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
> **Stacked on #300** (the public-API baseline). Base is `feature/V01.01.14.06-public-api-baseline`, not `main`. Merge #300 first.

## Summary

`HelperNames.cs` describes itself as *"the canonical table … a one-way contract that a rename on either side breaks (`[SFC-CG-2]`)"*. It was neither canonical nor complete, and one entry was actively dangerous.

The contract lived in **four** places:

1. `HelperNames.cs` — 47 entries
2. `RenderCodeWriter.cs:25,31,35,40,44` — five more names hardcoded as private consts
3. `SingleFileComponentSourceEmitter.cs:52-64` — a parallel ten-entry `DomRenderHelperNames` array, substring-scanned against the emitted body to decide whether to write the DOM `using static`
4. `HelperNames.ResolveFilter` — naming `_resolveFilter`, which **exists on no runtime surface**

The `DomRenderHelperNames` array was the sharpest failure mode: add an 11th DOM helper and forget it, and the `using static` is silently omitted — failing with **CS0103 in the consuming application's build**, not Viu's.

## Changes

- **Deleted** `ResolveFilter`, `Capitalize`, `IsRef` (all verified unreferenced) and the runtime `RenderHelpers._isRef` forwarder, plus its design-doc mention.
- **Completed the table**: the five writer-only names now reuse it, kept in a fenced region and deliberately **not** routed through `TransformContext.Helper()`, which would have added them to the public `TransformResult.Helpers` collection and changed an observable contract.
- **`DomHelpers` is now derived** — DOM declarations self-register, and the emitter reads that array instead of a hand-maintained duplicate.
- **Conformance test** asserting every entry's `"_" + Name` resolves to a real public member of `RenderHelpers`/`DomRenderHelpers`. It lives in a nested sibling project following the `Assimalign.Viu.Browser.CompiledRenderTests` pattern, because `Syntax.Templates.Tests` hits CS0433 on the linked `PatchFlags`/`SlotFlags` copies.
- **Deduplicated** `Camelize`/`Capitalize` into a new `Assimalign.Viu.Shared.NameNormalization`; all five private copies now forward to it.
- `NormalizeRoot` deliberately stays outside the table with an explanatory comment — both prefixing sites build the emitted name as `"_" + helper.Name`, and a PascalCase entry is unrepresentable.

## Verification

- `dotnet build Assimalign.Viu.slnx -c Release -warnaserror` — 0 warnings, 0 errors; full test suite passes
- **The conformance test provably bites.** Injecting a bogus entry produced exactly the `ResolveFilter` failure mode, now caught mechanically:
  `Shouldly.ShouldAssertException : ["BogusProbe -> Assimalign.Viu.RenderHelpers._bogusProbe"]`
  Verified independently, then reverted.
- `Pack-Release.ps1` still produces 14 packages

## Public API delta

Because this stacks on the baseline, the entire surface change is four lines — which is the point of #300:

```
Core/PublicAPI.Unshipped.txt:
  *REMOVED*static Assimalign.Viu.RenderHelpers._isRef(object? value) -> bool

Shared/PublicAPI.Unshipped.txt:
  Assimalign.Viu.Shared.NameNormalization
  static Assimalign.Viu.Shared.NameNormalization.Camelize(string! value) -> string!
  static Assimalign.Viu.Shared.NameNormalization.Capitalize(string! value) -> string!
```

## Work items resolved by this PR

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)