### PR TITLE
docs: bring the API hardening plan's state table current [V01.01.14]

### DIFF
--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -146,6 +146,34 @@ Viu.
 - **Single-threaded model**: the runtime targets the JS event loop. Ambient `static` state is acceptable,
   but any non-thread-safe type must say so in its XML docs.
 
+## Assembly boundaries — `InternalsVisibleTo` is for tests only
+
+- **`InternalsVisibleTo` grants access to a project's own test assembly. Nothing else.** It is not a
+  mechanism for sharing internals between libraries, including between two build-time-only libraries.
+- **Why.** The reason a project is a separate project is to draw a boundary. A cross-library grant makes
+  that boundary a fiction: the assemblies compile as one unit while presenting themselves as two, so the
+  seam is never designed, never documented, and never reviewed. Two assemblies that need each other's
+  internals are either one assembly, or they have an API nobody wrote.
+- **When a sibling library needs something**, choose deliberately — do not reach for a grant:
+  1. **Design the contract.** If the sibling genuinely depends on it, it is API. Make it `public` on
+     purpose, document it, and let the public-API baseline record it.
+  2. **Move the type** to the consumer, when there is exactly one and it belongs there.
+  3. **Express it through an interface** under `Abstraction/`, keeping the concrete type `internal` —
+     the interface-first rule above.
+  4. **Merge the projects**, if the boundary turns out not to be real.
+  Being non-shipping is *not* a reason to skip this. A build-time assembly's surface is invisible to app
+  developers, but the boundary still exists for the people maintaining it.
+- **Placement.** Grants live in `src/Properties/AssemblyInfo.cs` — one file per project, nowhere else.
+  Not in a csproj `<InternalsVisibleTo>` item, and not scattered across source files.
+
+  ```csharp
+  using System.Runtime.CompilerServices;
+
+  [assembly: InternalsVisibleTo("Assimalign.Viu.<Name>.Tests")]
+  ```
+
+Recorded as **D8** in [`docs/API-HARDENING-PLAN.md`](../../docs/API-HARDENING-PLAN.md).
+
 ## AOT / trimming (hard constraints)
 
 - Trimming- and WASM/NativeAOT-safe: **no reflection-based serialization, no dynamic code generation, no

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -151,13 +151,8 @@ them, and only one group is genuinely hard.
 | **Consumed by a sibling shipping library** (3 grants, all from `Core`) | The real work — see below. |
 
 **The `Core` cases.** `Core` grants internals to `Browser`, `ServerRenderer` and `Testing`. Of its 39
-internal types, only **six** are reached across the boundary: `ComponentContext`, `EmptyServiceProvider`,
-`MountedTemplateNode`, `EmptyComponentFactory`, `ApplicationState`, `MountedComponent`.
-
-Each needs a deliberate answer — promote to public API, move to its sole consumer, or express through an
-interface with the concrete type staying internal. Two probably *want* to be public regardless:
-`ApplicationState` is the D5 lifecycle enum a host legitimately observes, and the empty resolvers are
-D5's "a primitive application should not need dummy dependencies" defaults.
+internal types, only **six** are reached across the boundary. Each has now been measured and given a
+deliberate answer — see the section below. **None is promoted whole**; the surface added is nine members.
 
 **The `tooling/` cases, measured.** Three of the five grants share exactly **one** type each —
 `SingleFileComponentPathComparison` (twice) and `CompilerDomKnowledge` — each a promote-or-move decision
@@ -178,6 +173,140 @@ is a real design call rather than an accessibility edit.
 **Expect the headline number to fall.** The original "~120 types internalized" assumed grants were
 available. Under D8 a meaningful share stays public — correctly, because the assembly boundary is real.
 The gain is honesty about that boundary rather than a smaller type count.
+
+### D8 applied to `Core` — the six cross-boundary types
+
+`Core` grants internals to `Browser`, `ServerRenderer` and `Testing`. Of its 39 internal types, six are
+reached across that boundary. Each was measured for what the consumer *actually* uses, not what the type
+exposes. **No type is promoted whole**; the surface added is nine members.
+
+#### 1. `EmptyComponentFactory` and `EmptyServiceProvider` — deleted, not promoted
+
+Both are internal null-objects duplicated in **three** assemblies each (`Core`, `ServerRenderer`,
+`Testing`). Neither needs to exist:
+
+- `EmptyComponentFactory` throws "not registered" on every `Create`. `Assimalign.Viu.Components`'s
+  **already-public** `ComponentFactory` does the same thing when constructed with no registrations, so
+  `ApplicationOptions.Components` defaults to an empty `ComponentFactory` and the six duplicate types go.
+- `EmptyServiceProvider` returns `null` for every service — the "always non-null, sometimes useless"
+  pattern. It exists only to keep `Services` non-nullable, so making dependency injection genuinely
+  optional removes the reason for it.
+
+`ComponentFactory` becomes **derivable** (unsealed, `protected` registration, `virtual Create`) so
+applications can build on the default rather than reimplement it. The repo's sealing rule targets hot
+paths; component creation runs once per mount, so this is a deliberate, documented exception.
+
+**Dependency injection becomes opt-in:**
+
+| Member | Was | Becomes |
+|---|---|---|
+| `ApplicationOptions.Services` | `IServiceProvider` = `EmptyServiceProvider.Instance` | `IServiceProvider?` = `null` |
+| `IApplicationContext.Services` | `IServiceProvider` | `IServiceProvider?` |
+| `IComponentContext.Services` | `IServiceProvider` | `IServiceProvider?` |
+
+`BrowserApplicationBuilder`'s "Services cannot be null" guard goes with them — it exists only to defend
+the non-null fiction. Verified safe for code generation: the single-file-component emitter never touches
+`Context.Services`.
+
+No first-class DI hook is added. `IComponentFactory`'s own docs already state the contract *"intentionally
+does not prescribe how components are activated"*; an application that wants container-resolved components
+writes a factory that does that.
+
+#### 2. `ApplicationState` — promoted
+
+The `[APP-1]` lifecycle enum. A host legitimately observes which state an application is in, and
+`IApplicationContext.IsRunning` already exposes a coarser view of the same fact.
+
+#### 3. `ComponentContext` — **not** promoted; two members added to `IComponentContext`
+
+545 lines, but consumers reach past `IComponentContext` for exactly two things:
+
+- `ScopeIdentifier` — `ComponentTreeSerializer.cs:97`, stamping the scoped-CSS attribute
+- `Parent` — `ComponentWrapper.cs:296`, walking ancestors to resolve a query
+
+```csharp
+public interface IComponentContext
+{
+    // … existing members …
+    string? ScopeIdentifier { get; }
+    IComponentContext? Parent { get; }
+}
+```
+
+Neither leaks anything new: `ScopeIdentifier` is already public on `IComponentTemplate`, and a context
+having a parent is an ordinary thing to model. `ComponentContext` stays `internal`; the consumers'
+signatures change to `IComponentContext?`.
+
+#### 4. `MountedComponent` — **not** promoted; a render scope replaces it
+
+Used only by `ServerComponentRenderer`, which today drives the whole mount lifecycle by hand:
+
+```csharp
+instance = MountedComponent.Create(state.Application, request, parent, state.NextComponentIdentifier());
+await instance.InvokeServerPrefetchAsync().WaitAsync(state.CancellationToken);
+IComponent subtree = instance.Render();
+await ComponentTreeSerializer.RenderAsync(state, subtree, instance.Context);
+// finally: instance?.AbortMount();
+```
+
+The mount must stay alive while the caller serializes the subtree, so a fire-and-forget
+`RenderOnceAsync` does not fit. A disposable scope does:
+
+```csharp
+public interface IComponentRenderScope : IAsyncDisposable
+{
+    IComponent Tree { get; }
+    IComponentContext Context { get; }
+}
+
+public static class ComponentHost   // existing public static class
+{
+    public static ValueTask<IComponentRenderScope> RenderAsync(
+        IApplicationContext application,
+        ITemplateComponent request,
+        IComponentContext? parent,
+        int componentIdentifier,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The caller becomes `await using` instead of `try`/`finally`, and the ordering invariants — prefetch before
+render, abort on failure — move **into** Core rather than being re-derived by every host. Three public
+members instead of a 369-line lifecycle class.
+
+#### 5. `MountedTemplateNode<TNode>` — **not** promoted; a view interface replaces it
+
+Used only by `Testing`, which needs precisely three facts per mounted template: the context to match on
+(`ViuTest.FindMountedTemplate` compares by reference), and the first and last host node of the subtree
+(`TestQuery.HostNodes`). Everything after that is Testing's own node walking.
+
+```csharp
+public interface IMountedTemplateView<TNode>
+{
+    IComponentContext Context { get; }
+    TNode FirstHostNode { get; }
+    TNode LastHostNode { get; }
+}
+
+// on the existing public Renderer<TNode>
+public IReadOnlyList<IMountedTemplateView<TNode>> GetMountedTemplates(TNode container);
+```
+
+`MountedTemplateNode<TNode>` and `MountedRenderNode<TNode>` stay internal, so the render-tree shape is
+not published to reveal a first/last node pair.
+
+#### Why this is the point of D8
+
+`ServerRenderer` and `Testing` were both re-implementing engine operations by driving `Core`'s internals,
+because a grant made that free and so the seam was never designed. The outcome is not merely "fewer
+`internal` types made `public`" — `Core` now exposes the two **operations** these hosts need, *render a
+component once* and *inspect the mounted tree*, instead of the machinery they previously assembled by
+hand. That is a smaller public surface **and** stronger encapsulation than exists today.
+
+**No `IComponentFactoryBuilder`.** `ComponentFactory(IEnumerable<ComponentRegistration>)` already
+composes — merging generated and hand-written registrations is list concatenation. A builder would earn
+its place only if registration became incremental or order-dependent, and neither is true. Adding one now
+is the speculative surface T14 targets elsewhere in this arc.
 
 ## D6 — platform segmentation of the SDK and framework
 

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -65,6 +65,8 @@ taking `Browser` and its `browser-wasm` runtime pin.
 | D5 | **Redesign the application lifetime: delete `IApplicationPlugin`, separate build-time composition from runtime behavior, and make `Use(...)` a real middleware pipeline around the persistent host lifetime.** Direction set by Chase from an independent architecture review of `fc8a90ba`. Full design in the section below, as amended by D5a. | 2026-08-05 | `IApplicationPlugin` is a deferred initializer with no `next`, no short-circuiting, and no cleanup phase. Verified: it has **zero shipping implementations** — every implementor in the tree is a test double or the showcase's recorder. Deleting it before the polish waves avoids hardening, documenting, and renaming types that are about to be removed. **Requires a `docs/SPECIFICATION.md` amendment replacing `[CMP-25]` (line 333)**, filed per `.claude/rules/deviations.md`; this row is the recorded confirmation. |
 | D5a | **Maintainer amendment for PR #305:** `IApplication` exposes `StartAsync`/`StopAsync`; `RunAsync` is an extension; runtime state and the stopping token live on `IApplicationContext`; middleware receives that context directly; a lean `IApplicationBuilder` configures all composition through `ApplicationOptions`; Browser implements the lifetime and mount APIs directly; the generic Core application abstraction, abstract builders, execution wrapper, and static Browser facade are deleted. | 2026-08-06 | This is the accepted review shape for [V01.01.14.08]. It adopts the familiar split between starting a host and running it until shutdown, keeps host-specific mounting out of Core, and removes inheritance that exposed platform mechanics as Core API. The amendment below replaces the original D5 target shape while retaining D5's middleware, cleanup, borrowed-ownership, and server-separation decisions. |
 | D6 | **Segment the SDK and the shared framework by platform.** `Assimalign.Viu.Sdk` and `Assimalign.Viu.App` become platform-agnostic; `Assimalign.Viu.Sdk.Browser` and `Assimalign.Viu.App.Browser` carry everything browser-specific. Direction set by Chase. Full design in the section below. | 2026-08-06 | Today there is exactly one SDK and one framework, and both are browser-only by construction: `sdks/Assimalign.Viu.Sdk/Sdk/Sdk.props:8` opens with `<Import Sdk="Microsoft.NET.Sdk.WebAssembly" …>` under the comment *"A Viu app is a WASM browser app, so the chain starts at Microsoft.NET.Sdk.WebAssembly"*, and the single `Assimalign.Viu.App` framework bundles `Browser` with the host-agnostic libraries. So authoring a platform-agnostic Viu component library means taking the WebAssembly SDK and a `browser-wasm` runtime pin for code that renders nothing. The split gives that author a first-class path, and gives every future host (SSR, WebView) a shape to slot into rather than a fork. |
+| D7 | **`Assimalign.Viu.Hosting` (T06) is not implemented in this repository.** The host-authoring/app-authoring namespace split moves to the Cohesion project. | 2026-08-06 | Direction set by Chase. The finding stands and is worth keeping recorded — the `Assimalign.Viu` front door mixes app-authoring API with host-adapter plumbing — but the segmentation is being solved in Cohesion rather than duplicated here. D5 also already removed much of what T06 targeted: mounting moved into Browser and the generic Core application abstraction was deleted. T06 stays in the state table as **Will not do (see D7)** so a future session does not re-derive it as an open opportunity. |
+| D8 | **`InternalsVisibleTo` is for unit tests only.** It is not a mechanism for sharing internals between shipping libraries. | 2026-08-06 | Direction set by Chase. A cross-library grant makes the assembly boundary a fiction: two assemblies that need each other's internals are either one assembly, or have an API that was never designed. This reverses the premise of T05 as originally scoped, which planned to internalize ~120 types and add grants — see the T05 note below for what it becomes. Eight cross-library grants exist today and are in scope to remove. |
 
 ## State
 
@@ -88,9 +90,9 @@ in as each item is created.
 | D5-F | Specification: replace `[CMP-25]` with application lifecycle clauses; lifetime test suite | 2A | `.08` | #304 | **MERGED** (PR #305) |
 | — | Rename `Router.Browser` → `Browser.Router` | 2A | `.09` | #307 | **MERGED** (PR #308) |
 | — | Extension-member syntax; `Extensions/` and `Exception/` folders | 2 | `.10` | #309 | **MERGED** (PR #310) |
-| T05 | Internalize friend-only publics (~120 types) | 2 | — | — | **NEXT** — largest remaining surface reduction |
+| T05 | Reduce friend-only publics — **re-scoped by D8**, see note below | 2 | — | — | **NEXT** |
 | T13 | Single source of truth for the helper-name contract | 2 | `.07` | #301 | **MERGED** (PR #306) |
-| T06 | Namespace segmentation (`Assimalign.Viu.Hosting`) | 3 | — | — | Not started — reassess: D5 already moved mounting to Browser |
+| T06 | Namespace segmentation (`Assimalign.Viu.Hosting`) | — | — | — | **Will not do — see D7** (moving to Cohesion) |
 | T07 | Product-prefix stutter and duplicate facades | 3 | — | — | Not started |
 | T08 | Naming-rule compliance | 3 | — | — | Not started |
 | G3 | `SlotFlags` is named `*Flags` but is not a bitmask | 3 | — | — | Not started |
@@ -120,6 +122,32 @@ types that are about to be deleted:
 | T12 — the former abstract builder's configuration methods returned `IApplicationBuilder`, collapsing the concrete Browser builder | D5-B | The abstract base is deleted. The lean interface remains for platform-neutral construction, while concrete builders self-return and implement its two members explicitly where return covariance requires it. |
 | T14 — `Performance` has no production reader; `BrowserApplication.CreateServerRendererBuilder` has zero callers | D5-B, D5-D | Both are deleted rather than renamed or documented. |
 | T11 — `Router.ReadyAsync` takes no `CancellationToken` | D5-E | Cancellation is required for the middleware pipeline to be cancellable at all. |
+
+### T05 after D8 — what changed and what it costs
+
+T05 was scoped as *"internalize ~120 types and add `InternalsVisibleTo` grants."* **D8 removes the
+mechanism**, so the unit is re-scoped rather than merely constrained. The types divide by who consumes
+them, and only one group is genuinely hard.
+
+| Group | Treatment under D8 |
+|---|---|
+| **Zero consumers** — e.g. `PatchFlagNames`, `ShapeFlagsExtensions`, `Scheduler.IsFlushing`/`IsFlushPending` | Make `internal` outright. No grant needed; D8 is not engaged. |
+| **Consumed only by the assembly's own tests** — e.g. the generators' `*TrackingName` constants | `internal` + a **test** grant. Exactly what D8 sanctions. |
+| **Consumed by a sibling `tooling/` assembly** (5 of the 8 existing cross-library grants) | Make the member **public** and delete the grant. These assemblies do not ship ([V01.01.14.04]), so `public` costs nothing developer-facing — the surface is invisible to app developers either way. |
+| **Consumed by a sibling shipping library** (3 grants, all from `Core`) | The real work — see below. |
+
+**The `Core` cases.** `Core` grants internals to `Browser`, `ServerRenderer` and `Testing`. Of its 39
+internal types, only **six** are reached across the boundary: `ComponentContext`, `EmptyServiceProvider`,
+`MountedTemplateNode`, `EmptyComponentFactory`, `ApplicationState`, `MountedComponent`.
+
+Each needs a deliberate answer — promote to public API, move to its sole consumer, or express through an
+interface with the concrete type staying internal. Two probably *want* to be public regardless:
+`ApplicationState` is the D5 lifecycle enum a host legitimately observes, and the empty resolvers are
+D5's "a primitive application should not need dummy dependencies" defaults.
+
+**Expect the headline number to fall.** The original "~120 types internalized" assumed grants were
+available. Under D8 a meaningful share stays public — correctly, because the assembly boundary is real.
+The gain is honesty about that boundary rather than a smaller type count.
 
 ## D6 — platform segmentation of the SDK and framework
 

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -129,11 +129,25 @@ T05 was scoped as *"internalize ~120 types and add `InternalsVisibleTo` grants."
 mechanism**, so the unit is re-scoped rather than merely constrained. The types divide by who consumes
 them, and only one group is genuinely hard.
 
+> **"Public" means two different things here — keep them apart.**
+>
+> **Accessibility** (`public` vs `internal`) is what D8 governs. **Packaging** (`IsPackable`) is not,
+> and is unchanged.
+>
+> A `tooling/` type becoming `public` is a *correct and expected* outcome of D8, not a concession: it
+> makes a real dependency into a designed contract. It does **not** put that type on nuget.org. Those
+> assemblies stopped publishing in [V01.01.14.04] and stay unpublished — they reach builds only inside
+> `analyzers/dotnet/cs/` of the Ref pack. So an app developer's IntelliSense is unaffected either way.
+>
+> D8 exists to keep the boundaries between libraries honest, not to minimise public surface in
+> assemblies no app references. Do not read a `public` in `tooling/` as a regression of the unshipping
+> work, and do not "fix" it by re-adding a grant.
+
 | Group | Treatment under D8 |
 |---|---|
 | **Zero consumers** — e.g. `PatchFlagNames`, `ShapeFlagsExtensions`, `Scheduler.IsFlushing`/`IsFlushPending` | Make `internal` outright. No grant needed; D8 is not engaged. |
 | **Consumed only by the assembly's own tests** — e.g. the generators' `*TrackingName` constants | `internal` + a **test** grant. Exactly what D8 sanctions. |
-| **Consumed by a sibling `tooling/` assembly** (5 of the 8 grants) | Same treatment as a shipping library. D8 applies everywhere: not shipping is not a reason to skip designing the seam, because the boundary exists for maintainers even when no app developer can see it. |
+| **Consumed by a sibling `tooling/` assembly** (5 of the 8 grants) | Same decision procedure as a shipping library, and for most of these the answer is simply **make it `public`** — the dependency is real, so it is a contract. Costs nothing developer-facing, since these assemblies do not publish. |
 | **Consumed by a sibling shipping library** (3 grants, all from `Core`) | The real work — see below. |
 
 **The `Core` cases.** `Core` grants internals to `Browser`, `ServerRenderer` and `Testing`. Of its 39

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -1,7 +1,6 @@
 # API surface hardening plan — [V01.01.14]
 
-**Status: ARC OPEN. Wave 2A in progress on
-`feature/V01.01.14.08-application-lifetime`.**
+**Status: ARC OPEN. Waves 1 and 2A complete and merged; Wave 2 next (T05).**
 
 This document is the session-independent source of truth for the API-hardening arc. Any session
 (human or agent) resuming this work reads this file first, checks the *State* table, and continues
@@ -77,19 +76,21 @@ in as each item is created.
 | Theme | Description | Wave | WBS | Issue | Status |
 |---|---|---|---|---|---|
 | T01 + T15 | Ship XML documentation; sweep derivative doc phrasing | 1 | `.01` | #285 | **MERGED** (PR #288) |
-| T04 | Compiler-seam hardening (`[EditorBrowsable]` + language-service filter) | 1 | `.02` | #287 | **IN REVIEW** (PR #289) |
-| T16 | Drop the viral `RequiresPreviewFeatures` stamp | 1 | `.03` | #292 | **IN REVIEW** — supersedes #280 |
-| T03 | Unship build-time packages; delete `Syntax.JavaScript` (keep `Syntax.Html`, see D3) | 1 | `.04` | #294 | **IMPLEMENTED** — pending integration |
-| T02 | Public-API baseline and hardening-attribute conventions | 1 | `.06` | #299 | **IMPLEMENTED** — pending integration |
-| D5-A | Application lifetime: middleware pipeline, `StartAsync`/`StopAsync`, `RunAsync` extension, delete `IApplicationPlugin` | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| D5-B | Composition surface: lean `IApplicationBuilder`, options-only composition, frozen context | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| D5-C | Separate SSR: `ServerApplication` → `ServerRenderApplication`, off `IApplication` | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| D5-D | Browser entry point: direct `new BrowserApplicationBuilder()`; no static facade | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| D5-E | Router bootstrap: `UseRouter`, `ReadyAsync` cancellation, lazy history init | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| D5-F | Specification: replace `[CMP-25]` with application lifecycle clauses; lifetime test suite | 2A | `.08` | #304 | **IMPLEMENTED — pending integration** |
-| T05 | Internalize friend-only publics (~120 types) | 2 | — | — | Not started |
-| T13 | Single source of truth for the helper-name contract | 2 | — | — | Not started |
-| T06 | Namespace segmentation (`Assimalign.Viu.Hosting`) | 3 | — | — | Not started — decide after T04 lands |
+| T04 | Compiler-seam hardening (`[EditorBrowsable]` + language-service filter) | 1 | `.02` | #287 | **MERGED** (PR #289) |
+| T16 | Drop the viral `RequiresPreviewFeatures` stamp | 1 | `.03` | #292 | **MERGED** (PR #293) — superseded #280 |
+| T03 | Unship build-time packages; delete `Syntax.JavaScript` (retain `Syntax.Html`, unpublished — see D3a) | 1 | `.04` | #294 | **MERGED** (PR #295) |
+| T02 | Public-API baseline and hardening-attribute conventions | 1 | `.06` | #299 | **MERGED** (PR #300) |
+| D5-A | Application lifetime: middleware pipeline, `StartAsync`/`StopAsync`, `RunAsync` extension, delete `IApplicationPlugin` | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| D5-B | Composition surface: lean `IApplicationBuilder`, options-only composition, frozen context | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| D5-C | Separate SSR: `ServerApplication` → `ServerRenderApplication`, off `IApplication` | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| D5-D | Browser entry point: direct `new BrowserApplicationBuilder()`; no static facade | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| D5-E | Router bootstrap: `UseRouter`, `ReadyAsync` cancellation, lazy history init | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| D5-F | Specification: replace `[CMP-25]` with application lifecycle clauses; lifetime test suite | 2A | `.08` | #304 | **MERGED** (PR #305) |
+| — | Rename `Router.Browser` → `Browser.Router` | 2A | `.09` | #307 | **MERGED** (PR #308) |
+| — | Extension-member syntax; `Extensions/` and `Exception/` folders | 2 | `.10` | #309 | **MERGED** (PR #310) |
+| T05 | Internalize friend-only publics (~120 types) | 2 | — | — | **NEXT** — largest remaining surface reduction |
+| T13 | Single source of truth for the helper-name contract | 2 | `.07` | #301 | **MERGED** (PR #306) |
+| T06 | Namespace segmentation (`Assimalign.Viu.Hosting`) | 3 | — | — | Not started — reassess: D5 already moved mounting to Browser |
 | T07 | Product-prefix stutter and duplicate facades | 3 | — | — | Not started |
 | T08 | Naming-rule compliance | 3 | — | — | Not started |
 | G3 | `SlotFlags` is named `*Flags` but is not a bitmask | 3 | — | — | Not started |

--- a/docs/API-HARDENING-PLAN.md
+++ b/docs/API-HARDENING-PLAN.md
@@ -66,7 +66,7 @@ taking `Browser` and its `browser-wasm` runtime pin.
 | D5a | **Maintainer amendment for PR #305:** `IApplication` exposes `StartAsync`/`StopAsync`; `RunAsync` is an extension; runtime state and the stopping token live on `IApplicationContext`; middleware receives that context directly; a lean `IApplicationBuilder` configures all composition through `ApplicationOptions`; Browser implements the lifetime and mount APIs directly; the generic Core application abstraction, abstract builders, execution wrapper, and static Browser facade are deleted. | 2026-08-06 | This is the accepted review shape for [V01.01.14.08]. It adopts the familiar split between starting a host and running it until shutdown, keeps host-specific mounting out of Core, and removes inheritance that exposed platform mechanics as Core API. The amendment below replaces the original D5 target shape while retaining D5's middleware, cleanup, borrowed-ownership, and server-separation decisions. |
 | D6 | **Segment the SDK and the shared framework by platform.** `Assimalign.Viu.Sdk` and `Assimalign.Viu.App` become platform-agnostic; `Assimalign.Viu.Sdk.Browser` and `Assimalign.Viu.App.Browser` carry everything browser-specific. Direction set by Chase. Full design in the section below. | 2026-08-06 | Today there is exactly one SDK and one framework, and both are browser-only by construction: `sdks/Assimalign.Viu.Sdk/Sdk/Sdk.props:8` opens with `<Import Sdk="Microsoft.NET.Sdk.WebAssembly" …>` under the comment *"A Viu app is a WASM browser app, so the chain starts at Microsoft.NET.Sdk.WebAssembly"*, and the single `Assimalign.Viu.App` framework bundles `Browser` with the host-agnostic libraries. So authoring a platform-agnostic Viu component library means taking the WebAssembly SDK and a `browser-wasm` runtime pin for code that renders nothing. The split gives that author a first-class path, and gives every future host (SSR, WebView) a shape to slot into rather than a fork. |
 | D7 | **`Assimalign.Viu.Hosting` (T06) is not implemented in this repository.** The host-authoring/app-authoring namespace split moves to the Cohesion project. | 2026-08-06 | Direction set by Chase. The finding stands and is worth keeping recorded — the `Assimalign.Viu` front door mixes app-authoring API with host-adapter plumbing — but the segmentation is being solved in Cohesion rather than duplicated here. D5 also already removed much of what T06 targeted: mounting moved into Browser and the generic Core application abstraction was deleted. T06 stays in the state table as **Will not do (see D7)** so a future session does not re-derive it as an open opportunity. |
-| D8 | **`InternalsVisibleTo` is for unit tests only.** It is not a mechanism for sharing internals between shipping libraries. | 2026-08-06 | Direction set by Chase. A cross-library grant makes the assembly boundary a fiction: two assemblies that need each other's internals are either one assembly, or have an API that was never designed. This reverses the premise of T05 as originally scoped, which planned to internalize ~120 types and add grants — see the T05 note below for what it becomes. Eight cross-library grants exist today and are in scope to remove. |
+| D8 | **`InternalsVisibleTo` is for unit tests only, everywhere.** It is not a mechanism for sharing internals between libraries — including between two build-time-only libraries. Grants live in `src/Properties/AssemblyInfo.cs`. Recorded as a standing rule in `.claude/rules/general-rules.md`. | 2026-08-06 | Direction set by Chase. A cross-library grant makes the assembly boundary a fiction: two assemblies that need each other's internals are either one assembly, or have an API that was never designed. This reverses the premise of T05 as originally scoped, which planned to internalize ~120 types and add grants — see the T05 note below for what it becomes. Being non-shipping is not an exemption: a build-time assembly's surface is invisible to app developers, but the boundary still exists for maintainers. Eight cross-library grants exist today and are in scope to remove. |
 
 ## State
 
@@ -133,7 +133,7 @@ them, and only one group is genuinely hard.
 |---|---|
 | **Zero consumers** — e.g. `PatchFlagNames`, `ShapeFlagsExtensions`, `Scheduler.IsFlushing`/`IsFlushPending` | Make `internal` outright. No grant needed; D8 is not engaged. |
 | **Consumed only by the assembly's own tests** — e.g. the generators' `*TrackingName` constants | `internal` + a **test** grant. Exactly what D8 sanctions. |
-| **Consumed by a sibling `tooling/` assembly** (5 of the 8 existing cross-library grants) | Make the member **public** and delete the grant. These assemblies do not ship ([V01.01.14.04]), so `public` costs nothing developer-facing — the surface is invisible to app developers either way. |
+| **Consumed by a sibling `tooling/` assembly** (5 of the 8 grants) | Same treatment as a shipping library. D8 applies everywhere: not shipping is not a reason to skip designing the seam, because the boundary exists for maintainers even when no app developer can see it. |
 | **Consumed by a sibling shipping library** (3 grants, all from `Core`) | The real work — see below. |
 
 **The `Core` cases.** `Core` grants internals to `Browser`, `ServerRenderer` and `Testing`. Of its 39
@@ -144,6 +144,22 @@ Each needs a deliberate answer — promote to public API, move to its sole consu
 interface with the concrete type staying internal. Two probably *want* to be public regardless:
 `ApplicationState` is the D5 lifecycle enum a host legitimately observes, and the empty resolvers are
 D5's "a primitive application should not need dummy dependencies" defaults.
+
+**The `tooling/` cases, measured.** Three of the five grants share exactly **one** type each —
+`SingleFileComponentPathComparison` (twice) and `CompilerDomKnowledge` — each a promote-or-move decision
+and nothing more. The two substantial ones are both `Assimalign.Viu.Compiler.SingleFileComponent`:
+**12** types reach `Generators.Syntax` and **9** reach `LanguageService`, overlapping heavily
+(`SingleFileComponentProjection`, `SingleFileComponentSourceEmitter`, `SingleFileComponentDiagnostics`,
+`SingleFileComponentFormat`, `SingleFileComponentNameResolver`), for **16** distinct types.
+
+That is not accidental leakage. The projection core's own `docs/OVERVIEW.md` says it exists so that
+*"the two hosts that need that projection"* share one implementation — so those types **are** its
+contract, and are `internal` only because a grant made that easy. Under D8 they become a designed public
+API, which is what the assembly was always for. Watch for `EquatableArray` in that list: near-identical
+copies exist in other projects, so it is a duplication question rather than a promotion one.
+
+**Total deliberate decisions: ~23 types** — 6 in `Core`, ~17 across `tooling/`. Tractable, and each one
+is a real design call rather than an accessibility edit.
 
 **Expect the headline number to fall.** The original "~120 types internalized" assumed grants were
 available. Under D8 a meaningful share stays public — correctly, because the assembly boundary is real.


### PR DESCRIPTION
## Summary

The plan's own contract is that a resuming session reads the State table first and trusts it, and that it is updated in the same commit as a unit's progress. That held early and then drifted.

Stale entries, all of which are merged on `main`:

| Row | Said | Actually |
|---|---|---|
| T04 | IN REVIEW | Merged, PR #289 |
| T16 | IN REVIEW | Merged, PR #293 |
| T03 | pending integration | Merged, PR #295 |
| T02 | pending integration | Merged, PR #300 |
| D5-A … D5-F | pending integration | Merged, PR #305 |
| T13 | Not started | Merged, PR #306 |
| `.09`, `.10` | *no rows* | Merged, PRs #308, #310 |

A stale table is worse than no table, since the document exists precisely to be trusted without the originating conversation.

## Also

- Marks **T05** as next — the largest remaining surface reduction.
- Flags that **T06**'s premise needs reassessing: it proposed an `Assimalign.Viu.Hosting` namespace to separate host-authoring from app-authoring API, but D5 already moved mounting into Browser and deleted the generic Core application abstraction, which was much of what that segmentation was for.
- Header now reads *"Waves 1 and 2A complete and merged; Wave 2 next (T05)"* rather than naming a branch that has since merged.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)