### PR TITLE
feat(server-rendering): complete the SSR story [V01.01.07]

### DIFF
--- a/analyzers/Assimalign.Viu.Generators.Syntax/test/SingleFileComponentGeneratorTests.cs
+++ b/analyzers/Assimalign.Viu.Generators.Syntax/test/SingleFileComponentGeneratorTests.cs
@@ -172,6 +172,9 @@ namespace Demo
         generated.ShouldContain("public string Message = \"Hello\";");
         generated.ShouldContain("internal const string ExtractedStyles =");
         generated.ShouldContain(".box[data-v-");
+        generated.ShouldContain(
+            "ElementBinding.Attribute(new global::Assimalign.Viu.Components.QualifiedName(\"data-v-9d968641\"), " +
+            "string.Empty)");
         generated.ShouldNotContain("Scope" + "Identifier");
         generated.ShouldNotContain("internal const string ScopeId");
         _ = legacySnapshot;

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/Assimalign.Viu.Testing.Benchmarks.csproj
@@ -4,8 +4,9 @@
     app hosting two things on CoreCLR (never a browser, never trimmed/AOT'd — like a test project):
 
       1. BenchmarkDotNet micro/meso benchmarks of the pure-.NET hot paths the architecture bets on —
-         reactivity track/trigger and renderer diff/patch over the in-memory test adapter. Wall-clock
-         numbers are environment-relative, so they are published as artifacts, never a CI gate.
+         reactivity track/trigger, renderer diff/patch over the in-memory test adapter, and compiled
+         direct-write server rendering against virtual-tree traversal. Wall-clock numbers are
+         environment-relative, so they are published as artifacts, never a CI gate.
       2. A deterministic interop-count harness: it drives the js-framework-benchmark scenarios through
          the same in-memory adapter and counts node operations. Op count is the DOM-free proxy for
          JSImport crossings (Assimalign.Viu.Testing's op log == "N node ops == N interop calls"), so it
@@ -30,8 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The in-memory adapter (its op log is the interop proxy) plus the runtime core whose
-         micro/meso paths the benchmark measures directly. -->
+    <!-- The in-memory adapter (its op log is the interop proxy), the runtime core, and the server
+         renderer whose compiler-shaped direct-write path the benchmark measures directly. -->
+    <ViuProjectReference Include="Assimalign.Viu.ServerRenderer" />
     <ViuProjectReference Include="Assimalign.Viu.Testing" />
     <ViuProjectReference Include="Assimalign.Viu.Core" />
   </ItemGroup>

--- a/benchmarks/Assimalign.Viu.Testing.Benchmarks/CompiledServerRenderingBenchmarks.cs
+++ b/benchmarks/Assimalign.Viu.Testing.Benchmarks/CompiledServerRenderingBenchmarks.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+using Assimalign.Viu.ServerRenderer;
+
+namespace Assimalign.Viu.Testing.Benchmarks;
+
+/// <summary>
+/// Compares [V01.01.07.02]'s compiler-shaped direct-write server rendering with constructing and
+/// traversing the equivalent immutable virtual tree. The virtual-tree path is the baseline, so
+/// BenchmarkDotNet reports direct-write time and allocation ratios against the established runtime
+/// serializer. Both paths include the same request-local application and renderer setup.
+/// </summary>
+[MemoryDiagnoser]
+public class CompiledServerRenderingBenchmarks
+{
+    private static readonly ComponentFactory Components = new();
+    private static readonly VirtualNode CompiledPlaceholder = new TextNode(string.Empty);
+    private static readonly string[] ItemIdentifiers =
+    [
+        "1001",
+        "1002",
+        "1003",
+        "1004",
+        "1005",
+        "1006",
+        "1007",
+        "1008",
+    ];
+    private static readonly string[] ItemNames =
+    [
+        "Alpha & Beta",
+        "<Prototype>",
+        "Gamma",
+        "Delta",
+        "Epsilon",
+        "Zeta",
+        "Eta",
+        "Theta",
+    ];
+    private static readonly string[] ItemPrices =
+    [
+        "$12",
+        "$18",
+        "$21",
+        "$25",
+        "$29",
+        "$34",
+        "$38",
+        "$42",
+    ];
+
+    /// <summary>
+    /// Verifies before measurement that the compiler-shaped body and runtime serializer produce
+    /// byte-identical HTML, including escaping and attribute ordering.
+    /// </summary>
+    [GlobalSetup]
+    public void VerifyEquivalentOutput()
+    {
+        string virtualTreeOutput = VirtualTreeConstructionAndRenderingAsync()
+            .GetAwaiter()
+            .GetResult();
+        string compiledOutput = CompiledDirectWriteRenderingAsync()
+            .GetAwaiter()
+            .GetResult();
+
+        if (!string.Equals(virtualTreeOutput, compiledOutput, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "The compiled and virtual-tree server-render benchmark fixtures are not byte-equivalent.");
+        }
+    }
+
+    /// <summary>Constructs and serializes the representative catalog virtual tree.</summary>
+    /// <returns>The completed WHATWG HTML serialization.</returns>
+    [Benchmark(Baseline = true)]
+    public Task<string> VirtualTreeConstructionAndRenderingAsync()
+    {
+        VirtualNode root = CreateVirtualTree();
+        ServerRenderApplication application = new(root, Components);
+        return ServerRender.RenderToStringAsync(application);
+    }
+
+    /// <summary>Executes the representative compiler-shaped direct-write body.</summary>
+    /// <returns>The completed WHATWG HTML serialization.</returns>
+    [Benchmark]
+    public Task<string> CompiledDirectWriteRenderingAsync()
+    {
+        ServerRenderApplication application = new(CompiledPlaceholder, Components);
+        return ServerRender.RenderCompiledToStringAsync(application, RenderCompiledAsync);
+    }
+
+    private static VirtualNode CreateVirtualTree()
+    {
+        var itemNodes = new VirtualNode[ItemNames.Length];
+        for (int index = 0; index < itemNodes.Length; index++)
+        {
+            string itemClass = index == 0 ? "product featured" : "product";
+            itemNodes[index] = Element(
+                "li",
+                [
+                    ElementBinding.Attribute(new QualifiedName("class"), itemClass),
+                    ElementBinding.Attribute(
+                        new QualifiedName("data-item-id"),
+                        ItemIdentifiers[index]),
+                ],
+                [
+                    Element("span", children: [new TextNode(ItemNames[index])]),
+                    Element("strong", children: [new TextNode(ItemPrices[index])]),
+                ]);
+        }
+
+        return Element(
+            "main",
+            [
+                ElementBinding.Attribute(new QualifiedName("id"), "catalog"),
+                ElementBinding.Attribute(
+                    new QualifiedName("aria-label"),
+                    "Product & catalog"),
+            ],
+            [
+                Element(
+                    "header",
+                    children:
+                    [
+                        Element("h1", children: [new TextNode("Catalog <W5.2>")]),
+                        Element(
+                            "p",
+                            children:
+                            [
+                                new TextNode(
+                                    "Compiled direct writes versus virtual trees."),
+                            ]),
+                    ]),
+                Element(
+                    "ul",
+                    [ElementBinding.Attribute(new QualifiedName("class"), "products")],
+                    itemNodes),
+                Element("footer", children: [new TextNode("8 products")]),
+            ]);
+    }
+
+    private static Task RenderCompiledAsync(SsrRenderState state)
+    {
+        state.Push(
+            "<main id=\"catalog\" aria-label=\"Product &amp; catalog\"><header><h1>");
+        state.Push(ServerRender.EscapeHtml("Catalog <W5.2>"));
+        state.Push(
+            "</h1><p>Compiled direct writes versus virtual trees.</p></header>" +
+            "<ul class=\"products\">");
+
+        for (int index = 0; index < ItemNames.Length; index++)
+        {
+            state.Push(index == 0
+                ? "<li class=\"product featured\""
+                : "<li class=\"product\"");
+            state.Push(ServerRender.SsrRenderAttribute(
+                "data-item-id",
+                ItemIdentifiers[index]));
+            state.Push("><span>");
+            state.Push(ServerRender.EscapeHtml(ItemNames[index]));
+            state.Push("</span><strong>");
+            state.Push(ServerRender.EscapeHtml(ItemPrices[index]));
+            state.Push("</strong></li>");
+        }
+
+        state.Push("</ul><footer>8 products</footer></main>");
+        return Task.CompletedTask;
+    }
+
+    private static ElementNode Element(
+        string name,
+        IReadOnlyList<ElementBinding>? bindings = null,
+        IReadOnlyList<VirtualNode>? children = null) =>
+        new(new QualifiedName(name), bindings, children);
+}

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -9,8 +9,8 @@ strategy behind it.
 
 ## Where Viu stands
 
-The proof-of-concept stage is complete. On 2026-08-08 this checkout built with **0 warnings and
-0 errors**, and its 27 solution test assemblies passed **2,632 tests with 0 failures**. The tree now
+The proof-of-concept stage is complete. On 2026-08-09 this checkout built with **0 warnings and
+0 errors**, and its 27 solution test assemblies passed **2,717 tests with 0 failures**. The tree now
 contains the host-neutral Application Model and renderer, explicit reactivity, the authored
 component model and closed virtual-node algebra, compiler-informed block patching, keyed
 reconciliation, browser/server/testing hosts, routing and state conventions, the build-time
@@ -52,8 +52,8 @@ with no area wrapper folders. The following table is the exact shipping-library 
 | Components (`V01.01.15`) | `Assimalign.Viu.Components` | The closed `VirtualNode` algebra, compiler/runtime flags, authored-component model, contracts, bindings, and activation registrations | Reactivity |
 | State (`V01.01.09`) | `Assimalign.Viu.State` | State-management convention above the component model, attached through its public seams | Components, Reactivity |
 | Core (`V01.01.03`) | `Assimalign.Viu.Core` | The Application Model: composition root, lifetime and middleware, renderer/scheduler engine, mounted bookkeeping, and public operations; its root namespace is `Assimalign.Viu` | Components, Reactivity, State |
-| Browser (`V01.01.04`) | `Assimalign.Viu.Browser` | Browser host: batched DOM interop, bindings, events, directives, transitions, and application bootstrap | Components, Core, Reactivity |
-| Server rendering (`V01.01.07`) | `Assimalign.Viu.ServerRenderer` | One-shot WHATWG HTML serialization host and hydration-marker protocol | Components, Core |
+| Browser (`V01.01.04`) | `Assimalign.Viu.Browser` | Browser host: batched DOM interop, bindings, events, directives, transitions, state restore, lazy-hydration triggers, and application bootstrap | Components, Core, Reactivity, State |
+| Server rendering (`V01.01.07`) | `Assimalign.Viu.ServerRenderer` | WHATWG HTML serialization, direct compiled markup, hydration markers, state islands, and host-neutral request adaptation | Components, Core, State |
 | Testing (`V01.01.11`) | `Assimalign.Viu.Testing` | DOM-free in-memory host and component test surface over the production renderer | Components, Core |
 | Router (`V01.01.08`) | `Assimalign.Viu.Router` | Host-free navigation convention: matching, history, route components, and guard pipeline | Components, Reactivity |
 | Browser router (`V01.01.08`) | `Assimalign.Viu.Browser.Router` | Leaf integration between Browser click dispatch and Router navigation | Core, Router, Browser |
@@ -169,8 +169,8 @@ Work is tracked exactly like the sibling Cohesion repo:
 | **W01** | Rendering, reactivity, browser-host, testing, solution, and CI foundations are delivered; every planned feature row is closed | No planned feature row remains |
 | **W02** | The component/application foundation, watch/reactive collections, keyed reconciliation, browser bootstrap, and test utilities are delivered; every planned feature row is closed | No planned feature row remains |
 | **W03** | The primary compiler, single-file-component, block-patching, directive, and interop-batching paths are delivered | Complete deferred compiler optimizations and diagnostic source attribution, then restore publish-size, trimming, and startup budget enforcement; startup timing still depends on the browser harness |
-| **W04** | Router, State, built-ins, CSS compilation/modules, samples, and the getting-started path are delivered at their main feature boundaries | Close built-in edge cases, generated State/source-map work, hosted and multi-bundle CSS delivery, and the deferred scoped-CSS runtime |
-| **W05** | Host-neutral component-library and Browser SDK/framework segments, browser packaging, hydration foundations, editor hot-reload metadata, and a working `dotnet watch` CSS/component path exist | Finish server compiler/hosting and state hydration, lazy routing, runtime inspection, the browser harness, templates and the productized development loop, release automation, payload accounting, compatibility/conformance gates, and Cohesion hosting integration |
+| **W04** | Router, State, built-ins, CSS compilation/modules, samples, and the getting-started path are delivered at their main feature boundaries; generated trees and compiled SSR now share static scoped-style attributes | Close built-in edge cases, generated State/source-map work, hosted and multi-bundle CSS delivery, and the deferred reactive scoped-CSS runtime |
+| **W05** | Host-neutral component-library and Browser SDK/framework segments, browser packaging, hydration foundations plus lazy activation, direct server compiler output, host-neutral SSR adaptation, SSR state round-tripping, editor hot-reload metadata, and a working `dotnet watch` CSS/component path exist | Finish lazy routing, runtime inspection, the browser harness, templates and the productized development loop, release automation, payload accounting, compatibility/conformance gates, Cohesion hosting integration, and automatic server-profile selection once a server SDK topology exists |
 | **W06** | Utility composition and semantic `@script` language-server work have begun | Deliver complete Suspense, custom elements, static prerendering, persistent State extensions, the DevTools timeline/user interface, remaining editor support, generated API reference, and the documentation site |
 
 This snapshot reconciles the plan with live issue state on 2026-08-09. Newly tracked follow-ups for
@@ -313,6 +313,7 @@ completed P0–P6 sequence, and verification record remain in
 | `V01.01.07.01` | Implement the SSR string renderer and helper library | W05 | P004 |
 | `V01.01.07.02` | Implement SSR compiler transforms for string-concatenation codegen | W05 | P005 |
 | `V01.01.07.03` | Implement the hydration walker | W05 | P004 |
+| `V01.01.07.03.01` | Implement lazy hydration strategies for idle, visibility, media, and interaction triggers | W05 | P005 |
 | `V01.01.07.04` | Implement the host-agnostic server adaptor for SSR hosting | W05 | P005 |
 | `V01.01.07.05` | Implement static prerendering (SSG) | W06 | P006 |
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -125,15 +125,21 @@ Every later section depends on this one.
 
 ### 3.1 Threading
 
-`[EXE-1]` The Viu runtime targets **a single event loop and is not thread-safe**. Ambient `static`
-state — the scheduler's queues, the reactivity engine's tracking and batching stack — is a
-deliberate consequence of that model, not an oversight.
+`[EXE-1]` Each Viu application graph targets **one event loop and is not thread-safe**. Browser
+applications use one shared ambient execution state. A request-oriented host that runs independent
+graphs concurrently MUST enter a fresh logical execution flow for Core's current component and
+scheduler queues, Reactivity's tracking/batching/scope state, and State's setup/active-registry
+state. ServerRenderer establishes that boundary for every runtime-tree and compiled render. Values,
+scopes, registries, or scheduler jobs MUST NOT be shared across concurrent flows.
 
 `[EXE-2]` Every non-thread-safe public type MUST say so in its XML documentation.
 
-`[EXE-3]` A host MAY dispatch the scheduler's flush through a `SynchronizationContext`. When none is
-installed the flush falls back to the thread pool; on single-threaded browser WebAssembly that still
-lands on the main thread through the JavaScript event loop.
+`[EXE-3]` A host MAY dispatch the current logical flow's scheduler flush through a
+`SynchronizationContext`. When none is installed the flush falls back to the thread pool and carries
+that flow's execution context. A per-flow scheduler gate serializes the fallback continuation with a
+synchronous renderer flush; this prevents Viu from racing its own queues and does not authorize a
+caller to mutate one graph from several threads. On single-threaded browser WebAssembly dispatch
+still lands on the main thread through the JavaScript event loop.
 
 ### 3.2 AOT and trimming
 
@@ -907,12 +913,14 @@ exception is rethrown to the host.
 `[RND-HOST-1]` `RendererOptions<TNode>` is the complete host contract. Required operations:
 `Insert`, `Remove`, `CreateElement`, `CreateText`, `CreateComment`, `SetText`, `ParentNode`,
 `NextSibling`, `PatchAttribute`. Optional operations: `ResolveTeleportTarget`, `Commit`,
-`InsertStaticContent`, `CreateHydrationReader`. Style-scope stamping is absent while [STY-1] is
-Deferred; reintroduction is additive.
+`InsertStaticContent`, `CreateHydrationReader`, `ScheduleHydrationTrigger`. A generated static
+style-scope identifier is an ordinary element attribute under [STY-1]; no separate host stamping
+operation exists.
 
 `[RND-HOST-2]` A capability whose operation is absent is **unavailable, not degraded**. Rendering an
-`StaticNode` requires `InsertStaticContent`; hydration requires `CreateHydrationReader` and
-throws `NotSupportedException` without it.
+`StaticNode` requires `InsertStaticContent`; hydration requires `CreateHydrationReader`; and a
+non-immediate hydration strategy requires `ScheduleHydrationTrigger`. Each throws
+`NotSupportedException` when its capability is absent.
 
 `[RND-HOST-3]` **Core contains no host handles and no interop.** A host that uses a value-type
 handle reserves its default value for "no node". `Assimalign.Viu.Browser` is one adapter
@@ -1380,13 +1388,14 @@ compatibility", "Generator compatibility contract"; `docs/UTILITY-CSS-DESIGN.md`
 
 ### 10.1 Scoped CSS
 
-`[STY-1]` **Deferred under `[V01.01.06.12]`.** The `[V01.01.15]` arc is complete, but runtime
-style-scope identifiers remain parked. The adopted `ComponentContract`, `ComponentContext`,
-`VirtualNode` algebra, host contract, server serializer, and generated registration carry no
-style-scope state or stamping operation.
-Reintroduction is additive: it MAY add one contract/context value plus compiler, serializer, and host
-emission without changing the four-lifetime model. Until that work lands, this clause imposes no
-runtime scope-identifier requirement.
+`[STY-1]` A single-file component with a scoped style computes one stable
+`data-v-<path-derived-hash>` identifier. The template transform emits that identifier as an ordinary
+empty attribute binding on **every native element** in the interactive virtual-node tree, and the
+`ServerMarkup` profile writes the same attribute directly [SSR-COMPILE-3]. This static compiler
+stamping requires no `ComponentContract`, `ComponentContext`, `VirtualNode`, renderer-host, or
+server-serializer scope field. Hand-authored trees receive no implicit identifier. Runtime root
+restamping and reactive style-variable application remain deferred under `[V01.01.06.12]` and
+[STY-6].
 
 ### 10.2 CSS Modules
 
@@ -1460,7 +1469,9 @@ boundary:
 
 `[SSR-1]` `ServerRenderer.RenderToStringAsync` renders a configured `ServerRenderApplication` to a string;
 `RenderToStreamAsync` writes **completed component subtrees** to a `TextWriter` and awaits the
-writer's `FlushAsync`, so the destination controls backpressure.
+writer's `FlushAsync`. The host adaptor exposes the same write/flush boundary as
+`IServerRenderOutput`, so a `PipeWriter`, response body, or other host destination controls its own
+buffering and backpressure without entering ServerRenderer's dependency graph.
 
 `[SSR-2]` `ServerRenderApplication` is a plain per-render composition object carrying an immutable
 `IApplicationContext` **without a host node type**. It does not implement `IApplication`, owns no
@@ -1488,8 +1499,33 @@ style; renders boolean attributes by presence; preserves SVG and custom-element 
 an unsafe dynamic attribute name rather than attempting to escape it. `innerHTML` is the explicit
 raw-HTML path; `textContent` and a textarea's `value` are escaped and suppress child serialization.
 
-`[SSR-7]` `SsrContext` carries per-render teleport output and a free-form state handoff bag. Enabled
-teleport children belong to another target and are **buffered** until the render resolves.
+`[SSR-7]` `SsrContext` carries per-render teleport output and an optional, versioned
+`StateStorePayload`. Enabled teleport children belong to another target and are **buffered** until
+the render resolves. After traversal, a payload-capable application state registry captures only
+materialized stores into `{"version":1,"stores":{"key":state}}`; ServerRenderer stores that payload
+on the context and appends one inert `<script type="application/json" data-viu-state>` island. The
+island contains normalized JSON with HTML-sensitive characters escaped and never executable script.
+
+`[SSR-COMPILE-1]` `RenderFunctionTargetProfile.ServerMarkup` is the explicit build-time SSR target
+on the public Templates compiler facade. It accepts only a transform produced with
+`TransformOptions.IsServerRendering`; the default profile remains `VirtualNodeTree`, so selecting
+SSR cannot alter Browser code generation.
+
+`[SSR-COMPILE-2]` The server-markup profile coalesces provably serializable native markup into
+ordered `SsrRenderState.Push` calls and uses public ServerRenderer helpers for dynamic values. A
+static structure with interpolations allocates **zero `VirtualNode` instances**. Components and
+unsupported subtrees use a subtree-local virtual-node fallback and rejoin the same render state.
+
+`[SSR-COMPILE-3]` Direct output obeys [SSR-6]: interpolation and attributes escape identically;
+class and style use the shared normalizers; model directives emit `value`, `checked`, or `selected`;
+show directives append `display:none`; and every native element receives the transformed scope
+identifier. Suspense renders its default content, Transition is a markup pass-through, and Teleport
+uses the ordinary context target buffer and unchanged marker protocol.
+
+`[SSR-COMPILE-4]` `CompiledServerRender` and `ServerRender.RenderCompiledTo{String,Stream}Async`
+create renderer-owned request state, preserve cancellation, component-fallback flushes, teleports,
+state capture, and the final flush. Executed differential fixtures MUST byte-match the runtime-tree
+serializer, including escaping, normalization, fallback regions, and hydration markers.
 
 ### 11.2 The hydration marker protocol
 
@@ -1505,6 +1541,7 @@ to the hydration protocol.
 | Void element | `<tag attributes>` |
 | Fragment | `<!--[-->children<!--]-->` |
 | Component | the rendered subtree, with no wrapper |
+| Deferred component | `<!--lazy hydration idle\|visible\|media query\|interaction-->` + rendered subtree + `<!--lazy hydration end-->` |
 | Enabled teleport | `<!--teleport start--><!--teleport end-->` |
 | Disabled teleport | `<!--teleport start-->children<!--teleport end-->` |
 
@@ -1547,6 +1584,43 @@ already carries the trailing `<!--teleport anchor-->` the walker requires.
 
 `[HYD-7]` **Limit.** Suspense hydration throws [BLT-12].
 
+`[HYD-8]` A hydrating Browser application with composed state initializes the bridge, consumes and
+removes the single `script[data-viu-state]` island, validates schema version 1, and restores the
+payload-capable registry **before mount-target resolution, component setup, or first render**.
+Removing the island before the hydration snapshot keeps an island placed inside the mount container
+from becoming an extra root sibling. A missing island or incompatible registry fails before
+rendering rather than silently hydrating from default state.
+
+`[HYD-LAZY-1]` `ComponentInvocation.HydrationStrategy` is immutable invocation metadata. Immediate
+is the default. Idle, visible, media-query, and interaction strategies carry only host-neutral data;
+an asynchronous component definition may supply a default that an explicit invocation overrides.
+
+`[HYD-LAZY-2]` ServerRenderer surrounds a deferred component with the fixed markers in
+[SSR-MARKERS-1]. During the initial walk Core validates and adopts that complete marker-bounded
+range as opaque markup: host nodes retain identity, while component activation, setup, rendering,
+effects, and descendant lazy-boundary discovery remain deferred. Nested boundaries therefore
+register only after their deferred parent activates; an eager parent discovers its lazy child during
+the ordinary walk. An asynchronous definition owns exactly one outer boundary: its resolved target
+does not inherit the strategy, and Core waits for either target readiness or the wrapper's terminal
+error presentation before walking the adopted subtree.
+
+`[HYD-LAZY-3]` Core requests a trigger through `ScheduleHydrationTrigger` and schedules activation
+as a post-flush job. The host delivers a trigger asynchronously after registration, and each trigger
+activates at most once. Patching retains the latest dormant invocation, a change to Immediate
+activates, and any strategy-data change replaces the registration. Unmount or navigation before
+activation cancels the job and disposes every observer/listener.
+
+`[HYD-LAZY-4]` Browser maps idle to `requestIdleCallback` with a timer fallback, visible to
+`IntersectionObserver` over every top-level element in the marker range, media-query to `matchMedia`,
+and interaction to capture listeners scoped to the marker range. Testing supplies
+`TestHydrationTriggers`, whose explicit trigger methods enter the same Core post-flush path without a
+DOM or clock.
+
+`[HYD-LAZY-5]` **Interaction decision.** Browser captures only the first configured interaction
+inside a dormant boundary, prevents its premature delivery, and replays an equivalent event after
+Core activates and schedules the host commit. Cancellation before activation drops the captured
+event. Later interactions use the ordinary mounted listeners.
+
 ### 11.4 The hosting boundary
 
 `[SSR-8]` **No `Assimalign.Viu.*` library may reference a web framework.** Hosting is a downstream
@@ -1554,8 +1628,12 @@ adapter over a host-agnostic contract. ServerRenderer references Components and 
 has no DOM, Browser, WebView2, or JavaScript-interop dependency.
 
 `[SSR-9]` A server host SHOULD create **one server-render application per request** when services or
-state are request-scoped. The supplied factory, service provider, and state registry are borrowed
-and are never disposed by ServerRenderer [CMP-9], [APP-6].
+state are request-scoped. `ServerRenderAdaptor<TContext>` requires a structurally new
+`ServerRenderApplication` and `SsrContext` identity for every request and rejects reuse. Its factory,
+service provider, component factory, and state registry are borrowed and are never disposed by
+ServerRenderer [CMP-9], [APP-6]; the adaptor always disposes the request scope. Both identities are
+consumed before root validation because a rejected scope is still disposed and cannot safely
+reappear. Each render enters the independent logical execution state required by [EXE-1].
 
 `[SSR-10]` `ComponentHost.RenderAsync(ComponentRenderRequest, CancellationToken = default)` returns an
 `IComponentRenderScope` exposing exactly `VirtualNode? Tree` and `ComponentContext Context`.
@@ -1563,6 +1641,15 @@ The operation resolves and activates one registration, runs setup inside the com
 server prefetch, and invokes the renderer once. `DisposeAsync` aborts and releases the lease without
 client mount, update, or unmount hooks. A nested `ComponentRenderRequest` carries the active parent
 scope; Core uses that scope's still-valid `Context` as the nested component's parent.
+
+`[SSR-11]` `ServerRenderAdaptor<TContext>` creates exactly one typed request scope, validates that
+its application root is the request root, streams through `IServerRenderOutput`, awaits every flush,
+and disposes the scope on success, render/output failure, cancellation, and partial response. It has
+no HTTP status, header, route, or framework policy.
+
+`[SSR-12]` Ordinary adaptor failures return `ServerRenderResult` with the failure and whether output
+had started, allowing the downstream host to choose its response policy. Request cancellation
+propagates as `OperationCanceledException`; it is never converted into an ordinary failure result.
 
 *Authority: `libraries/Assimalign.Viu.ServerRenderer/docs/{OVERVIEW,DESIGN}.md`;
 `libraries/Assimalign.Viu.Core/src/Rendering/{Renderer.Hydration.cs,HydrationNodeReader{TNode}.cs,HydrationNodeKind.cs}`;
@@ -1680,6 +1767,14 @@ remains a single notification because it wraps its writes in a batch.
 `[STA-8]` Actions are observable **only** when their implementation uses the protected action
 helper — there is no interception layer [RCT-6]. Asynchronous helpers await the task before running
 the after-hook, so it receives the resolved value; faults run error hooks and then propagate.
+
+`[STA-9]` SSR persistence is explicit and reflection-free. A serializable definition registers an
+`IStateStoreSerializer<TStore>` (the supplied JSON implementation requires `JsonTypeInfo<TState>`).
+Capture includes only stores materialized in that registry and fails actionably when one lacks a
+serializer. Restore applies immediately to an existing store or stages state until its first
+`GetOrCreate`; either path applies before the caller observes the store. Keys are non-empty,
+request-local, ordinal strings, schema version 1 is strict, and normalized JSON is safe for the inert
+state island [SSR-7], [EXE-4].
 
 *Authority: `libraries/Assimalign.Viu.State/{src,docs/{OVERVIEW,DESIGN}.md}`;
 `docs/COMPONENT-MODEL-PLAN.md` §2a.*

--- a/libraries/Assimalign.Viu.Browser/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Browser/docs/DESIGN.md
@@ -48,6 +48,22 @@ Browser snapshots the live DOM once and exposes it through Core's generic hydrat
 owns tree matching and mismatch recovery; Browser owns node classification, property reads, and
 foreign-handle registration (`[HYD-1]`, `[HYD-2]`).
 
+Deferred component ranges use the optional host trigger operation. Idle registrations use
+`requestIdleCallback` when available and a cancelable timer otherwise; visibility observes every
+top-level element between the markers; media registrations subscribe through `matchMedia`; and
+interaction registrations capture the first configured event within the range. The JavaScript side
+delivers every trigger asynchronously after registration, disconnects observers and listeners on
+fire or cancellation, and replays a cloned interaction only after Core reports activation complete
+(`[HYD-LAZY-3]` through `[HYD-LAZY-5]`).
+
+When hydration has application state, Browser performs one `textContent` interop operation that
+consumes and removes `script[data-viu-state]` after the bridge is ready and before mount-target
+resolution. It parses the versioned State payload without reflection and restores the composed
+registry before component setup. Removal occurs before Core snapshots the mount container, so the
+transport cannot appear as an extra root sibling. A missing island or a registry without
+`IStateStorePayloadRegistry` fails startup before the first render, preventing a default-state
+hydration mismatch ([HYD-8], [V01.01.09.03], [EXE-4]).
+
 Browser directives are registered through the application's public directive resolver. The model
 directives, `VShow`, and transition operations use host elements and browser events without adding
 members to `ComponentContext`. Transition nodes remain host-neutral descriptions; Browser supplies
@@ -65,5 +81,6 @@ serialization, runtime member discovery, emitted code, or dynamically generated 
 
 Browser does not own the virtual-node vocabulary, mounted diff engine, component activation,
 application composition dependencies, routing, server serialization, or scoped-CSS rewriting.
-Routing joins through Browser.Router. Scoped style compilation and host stamping remain deferred
-with the scoped-CSS work (`[STY-1]`, `[STY-6]`).
+Routing joins through Browser.Router. Generated scope identifiers arrive as ordinary attributes;
+host-driven scope stamping and reactive style-variable application remain absent (`[STY-1]`,
+`[STY-6]`).

--- a/libraries/Assimalign.Viu.Browser/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Browser/docs/OVERVIEW.md
@@ -19,3 +19,20 @@ full-page hot-reload signaling. Browser directives are available through the def
 directive resolver, and CSS transitions consume the public transition-node contract. Top-level
 startup is asynchronous; lower-level mount APIs deliberately bypass lifetime middleware as specified
 by `[APP-1]`, `[APP-2]`, `[APP-6]`, and `[APP-7]`.
+
+Scoped-style identifiers need no Browser-specific path: compiled virtual trees carry the stable
+`data-v-*` value as an ordinary attribute, so the same buffered binding operation used for authored
+attributes applies it (`[STY-1]`).
+
+For a hydrating application with a composed state registry, Browser consumes and removes the single
+`script[data-viu-state]` JSON island after bridge initialization and calls the registry's explicit
+payload restore contract before resolving the mount target. Removal also keeps an island placed in
+the mount container out of Core's hydration snapshot. Stores resolved earlier update immediately;
+stores resolved during component setup receive their server state before first render
+([HYD-8], [V01.01.09.03], [EXE-4]).
+
+Browser also implements Core's deferred-hydration trigger seam. It maps idle requests to
+`requestIdleCallback` with a timer fallback, visibility to `IntersectionObserver`, media conditions
+to `matchMedia`, and interactions to marker-range capture listeners. Every registration is
+cancelable; the first captured interaction is replayed asynchronously only after activation and the
+scheduled host commit (`[HYD-LAZY-3]` through `[HYD-LAZY-5]`).

--- a/libraries/Assimalign.Viu.Browser/src/Assimalign.Viu.Browser.csproj
+++ b/libraries/Assimalign.Viu.Browser/src/Assimalign.Viu.Browser.csproj
@@ -9,5 +9,6 @@
     <ViuProjectReference Include="Assimalign.Viu.Components" />
     <ViuProjectReference Include="Assimalign.Viu.Core" />
     <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
+    <ViuProjectReference Include="Assimalign.Viu.State" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Viu.Browser/src/BrowserApplication.cs
+++ b/libraries/Assimalign.Viu.Browser/src/BrowserApplication.cs
@@ -278,6 +278,11 @@ public sealed class BrowserApplication : IApplication
             context,
             operations,
             hydrate,
+            initialize: hydrate && context.State is { } state
+                ? cancellationToken => BrowserStateHydration.InitializeAsync(
+                    state,
+                    cancellationToken)
+                : null,
             mountTargetSelector: mountTargetSelector);
     }
 

--- a/libraries/Assimalign.Viu.Browser/src/BrowserRendererHost.cs
+++ b/libraries/Assimalign.Viu.Browser/src/BrowserRendererHost.cs
@@ -41,6 +41,39 @@ public sealed class BrowserRendererHost
         Func<int, int>? parentNode = null,
         Func<int, int>? nextSibling = null,
         Func<int, string>? snapshotHydration = null)
+        : this(
+            applyCommandFrame,
+            parentNode,
+            nextSibling,
+            snapshotHydration,
+            scheduleHydrationTrigger: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a DOM-less buffered host with explicit hydration snapshot and trigger seams.
+    /// </summary>
+    /// <param name="applyCommandFrame">
+    /// The operation that applies one complete frame and reports released handles.
+    /// </param>
+    /// <param name="parentNode">The nullable forced-flush parent read.</param>
+    /// <param name="nextSibling">The nullable forced-flush next-sibling read.</param>
+    /// <param name="snapshotHydration">The nullable serialized hydration snapshot operation.</param>
+    /// <param name="scheduleHydrationTrigger">
+    /// The nullable host-neutral deferred-hydration trigger seam.
+    /// </param>
+    /// <remarks>
+    /// Trigger delivery and interaction replay must be asynchronous, and disposing the returned
+    /// registration must release all host observers and listeners. Specified by
+    /// <c>[HYD-LAZY-3]</c> through <c>[HYD-LAZY-5]</c>.
+    /// </remarks>
+    public BrowserRendererHost(
+        BrowserCommandFrameApplier applyCommandFrame,
+        Func<int, int>? parentNode,
+        Func<int, int>? nextSibling,
+        Func<int, string>? snapshotHydration,
+        Func<HydrationTriggerRequest<int>, IHydrationTriggerRegistration>?
+            scheduleHydrationTrigger)
     {
         ArgumentNullException.ThrowIfNull(applyCommandFrame);
         _operations = new BufferedBrowserNodeOperations(
@@ -49,7 +82,8 @@ public sealed class BrowserRendererHost
             parentNode ?? (static _ => 0),
             nextSibling ?? (static _ => 0),
             insertStaticContent: null,
-            snapshotHydration);
+            snapshotHydration,
+            scheduleHydrationTrigger);
         Options = _operations.Create();
     }
 

--- a/libraries/Assimalign.Viu.Browser/src/Internal/BrowserDomBridge.cs
+++ b/libraries/Assimalign.Viu.Browser/src/Internal/BrowserDomBridge.cs
@@ -33,6 +33,18 @@ internal static partial class BrowserDomBridge
         }
     }
 
+    internal static string ConsumeTextContent(string selector)
+    {
+        try
+        {
+            return Imports.ConsumeTextContent(selector);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("consumeTextContent", 0, exception);
+        }
+    }
+
     internal static int CreateElement(string tagName, string? namespaceName)
     {
         try
@@ -150,6 +162,56 @@ internal static partial class BrowserDomBridge
         catch (JSException exception)
         {
             throw Translate("snapshotHydration", containerHandle, exception);
+        }
+    }
+
+    internal static int ScheduleHydrationTrigger(
+        int startHandle,
+        int endHandle,
+        int strategyKind,
+        int timeoutMilliseconds,
+        string? condition,
+        string[] eventNames,
+        Action trigger)
+    {
+        try
+        {
+            return Imports.ScheduleHydrationTrigger(
+                startHandle,
+                endHandle,
+                strategyKind,
+                timeoutMilliseconds,
+                condition,
+                eventNames,
+                trigger);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("scheduleHydrationTrigger", startHandle, exception);
+        }
+    }
+
+    internal static void CompleteHydrationTrigger(int token)
+    {
+        try
+        {
+            Imports.CompleteHydrationTrigger(token);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("completeHydrationTrigger", token, exception);
+        }
+    }
+
+    internal static void CancelHydrationTrigger(int token)
+    {
+        try
+        {
+            Imports.CancelHydrationTrigger(token);
+        }
+        catch (JSException exception)
+        {
+            throw Translate("cancelHydrationTrigger", token, exception);
         }
     }
 
@@ -529,6 +591,9 @@ internal static partial class BrowserDomBridge
         [JSImport("dom.querySelector", ModuleName)]
         internal static partial int QuerySelector(string selector);
 
+        [JSImport("dom.consumeTextContent", ModuleName)]
+        internal static partial string ConsumeTextContent(string selector);
+
         [JSImport("dom.createElement", ModuleName)]
         internal static partial int CreateElement(string tagName, string? namespaceName);
 
@@ -558,6 +623,22 @@ internal static partial class BrowserDomBridge
 
         [JSImport("dom.snapshotHydration", ModuleName)]
         internal static partial string SnapshotHydration(int containerHandle);
+
+        [JSImport("dom.scheduleHydrationTrigger", ModuleName)]
+        internal static partial int ScheduleHydrationTrigger(
+            int startHandle,
+            int endHandle,
+            int strategyKind,
+            int timeoutMilliseconds,
+            string? condition,
+            [JSMarshalAs<JSType.Array<JSType.String>>] string[] eventNames,
+            [JSMarshalAs<JSType.Function>] Action trigger);
+
+        [JSImport("dom.completeHydrationTrigger", ModuleName)]
+        internal static partial void CompleteHydrationTrigger(int token);
+
+        [JSImport("dom.cancelHydrationTrigger", ModuleName)]
+        internal static partial void CancelHydrationTrigger(int token);
 
         [JSImport("dom.insertStaticContent", ModuleName)]
         internal static partial int[] InsertStaticContent(string content, int parentHandle, int anchorHandle, string? namespaceName);

--- a/libraries/Assimalign.Viu.Browser/src/Internal/BrowserLazyHydrationTriggerRegistration.cs
+++ b/libraries/Assimalign.Viu.Browser/src/Internal/BrowserLazyHydrationTriggerRegistration.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu.Browser;
+
+/// <summary>Owns one Browser observer or event-listener registration for deferred hydration.</summary>
+/// <remarks>
+/// The registration is confined to the single-threaded Browser event loop. Completion replays a
+/// captured interaction only after Core has activated the boundary; disposal drops it and releases
+/// every JavaScript observer or listener. Specified by <c>[HYD-LAZY-3]</c> through
+/// <c>[HYD-LAZY-5]</c>.
+/// </remarks>
+[SupportedOSPlatform("browser")]
+internal sealed class BrowserLazyHydrationTriggerRegistration :
+    IHydrationTriggerRegistration
+{
+    private int _token;
+
+    private BrowserLazyHydrationTriggerRegistration(
+        HydrationTriggerRequest<int> request)
+    {
+        HydrationStrategy strategy = request.Strategy;
+        string? condition = strategy.Kind switch
+        {
+            HydrationStrategyKind.Visible => strategy.VisibilityRootMargin,
+            HydrationStrategyKind.MediaQuery => strategy.MediaQuery,
+            _ => null,
+        };
+        IReadOnlyList<string> interactionEvents = strategy.InteractionEvents;
+        string[] eventNames = new string[interactionEvents.Count];
+        for (int index = 0; index < interactionEvents.Count; index++)
+        {
+            eventNames[index] = interactionEvents[index];
+        }
+
+        _token = BrowserDomBridge.ScheduleHydrationTrigger(
+            request.StartAnchor,
+            request.EndAnchor,
+            (int)strategy.Kind,
+            strategy.IdleTimeoutMilliseconds ?? -1,
+            condition,
+            eventNames,
+            request.Trigger);
+    }
+
+    /// <summary>Registers the host trigger represented by <paramref name="request"/>.</summary>
+    /// <param name="request">The marker-bounded Core trigger request.</param>
+    /// <returns>The owned trigger registration.</returns>
+    internal static IHydrationTriggerRegistration Schedule(
+        HydrationTriggerRequest<int> request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new BrowserLazyHydrationTriggerRegistration(request);
+    }
+
+    /// <inheritdoc />
+    public void Complete()
+    {
+        int token = TakeToken();
+        if (token != 0)
+        {
+            BrowserDomBridge.CompleteHydrationTrigger(token);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        int token = TakeToken();
+        if (token != 0)
+        {
+            BrowserDomBridge.CancelHydrationTrigger(token);
+        }
+    }
+
+    private int TakeToken()
+    {
+        int token = _token;
+        _token = 0;
+        return token;
+    }
+}

--- a/libraries/Assimalign.Viu.Browser/src/Internal/BrowserStateHydration.cs
+++ b/libraries/Assimalign.Viu.Browser/src/Internal/BrowserStateHydration.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu.Browser;
+
+/// <summary>
+/// Restores the application-composed state registry from the server JSON island after bridge
+/// initialization and before the first component setup or render.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static class BrowserStateHydration
+{
+    internal const string StateIslandSelector = "script[data-viu-state]";
+
+    internal static async Task InitializeAsync(
+        IStateStoreRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        await BrowserRuntime.EnsureBridgeAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        RestorePayload(registry, BrowserDomBridge.ConsumeTextContent);
+    }
+
+    internal static void RestorePayload(
+        IStateStoreRegistry registry,
+        Func<string, string> consumeTextContent)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(consumeTextContent);
+        if (registry is not IStateStorePayloadRegistry payloadRegistry)
+        {
+            throw new InvalidOperationException(
+                "A hydrating Browser application configured a state registry that does not "
+                + "implement IStateStorePayloadRegistry. Use StateStoreRegistry or provide an "
+                + "explicit AOT-safe payload registry implementation.");
+        }
+
+        string json = consumeTextContent(StateIslandSelector);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new InvalidOperationException(
+                $"A hydrating Browser application with composed state requires the server state "
+                + $"island selected by \"{StateIslandSelector}\" before mount.");
+        }
+
+        payloadRegistry.RestorePayload(StateStorePayload.Parse(json));
+    }
+}

--- a/libraries/Assimalign.Viu.Browser/src/Internal/BufferedBrowserNodeOperations.cs
+++ b/libraries/Assimalign.Viu.Browser/src/Internal/BufferedBrowserNodeOperations.cs
@@ -54,6 +54,8 @@ internal sealed class BufferedBrowserNodeOperations
     private readonly Func<int, int> _nextSibling;
     private readonly Func<string, int, int, string?, (int First, int Last)>? _insertStaticContent;
     private readonly Func<int, string>? _snapshotHydration;
+    private readonly Func<HydrationTriggerRequest<int>, IHydrationTriggerRegistration>?
+        _scheduleHydrationTrigger;
 
     private BrowserEventInvokerRegistry? _previousInvokerRegistry;
     private BrowserDirectiveOperations? _previousDirectiveOperations;
@@ -67,7 +69,9 @@ internal sealed class BufferedBrowserNodeOperations
         Func<int, int> parentNode,
         Func<int, int> nextSibling,
         Func<string, int, int, string?, (int First, int Last)>? insertStaticContent,
-        Func<int, string>? snapshotHydration = null)
+        Func<int, string>? snapshotHydration = null,
+        Func<HydrationTriggerRequest<int>, IHydrationTriggerRegistration>?
+            scheduleHydrationTrigger = null)
     {
         _applier = applier;
         _querySelector = querySelector;
@@ -75,6 +79,7 @@ internal sealed class BufferedBrowserNodeOperations
         _nextSibling = nextSibling;
         _insertStaticContent = insertStaticContent;
         _snapshotHydration = snapshotHydration;
+        _scheduleHydrationTrigger = scheduleHydrationTrigger;
         _invokers = new BrowserEventInvokerRegistry(
             (handle, eventName, once, capture, passive) => _buffer.WriteAddEventListener(handle, eventName, once, capture, passive),
             (handle, eventName, capture) => _buffer.WriteRemoveEventListener(handle, eventName, capture));
@@ -154,6 +159,7 @@ internal sealed class BufferedBrowserNodeOperations
         CreateHydrationReader = _snapshotHydration is null
             ? null
             : CreateHydrationReader,
+        ScheduleHydrationTrigger = _scheduleHydrationTrigger,
     };
 
     /// <summary>
@@ -357,7 +363,8 @@ internal sealed class BufferedBrowserNodeOperations
                 var span = BrowserDomBridge.InsertStaticContent(content, parent, anchor, elementNamespace);
                 return (span[0], span[1]);
             },
-            static container => BrowserDomBridge.SnapshotHydration(container));
+            static container => BrowserDomBridge.SnapshotHydration(container),
+            BrowserLazyHydrationTriggerRegistration.Schedule);
         return operations;
     }
 

--- a/libraries/Assimalign.Viu.Browser/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Browser/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Assimalign.Viu.Browser.BrowserRendererHost.BrowserRendererHost(Assimalign.Viu.Browser.BrowserCommandFrameApplier! applyCommandFrame, System.Func<int, int>? parentNode, System.Func<int, int>? nextSibling, System.Func<int, string!>? snapshotHydration, System.Func<Assimalign.Viu.HydrationTriggerRequest<int>!, Assimalign.Viu.IHydrationTriggerRegistration!>? scheduleHydrationTrigger) -> void
 *REMOVED*Assimalign.Viu.Browser.ViuModelBinding
 *REMOVED*Assimalign.Viu.Browser.ViuModelBinding.Modifiers.get -> System.Collections.Generic.IReadOnlyList<string!>!
 *REMOVED*Assimalign.Viu.Browser.ViuModelBinding.Setter.get -> System.Action<object?>!

--- a/libraries/Assimalign.Viu.Browser/src/wwwroot/viu-dom.js
+++ b/libraries/Assimalign.Viu.Browser/src/wwwroot/viu-dom.js
@@ -245,6 +245,80 @@ function getTransitionInfo(el, expectedType) {
     return { type, timeout, propCount, hasTransform }
 }
 
+// Deferred hydration registrations ([V01.01.07.03.01]): Core supplies marker handles and immutable
+// strategy data. Browser owns observers/listeners and releases them on activation or cancellation.
+// The numeric kinds are the stable HydrationStrategyKind values emitted by managed code.
+const HYDRATE_ON_IDLE = 1
+const HYDRATE_ON_VISIBLE = 2
+const HYDRATE_ON_MEDIA_QUERY = 3
+const HYDRATE_ON_INTERACTION = 4
+let nextHydrationTriggerToken = 1
+const hydrationTriggers = new Map()
+
+function enqueueMicrotask(callback) {
+    if (typeof globalThis.queueMicrotask === 'function') {
+        globalThis.queueMicrotask(callback)
+    } else {
+        Promise.resolve().then(callback)
+    }
+}
+
+function boundaryContainsTarget(start, end, target) {
+    let current = start.nextSibling
+    while (current && current !== end) {
+        if (current === target ||
+            (current.nodeType === Node.ELEMENT_NODE && current.contains(target))) {
+            return true
+        }
+        current = current.nextSibling
+    }
+    return false
+}
+
+function boundaryElements(start, end) {
+    const elements = []
+    let current = start.nextSibling
+    while (current && current !== end) {
+        if (current.nodeType === Node.ELEMENT_NODE) {
+            elements.push(current)
+        }
+        current = current.nextSibling
+    }
+    return elements
+}
+
+function fireHydrationTrigger(registration) {
+    if (registration.fired || registration.cancelled || typeof registration.trigger !== 'function') {
+        return
+    }
+
+    registration.fired = true
+    registration.cleanup()
+    registration.cleanup = () => {}
+    const trigger = registration.trigger
+    registration.trigger = null
+    enqueueMicrotask(trigger)
+}
+
+function replayInteraction(interaction) {
+    if (!interaction || !interaction.target.isConnected) {
+        return
+    }
+
+    const source = interaction.event
+    let replay
+    try {
+        replay = new source.constructor(source.type, source)
+    } catch {
+        replay = new Event(source.type, {
+            bubbles: source.bubbles,
+            cancelable: source.cancelable,
+            composed: source.composed
+        })
+    }
+    interaction.target.dispatchEvent(replay)
+}
+
 export async function initialize() {
     // Bind the single .NET dispatch entry point ([V01.01.04.03]): one JSExport carries the
     // whole typed payload as primitives and returns stop/prevent flags for the live event.
@@ -261,6 +335,153 @@ export const dom = {
         }
 
         return registerNode(node)
+    },
+
+    consumeTextContent: selector => {
+        const node = document.querySelector(selector)
+        if (!node) {
+            return ''
+        }
+
+        const textContent = node.textContent ?? ''
+        node.remove()
+        return textContent
+    },
+
+    scheduleHydrationTrigger: (
+        startHandle,
+        endHandle,
+        strategyKind,
+        timeoutMilliseconds,
+        condition,
+        eventNames,
+        trigger) => {
+        const start = getNode('scheduleHydrationTrigger', startHandle)
+        const end = getNode('scheduleHydrationTrigger', endHandle)
+        if (!start.parentNode || start.parentNode !== end.parentNode) {
+            fail('scheduleHydrationTrigger', startHandle, 'boundary markers do not share a parent')
+        }
+
+        const token = nextHydrationTriggerToken++
+        const registration = {
+            cancelled: false,
+            cleanup: () => {},
+            fired: false,
+            pendingInteraction: null,
+            trigger
+        }
+        hydrationTriggers.set(token, registration)
+
+        try {
+            if (strategyKind === HYDRATE_ON_IDLE) {
+                if (typeof globalThis.requestIdleCallback === 'function') {
+                    const options = timeoutMilliseconds >= 0
+                        ? { timeout: timeoutMilliseconds }
+                        : undefined
+                    const idleToken = globalThis.requestIdleCallback(
+                        () => fireHydrationTrigger(registration),
+                        options)
+                    registration.cleanup = () => globalThis.cancelIdleCallback?.(idleToken)
+                } else {
+                    const delay = timeoutMilliseconds >= 0 ? timeoutMilliseconds : 1
+                    const timeoutToken = globalThis.setTimeout(
+                        () => fireHydrationTrigger(registration),
+                        delay)
+                    registration.cleanup = () => globalThis.clearTimeout(timeoutToken)
+                }
+            } else if (strategyKind === HYDRATE_ON_VISIBLE) {
+                const elements = boundaryElements(start, end)
+                if (elements.length === 0 || typeof globalThis.IntersectionObserver !== 'function') {
+                    enqueueMicrotask(() => fireHydrationTrigger(registration))
+                } else {
+                    const observer = new globalThis.IntersectionObserver(entries => {
+                        if (entries.some(entry => entry.isIntersecting)) {
+                            fireHydrationTrigger(registration)
+                        }
+                    }, { rootMargin: condition || '0px' })
+                    for (const element of elements) {
+                        observer.observe(element)
+                    }
+                    registration.cleanup = () => observer.disconnect()
+                }
+            } else if (strategyKind === HYDRATE_ON_MEDIA_QUERY) {
+                const media = globalThis.matchMedia(condition)
+                const onChange = event => {
+                    if (event.matches) {
+                        fireHydrationTrigger(registration)
+                    }
+                }
+                if (typeof media.addEventListener === 'function') {
+                    media.addEventListener('change', onChange)
+                    registration.cleanup = () => media.removeEventListener('change', onChange)
+                } else {
+                    media.addListener(onChange)
+                    registration.cleanup = () => media.removeListener(onChange)
+                }
+                if (media.matches) {
+                    enqueueMicrotask(() => fireHydrationTrigger(registration))
+                }
+            } else if (strategyKind === HYDRATE_ON_INTERACTION) {
+                const parent = start.parentNode
+                const onInteraction = event => {
+                    if (!boundaryContainsTarget(start, end, event.target)) {
+                        return
+                    }
+
+                    if (event.cancelable) {
+                        event.preventDefault()
+                    }
+                    event.stopImmediatePropagation()
+                    registration.pendingInteraction = { event, target: event.target }
+                    fireHydrationTrigger(registration)
+                }
+                for (const eventName of eventNames) {
+                    parent.addEventListener(eventName, onInteraction, true)
+                }
+                registration.cleanup = () => {
+                    for (const eventName of eventNames) {
+                        parent.removeEventListener(eventName, onInteraction, true)
+                    }
+                }
+            } else {
+                fail('scheduleHydrationTrigger', startHandle, `unknown strategy kind ${strategyKind}`)
+            }
+        } catch (error) {
+            registration.cleanup()
+            hydrationTriggers.delete(token)
+            if (String(error.message).startsWith('viu-dom|')) {
+                throw error
+            }
+            fail('scheduleHydrationTrigger', startHandle, error.message)
+        }
+
+        return token
+    },
+
+    completeHydrationTrigger: token => {
+        const registration = hydrationTriggers.get(token)
+        if (!registration) {
+            return
+        }
+
+        registration.cleanup()
+        hydrationTriggers.delete(token)
+        const interaction = registration.pendingInteraction
+        registration.pendingInteraction = null
+        enqueueMicrotask(() => replayInteraction(interaction))
+    },
+
+    cancelHydrationTrigger: token => {
+        const registration = hydrationTriggers.get(token)
+        if (!registration) {
+            return
+        }
+
+        registration.cleanup()
+        registration.cancelled = true
+        registration.pendingInteraction = null
+        registration.trigger = null
+        hydrationTriggers.delete(token)
     },
 
     createElement: (tagName, namespaceName) => {

--- a/libraries/Assimalign.Viu.Browser/test/Assimalign.Viu.Browser.Tests.csproj
+++ b/libraries/Assimalign.Viu.Browser/test/Assimalign.Viu.Browser.Tests.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ViuProjectReference Include="Assimalign.Viu.Browser" />
+    <ViuProjectReference Include="Assimalign.Viu.State" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Viu.Browser/test/BrowserRendererHostTests.cs
+++ b/libraries/Assimalign.Viu.Browser/test/BrowserRendererHostTests.cs
@@ -76,6 +76,34 @@ public sealed class BrowserRendererHostTests
     }
 
     [Fact]
+    public void Options_ExplicitHydrationTriggerSeam_ForwardsTheMarkerBoundedRequest()
+    {
+        HydrationTriggerRequest<int>? received = null;
+        var registration = new TrackingHydrationTriggerRegistration();
+        var host = new BrowserRendererHost(
+            (_, _) => [],
+            parentNode: null,
+            nextSibling: null,
+            snapshotHydration: null,
+            scheduleHydrationTrigger: request =>
+            {
+                received = request;
+                return registration;
+            });
+        HydrationTriggerRequest<int> request = new(
+            HydrationStrategy.OnIdle(25),
+            startAnchor: 7,
+            endAnchor: 11,
+            trigger: static () => { });
+
+        IHydrationTriggerRegistration actual =
+            host.Options.ScheduleHydrationTrigger!(request);
+
+        received.ShouldBeSameAs(request);
+        actual.ShouldBeSameAs(registration);
+    }
+
+    [Fact]
     public void Activate_SecondHost_RejectsUntilFirstLeaseIsDisposed()
     {
         var firstHost = new BrowserRendererHost((_, _) => []);
@@ -600,6 +628,18 @@ public sealed class BrowserRendererHostTests
             return static _ => new ElementNode(
                 new QualifiedName("span"),
                 children: [new TextNode("kept alive")]);
+        }
+    }
+
+    private sealed class TrackingHydrationTriggerRegistration :
+        IHydrationTriggerRegistration
+    {
+        public void Complete()
+        {
+        }
+
+        public void Dispose()
+        {
         }
     }
 

--- a/libraries/Assimalign.Viu.Browser/test/BrowserStateHydrationTests.cs
+++ b/libraries/Assimalign.Viu.Browser/test/BrowserStateHydrationTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu.Browser.Tests;
+
+public sealed class BrowserStateHydrationTests
+{
+    private static readonly StateStoreDefinition<BrowserPayloadStore> StoreDefinition =
+        StateStores.Define(
+            "browser-state",
+            static () => new BrowserPayloadStore(),
+            new StateStoreJsonSerializer<BrowserPayloadStore, BrowserPayloadState>(
+                static stateStore => stateStore.State,
+                static (stateStore, state) => stateStore.State = state,
+                BrowserStateHydrationJsonContext.Default.BrowserPayloadState));
+
+    [Fact]
+    public void RestorePayload_StoreResolvedDuringMount_UsesServerStateInsteadOfDefaults()
+    {
+        StateStorePayload payload = CreatePayload("server-value");
+        using IStateStoreRegistry clientRegistry = StateStores.CreateRegistry();
+        string? observedSelector = null;
+
+        BrowserStateHydration.RestorePayload(
+            clientRegistry,
+            selector =>
+            {
+                observedSelector = selector;
+                return payload.Json;
+            });
+
+        observedSelector.ShouldBe(BrowserStateHydration.StateIslandSelector);
+        StoreDefinition.Use(clientRegistry).State.Message.ShouldBe("server-value");
+    }
+
+    [Fact]
+    public void RestorePayload_StoreResolvedBeforeMount_IsUpdatedBeforeFirstRender()
+    {
+        StateStorePayload payload = CreatePayload("server-value");
+        using IStateStoreRegistry clientRegistry = StateStores.CreateRegistry();
+        BrowserPayloadStore stateStore = StoreDefinition.Use(clientRegistry);
+        stateStore.State.Message.ShouldBe("client-default");
+
+        BrowserStateHydration.RestorePayload(
+            clientRegistry,
+            _ => payload.Json);
+
+        stateStore.State.Message.ShouldBe("server-value");
+    }
+
+    [Fact]
+    public void RestorePayload_StateIslandInsideMountContainer_IsConsumedBeforeHydration()
+    {
+        StateStorePayload payload = CreatePayload("server-value");
+        using IStateStoreRegistry clientRegistry = StateStores.CreateRegistry();
+        List<string> mountChildren = ["server-root", "state-island"];
+
+        BrowserStateHydration.RestorePayload(
+            clientRegistry,
+            selector =>
+            {
+                selector.ShouldBe(BrowserStateHydration.StateIslandSelector);
+                mountChildren.Remove("state-island").ShouldBeTrue();
+                return payload.Json;
+            });
+
+        mountChildren.ShouldBe(["server-root"]);
+        StoreDefinition.Use(clientRegistry).State.Message.ShouldBe("server-value");
+    }
+
+    [Fact]
+    public void RestorePayload_MissingIsland_ThrowsBeforeAnyStoreIsResolved()
+    {
+        using IStateStoreRegistry clientRegistry = StateStores.CreateRegistry();
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(
+            () => BrowserStateHydration.RestorePayload(clientRegistry, _ => string.Empty));
+
+        exception.Message.ShouldContain(BrowserStateHydration.StateIslandSelector);
+        clientRegistry.Count.ShouldBe(0);
+    }
+
+    private static StateStorePayload CreatePayload(string message)
+    {
+        using IStateStoreRegistry serverRegistry = StateStores.CreateRegistry();
+        StoreDefinition.Use(serverRegistry).State.Message = message;
+        return ((IStateStorePayloadRegistry)serverRegistry).CapturePayload();
+    }
+}
+
+internal sealed class BrowserPayloadStore
+{
+    internal BrowserPayloadState State { get; set; } = new()
+    {
+        Message = "client-default",
+    };
+}
+
+internal sealed class BrowserPayloadState
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+[JsonSerializable(typeof(BrowserPayloadState))]
+internal sealed partial class BrowserStateHydrationJsonContext : JsonSerializerContext
+{
+}

--- a/libraries/Assimalign.Viu.Components/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Components/docs/DESIGN.md
@@ -48,6 +48,12 @@ normalizes aliases, classifies listeners and fallthrough, validates values, and 
 Core owns default-value caching, warning timing, once-listener state, and fallthrough application
 (`[CMP-12]` through `[CMP-19]`).
 
+An invocation may also carry a `HydrationStrategy`. The strategy is a sealed data value rather than
+a callback: this keeps the component description immutable and host-neutral while allowing Core to
+ask the active host for an idle, visibility, media-query, or interaction trigger. An asynchronous
+definition may provide a default strategy, and an explicit invocation remains authoritative
+(`[HYD-LAZY-1]`).
+
 `ComponentContext` exposes only cross-cutting component operations: bindings, nullable services,
 lifecycle, reactive scope, watch scheduling, explicit parent context, emit, expose, warn, and scoped
 watch. Core supplies the live implementation. State, routing, styling, and host integrations attach
@@ -72,5 +78,5 @@ full diff (`[CMP-34]`).
 
 Components does not mount or patch trees, schedule updates, implement built-ins, serialize HTML,
 interpret DOM events, own application lifetime, discover constructors, or provide an ambient
-hierarchical dependency API. Scoped style identity is absent while scoped CSS is deferred
-(`[CMP-24]`, `[STY-1]`).
+hierarchical dependency API. Scoped style identity is absent from the component contract; generated
+native elements carry an ordinary static attribute instead (`[CMP-24]`, `[STY-1]`).

--- a/libraries/Assimalign.Viu.Components/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Components/docs/OVERVIEW.md
@@ -16,7 +16,8 @@ Emit, Expose, Warn, concrete Watch), `ComponentBase`, `ComponentBindings` and it
 `Resolve`, `ComponentLifecycle`, `ComponentRegistration (Reference, Contract, Activator)`, and
 `IComponentFactory`/`ComponentFactory`. The runtime provides the single context implementation;
 conventions such as State attach only through `Services` and the ambient reactive scope and never
-earn a context member. Deliberately absent: any style-scope identity — scoped CSS is deferred.
+earn a context member. The model deliberately carries no style-scope identity; compiled trees stamp
+their static scope id as an ordinary element attribute (`[STY-1]`).
 
 `ComponentBindings.Resolve` performs the full pure resolution step: exact, camelized, and
 hyphenated parameter aliases; declared-listener and node-lifecycle filtering; fallthrough splitting;
@@ -41,6 +42,11 @@ Code-first components are `ComponentRegistration.Define(name, contract, setup)` 
 [ADR-0004](../../../../docs/adr/0004-composition-only-component-model.md); no options-object
 form); hand-built subtrees carry `RenderPlan.None` and patch by full diff unless plans are
 supplied.
+
+`ComponentInvocation.HydrationStrategy` is immutable, host-neutral metadata for adopting a
+server-rendered component now and activating it later. Immediate is the default; idle, visible,
+media-query, and interaction strategies carry only timing or matching data. Components never owns a
+browser observer, event listener, or scheduler callback (`[HYD-LAZY-1]`).
 
 Adopted disposition:
 [`../../../../docs/COMPONENT-MODEL-PLAN.md`](../../../../docs/COMPONENT-MODEL-PLAN.md) §2/§2a.

--- a/libraries/Assimalign.Viu.Components/src/Components/ComponentInvocation.cs
+++ b/libraries/Assimalign.Viu.Components/src/Components/ComponentInvocation.cs
@@ -8,8 +8,9 @@ namespace Assimalign.Viu.Components;
 /// </summary>
 /// <remarks>
 /// Arguments, slots, listeners, and directives are copied when the invocation is constructed and
-/// are never contract-resolved in place. Specified by <c>[CMP-2]</c>, <c>[CMP-7]</c>, and
-/// <c>[CMP-18]</c>.
+/// are never contract-resolved in place. Hydration policy remains data-only invocation metadata.
+/// Specified by <c>[CMP-2]</c>, <c>[CMP-7]</c>, <c>[CMP-18]</c>, and
+/// <c>[HYD-LAZY-1]</c>.
 /// </remarks>
 public sealed class ComponentInvocation
 {
@@ -31,12 +32,17 @@ public sealed class ComponentInvocation
     /// <see cref="Components.SlotStability.Stable"/>; callers whose slot structure can change must
     /// explicitly select <see cref="Components.SlotStability.Dynamic"/>.
     /// </param>
+    /// <param name="hydrationStrategy">
+    /// The optional invocation-local activation policy for adopted server markup. A null value
+    /// lets an asynchronous definition supply its default; ordinary invocations hydrate eagerly.
+    /// </param>
     public ComponentInvocation(
         IReadOnlyDictionary<string, object?>? arguments = null,
         IReadOnlyDictionary<string, ComponentSlot>? slots = null,
         IReadOnlyDictionary<string, ComponentEventListener>? listeners = null,
         IEnumerable<DirectiveInvocation>? directives = null,
-        SlotStability slotStability = SlotStability.Stable)
+        SlotStability slotStability = SlotStability.Stable,
+        HydrationStrategy? hydrationStrategy = null)
     {
         if (slotStability is not SlotStability.Stable
             and not SlotStability.Dynamic
@@ -54,6 +60,7 @@ public sealed class ComponentInvocation
         Listeners = CollectionSnapshot.CopyNonNullDictionary(listeners, nameof(listeners));
         Directives = CollectionSnapshot.CopyNonNull(directives, nameof(directives));
         SlotStability = slotStability;
+        HydrationStrategy = hydrationStrategy;
     }
 
     /// <summary>Gets raw named arguments before contract resolution.</summary>
@@ -74,4 +81,10 @@ public sealed class ComponentInvocation
     /// component by Core. Specified by <c>[CMP-18]</c> and <c>[CMP-19]</c>.
     /// </summary>
     public SlotStability SlotStability { get; }
+
+    /// <summary>
+    /// Gets the invocation-local hydration strategy, or null when the definition supplies the
+    /// default eager behavior. Specified by <c>[HYD-LAZY-1]</c>.
+    /// </summary>
+    public HydrationStrategy? HydrationStrategy { get; }
 }

--- a/libraries/Assimalign.Viu.Components/src/Hydration/HydrationStrategy.cs
+++ b/libraries/Assimalign.Viu.Components/src/Hydration/HydrationStrategy.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Components;
+
+/// <summary>Describes the host trigger for activating adopted server-rendered markup.</summary>
+/// <remarks>
+/// A strategy carries data only. It never captures a host node, browser object, or callback, and
+/// is safe to retain in an immutable <see cref="ComponentInvocation"/>. Specified by
+/// <c>[HYD-LAZY-1]</c> and <c>[HYD-LAZY-2]</c>.
+/// </remarks>
+public sealed class HydrationStrategy
+{
+    private static readonly IReadOnlyList<string> NoInteractionEvents =
+        Array.AsReadOnly(Array.Empty<string>());
+
+    private HydrationStrategy(
+        HydrationStrategyKind kind,
+        int? idleTimeoutMilliseconds,
+        string? visibilityRootMargin,
+        string? mediaQuery,
+        IReadOnlyList<string> interactionEvents)
+    {
+        Kind = kind;
+        IdleTimeoutMilliseconds = idleTimeoutMilliseconds;
+        VisibilityRootMargin = visibilityRootMargin;
+        MediaQuery = mediaQuery;
+        InteractionEvents = interactionEvents;
+    }
+
+    /// <summary>Gets the eager strategy used when no deferred trigger is declared.</summary>
+    public static HydrationStrategy Immediate { get; } = new(
+        HydrationStrategyKind.Immediate,
+        null,
+        null,
+        null,
+        NoInteractionEvents);
+
+    /// <summary>Gets the trigger kind interpreted by the active hydration host.</summary>
+    public HydrationStrategyKind Kind { get; }
+
+    /// <summary>Gets the optional maximum idle delay in milliseconds.</summary>
+    public int? IdleTimeoutMilliseconds { get; }
+
+    /// <summary>Gets the optional host visibility root margin.</summary>
+    public string? VisibilityRootMargin { get; }
+
+    /// <summary>Gets the media condition required by a media-query strategy.</summary>
+    public string? MediaQuery { get; }
+
+    /// <summary>Gets the event names that can activate an interaction strategy.</summary>
+    public IReadOnlyList<string> InteractionEvents { get; }
+
+    /// <summary>Creates an idle-turn strategy with an optional maximum delay.</summary>
+    /// <param name="timeoutMilliseconds">The optional non-negative fallback delay.</param>
+    /// <returns>The immutable idle strategy.</returns>
+    public static HydrationStrategy OnIdle(int? timeoutMilliseconds = null)
+    {
+        if (timeoutMilliseconds is < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeoutMilliseconds),
+                "The idle hydration timeout cannot be negative.");
+        }
+
+        return new HydrationStrategy(
+            HydrationStrategyKind.Idle,
+            timeoutMilliseconds,
+            null,
+            null,
+            NoInteractionEvents);
+    }
+
+    /// <summary>Creates a visibility strategy with an optional host root margin.</summary>
+    /// <param name="rootMargin">The optional host visibility root margin.</param>
+    /// <returns>The immutable visibility strategy.</returns>
+    public static HydrationStrategy OnVisible(string? rootMargin = null) => new(
+        HydrationStrategyKind.Visible,
+        null,
+        rootMargin,
+        null,
+        NoInteractionEvents);
+
+    /// <summary>Creates a media-query strategy.</summary>
+    /// <param name="mediaQuery">The non-empty host media condition.</param>
+    /// <returns>The immutable media strategy.</returns>
+    public static HydrationStrategy OnMediaQuery(string mediaQuery)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mediaQuery);
+        return new HydrationStrategy(
+            HydrationStrategyKind.MediaQuery,
+            null,
+            null,
+            mediaQuery,
+            NoInteractionEvents);
+    }
+
+    /// <summary>Creates a first-interaction strategy whose triggering event is replayed.</summary>
+    /// <param name="eventNames">One or more non-empty host event names.</param>
+    /// <returns>The immutable interaction strategy.</returns>
+    public static HydrationStrategy OnInteraction(params string[] eventNames)
+    {
+        ArgumentNullException.ThrowIfNull(eventNames);
+        if (eventNames.Length == 0)
+        {
+            throw new ArgumentException(
+                "At least one interaction event is required.",
+                nameof(eventNames));
+        }
+
+        string[] copy = new string[eventNames.Length];
+        for (int index = 0; index < eventNames.Length; index++)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(eventNames[index]);
+            copy[index] = eventNames[index];
+        }
+
+        return new HydrationStrategy(
+            HydrationStrategyKind.Interaction,
+            null,
+            null,
+            null,
+            Array.AsReadOnly(copy));
+    }
+}

--- a/libraries/Assimalign.Viu.Components/src/Hydration/HydrationStrategyKind.cs
+++ b/libraries/Assimalign.Viu.Components/src/Hydration/HydrationStrategyKind.cs
@@ -1,0 +1,24 @@
+namespace Assimalign.Viu.Components;
+
+/// <summary>Identifies when an adopted server-rendered component becomes interactive.</summary>
+/// <remarks>
+/// The value is immutable invocation metadata. Core interprets it only through a host trigger
+/// seam, so Browser APIs never enter the component model. Specified by <c>[HYD-LAZY-1]</c>.
+/// </remarks>
+public enum HydrationStrategyKind
+{
+    /// <summary>Activates the component during the initial hydration walk.</summary>
+    Immediate = 0,
+
+    /// <summary>Activates the component when the host reports an idle turn.</summary>
+    Idle = 1,
+
+    /// <summary>Activates the component when its adopted markup becomes visible.</summary>
+    Visible = 2,
+
+    /// <summary>Activates the component when a host media condition matches.</summary>
+    MediaQuery = 3,
+
+    /// <summary>Activates the component on the first configured interaction.</summary>
+    Interaction = 4,
+}

--- a/libraries/Assimalign.Viu.Components/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Components/src/PublicAPI.Unshipped.txt
@@ -9,7 +9,8 @@
 *REMOVED*Assimalign.Viu.Components.SlotFlags.Dynamic = 2 -> Assimalign.Viu.Components.SlotFlags
 *REMOVED*Assimalign.Viu.Components.SlotFlags.Forwarded = 3 -> Assimalign.Viu.Components.SlotFlags
 *REMOVED*Assimalign.Viu.Components.SlotFlags.Stable = 1 -> Assimalign.Viu.Components.SlotFlags
-Assimalign.Viu.Components.ComponentInvocation.ComponentInvocation(System.Collections.Generic.IReadOnlyDictionary<string!, object?>? arguments = null, System.Collections.Generic.IReadOnlyDictionary<string!, Assimalign.Viu.Components.ComponentSlot!>? slots = null, System.Collections.Generic.IReadOnlyDictionary<string!, Assimalign.Viu.Components.ComponentEventListener!>? listeners = null, System.Collections.Generic.IEnumerable<Assimalign.Viu.Components.DirectiveInvocation!>? directives = null, Assimalign.Viu.Components.SlotStability slotStability = Assimalign.Viu.Components.SlotStability.Stable) -> void
+Assimalign.Viu.Components.ComponentInvocation.ComponentInvocation(System.Collections.Generic.IReadOnlyDictionary<string!, object?>? arguments = null, System.Collections.Generic.IReadOnlyDictionary<string!, Assimalign.Viu.Components.ComponentSlot!>? slots = null, System.Collections.Generic.IReadOnlyDictionary<string!, Assimalign.Viu.Components.ComponentEventListener!>? listeners = null, System.Collections.Generic.IEnumerable<Assimalign.Viu.Components.DirectiveInvocation!>? directives = null, Assimalign.Viu.Components.SlotStability slotStability = Assimalign.Viu.Components.SlotStability.Stable, Assimalign.Viu.Components.HydrationStrategy? hydrationStrategy = null) -> void
+Assimalign.Viu.Components.ComponentInvocation.HydrationStrategy.get -> Assimalign.Viu.Components.HydrationStrategy?
 Assimalign.Viu.Components.ComponentInvocation.SlotStability.get -> Assimalign.Viu.Components.SlotStability
 Assimalign.Viu.Components.PatchFlags.DevelopmentRootFragment = 2048 -> Assimalign.Viu.Components.PatchFlags
 Assimalign.Viu.Components.PatchFlags.FullProperties = 16 -> Assimalign.Viu.Components.PatchFlags
@@ -19,3 +20,20 @@ Assimalign.Viu.Components.SlotStability
 Assimalign.Viu.Components.SlotStability.Dynamic = 2 -> Assimalign.Viu.Components.SlotStability
 Assimalign.Viu.Components.SlotStability.Forwarded = 3 -> Assimalign.Viu.Components.SlotStability
 Assimalign.Viu.Components.SlotStability.Stable = 1 -> Assimalign.Viu.Components.SlotStability
+Assimalign.Viu.Components.HydrationStrategy
+Assimalign.Viu.Components.HydrationStrategy.IdleTimeoutMilliseconds.get -> int?
+Assimalign.Viu.Components.HydrationStrategy.InteractionEvents.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Assimalign.Viu.Components.HydrationStrategy.Kind.get -> Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategy.MediaQuery.get -> string?
+Assimalign.Viu.Components.HydrationStrategy.VisibilityRootMargin.get -> string?
+Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategyKind.Idle = 1 -> Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategyKind.Immediate = 0 -> Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategyKind.Interaction = 4 -> Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategyKind.MediaQuery = 3 -> Assimalign.Viu.Components.HydrationStrategyKind
+Assimalign.Viu.Components.HydrationStrategyKind.Visible = 2 -> Assimalign.Viu.Components.HydrationStrategyKind
+static Assimalign.Viu.Components.HydrationStrategy.Immediate.get -> Assimalign.Viu.Components.HydrationStrategy!
+static Assimalign.Viu.Components.HydrationStrategy.OnIdle(int? timeoutMilliseconds = null) -> Assimalign.Viu.Components.HydrationStrategy!
+static Assimalign.Viu.Components.HydrationStrategy.OnInteraction(params string![]! eventNames) -> Assimalign.Viu.Components.HydrationStrategy!
+static Assimalign.Viu.Components.HydrationStrategy.OnMediaQuery(string! mediaQuery) -> Assimalign.Viu.Components.HydrationStrategy!
+static Assimalign.Viu.Components.HydrationStrategy.OnVisible(string? rootMargin = null) -> Assimalign.Viu.Components.HydrationStrategy!

--- a/libraries/Assimalign.Viu.Core/docs/ASYNCHRONOUS-AND-DYNAMIC-COMPONENTS.md
+++ b/libraries/Assimalign.Viu.Core/docs/ASYNCHRONOUS-AND-DYNAMIC-COMPONENTS.md
@@ -63,6 +63,14 @@ renderer therefore waits for a successful or handled failed load before serializ
 resolved or error tree. This uses the ordinary component lifecycle contract rather than adding an
 HTTP, browser, or server-renderer dependency to Core.
 
+When an asynchronous definition declares deferred hydration, ServerRenderer emits one marker range
+around the wrapper. Core adopts that range without replacing its nodes, activates the wrapper only
+after the host trigger, and then waits for either the resolved target or a terminal timeout/error
+presentation before hydrating inside the range. The strategy is removed from the invocation
+forwarded to the resolved target, preventing a duplicate boundary and second trigger. Navigation or
+unmount cancels the registration, pending activation, and captured interaction (`[HYD-LAZY-2]`,
+`[HYD-LAZY-3]`).
+
 The wrapper forwards the latest raw arguments, slots, listeners, directives, key, and template
 reference to the resolved template request. The reference stays unset while loading, error, or
 empty presentation content is active, then receives the resolved component's exposed surface (or

--- a/libraries/Assimalign.Viu.Core/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Core/docs/DESIGN.md
@@ -67,6 +67,14 @@ post-flush watches, commits hosts at defined boundaries, and restores requeueabl
 (`[SCH-1]` through `[SCH-12]`). Scheduling policy belongs to Core; host batching crosses only the
 per-renderer `Commit` delegate.
 
+The default Browser path retains one shared event-loop state. `CoreExecutionIsolation` is the
+internal request-host boundary: it selects fresh Core, Reactivity, State, and scheduler bookkeeping
+for one asynchronous render and restores the caller's state afterward. Scheduler continuations
+capture that logical execution context even when the thread pool dispatches them; a per-flow gate
+also serializes that continuation with the synchronous-render flush. This permits distinct
+request-owned graphs to render concurrently and prevents Core from racing its own scheduler, without
+making any individual graph thread-safe (`[EXE-1]`, `[EXE-3]`).
+
 ## Structural built-ins and hydration
 
 Teleport, KeepAlive, Suspense, and Transition are internal executors for their Components-owned
@@ -77,6 +85,14 @@ host contract.
 Core owns the `HydrationMarkers` wire vocabulary and the generic hydration walk. A host supplies a
 snapshot reader; Core adopts matching nodes and remounts only the smallest mismatched range
 (`[SSR-MARKERS-1]` through `[SSR-MARKERS-3]`, `[HYD-1]` through `[HYD-7]`).
+
+Deferred hydration is marker-range bookkeeping, not a second renderer. Core validates and adopts
+the range as opaque host state, registers the invocation's data-only strategy through
+`ScheduleHydrationTrigger`, and creates the ordinary mounted component only from a post-flush job.
+Unmount cancels both the host registration and any queued or pending asynchronous activation.
+Nested boundaries remain undiscovered until their parent activates; asynchronous wrappers wait for
+their resolved target or terminal error and remove the strategy before forwarding the target, so
+one authored definition owns one boundary (`[HYD-LAZY-1]` through `[HYD-LAZY-5]`).
 
 ## Generated-code and AOT constraints
 

--- a/libraries/Assimalign.Viu.Core/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Core/docs/OVERVIEW.md
@@ -50,6 +50,11 @@ start/stop/failure state machine. `Scheduler` orders component and watcher jobs,
 and drains pre-flush, commit, and post-flush phases [APP-1] through [APP-7] and [SCH-1] through
 [SCH-12].
 
+Browser uses one shared single-event-loop execution state. ServerRenderer enters a fresh internal
+Core/Reactivity/State execution state for every runtime-tree or compiled render, so independently
+owned request graphs do not share the current component, scope, tracking/batching state, active
+registry, or scheduler queues [EXE-1]. Individual graphs remain single-event-loop and not thread-safe.
+
 ## Hydration and development updates
 
 `HydrationMarkers` is the single marker vocabulary shared with serialization and hosts.
@@ -57,6 +62,12 @@ and drains pre-flush, commit, and post-flush phases [APP-1] through [APP-7] and 
 smallest mismatched range is remounted. Class and style comparison is semantic, and
 `data-allow-mismatch` suppresses expected divergence [SSR-MARKERS-1] through [SSR-MARKERS-3] and
 [HYD-1] through [HYD-7].
+
+For a deferred component marker range, Core adopts the existing host nodes immediately but leaves
+setup, effects, rendering, and descendant discovery dormant. It asks the host for one trigger,
+queues activation post-flush, reschedules when strategy data changes, and cancels registrations and
+queued work on unmount. Pending asynchronous definitions preserve adopted markup until their target
+or terminal error presentation is ready (`[HYD-LAZY-1]` through `[HYD-LAZY-5]`).
 
 Generated development builds call the hidden `ComponentHotReload.Register` binary interface with
 stable component and marker type identities. `ApplyUpdates` classifies marker sets without

--- a/libraries/Assimalign.Viu.Core/src/Abstraction/IHydrationTriggerRegistration.cs
+++ b/libraries/Assimalign.Viu.Core/src/Abstraction/IHydrationTriggerRegistration.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Assimalign.Viu;
+
+/// <summary>Owns one host trigger registered for a deferred hydration boundary.</summary>
+/// <remarks>
+/// Disposal cancels an unfired trigger and releases host observers or listeners. Trigger delivery
+/// occurs after registration on the host event loop; Core still schedules activation post-flush.
+/// After activation, <see cref="Complete"/> lets an interaction host queue asynchronous replay of
+/// its captured event rather than delivering it inside component setup. Specified by
+/// <c>[HYD-LAZY-3]</c> through <c>[HYD-LAZY-5]</c>.
+/// </remarks>
+public interface IHydrationTriggerRegistration : IDisposable
+{
+    /// <summary>
+    /// Signals that activation and host writes are scheduled, allowing the host to complete any
+    /// deferred asynchronous interaction replay after its commit boundary.
+    /// </summary>
+    void Complete();
+}

--- a/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponentDefinition.cs
+++ b/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponentDefinition.cs
@@ -63,15 +63,34 @@ public sealed class AsynchronousComponentDefinition
         MountReference? mountReference = null,
         RenderPlan? renderPlan = null)
     {
+        ComponentInvocation resolvedInvocation = ResolveHydrationStrategy(invocation);
         return new ComponentNode(
             Reference,
-            invocation,
+            resolvedInvocation,
             key,
             mountReference,
             renderPlan);
     }
 
     internal AsynchronousComponentOptions Options => _options;
+
+    private ComponentInvocation ResolveHydrationStrategy(ComponentInvocation? invocation)
+    {
+        ComponentInvocation resolved = invocation ?? ComponentInvocation.Empty;
+        if (resolved.HydrationStrategy is not null
+            || _options.HydrationStrategy.Kind == HydrationStrategyKind.Immediate)
+        {
+            return resolved;
+        }
+
+        return new ComponentInvocation(
+            resolved.Arguments,
+            resolved.Slots,
+            resolved.Listeners,
+            resolved.Directives,
+            resolved.SlotStability,
+            _options.HydrationStrategy);
+    }
 
     internal AsynchronousComponentLoadLease AcquireLoad()
     {

--- a/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponentOptions.cs
+++ b/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponentOptions.cs
@@ -5,7 +5,8 @@ namespace Assimalign.Viu;
 /// <summary>Configures an asynchronous component definition.</summary>
 /// <remarks>
 /// Definitions share loader state while every mount owns its wrapper instance and immutable output
-/// nodes. Specified by <c>[BLT-14]</c>.
+/// nodes. A definition-level hydration strategy applies only to its outer wrapper boundary.
+/// Specified by <c>[BLT-14]</c> and <c>[HYD-LAZY-1]</c>.
 /// </remarks>
 public sealed class AsynchronousComponentOptions
 {
@@ -29,4 +30,11 @@ public sealed class AsynchronousComponentOptions
 
     /// <summary>Gets the optional retry-or-fail policy.</summary>
     public AsynchronousComponentErrorHandler? OnError { get; init; }
+
+    /// <summary>
+    /// Gets the default client hydration strategy copied to invocation nodes that do not declare
+    /// one explicitly. The default is eager. Specified by <c>[HYD-LAZY-1]</c>.
+    /// </summary>
+    public HydrationStrategy HydrationStrategy { get; init; } =
+        HydrationStrategy.Immediate;
 }

--- a/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponents.cs
+++ b/libraries/Assimalign.Viu.Core/src/AsynchronousComponents/AsynchronousComponents.cs
@@ -67,6 +67,7 @@ public static class AsynchronousComponents
         ArgumentNullException.ThrowIfNull(componentType);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.Loader);
+        ArgumentNullException.ThrowIfNull(options.HydrationStrategy);
         if (name is not null)
         {
             ArgumentException.ThrowIfNullOrEmpty(name);

--- a/libraries/Assimalign.Viu.Core/src/Internal/AsynchronousComponentWrapper.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/AsynchronousComponentWrapper.cs
@@ -19,6 +19,8 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
     private AsynchronousComponentTarget _target;
     private IDisposable? _delayTimer;
     private IDisposable? _timeoutTimer;
+    private Task _hydrationReadiness = Task.CompletedTask;
+    private TaskCompletionSource? _hydrationReadinessCompletion;
     private bool _hasTarget;
     private bool _isActive;
     private bool _suspenseControlled;
@@ -57,6 +59,10 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
         else
         {
             Task<AsynchronousComponentTarget> pendingLoad = _load.PendingLoad;
+            TaskCompletionSource hydrationReadiness = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _hydrationReadinessCompletion = hydrationReadiness;
+            _hydrationReadiness = hydrationReadiness.Task;
             if (options.Suspensible && runtime is not null)
             {
                 _suspenseControlled = runtime.RegisterAsynchronousDependency(
@@ -78,6 +84,8 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
 
         return Render;
     }
+
+    internal Task HydrationReadiness => _hydrationReadiness;
 
     private static ComponentInvocation CreateFallbackInvocation(ComponentContext context)
     {
@@ -165,6 +173,7 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
         finally
         {
             runtime?.SettleAsynchronousDependency(pendingLoad);
+            SignalHydrationReadiness();
         }
     }
 
@@ -176,17 +185,29 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
         }
 
         _error!.Value = error;
-        _runtime?.RouteAsynchronousError(
-            error,
-            rethrowIfUnhandled: _definition.Options.ErrorComponent is null);
+        try
+        {
+            _runtime?.RouteAsynchronousError(
+                error,
+                rethrowIfUnhandled: _definition.Options.ErrorComponent is null);
+        }
+        finally
+        {
+            SignalHydrationReadiness();
+        }
     }
+
+    private void SignalHydrationReadiness() =>
+        _hydrationReadinessCompletion?.TrySetResult();
 
     private VirtualNode? Render(ComponentRenderFrame frame)
     {
         if (_loaded!.Value && _hasTarget)
         {
             ComponentInvocation invocation = _runtime?.Invocation ?? _fallbackInvocation;
-            return _target.CreateComponent(invocation, _runtime?.MountReference);
+            return _target.CreateComponent(
+                WithoutDeferredHydration(invocation),
+                _runtime?.MountReference);
         }
 
         if (_error!.Value is { } error)
@@ -209,6 +230,22 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
         return new CommentNode(string.Empty);
     }
 
+    private static ComponentInvocation WithoutDeferredHydration(
+        ComponentInvocation invocation)
+    {
+        if (invocation.HydrationStrategy is not { Kind: not HydrationStrategyKind.Immediate })
+        {
+            return invocation;
+        }
+
+        return new ComponentInvocation(
+            invocation.Arguments,
+            invocation.Slots,
+            invocation.Listeners,
+            invocation.Directives,
+            invocation.SlotStability);
+    }
+
     public void Dispose()
     {
         if (!_isActive)
@@ -217,6 +254,7 @@ internal sealed class AsynchronousComponentWrapper : IComponent, IDisposable
         }
 
         _isActive = false;
+        SignalHydrationReadiness();
         _delayTimer?.Dispose();
         _delayTimer = null;
         _timeoutTimer?.Dispose();

--- a/libraries/Assimalign.Viu.Core/src/Internal/CoreExecutionIsolation.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/CoreExecutionIsolation.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu;
+
+/// <summary>
+/// Selects request-local Core, Reactivity, and State ambient execution state while retaining the
+/// shared single-event-loop default for Browser applications.
+/// </summary>
+internal static class CoreExecutionIsolation
+{
+    private static readonly AsyncLocal<CoreExecutionState?> IsolatedState = new();
+    private static readonly CoreExecutionState SharedState = new();
+
+    internal static CoreExecutionState Current => IsolatedState.Value ?? SharedState;
+
+    internal static IDisposable Enter()
+    {
+        CoreExecutionState? previous = IsolatedState.Value;
+        IsolatedState.Value = new CoreExecutionState();
+        IDisposable reactivity = ReactivityExecutionIsolation.Enter();
+        IDisposable state = StateExecutionIsolation.Enter();
+        return new IsolationLease(previous, reactivity, state);
+    }
+
+    private sealed class IsolationLease : IDisposable
+    {
+        private readonly CoreExecutionState? _previous;
+        private readonly IDisposable _reactivity;
+        private readonly IDisposable _state;
+        private bool _isDisposed;
+
+        internal IsolationLease(
+            CoreExecutionState? previous,
+            IDisposable reactivity,
+            IDisposable state)
+        {
+            _previous = previous;
+            _reactivity = reactivity;
+            _state = state;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            try
+            {
+                _state.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    _reactivity.Dispose();
+                }
+                finally
+                {
+                    IsolatedState.Value = _previous;
+                }
+            }
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Core/src/Internal/CoreExecutionState.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/CoreExecutionState.cs
@@ -1,0 +1,9 @@
+namespace Assimalign.Viu;
+
+/// <summary>Owns Core ambient values for one logical execution flow.</summary>
+internal sealed class CoreExecutionState
+{
+    internal RuntimeComponentContext? CurrentComponent { get; set; }
+
+    internal SchedulerExecutionState Scheduler { get; } = new();
+}

--- a/libraries/Assimalign.Viu.Core/src/Internal/MountedLazyHydration{TNode}.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/MountedLazyHydration{TNode}.cs
@@ -1,0 +1,44 @@
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu;
+
+internal sealed class MountedLazyHydration<TNode> : MountedNode<TNode>
+    where TNode : notnull
+{
+    internal MountedLazyHydration(
+        ComponentNode value,
+        HydrationNodeReader<TNode> reader,
+        TNode container,
+        TNode startAnchor,
+        TNode endAnchor,
+        RuntimeComponentContext? owner)
+        : base(value, owner)
+    {
+        Reader = reader;
+        Container = container;
+        StartAnchor = startAnchor;
+        EndAnchor = endAnchor;
+    }
+
+    internal HydrationNodeReader<TNode> Reader;
+
+    internal TNode Container;
+
+    internal TNode StartAnchor;
+
+    internal TNode EndAnchor;
+
+    internal MountedComponent<TNode>? ActivatedComponent;
+
+    internal ComponentActivation? PendingActivation;
+
+    internal int PendingComponentIdentifier;
+
+    internal IHydrationTriggerRegistration? TriggerRegistration;
+
+    internal SchedulerJob? ActivationJob;
+
+    internal override TNode FirstHostNode => StartAnchor;
+
+    internal override TNode LastHostNode => EndAnchor;
+}

--- a/libraries/Assimalign.Viu.Core/src/Internal/RuntimeComponentContext.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/RuntimeComponentContext.cs
@@ -11,8 +11,6 @@ namespace Assimalign.Viu;
 
 internal sealed class RuntimeComponentContext : ComponentContext, IAsynchronousComponentRuntime
 {
-    private static RuntimeComponentContext? _current;
-
     private readonly ComponentContract _contract;
     private readonly Dictionary<string, ComponentEvent> _eventAliases =
         new(StringComparer.Ordinal);
@@ -72,7 +70,7 @@ internal sealed class RuntimeComponentContext : ComponentContext, IAsynchronousC
 
     }
 
-    internal static RuntimeComponentContext? Current => _current;
+    internal static RuntimeComponentContext? Current => CoreExecutionIsolation.Current.CurrentComponent;
 
     public override ComponentBindings Bindings => _bindings;
 
@@ -246,30 +244,32 @@ internal sealed class RuntimeComponentContext : ComponentContext, IAsynchronousC
     internal void Run(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
-        RuntimeComponentContext? previous = _current;
-        _current = this;
+        CoreExecutionState executionState = CoreExecutionIsolation.Current;
+        RuntimeComponentContext? previous = executionState.CurrentComponent;
+        executionState.CurrentComponent = this;
         try
         {
             action();
         }
         finally
         {
-            _current = previous;
+            executionState.CurrentComponent = previous;
         }
     }
 
     internal TResult Run<TResult>(Func<TResult> function)
     {
         ArgumentNullException.ThrowIfNull(function);
-        RuntimeComponentContext? previous = _current;
-        _current = this;
+        CoreExecutionState executionState = CoreExecutionIsolation.Current;
+        RuntimeComponentContext? previous = executionState.CurrentComponent;
+        executionState.CurrentComponent = this;
         try
         {
             return function();
         }
         finally
         {
-            _current = previous;
+            executionState.CurrentComponent = previous;
         }
     }
 

--- a/libraries/Assimalign.Viu.Core/src/Internal/SchedulerExecutionState.cs
+++ b/libraries/Assimalign.Viu.Core/src/Internal/SchedulerExecutionState.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu;
+
+/// <summary>Owns scheduler queues and flush bookkeeping for one logical execution flow.</summary>
+internal sealed class SchedulerExecutionState
+{
+    internal object Synchronization { get; } = new();
+
+    internal List<SchedulerJob> Queue { get; } = [];
+
+    internal List<SchedulerJob> PendingPostFlushCallbacks { get; } = [];
+
+    internal List<Action> PendingHostCommits { get; } = [];
+
+    internal List<SchedulerJob>? ActivePostFlushCallbacks { get; set; }
+
+    internal List<SchedulerJob>? ExecutedInFlushChain { get; set; }
+
+    internal Action<Action>? FlushDispatcher { get; set; }
+
+    internal int FlushIndex { get; set; } = -1;
+
+    internal bool IsFlushing { get; set; }
+
+    internal bool IsFlushPending { get; set; }
+
+    internal TaskCompletionSource? FlushCompletion { get; set; }
+
+    internal long NextInsertionSequence { get; set; }
+}

--- a/libraries/Assimalign.Viu.Core/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.Core/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assimalign.Viu.Core.Tests")]
+[assembly: InternalsVisibleTo("Assimalign.Viu.ServerRenderer")]

--- a/libraries/Assimalign.Viu.Core/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Core/src/PublicAPI.Unshipped.txt
@@ -13,3 +13,17 @@ static Assimalign.Viu.AsynchronousComponents.Define<TComponent>(Assimalign.Viu.A
 static Assimalign.Viu.DynamicComponents.Create(object? source, Assimalign.Viu.Components.ComponentInvocation? invocation = null, System.Collections.Generic.IEnumerable<Assimalign.Viu.Components.ElementBinding!>? bindings = null, System.Collections.Generic.IEnumerable<Assimalign.Viu.Components.VirtualNode!>? children = null, System.Collections.Generic.IEnumerable<Assimalign.Viu.Components.DirectiveInvocation!>? directives = null, object? key = null, Assimalign.Viu.Components.MountReference? mountReference = null, Assimalign.Viu.Components.RenderPlan? renderPlan = null) -> Assimalign.Viu.Components.VirtualNode!
 static Assimalign.Viu.DynamicComponents.Resolve(object? source) -> object?
 static Assimalign.Viu.Scheduler.NextTickAsync() -> System.Threading.Tasks.Task!
+Assimalign.Viu.HydrationTriggerRequest<TNode>
+Assimalign.Viu.HydrationTriggerRequest<TNode>.EndAnchor.get -> TNode
+Assimalign.Viu.HydrationTriggerRequest<TNode>.HydrationTriggerRequest(Assimalign.Viu.Components.HydrationStrategy! strategy, TNode startAnchor, TNode endAnchor, System.Action! trigger) -> void
+Assimalign.Viu.HydrationTriggerRequest<TNode>.StartAnchor.get -> TNode
+Assimalign.Viu.HydrationTriggerRequest<TNode>.Strategy.get -> Assimalign.Viu.Components.HydrationStrategy!
+Assimalign.Viu.HydrationTriggerRequest<TNode>.Trigger.get -> System.Action!
+Assimalign.Viu.IHydrationTriggerRegistration
+Assimalign.Viu.IHydrationTriggerRegistration.Complete() -> void
+Assimalign.Viu.AsynchronousComponentOptions.HydrationStrategy.get -> Assimalign.Viu.Components.HydrationStrategy!
+Assimalign.Viu.AsynchronousComponentOptions.HydrationStrategy.init -> void
+Assimalign.Viu.RendererOptions<TNode>.ScheduleHydrationTrigger.get -> System.Func<Assimalign.Viu.HydrationTriggerRequest<TNode>!, Assimalign.Viu.IHydrationTriggerRegistration!>?
+Assimalign.Viu.RendererOptions<TNode>.ScheduleHydrationTrigger.init -> void
+const Assimalign.Viu.HydrationMarkers.LazyHydrationEnd = "<!--lazy hydration end-->" -> string!
+static Assimalign.Viu.HydrationMarkers.GetLazyHydrationStart(Assimalign.Viu.Components.HydrationStrategyKind kind) -> string!

--- a/libraries/Assimalign.Viu.Core/src/Rendering/HydrationMarkers.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/HydrationMarkers.cs
@@ -1,3 +1,7 @@
+using System;
+
+using Assimalign.Viu.Components;
+
 namespace Assimalign.Viu;
 
 /// <summary>
@@ -29,10 +33,37 @@ public static class HydrationMarkers
     /// <summary>Gets the serialized comment that terminates one teleport target range.</summary>
     public const string TeleportAnchor = "<!--teleport anchor-->";
 
+    /// <summary>Gets the serialized comment that closes a deferred hydration range.</summary>
+    public const string LazyHydrationEnd = "<!--lazy hydration end-->";
+
+    /// <summary>Gets the opening marker for a non-immediate hydration strategy.</summary>
+    /// <param name="kind">The deferred strategy kind.</param>
+    /// <returns>The stable serialized opening comment.</returns>
+    public static string GetLazyHydrationStart(HydrationStrategyKind kind) => kind switch
+    {
+        HydrationStrategyKind.Idle => "<!--lazy hydration idle-->",
+        HydrationStrategyKind.Visible => "<!--lazy hydration visible-->",
+        HydrationStrategyKind.MediaQuery => "<!--lazy hydration media query-->",
+        HydrationStrategyKind.Interaction => "<!--lazy hydration interaction-->",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(kind),
+            "An immediate or unknown strategy has no deferred hydration marker."),
+    };
+
     internal const string FragmentStartData = "[";
     internal const string FragmentEndData = "]";
     internal const string EmptyCommentData = "";
     internal const string TeleportStartData = "teleport start";
     internal const string TeleportEndData = "teleport end";
     internal const string TeleportAnchorData = "teleport anchor";
+    internal const string LazyHydrationEndData = "lazy hydration end";
+
+    internal static string GetLazyHydrationStartData(HydrationStrategyKind kind) =>
+        GetLazyHydrationStart(kind)[4..^3];
+
+    internal static bool IsLazyHydrationStartData(string data) =>
+        string.Equals(data, "lazy hydration idle", StringComparison.Ordinal)
+        || string.Equals(data, "lazy hydration visible", StringComparison.Ordinal)
+        || string.Equals(data, "lazy hydration media query", StringComparison.Ordinal)
+        || string.Equals(data, "lazy hydration interaction", StringComparison.Ordinal);
 }

--- a/libraries/Assimalign.Viu.Core/src/Rendering/HydrationTriggerRequest{TNode}.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/HydrationTriggerRequest{TNode}.cs
@@ -1,0 +1,59 @@
+using System;
+
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu;
+
+/// <summary>Supplies a host with one marker-bounded deferred hydration trigger.</summary>
+/// <typeparam name="TNode">The opaque host node type.</typeparam>
+/// <remarks>
+/// The request is a cold-path capability object. Core retains platform neutrality while Browser,
+/// Testing, or another host interprets the strategy. Specified by <c>[HYD-LAZY-2]</c> and
+/// <c>[HYD-LAZY-3]</c>.
+/// </remarks>
+public sealed class HydrationTriggerRequest<TNode>
+    where TNode : notnull
+{
+    /// <summary>Initializes one host trigger request.</summary>
+    /// <param name="strategy">The non-immediate strategy declared by the component invocation.</param>
+    /// <param name="startAnchor">The adopted opening marker.</param>
+    /// <param name="endAnchor">The adopted closing marker.</param>
+    /// <param name="trigger">The callback the host invokes at most once.</param>
+    public HydrationTriggerRequest(
+        HydrationStrategy strategy,
+        TNode startAnchor,
+        TNode endAnchor,
+        Action trigger)
+    {
+        ArgumentNullException.ThrowIfNull(strategy);
+        ArgumentNullException.ThrowIfNull(startAnchor);
+        ArgumentNullException.ThrowIfNull(endAnchor);
+        ArgumentNullException.ThrowIfNull(trigger);
+        if (strategy.Kind == HydrationStrategyKind.Immediate)
+        {
+            throw new ArgumentException(
+                "A host trigger request requires a deferred hydration strategy.",
+                nameof(strategy));
+        }
+
+        Strategy = strategy;
+        StartAnchor = startAnchor;
+        EndAnchor = endAnchor;
+        Trigger = trigger;
+    }
+
+    /// <summary>Gets the immutable trigger strategy.</summary>
+    public HydrationStrategy Strategy { get; }
+
+    /// <summary>Gets the adopted opening marker.</summary>
+    public TNode StartAnchor { get; }
+
+    /// <summary>Gets the adopted closing marker.</summary>
+    public TNode EndAnchor { get; }
+
+    /// <summary>
+    /// Gets the at-most-once callback that the host invokes asynchronously after registration
+    /// returns to schedule activation through Core.
+    /// </summary>
+    public Action Trigger { get; }
+}

--- a/libraries/Assimalign.Viu.Core/src/Rendering/Renderer.Hydration.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/Renderer.Hydration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 
 using Assimalign.Viu.Components;
 using Assimalign.Viu.Reactivity;
@@ -399,6 +400,186 @@ public sealed partial class Renderer<TNode>
         TNode container,
         RuntimeComponentContext? owner)
     {
+        HydrationStrategy? strategy = value.Invocation.HydrationStrategy;
+        if (strategy is not null
+            && strategy.Kind != HydrationStrategyKind.Immediate)
+        {
+            return HydrateLazyComponent(
+                tree,
+                reader,
+                node,
+                value,
+                container,
+                owner,
+                strategy);
+        }
+
+        return HydrateComponentImmediately(
+            tree,
+            reader,
+            node,
+            value,
+            container,
+            owner);
+    }
+
+    private (MountedNode<TNode> Mounted, TNode? Next) HydrateLazyComponent(
+        MountedTree<TNode> tree,
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        ComponentNode value,
+        TNode container,
+        RuntimeComponentContext? owner,
+        HydrationStrategy strategy)
+    {
+        string openingMarker = HydrationMarkers.GetLazyHydrationStartData(strategy.Kind);
+        if (!IsCommentMarker(reader, node, openingMarker))
+        {
+            return HydrateMismatch(tree, reader, node, value, container, owner);
+        }
+
+        TNode? closing = FindLazyHydrationClosingMarker(reader, node);
+        if (!HasHostNode(closing))
+        {
+            return HydrateMismatch(tree, reader, node, value, container, owner);
+        }
+
+        _ = _options.ScheduleHydrationTrigger
+            ?? throw new NotSupportedException(
+                "The active host does not provide deferred hydration triggers.");
+        TNode boundaryContainer = HasHostNode(reader.ParentNode(node))
+            ? reader.ParentNode(node)!
+            : container;
+        MountedLazyHydration<TNode> mounted = new(
+            value,
+            reader,
+            boundaryContainer,
+            node,
+            closing!,
+            owner);
+        ScheduleLazyHydrationTrigger(tree, mounted, strategy);
+        Register(tree, value, mounted);
+        return (mounted, reader.NextSibling(closing!));
+    }
+
+    private void ActivateLazyHydration(
+        MountedTree<TNode> tree,
+        MountedLazyHydration<TNode> mounted)
+    {
+        if (mounted.IsUnmounted || mounted.ActivatedComponent is not null)
+        {
+            return;
+        }
+
+        TNode? first = mounted.Reader.NextSibling(mounted.StartAnchor);
+        if (!HasHostNode(first) || NodeComparer.Equals(first!, mounted.EndAnchor))
+        {
+            ReportHydrationWarning(
+                tree,
+                "Lazy hydration boundary had no server-rendered component subtree.");
+            return;
+        }
+
+        ComponentActivation activation;
+        int componentIdentifier;
+        if (mounted.PendingActivation is { } pendingActivation)
+        {
+            activation = pendingActivation;
+            componentIdentifier = mounted.PendingComponentIdentifier;
+        }
+        else
+        {
+            (activation, componentIdentifier) = CreateHydrationActivation(
+                tree,
+                (ComponentNode)mounted.Value,
+                mounted.Owner);
+            if (activation.Instance is AsynchronousComponentWrapper asynchronousComponent
+                && !asynchronousComponent.HydrationReadiness.IsCompleted)
+            {
+                mounted.PendingActivation = activation;
+                mounted.PendingComponentIdentifier = componentIdentifier;
+                _ = ResumeLazyHydrationWhenReadyAsync(
+                    asynchronousComponent.HydrationReadiness,
+                    mounted,
+                    mounted.ActivationJob!);
+                return;
+            }
+        }
+
+        mounted.PendingActivation = null;
+        mounted.PendingComponentIdentifier = 0;
+        (MountedNode<TNode> activatedNode, TNode? next) = HydrateActivatedComponentImmediately(
+            tree,
+            mounted.Reader,
+            first!,
+            (ComponentNode)mounted.Value,
+            mounted.Container,
+            mounted.Owner,
+            activation,
+            componentIdentifier);
+        MountedComponent<TNode> activated = (MountedComponent<TNode>)activatedNode;
+        if (!HasHostNode(next) || !NodeComparer.Equals(next!, mounted.EndAnchor))
+        {
+            ReportHydrationWarning(
+                tree,
+                "Lazy hydration boundary contained extra server-rendered nodes.");
+            TNode? cursor = next;
+            while (HasHostNode(cursor)
+                && !NodeComparer.Equals(cursor!, mounted.EndAnchor))
+            {
+                TNode current = cursor!;
+                cursor = mounted.Reader.NextSibling(current);
+                _options.Remove(current);
+            }
+        }
+
+        mounted.ActivatedComponent = activated;
+        mounted.ActivationJob = null;
+        QueueHostCommit();
+        IHydrationTriggerRegistration? registration = mounted.TriggerRegistration;
+        mounted.TriggerRegistration = null;
+        registration?.Complete();
+    }
+
+    private static async Task ResumeLazyHydrationWhenReadyAsync(
+        Task readiness,
+        MountedLazyHydration<TNode> mounted,
+        SchedulerJob activationJob)
+    {
+        await readiness.ConfigureAwait(false);
+        if (!mounted.IsUnmounted && !activationJob.IsDisposed)
+        {
+            Scheduler.QueuePostFlushCallback(activationJob);
+        }
+    }
+
+    private (MountedNode<TNode> Mounted, TNode? Next) HydrateComponentImmediately(
+        MountedTree<TNode> tree,
+        HydrationNodeReader<TNode> reader,
+        TNode node,
+        ComponentNode value,
+        TNode container,
+        RuntimeComponentContext? owner)
+    {
+        (ComponentActivation activation, int componentIdentifier) =
+            CreateHydrationActivation(tree, value, owner);
+        return HydrateActivatedComponentImmediately(
+            tree,
+            reader,
+            node,
+            value,
+            container,
+            owner,
+            activation,
+            componentIdentifier);
+    }
+
+    private (ComponentActivation Activation, int ComponentIdentifier)
+        CreateHydrationActivation(
+            MountedTree<TNode> tree,
+            ComponentNode value,
+            RuntimeComponentContext? owner)
+    {
         IApplicationContext application = tree.Application
             ?? throw new InvalidOperationException(
                 "Hydrating an authored component requires an application context.");
@@ -417,7 +598,20 @@ public sealed partial class Renderer<TNode>
             owner,
             watchScheduler,
             suspenseBoundary: _activeSuspenseBoundary);
+        return (activation, componentIdentifier);
+    }
 
+    private (MountedNode<TNode> Mounted, TNode? Next)
+        HydrateActivatedComponentImmediately(
+            MountedTree<TNode> tree,
+            HydrationNodeReader<TNode> reader,
+            TNode node,
+            ComponentNode value,
+            TNode container,
+            RuntimeComponentContext? owner,
+            ComponentActivation activation,
+            int componentIdentifier)
+    {
         MountedComponent<TNode>? mounted = null;
         VirtualNode? initialTree = null;
         ReactiveEffect? renderEffect = null;
@@ -898,7 +1092,10 @@ public sealed partial class Renderer<TNode>
         }
 
         string start = reader.Data(first);
-        string? end = start switch
+        bool isLazyHydrationRange = HydrationMarkers.IsLazyHydrationStartData(start);
+        string? end = isLazyHydrationRange
+            ? HydrationMarkers.LazyHydrationEndData
+            : start switch
         {
             HydrationMarkers.FragmentStartData => HydrationMarkers.FragmentEndData,
             HydrationMarkers.TeleportStartData => HydrationMarkers.TeleportEndData,
@@ -918,7 +1115,9 @@ public sealed partial class Renderer<TNode>
             if (reader.Kind(current) == HydrationNodeKind.Comment)
             {
                 string data = reader.Data(current);
-                if (string.Equals(data, start, StringComparison.Ordinal))
+                if (isLazyHydrationRange
+                        ? HydrationMarkers.IsLazyHydrationStartData(data)
+                        : string.Equals(data, start, StringComparison.Ordinal))
                 {
                     depth++;
                 }
@@ -1128,7 +1327,8 @@ public sealed partial class Renderer<TNode>
         || string.Equals(
             data,
             HydrationMarkers.TeleportStartData,
-            StringComparison.Ordinal);
+            StringComparison.Ordinal)
+        || HydrationMarkers.IsLazyHydrationStartData(data);
 
     private static bool IsCommentMarker(
         HydrationNodeReader<TNode> reader,
@@ -1175,6 +1375,42 @@ public sealed partial class Renderer<TNode>
                     depth++;
                 }
                 else if (string.Equals(data, closingMarker, StringComparison.Ordinal))
+                {
+                    if (depth == 0)
+                    {
+                        return current;
+                    }
+
+                    depth--;
+                }
+            }
+
+            cursor = reader.NextSibling(current);
+        }
+
+        return default;
+    }
+
+    private static TNode? FindLazyHydrationClosingMarker(
+        HydrationNodeReader<TNode> reader,
+        TNode start)
+    {
+        int depth = 0;
+        TNode? cursor = reader.NextSibling(start);
+        while (HasHostNode(cursor))
+        {
+            TNode current = cursor!;
+            if (reader.Kind(current) == HydrationNodeKind.Comment)
+            {
+                string data = reader.Data(current);
+                if (HydrationMarkers.IsLazyHydrationStartData(data))
+                {
+                    depth++;
+                }
+                else if (string.Equals(
+                    data,
+                    HydrationMarkers.LazyHydrationEndData,
+                    StringComparison.Ordinal))
                 {
                     if (depth == 0)
                     {

--- a/libraries/Assimalign.Viu.Core/src/Rendering/Renderer.LazyHydration.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/Renderer.LazyHydration.cs
@@ -1,0 +1,143 @@
+using System;
+
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu;
+
+/// <summary>Contains deferred hydration lifetime handling for <see cref="Renderer{TNode}"/>.</summary>
+public sealed partial class Renderer<TNode>
+    where TNode : notnull
+{
+    private void PatchLazyHydration(
+        MountedTree<TNode> tree,
+        MountedLazyHydration<TNode> mounted,
+        ComponentNode next,
+        TNode container)
+    {
+        if (mounted.ActivatedComponent is { } activated)
+        {
+            PatchComponent(tree, activated, next, container);
+            ReplaceValue(tree, mounted, next);
+            return;
+        }
+
+        ComponentNode previous = (ComponentNode)mounted.Value;
+        ReplaceValue(tree, mounted, next);
+        if (mounted.PendingActivation is { } pendingActivation)
+        {
+            pendingActivation.Update(next);
+            return;
+        }
+
+        HydrationStrategy? nextStrategy = next.Invocation.HydrationStrategy;
+        if (nextStrategy is null
+            || nextStrategy.Kind == HydrationStrategyKind.Immediate)
+        {
+            mounted.TriggerRegistration?.Dispose();
+            mounted.TriggerRegistration = null;
+            ActivateLazyHydration(tree, mounted);
+            return;
+        }
+
+        HydrationStrategy? previousStrategy = previous.Invocation.HydrationStrategy;
+        if (HasSameHydrationTrigger(previousStrategy, nextStrategy))
+        {
+            return;
+        }
+
+        mounted.TriggerRegistration?.Dispose();
+        mounted.TriggerRegistration = null;
+        ScheduleLazyHydrationTrigger(tree, mounted, nextStrategy);
+    }
+
+    private static bool HasSameHydrationTrigger(
+        HydrationStrategy? previous,
+        HydrationStrategy next)
+    {
+        if (previous is null
+            || previous.Kind != next.Kind
+            || previous.IdleTimeoutMilliseconds != next.IdleTimeoutMilliseconds
+            || !string.Equals(
+                previous.VisibilityRootMargin,
+                next.VisibilityRootMargin,
+                StringComparison.Ordinal)
+            || !string.Equals(
+                previous.MediaQuery,
+                next.MediaQuery,
+                StringComparison.Ordinal)
+            || previous.InteractionEvents.Count != next.InteractionEvents.Count)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < previous.InteractionEvents.Count; index++)
+        {
+            if (!string.Equals(
+                previous.InteractionEvents[index],
+                next.InteractionEvents[index],
+                StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void ScheduleLazyHydrationTrigger(
+        MountedTree<TNode> tree,
+        MountedLazyHydration<TNode> mounted,
+        HydrationStrategy strategy)
+    {
+        Func<HydrationTriggerRequest<TNode>, IHydrationTriggerRegistration> schedule =
+            _options.ScheduleHydrationTrigger
+            ?? throw new NotSupportedException(
+                "The active host does not provide deferred hydration triggers.");
+        SchedulerJob activationJob = mounted.ActivationJob ?? new SchedulerJob(
+            () => ActivateLazyHydration(tree, mounted))
+        {
+            Name = "lazy hydration activation",
+        };
+        mounted.ActivationJob = activationJob;
+        mounted.TriggerRegistration = schedule(
+            new HydrationTriggerRequest<TNode>(
+                strategy,
+                mounted.StartAnchor,
+                mounted.EndAnchor,
+                () =>
+                {
+                    if (!mounted.IsUnmounted && mounted.ActivatedComponent is null)
+                    {
+                        Scheduler.QueuePostFlushCallback(activationJob);
+                    }
+                }));
+    }
+
+    private void UnmountLazyHydration(
+        MountedTree<TNode> tree,
+        MountedLazyHydration<TNode> mounted,
+        bool removeHostNodes)
+    {
+        if (mounted.ActivationJob is { } activationJob)
+        {
+            activationJob.IsDisposed = true;
+        }
+
+        mounted.ActivationJob = null;
+        mounted.PendingActivation?.Release();
+        mounted.PendingActivation = null;
+        mounted.PendingComponentIdentifier = 0;
+        mounted.TriggerRegistration?.Dispose();
+        mounted.TriggerRegistration = null;
+        if (mounted.ActivatedComponent is { } activated)
+        {
+            Unmount(tree, activated, removeHostNodes: false);
+            mounted.ActivatedComponent = null;
+        }
+
+        if (removeHostNodes)
+        {
+            RemoveRange(mounted.StartAnchor, mounted.EndAnchor);
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Core/src/Rendering/RendererOptions{TNode}.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/RendererOptions{TNode}.cs
@@ -64,4 +64,11 @@ public sealed class RendererOptions<TNode>
 
     /// <summary>Gets the optional existing-subtree reader factory used for hydration.</summary>
     public Func<TNode, HydrationNodeReader<TNode>>? CreateHydrationReader { get; init; }
+
+    /// <summary>
+    /// Gets the optional host scheduler for marker-bounded deferred hydration. A host that omits
+    /// this capability rejects non-immediate strategies. Specified by <c>[HYD-LAZY-3]</c>.
+    /// </summary>
+    public Func<HydrationTriggerRequest<TNode>, IHydrationTriggerRegistration>?
+        ScheduleHydrationTrigger { get; init; }
 }

--- a/libraries/Assimalign.Viu.Core/src/Rendering/Renderer{TNode}.cs
+++ b/libraries/Assimalign.Viu.Core/src/Rendering/Renderer{TNode}.cs
@@ -168,6 +168,10 @@ public sealed partial class Renderer<TNode>
                 views.Add(component.View);
                 CollectMountedComponentViews(component.Subtree, views);
                 break;
+            case MountedLazyHydration<TNode> lazyHydration
+                when lazyHydration.ActivatedComponent is { } activated:
+                CollectMountedComponentViews(activated, views);
+                break;
             case MountedElement<TNode> element:
                 CollectMountedComponentViews(element.Children, views);
                 break;
@@ -254,6 +258,9 @@ public sealed partial class Renderer<TNode>
                 break;
             case (MountedComponent<TNode> component, ComponentNode componentValue):
                 PatchComponent(tree, component, componentValue, container);
+                break;
+            case (MountedLazyHydration<TNode> lazyHydration, ComponentNode componentValue):
+                PatchLazyHydration(tree, lazyHydration, componentValue, container);
                 break;
             case (MountedTeleport<TNode> teleport, TeleportNode teleportValue):
                 PatchTeleport(tree, teleport, teleportValue, container);
@@ -986,6 +993,16 @@ public sealed partial class Renderer<TNode>
                 }
 
                 return ReplaceMountedNodeReference(component.Subtree, current, replacement);
+            case MountedLazyHydration<TNode> lazyHydration
+                when lazyHydration.ActivatedComponent is { } activated:
+                if (ReferenceEquals(activated, current)
+                    && replacement is MountedComponent<TNode> replacementComponent)
+                {
+                    lazyHydration.ActivatedComponent = replacementComponent;
+                    return true;
+                }
+
+                return ReplaceMountedNodeReference(activated, current, replacement);
             case MountedElement<TNode> element:
                 return ReplaceMountedNodeReference(element.Children, current, replacement);
             case MountedRange<TNode> range:
@@ -1267,6 +1284,10 @@ public sealed partial class Renderer<TNode>
                 break;
             case MountedComponent<TNode> component:
                 CollectDirectiveHostElements(component.Subtree, localName, elements);
+                break;
+            case MountedLazyHydration<TNode> lazyHydration
+                when lazyHydration.ActivatedComponent is { } activated:
+                CollectDirectiveHostElements(activated, localName, elements);
                 break;
             case MountedRange<TNode> range:
                 for (int index = 0; index < range.Children.Count; index++)
@@ -1712,6 +1733,13 @@ public sealed partial class Renderer<TNode>
             case MountedComponent<TNode> component:
                 Move(component.Subtree, container, anchor);
                 break;
+            case MountedLazyHydration<TNode> lazyHydration:
+                MoveRange(
+                    lazyHydration.StartAnchor,
+                    lazyHydration.EndAnchor,
+                    container,
+                    anchor);
+                break;
             case MountedElement<TNode> element:
                 _options.Insert(element.HostNode, container, anchor);
                 break;
@@ -1767,11 +1795,17 @@ public sealed partial class Renderer<TNode>
         }
 
         UnmountVisitCount++;
-        ClearReference(tree, mounted);
+        if (mounted is not MountedLazyHydration<TNode>)
+        {
+            ClearReference(tree, mounted);
+        }
         switch (mounted)
         {
             case MountedComponent<TNode> component:
                 UnmountComponent(tree, component, removeHostNodes);
+                break;
+            case MountedLazyHydration<TNode> lazyHydration:
+                UnmountLazyHydration(tree, lazyHydration, removeHostNodes);
                 break;
             case MountedElement<TNode> element:
                 ElementNode elementValue = (ElementNode)element.Value;
@@ -2026,6 +2060,7 @@ public sealed partial class Renderer<TNode>
         }
 
         return mounted is MountedComponent<TNode>
+            or MountedLazyHydration<TNode>
             or MountedTeleport<TNode>
             or MountedKeepAlive<TNode>
             or MountedSuspense<TNode>
@@ -2163,6 +2198,9 @@ public sealed partial class Renderer<TNode>
             MountedComponent<TNode> component when component.Context.HasExposedValue =>
                 component.Context.ExposedValue,
             MountedComponent<TNode> component => component.Instance,
+            MountedLazyHydration<TNode> lazyHydration
+                when lazyHydration.ActivatedComponent is { } activated =>
+                ReferenceValue(activated),
             MountedElement<TNode> element => element.HostNode,
             MountedLeaf<TNode> leaf => leaf.HostNode,
             _ => mounted.FirstHostNode,

--- a/libraries/Assimalign.Viu.Core/src/Scheduling/Scheduler.cs
+++ b/libraries/Assimalign.Viu.Core/src/Scheduling/Scheduler.cs
@@ -10,31 +10,99 @@ namespace Assimalign.Viu;
 /// Coalesces application work into ordered pre-flush, render, and post-flush phases.
 /// </summary>
 /// <remarks>
-/// The scheduler is ambient and deliberately single-threaded for the JavaScript event-loop model.
-/// Jobs queued during one synchronous turn share one continuation. Specified by <c>[SCH-1]</c>
+/// The scheduler is ambient and single-threaded within one logical execution flow. Browser work
+/// shares its JavaScript event-loop state; request-oriented hosts use isolated queues. Jobs queued
+/// during one synchronous turn share one continuation. A per-flow gate prevents a thread-pool
+/// fallback continuation from racing a synchronous renderer flush; callers still must not mutate
+/// one graph from several threads. Specified by <c>[EXE-1]</c>, <c>[EXE-3]</c>, and <c>[SCH-1]</c>
 /// through <c>[SCH-12]</c>.
 /// </remarks>
 public static class Scheduler
 {
     private const int RecursionLimit = 100;
 
-    private static readonly List<SchedulerJob> _queue = [];
-    private static readonly List<SchedulerJob> _pendingPostFlushCallbacks = [];
-    private static readonly List<Action> _pendingHostCommits = [];
-    private static List<SchedulerJob>? _activePostFlushCallbacks;
-    private static List<SchedulerJob>? _executedInFlushChain;
-    private static Action<Action>? _flushDispatcher;
-    private static int _flushIndex = -1;
-    private static bool _isFlushing;
-    private static bool _isFlushPending;
-    private static TaskCompletionSource? _flushCompletion;
-    private static long _nextInsertionSequence;
+    private static SchedulerExecutionState State => CoreExecutionIsolation.Current.Scheduler;
+
+    private static List<SchedulerJob> _queue => State.Queue;
+
+    private static List<SchedulerJob> _pendingPostFlushCallbacks =>
+        State.PendingPostFlushCallbacks;
+
+    private static List<Action> _pendingHostCommits => State.PendingHostCommits;
+
+    private static List<SchedulerJob>? _activePostFlushCallbacks
+    {
+        get => State.ActivePostFlushCallbacks;
+        set => State.ActivePostFlushCallbacks = value;
+    }
+
+    private static List<SchedulerJob>? _executedInFlushChain
+    {
+        get => State.ExecutedInFlushChain;
+        set => State.ExecutedInFlushChain = value;
+    }
+
+    private static Action<Action>? _flushDispatcher
+    {
+        get => State.FlushDispatcher;
+        set => State.FlushDispatcher = value;
+    }
+
+    private static int _flushIndex
+    {
+        get => State.FlushIndex;
+        set => State.FlushIndex = value;
+    }
+
+    private static bool _isFlushing
+    {
+        get => State.IsFlushing;
+        set => State.IsFlushing = value;
+    }
+
+    private static bool _isFlushPending
+    {
+        get => State.IsFlushPending;
+        set => State.IsFlushPending = value;
+    }
+
+    private static TaskCompletionSource? _flushCompletion
+    {
+        get => State.FlushCompletion;
+        set => State.FlushCompletion = value;
+    }
+
+    private static long _nextInsertionSequence
+    {
+        get => State.NextInsertionSequence;
+        set => State.NextInsertionSequence = value;
+    }
 
     /// <summary>Gets whether a flush is executing.</summary>
-    public static bool IsFlushing => _isFlushing;
+    public static bool IsFlushing
+    {
+        get
+        {
+            SchedulerExecutionState state = State;
+            lock (state.Synchronization)
+            {
+                return state.IsFlushing;
+            }
+        }
+    }
 
     /// <summary>Gets whether a continuation has been scheduled for pending work.</summary>
-    public static bool IsFlushPending => _isFlushPending;
+    public static bool IsFlushPending
+    {
+        get
+        {
+            SchedulerExecutionState state = State;
+            lock (state.Synchronization)
+            {
+                return state.IsFlushPending;
+            }
+        }
+    }
 
     /// <summary>
     /// Installs a deterministic continuation dispatcher and returns a lease that restores the
@@ -48,9 +116,16 @@ public static class Scheduler
     public static IDisposable UseFlushDispatcher(Action<Action> dispatcher)
     {
         ArgumentNullException.ThrowIfNull(dispatcher);
-        var registration = new FlushDispatcherRegistration(_flushDispatcher, dispatcher);
-        _flushDispatcher = dispatcher;
-        return registration;
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
+        {
+            var registration = new FlushDispatcherRegistration(
+                state,
+                state.FlushDispatcher,
+                dispatcher);
+            state.FlushDispatcher = dispatcher;
+            return registration;
+        }
     }
 
     /// <summary>
@@ -61,24 +136,28 @@ public static class Scheduler
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void Reset()
     {
-        ClearQueuedFlag(_queue);
-        ClearQueuedFlag(_pendingPostFlushCallbacks);
-        if (_activePostFlushCallbacks is not null)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            ClearQueuedFlag(_activePostFlushCallbacks);
-        }
+            ClearQueuedFlag(_queue);
+            ClearQueuedFlag(_pendingPostFlushCallbacks);
+            if (_activePostFlushCallbacks is not null)
+            {
+                ClearQueuedFlag(_activePostFlushCallbacks);
+            }
 
-        _queue.Clear();
-        _pendingPostFlushCallbacks.Clear();
-        _pendingHostCommits.Clear();
-        _activePostFlushCallbacks = null;
-        _flushIndex = -1;
-        _isFlushing = false;
-        _isFlushPending = false;
-        _nextInsertionSequence = 0;
-        ResetExecutionCounters();
-        _flushCompletion?.TrySetResult();
-        _flushCompletion = null;
+            _queue.Clear();
+            _pendingPostFlushCallbacks.Clear();
+            _pendingHostCommits.Clear();
+            _activePostFlushCallbacks = null;
+            _flushIndex = -1;
+            _isFlushing = false;
+            _isFlushPending = false;
+            _nextInsertionSequence = 0;
+            ResetExecutionCounters();
+            _flushCompletion?.TrySetResult();
+            _flushCompletion = null;
+        }
     }
 
     /// <summary>
@@ -89,14 +168,18 @@ public static class Scheduler
     public static void QueueJob(SchedulerJob job)
     {
         ArgumentNullException.ThrowIfNull(job);
-        if ((job.Flags & SchedulerJobFlags.Queued) != 0)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            return;
-        }
+            if ((job.Flags & SchedulerJobFlags.Queued) != 0)
+            {
+                return;
+            }
 
-        _queue.Insert(FindInsertionIndex(job.OrderKey), job);
-        job.Flags |= SchedulerJobFlags.Queued;
-        ScheduleFlush();
+            _queue.Insert(FindInsertionIndex(job.OrderKey), job);
+            job.Flags |= SchedulerJobFlags.Queued;
+            ScheduleFlush();
+        }
     }
 
     /// <summary>
@@ -107,15 +190,19 @@ public static class Scheduler
     public static void QueuePostFlushCallback(SchedulerJob callback)
     {
         ArgumentNullException.ThrowIfNull(callback);
-        if ((callback.Flags & SchedulerJobFlags.Queued) != 0)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            return;
-        }
+            if ((callback.Flags & SchedulerJobFlags.Queued) != 0)
+            {
+                return;
+            }
 
-        callback.InsertionSequence = _nextInsertionSequence++;
-        _pendingPostFlushCallbacks.Add(callback);
-        callback.Flags |= SchedulerJobFlags.Queued;
-        ScheduleFlush();
+            callback.InsertionSequence = _nextInsertionSequence++;
+            _pendingPostFlushCallbacks.Add(callback);
+            callback.Flags |= SchedulerJobFlags.Queued;
+            ScheduleFlush();
+        }
     }
 
     /// <summary>
@@ -123,41 +210,52 @@ public static class Scheduler
     /// from post-flush callbacks. Specified by <c>[SCH-9]</c>.
     /// </summary>
     /// <returns>The current flush completion, or a completed task when no work is queued.</returns>
-    public static Task NextTickAsync() => _flushCompletion?.Task ?? Task.CompletedTask;
+    public static Task NextTickAsync()
+    {
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
+        {
+            return state.FlushCompletion?.Task ?? Task.CompletedTask;
+        }
+    }
 
     /// <summary>Runs pending pre-flush jobs immediately in order-key order.</summary>
     /// <remarks>Used by a synchronous renderer before it patches its tree.</remarks>
     public static void FlushPreFlushCallbacks()
     {
-        for (int index = _isFlushing ? _flushIndex + 1 : 0; index < _queue.Count; index++)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            SchedulerJob job = _queue[index];
-            if (!job.IsPreFlush)
+            for (int index = _isFlushing ? _flushIndex + 1 : 0; index < _queue.Count; index++)
             {
-                continue;
-            }
+                SchedulerJob job = _queue[index];
+                if (!job.IsPreFlush)
+                {
+                    continue;
+                }
 
-            _queue.RemoveAt(index);
-            index--;
-            if (job.IsDisposed)
-            {
-                job.Flags &= ~SchedulerJobFlags.Queued;
-                continue;
-            }
+                _queue.RemoveAt(index);
+                index--;
+                if (job.IsDisposed)
+                {
+                    job.Flags &= ~SchedulerJobFlags.Queued;
+                    continue;
+                }
 
-            CheckRecursiveUpdates(job);
-            if (job.AllowRecurse)
-            {
-                job.Flags &= ~SchedulerJobFlags.Queued;
-            }
+                CheckRecursiveUpdates(job);
+                if (job.AllowRecurse)
+                {
+                    job.Flags &= ~SchedulerJobFlags.Queued;
+                }
 
-            try
-            {
-                job.Invoke();
-            }
-            finally
-            {
-                job.Flags &= ~SchedulerJobFlags.Queued;
+                try
+                {
+                    job.Invoke();
+                }
+                finally
+                {
+                    job.Flags &= ~SchedulerJobFlags.Queued;
+                }
             }
         }
     }
@@ -168,64 +266,72 @@ public static class Scheduler
     /// </summary>
     public static void FlushPostFlushCallbacks()
     {
-        if (_activePostFlushCallbacks is not null)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            return;
-        }
-
-        while (_pendingPostFlushCallbacks.Count > 0)
-        {
-            var callbacks = new List<SchedulerJob>(_pendingPostFlushCallbacks);
-            _pendingPostFlushCallbacks.Clear();
-            callbacks.Sort(static (left, right) =>
+            if (_activePostFlushCallbacks is not null)
             {
-                int orderComparison = left.OrderKey.CompareTo(right.OrderKey);
-                return orderComparison != 0
-                    ? orderComparison
-                    : left.InsertionSequence.CompareTo(right.InsertionSequence);
-            });
-            _activePostFlushCallbacks = callbacks;
+                return;
+            }
 
-            try
+            while (_pendingPostFlushCallbacks.Count > 0)
             {
-                for (int index = 0; index < callbacks.Count; index++)
+                var callbacks = new List<SchedulerJob>(_pendingPostFlushCallbacks);
+                _pendingPostFlushCallbacks.Clear();
+                callbacks.Sort(static (left, right) =>
                 {
-                    SchedulerJob callback = callbacks[index];
-                    if (callback.IsDisposed)
-                    {
-                        callback.Flags &= ~SchedulerJobFlags.Queued;
-                        continue;
-                    }
+                    int orderComparison = left.OrderKey.CompareTo(right.OrderKey);
+                    return orderComparison != 0
+                        ? orderComparison
+                        : left.InsertionSequence.CompareTo(right.InsertionSequence);
+                });
+                _activePostFlushCallbacks = callbacks;
 
-                    CheckRecursiveUpdates(callback);
-                    if (callback.AllowRecurse)
+                try
+                {
+                    for (int index = 0; index < callbacks.Count; index++)
                     {
+                        SchedulerJob callback = callbacks[index];
+                        if (callback.IsDisposed)
+                        {
+                            callback.Flags &= ~SchedulerJobFlags.Queued;
+                            continue;
+                        }
+
+                        CheckRecursiveUpdates(callback);
+                        if (callback.AllowRecurse)
+                        {
+                            callback.Flags &= ~SchedulerJobFlags.Queued;
+                        }
+
+                        callback.Invoke();
                         callback.Flags &= ~SchedulerJobFlags.Queued;
                     }
-
-                    callback.Invoke();
-                    callback.Flags &= ~SchedulerJobFlags.Queued;
                 }
-            }
-            catch
-            {
-                ClearQueuedFlag(callbacks);
-                throw;
-            }
-            finally
-            {
-                _activePostFlushCallbacks = null;
+                catch
+                {
+                    ClearQueuedFlag(callbacks);
+                    throw;
+                }
+                finally
+                {
+                    _activePostFlushCallbacks = null;
+                }
             }
         }
     }
 
     internal static void InvalidateJob(SchedulerJob job)
     {
-        int index = _queue.IndexOf(job);
-        if (index > _flushIndex)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            _queue.RemoveAt(index);
-            job.Flags &= ~SchedulerJobFlags.Queued;
+            int index = _queue.IndexOf(job);
+            if (index > _flushIndex)
+            {
+                _queue.RemoveAt(index);
+                job.Flags &= ~SchedulerJobFlags.Queued;
+            }
         }
     }
 
@@ -236,42 +342,50 @@ public static class Scheduler
             return;
         }
 
-        for (int index = 0; index < _pendingHostCommits.Count; index++)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            if (ReferenceEquals(_pendingHostCommits[index], commit))
+            for (int index = 0; index < _pendingHostCommits.Count; index++)
             {
-                return;
+                if (ReferenceEquals(_pendingHostCommits[index], commit))
+                {
+                    return;
+                }
             }
-        }
 
-        _pendingHostCommits.Add(commit);
+            _pendingHostCommits.Add(commit);
+        }
     }
 
     internal static void FlushAfterSynchronousRender()
     {
-        if (_isFlushing)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            return;
-        }
-
-        try
-        {
-            FlushPreFlushCallbacks();
-            FlushHostCommits();
-            FlushPostFlushCallbacks();
-            FlushHostCommits();
-
-            if (_isFlushPending && _queue.Count == 0 && _pendingPostFlushCallbacks.Count == 0)
+            if (_isFlushing)
             {
-                _isFlushPending = false;
-                CompleteFlushChain();
+                return;
             }
-        }
-        catch
-        {
-            AbandonFlush();
-            CompleteFlushChain();
-            throw;
+
+            try
+            {
+                FlushPreFlushCallbacks();
+                FlushHostCommits();
+                FlushPostFlushCallbacks();
+                FlushHostCommits();
+
+                if (_isFlushPending && _queue.Count == 0 && _pendingPostFlushCallbacks.Count == 0)
+                {
+                    _isFlushPending = false;
+                    CompleteFlushChain();
+                }
+            }
+            catch
+            {
+                AbandonFlush();
+                CompleteFlushChain();
+                throw;
+            }
         }
     }
 
@@ -306,71 +420,90 @@ public static class Scheduler
         _flushCompletion ??= new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
+        Action flush = CreateFlushAction();
         if (_flushDispatcher is not null)
         {
-            _flushDispatcher(static () => FlushJobs());
+            _flushDispatcher(flush);
             return;
         }
 
         SynchronizationContext? context = SynchronizationContext.Current;
         if (context is not null)
         {
-            context.Post(static _ => FlushJobs(), null);
+            context.Post(static state => ((Action)state!).Invoke(), flush);
             return;
         }
 
-        ThreadPool.UnsafeQueueUserWorkItem(static _ => FlushJobs(), null);
+        ThreadPool.UnsafeQueueUserWorkItem(static state => ((Action)state!).Invoke(), flush);
+    }
+
+    private static Action CreateFlushAction()
+    {
+        ExecutionContext? executionContext = ExecutionContext.Capture();
+        if (executionContext is null)
+        {
+            return FlushJobs;
+        }
+
+        return () => ExecutionContext.Run(
+            executionContext.CreateCopy(),
+            static _ => FlushJobs(),
+            null);
     }
 
     private static void FlushJobs()
     {
-        if (!_isFlushPending)
+        SchedulerExecutionState state = State;
+        lock (state.Synchronization)
         {
-            return;
-        }
-
-        _isFlushPending = false;
-        _isFlushing = true;
-        try
-        {
-            do
+            if (!_isFlushPending)
             {
-                for (_flushIndex = 0; _flushIndex < _queue.Count; _flushIndex++)
-                {
-                    SchedulerJob job = _queue[_flushIndex];
-                    if (job.IsDisposed)
-                    {
-                        job.Flags &= ~SchedulerJobFlags.Queued;
-                        continue;
-                    }
-
-                    CheckRecursiveUpdates(job);
-                    if (job.AllowRecurse)
-                    {
-                        job.Flags &= ~SchedulerJobFlags.Queued;
-                    }
-
-                    job.Invoke();
-                    job.Flags &= ~SchedulerJobFlags.Queued;
-                }
-
-                _queue.Clear();
-                _flushIndex = -1;
-                FlushHostCommits();
-                FlushPostFlushCallbacks();
-                FlushHostCommits();
+                return;
             }
-            while (_queue.Count > 0 || _pendingPostFlushCallbacks.Count > 0);
 
-            _isFlushing = false;
-            CompleteFlushChain();
-        }
-        catch
-        {
-            AbandonFlush();
-            _isFlushing = false;
-            CompleteFlushChain();
-            throw;
+            _isFlushPending = false;
+            _isFlushing = true;
+            try
+            {
+                do
+                {
+                    for (_flushIndex = 0; _flushIndex < _queue.Count; _flushIndex++)
+                    {
+                        SchedulerJob job = _queue[_flushIndex];
+                        if (job.IsDisposed)
+                        {
+                            job.Flags &= ~SchedulerJobFlags.Queued;
+                            continue;
+                        }
+
+                        CheckRecursiveUpdates(job);
+                        if (job.AllowRecurse)
+                        {
+                            job.Flags &= ~SchedulerJobFlags.Queued;
+                        }
+
+                        job.Invoke();
+                        job.Flags &= ~SchedulerJobFlags.Queued;
+                    }
+
+                    _queue.Clear();
+                    _flushIndex = -1;
+                    FlushHostCommits();
+                    FlushPostFlushCallbacks();
+                    FlushHostCommits();
+                }
+                while (_queue.Count > 0 || _pendingPostFlushCallbacks.Count > 0);
+
+                _isFlushing = false;
+                CompleteFlushChain();
+            }
+            catch
+            {
+                AbandonFlush();
+                _isFlushing = false;
+                CompleteFlushChain();
+                throw;
+            }
         }
     }
 
@@ -454,13 +587,16 @@ public static class Scheduler
 
     private sealed class FlushDispatcherRegistration : IDisposable
     {
+        private readonly SchedulerExecutionState _state;
         private readonly Action<Action>? _previous;
         private Action<Action>? _installed;
 
         internal FlushDispatcherRegistration(
+            SchedulerExecutionState state,
             Action<Action>? previous,
             Action<Action> installed)
         {
+            _state = state;
             _previous = previous;
             _installed = installed;
         }
@@ -472,14 +608,17 @@ public static class Scheduler
                 return;
             }
 
-            if (!ReferenceEquals(_flushDispatcher, _installed))
+            lock (_state.Synchronization)
             {
-                throw new InvalidOperationException(
-                    "Flush dispatcher leases must be disposed in reverse installation order.");
-            }
+                if (!ReferenceEquals(_state.FlushDispatcher, _installed))
+                {
+                    throw new InvalidOperationException(
+                        "Flush dispatcher leases must be disposed in reverse installation order.");
+                }
 
-            _flushDispatcher = _previous;
-            _installed = null;
+                _state.FlushDispatcher = _previous;
+                _installed = null;
+            }
         }
     }
 }

--- a/libraries/Assimalign.Viu.Core/test/AsynchronousComponentsTests.cs
+++ b/libraries/Assimalign.Viu.Core/test/AsynchronousComponentsTests.cs
@@ -31,6 +31,28 @@ public sealed class AsynchronousComponentsTests
     }
 
     [Fact]
+    public void Definition_HydrationDefault_CopiedUnlessInvocationOverridesIt()
+    {
+        HydrationStrategy defaultStrategy = HydrationStrategy.OnIdle(100);
+        AsynchronousComponentDefinition definition =
+            AsynchronousComponents.Define<WrapperIdentityComponent>(
+                new AsynchronousComponentOptions
+                {
+                    Loader = _ => Task.FromResult(
+                        AsynchronousComponentTarget.From<TargetComponent>()),
+                    HydrationStrategy = defaultStrategy,
+                });
+
+        ComponentNode defaultNode = definition.CreateComponent();
+        HydrationStrategy explicitStrategy = HydrationStrategy.OnVisible("20px");
+        ComponentNode explicitNode = definition.CreateComponent(
+            new ComponentInvocation(hydrationStrategy: explicitStrategy));
+
+        defaultNode.Invocation.HydrationStrategy.ShouldBeSameAs(defaultStrategy);
+        explicitNode.Invocation.HydrationStrategy.ShouldBeSameAs(explicitStrategy);
+    }
+
+    [Fact]
     public async Task ConcurrentMounts_SharedSuccessfulLoad_ProduceFreshTargetNodesWithRawInvocation()
     {
         int loadRuns = 0;

--- a/libraries/Assimalign.Viu.Core/test/SchedulerTests.cs
+++ b/libraries/Assimalign.Viu.Core/test/SchedulerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Shouldly;
@@ -282,6 +283,43 @@ public sealed class SchedulerTests : IDisposable
         _pump.RunUntilIdle();
 
         runs.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task FlushAfterSynchronousRender_ThreadPoolFlushOwnsFlow_WaitsWithoutQueueRace()
+    {
+        Action? scheduledFlush = null;
+        using ManualResetEventSlim callbackEntered = new();
+        using ManualResetEventSlim releaseCallback = new();
+        int callbackRuns = 0;
+        using IDisposable dispatcher = Scheduler.UseFlushDispatcher(
+            flush => scheduledFlush = flush);
+        Scheduler.QueuePostFlushCallback(
+            new SchedulerJob(() =>
+            {
+                callbackEntered.Set();
+                releaseCallback.Wait(TimeSpan.FromSeconds(5));
+                callbackRuns++;
+            }));
+        scheduledFlush.ShouldNotBeNull();
+
+        Task backgroundFlush = Task.Run(scheduledFlush!);
+        callbackEntered.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+        Task synchronousFlush = Task.Run(Scheduler.FlushAfterSynchronousRender);
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
+            synchronousFlush.IsCompleted.ShouldBeFalse();
+        }
+        finally
+        {
+            releaseCallback.Set();
+        }
+
+        await Task.WhenAll(backgroundFlush, synchronousFlush)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        callbackRuns.ShouldBe(1);
+        Scheduler.IsFlushing.ShouldBeFalse();
     }
 
     [Fact]

--- a/libraries/Assimalign.Viu.Reactivity/src/Effects/EffectScope.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Effects/EffectScope.cs
@@ -12,14 +12,11 @@ namespace Assimalign.Viu.Reactivity;
 /// values after <see cref="Stop()"/>; its cleanup is automatic, driven by the subscriber count
 /// (losing the last subscriber soft-detaches it from its sources). Nested scopes register with
 /// (and stop with) their parent unless created detached. The ambient
-/// <see cref="Reactive.CurrentScope"/> scope
-/// is a plain static field: NOT thread-safe by design, per the single-threaded JS event-loop
-/// model.
+/// <see cref="Reactive.CurrentScope"/> scope uses shared state on the single-threaded Browser event
+/// loop and execution-flow-local state in request-oriented hosts.
 /// </summary>
 public sealed class EffectScope : IReactiveEffectScope
 {
-    private static EffectScope? _current;
-
     private readonly bool _detached;
     private readonly List<ReactiveEffect> _effects = new();
     private readonly List<Action> _cleanups = new();
@@ -38,16 +35,17 @@ public sealed class EffectScope : IReactiveEffectScope
     internal EffectScope(bool detached = false)
     {
         _detached = detached;
-        _parent = _current;
-        if (!detached && _current is not null)
+        ReactivityExecutionState executionState = ReactivityExecutionIsolation.Current;
+        _parent = executionState.CurrentScope;
+        if (!detached && executionState.CurrentScope is not null)
         {
-            _index = (_current._scopes ??= new List<EffectScope>()).Count;
-            _current._scopes.Add(this);
+            _index = (executionState.CurrentScope._scopes ??= new List<EffectScope>()).Count;
+            executionState.CurrentScope._scopes.Add(this);
         }
     }
 
     /// <summary>The ambient scope that new effects and computeds register with, if any.</summary>
-    internal static EffectScope? Current => _current;
+    internal static EffectScope? Current => ReactivityExecutionIsolation.Current.CurrentScope;
 
     /// <summary>Whether the scope has not been stopped.</summary>
     public bool IsActive => _active;
@@ -79,10 +77,11 @@ public sealed class EffectScope : IReactiveEffectScope
     public void Run(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
-        var previous = _current;
+        ReactivityExecutionState executionState = ReactivityExecutionIsolation.Current;
+        EffectScope? previous = executionState.CurrentScope;
         if (_active)
         {
-            _current = this;
+            executionState.CurrentScope = this;
         }
         try
         {
@@ -90,7 +89,7 @@ public sealed class EffectScope : IReactiveEffectScope
         }
         finally
         {
-            _current = previous;
+            executionState.CurrentScope = previous;
         }
     }
 
@@ -105,10 +104,11 @@ public sealed class EffectScope : IReactiveEffectScope
     public TResult Run<TResult>(Func<TResult> function)
     {
         ArgumentNullException.ThrowIfNull(function);
-        var previous = _current;
+        ReactivityExecutionState executionState = ReactivityExecutionIsolation.Current;
+        EffectScope? previous = executionState.CurrentScope;
         if (_active)
         {
-            _current = this;
+            executionState.CurrentScope = this;
         }
         try
         {
@@ -116,7 +116,7 @@ public sealed class EffectScope : IReactiveEffectScope
         }
         finally
         {
-            _current = previous;
+            executionState.CurrentScope = previous;
         }
     }
 

--- a/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityExecutionIsolation.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityExecutionIsolation.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+
+namespace Assimalign.Viu.Reactivity;
+
+/// <summary>
+/// Selects execution-flow-local bookkeeping for multi-request hosts while preserving the shared
+/// single-event-loop state used by ordinary Browser applications.
+/// </summary>
+internal static class ReactivityExecutionIsolation
+{
+    private static readonly AsyncLocal<ReactivityExecutionState?> IsolatedState = new();
+    private static readonly ReactivityExecutionState SharedState = new();
+
+    internal static ReactivityExecutionState Current => IsolatedState.Value ?? SharedState;
+
+    internal static IDisposable Enter()
+    {
+        ReactivityExecutionState? previous = IsolatedState.Value;
+        IsolatedState.Value = new ReactivityExecutionState();
+        return new IsolationLease(previous);
+    }
+
+    private sealed class IsolationLease : IDisposable
+    {
+        private readonly ReactivityExecutionState? _previous;
+        private bool _isDisposed;
+
+        internal IsolationLease(ReactivityExecutionState? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            IsolatedState.Value = _previous;
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityExecutionState.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityExecutionState.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.Reactivity;
+
+/// <summary>Owns ambient reactivity bookkeeping for one logical execution flow.</summary>
+internal sealed class ReactivityExecutionState
+{
+    internal Subscriber? ActiveSubscriber { get; set; }
+
+    internal bool ShouldTrack { get; set; } = true;
+
+    internal int GlobalVersion { get; set; }
+
+    internal Stack<bool> TrackStack { get; } = new();
+
+    internal int BatchDepth { get; set; }
+
+    internal Subscriber? BatchedSubscriber { get; set; }
+
+    internal Subscriber? BatchedComputed { get; set; }
+
+    internal EffectScope? CurrentScope { get; set; }
+}

--- a/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityState.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Internal/ReactivityState.cs
@@ -1,22 +1,28 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 
 namespace Assimalign.Viu.Reactivity;
 
 /// <summary>
-/// Ambient (static) reactivity state: the active subscriber, the should-track switch, the global
-/// version counter, and the batch queues. This type is NOT thread-safe by design — the runtime
-/// targets the single-threaded JS event-loop model (browser WASM), so plain static fields are used
-/// deliberately and no synchronization is performed.
+/// Ambient reactivity state: the active subscriber, the should-track switch, the global version
+/// counter, and the batch queues. Browser execution uses one shared single-event-loop state;
+/// request-oriented hosts select an execution-flow-local state before running user code.
 /// </summary>
 internal static class ReactivityState
 {
     /// <summary>The subscriber currently collecting dependencies, if any.</summary>
-    internal static Subscriber? ActiveSubscriber;
+    internal static Subscriber? ActiveSubscriber
+    {
+        get => ReactivityExecutionIsolation.Current.ActiveSubscriber;
+        set => ReactivityExecutionIsolation.Current.ActiveSubscriber = value;
+    }
 
     /// <summary>Whether dependency tracking is currently enabled.</summary>
-    internal static bool ShouldTrack = true;
+    internal static bool ShouldTrack
+    {
+        get => ReactivityExecutionIsolation.Current.ShouldTrack;
+        set => ReactivityExecutionIsolation.Current.ShouldTrack = value;
+    }
 
     /// <summary>
     /// Whether a read right now would establish a dependency (there is an active subscriber and
@@ -29,42 +35,44 @@ internal static class ReactivityState
     /// Incremented on every reactive mutation anywhere; lets computeds skip dependency traversal
     /// entirely when nothing anywhere in the graph has changed.
     /// </summary>
-    internal static int GlobalVersion;
-
-    private static readonly Stack<bool> TrackStack = new();
-    private static int _batchDepth;
-    private static Subscriber? _batchedSubscriber;
-    private static Subscriber? _batchedComputed;
+    internal static int GlobalVersion
+    {
+        get => ReactivityExecutionIsolation.Current.GlobalVersion;
+        set => ReactivityExecutionIsolation.Current.GlobalVersion = value;
+    }
 
     /// <summary>Pushes the current tracking state and disables tracking.</summary>
     internal static void PauseTracking()
     {
-        TrackStack.Push(ShouldTrack);
-        ShouldTrack = false;
+        ReactivityExecutionState state = ReactivityExecutionIsolation.Current;
+        state.TrackStack.Push(state.ShouldTrack);
+        state.ShouldTrack = false;
     }
 
     /// <summary>Pops the previously pushed tracking state (re-enables tracking when the stack is empty).</summary>
     internal static void ResetTracking()
     {
-        ShouldTrack = TrackStack.Count == 0 || TrackStack.Pop();
+        ReactivityExecutionState state = ReactivityExecutionIsolation.Current;
+        state.ShouldTrack = state.TrackStack.Count == 0 || state.TrackStack.Pop();
     }
 
     /// <summary>Queues a notified subscriber for execution when the outermost batch ends.</summary>
     internal static void Batch(Subscriber subscriber, bool isComputed)
     {
+        ReactivityExecutionState state = ReactivityExecutionIsolation.Current;
         subscriber.Flags |= SubscriberFlags.Notified;
         if (isComputed)
         {
-            subscriber.NextBatched = _batchedComputed;
-            _batchedComputed = subscriber;
+            subscriber.NextBatched = state.BatchedComputed;
+            state.BatchedComputed = subscriber;
             return;
         }
-        subscriber.NextBatched = _batchedSubscriber;
-        _batchedSubscriber = subscriber;
+        subscriber.NextBatched = state.BatchedSubscriber;
+        state.BatchedSubscriber = subscriber;
     }
 
     /// <summary>Increments the batch depth; triggers are queued until the matching <see cref="EndBatch"/>.</summary>
-    internal static void StartBatch() => _batchDepth++;
+    internal static void StartBatch() => ReactivityExecutionIsolation.Current.BatchDepth++;
 
     /// <summary>
     /// Decrements the batch depth and, when it reaches zero, flushes queued subscribers. Computeds
@@ -75,18 +83,19 @@ internal static class ReactivityState
     /// <exception cref="InvalidOperationException">There is no open batch to close.</exception>
     internal static void EndBatch()
     {
-        if (_batchDepth == 0)
+        ReactivityExecutionState state = ReactivityExecutionIsolation.Current;
+        if (state.BatchDepth == 0)
         {
             throw new InvalidOperationException("EndBatch called without a matching StartBatch.");
         }
-        if (--_batchDepth > 0)
+        if (--state.BatchDepth > 0)
         {
             return;
         }
-        if (_batchedComputed is not null)
+        if (state.BatchedComputed is not null)
         {
-            var computed = _batchedComputed;
-            _batchedComputed = null;
+            Subscriber? computed = state.BatchedComputed;
+            state.BatchedComputed = null;
             while (computed is not null)
             {
                 var next = computed.NextBatched;
@@ -96,10 +105,10 @@ internal static class ReactivityState
             }
         }
         ExceptionDispatchInfo? error = null;
-        while (_batchedSubscriber is not null)
+        while (state.BatchedSubscriber is not null)
         {
-            var subscriber = _batchedSubscriber;
-            _batchedSubscriber = null;
+            Subscriber? subscriber = state.BatchedSubscriber;
+            state.BatchedSubscriber = null;
             while (subscriber is not null)
             {
                 var next = subscriber.NextBatched;

--- a/libraries/Assimalign.Viu.Reactivity/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Assimalign.Viu.Reactivity.Tests")]
+[assembly: InternalsVisibleTo("Assimalign.Viu.Core")]

--- a/libraries/Assimalign.Viu.Reactivity/src/Reactive.cs
+++ b/libraries/Assimalign.Viu.Reactivity/src/Reactive.cs
@@ -7,8 +7,10 @@ namespace Assimalign.Viu.Reactivity;
 /// <summary>
 /// The static entry-point facade for Viu's reactivity system: references, computeds, effects,
 /// effect scopes, watches, tracking control, and batching. This is the whole discoverable surface
-/// — the ratified member list is <c>[RCT-5]</c>. All ambient state is static and NOT thread-safe
-/// by design — the runtime targets the single-threaded JS event-loop model (browser WASM).
+/// — the ratified member list is <c>[RCT-5]</c>. One application graph remains single-event-loop
+/// and not thread-safe; ServerRenderer selects execution-flow-local ambient bookkeeping so distinct
+/// request-owned graphs cannot share tracking, batching, or scope state. Specified by
+/// <c>[EXE-1]</c>.
 /// </summary>
 public static class Reactive
 {

--- a/libraries/Assimalign.Viu.ServerRenderer/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.ServerRenderer/docs/DESIGN.md
@@ -28,6 +28,13 @@ Markup Language payloads are rejected because they require a different serialize
 `TextWriter` and flushes after a completed component subtree, so the destination controls
 backpressure. The renderer borrows the writer and never closes or disposes it (`[SSR-1]`).
 
+The compiler's `ServerMarkup` target lowers a proven static/native region to direct
+`SsrRenderState.Push` calls. Dynamic values use ServerRenderer's public escaping and normalization
+helpers; components and unsupported binding shapes build only their local fallback subtree. The
+public compiled-render entry point owns exactly the same cancellation, component-scope, teleport,
+state, streaming, and flush protocol as the tree path. Executed differential fixtures, rather than
+source snapshots alone, pin ordinal byte equality (`[SSR-COMPILE-1]` through `[SSR-COMPILE-4]`).
+
 Ordinary client lifecycle hooks do not run. Core awaits every `OnServerPrefetch` callback before the
 first render, and cancellation interrupts that wait. Suspense serializes its resolved default branch;
 KeepAlive and Transition serialize their lazy content without client-only behavior.
@@ -40,8 +47,17 @@ consumes those values directly so server output and client hydration cannot drif
 
 An enabled teleport emits origin anchors and buffers its children plus the target anchor. A disabled
 teleport renders children at the origin and contributes only the target anchor. `SsrContext` owns
-those per-render buffers and a free-form state handoff bag; the serializer does not interpret the
-state values (`[SSR-7]`).
+those per-render buffers and a `StateStorePayload` whose fixed schema is
+`{"version":1,"stores":{"store-key":state}}`. After traversal, ServerRenderer captures only the
+request registry's materialized stores and appends an inert `script[data-viu-state]` island. Store
+definitions, not ServerRenderer, own the source-generated serializers (`[SSR-7]`,
+`[V01.01.09.03]`, `[EXE-4]`).
+
+A component invocation with a non-immediate hydration strategy receives one fixed opening marker
+and `LazyHydrationEnd` after its fully rendered subtree. Marker text carries only the strategy kind;
+strategy parameters remain invocation metadata used by the client host. An asynchronous definition
+owns the outer marker and strips the strategy from its resolved target, preventing nested duplicate
+boundaries (`[SSR-MARKERS-1]`, `[HYD-LAZY-1]`, `[HYD-LAZY-2]`).
 
 ## Composition, ownership, and AOT
 
@@ -51,12 +67,46 @@ one application per request when those dependencies are request-scoped (`[CMP-9]
 Viu library references a web framework; a web adapter is downstream and maps its request, response,
 services, abort token, and state separately (`[SSR-8]`).
 
+`ServerRenderAdaptor<TContext>` makes that downstream boundary executable without naming an HTTP
+stack. A typed `ServerRenderRequest<TContext>` carries the root plus the host's own request context;
+`IServerRenderRequestScopeFactory<TContext>` must return an async-disposable scope containing a fresh
+`ServerRenderApplication` and `SsrContext`. The adaptor invokes the factory once, consumes both weak
+identities before validating that the application uses the requested root, streams through
+`IServerRenderOutput`, and disposes the scope on success, failure, or cancellation. Consuming both
+identities matters because a rejected scope is disposed and neither object may safely reappear.
+Weak identity tracking prevents reuse without retaining completed requests (`[V01.01.07.04]`).
+
+Both renderer entry paths enter `CoreExecutionIsolation` before user component code. That internal
+lease supplies independent component-current, scheduler, reactive tracking/batching/scope, and State
+setup/active-registry bookkeeping across asynchronous continuations, then restores the caller's
+logical state. This closes ambient cross-request races without making a request graph itself
+thread-safe (`[EXE-1]`, `[SSR-9]`).
+
+`ServerRenderResult` separates render execution from host policy. It reports the exception and
+whether content started, allowing a downstream server to choose its own status and error page.
+Request cancellation remains an `OperationCanceledException`, because it belongs to the host's
+abort path rather than its failure-response path. The output's `WriteAsync` and `FlushAsync` are both
+awaited; component-subtree flush boundaries therefore preserve progressive delivery and the host's
+backpressure.
+
+The generic hydration handoff is `SsrStateIsland`. It accepts only explicitly serialized JSON,
+normalizes it through reflection-free System.Text.Json metadata, and emits
+`<script type="application/json" data-viu-state>...</script>`. Client hosts locate
+`SsrStateIsland.Selector` and deserialize through a caller-supplied `JsonTypeInfo<T>` before
+hydration. Store schema, capture, and restoration belong to State; the island transport has no store
+dependency (`[EXE-4]`, `[V01.01.07.04]`).
+
 Component activation is explicit and registration-based. Serialization dispatches known node kinds
 and binding forms without runtime type discovery, reflection-based serialization, emitted code, or
-dynamic activation (`[EXE-4]`).
+dynamic activation. State payload capture requires an `IStateStorePayloadRegistry`; a custom
+registry that materializes stores without that contract fails instead of emitting an incomplete
+payload (`[EXE-4]`).
 
 ## Non-goals
 
-ServerRenderer does not own request scopes, web responses, browser application lifetime, DOM
-hydration, client directives, transition timing, persistent mounted state, or dependency disposal.
-Scoped style stamping is absent while scoped CSS is deferred (`[STY-1]`).
+The low-level render entry points do not own request scopes. The host adaptor owns only the
+factory-returned scope for one invocation; it never owns the output or prescribes an HTTP response.
+ServerRenderer does not own browser application lifetime, DOM hydration, client directives,
+transition timing, or persistent mounted state. The runtime-tree entry point has no compiled
+scope-identifier input; scoped identifiers are emitted only by the server compiler profile
+(`[SSR-COMPILE-3]`).

--- a/libraries/Assimalign.Viu.ServerRenderer/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.ServerRenderer/docs/OVERVIEW.md
@@ -5,6 +5,18 @@ either an immutable `ServerRenderApplication` or a primitive `VirtualNode` tree 
 string or a caller-owned `TextWriter`. Streaming flushes at completed component-subtree boundaries,
 so the destination controls backpressure without imposing a web-framework dependency.
 
+`ServerRenderAdaptor<TContext>` is the request-hosting layer over those entry points. A downstream
+server supplies an `IServerRenderRequestScopeFactory<TContext>` and `IServerRenderOutput`; Viu asks
+for a fresh async-disposable application/context scope on every request, awaits every write and
+flush, and reports completion or a host-mappable failure through `ServerRenderResult`. Reusing an
+application or `SsrContext` is rejected. Cancellation propagates to component prefetch, serialization,
+output, and scope teardown without being converted into an application error.
+
+Every runtime-tree and compiled render selects fresh logical Core, Reactivity, State, and scheduler
+bookkeeping. Parallel request-owned graphs therefore cannot exchange ambient component/setup state,
+effects, batch queues, active registries, or scheduled jobs; sharing graph objects between requests
+remains unsupported [EXE-1], [SSR-9].
+
 The serializer dispatches all ten `VirtualNodeKind` values. Component nodes execute only through
 `ComponentHost.RenderAsync`; it holds the returned `IComponentRenderScope` while consuming
 `scope.Tree`, passes that active scope as the parent of nested requests, and disposes the scope after
@@ -20,9 +32,29 @@ they require a different host serializer.
 `HydrationMarkers` is the sole marker vocabulary. Fragments emit its range markers; enabled
 teleports leave origin anchors and buffer children plus a target anchor; disabled teleports render
 children in place and contribute only their target anchor. `SsrContext` exposes the resolved target
-buffers and a renderer-uninterpreted state handoff bag. Suspense serializes only its resolved default
-branch; KeepAlive and Transition serialize their lazy default slots without client-only behavior.
+buffers and the versioned `StateStorePayload` captured from the request registry after traversal.
+When state is composed, the renderer appends the island to its emitted HTML. `SsrStateIsland`
+provides the store-independent transport: it validates raw JSON, emits an inert
+`data-viu-state` script, and restores a typed payload only through caller-supplied source-generated
+`JsonTypeInfo<T>`. Suspense serializes only its resolved default branch; KeepAlive and Transition
+serialize their lazy default slots without client-only behavior.
 
-Scoped CSS remains deferred for this wave, so ServerRenderer performs no scope-identifier attribute
-pass. Application services, factories, directives, state registries, and diagnostics are borrowed
-from `IApplicationContext` and are never disposed by this package.
+The Templates compiler's `ServerMarkup` profile is the build-time fast path. It writes proven native
+structure and interpolations directly through `SsrRenderState`, while dynamic components and
+unsupported binding shapes fall back to a local virtual tree on that same render state. The public
+`CompiledServerRender` seam supplies renderer-owned cancellation, component leases, streaming,
+teleports, state capture, and final flush. Differential fixtures execute both paths and require
+ordinal byte equality (`[SSR-COMPILE-1]` through `[SSR-COMPILE-4]`).
+
+A non-immediate component invocation is serialized inside Core's fixed lazy-hydration markers.
+Server rendering still resolves the authored subtree; the client may then adopt the complete range
+without activating it until its host trigger fires. Asynchronous definitions emit exactly one outer
+boundary (`[SSR-MARKERS-1]`, `[HYD-LAZY-1]`, `[HYD-LAZY-2]`).
+
+The runtime-tree serializer has no scope-identifier input, so it performs no scope-identifier
+attribute pass. The compiler profile does emit the transform's known scope identifier on every
+native element. Application services, factories, directives, state registries, and diagnostics are borrowed
+from `IApplicationContext`. The low-level renderer never disposes them; the host adaptor disposes
+only the request scope explicitly returned by the downstream factory. The test project includes a
+BCL-only loopback HTTP smoke host, proving that neither the contract nor its execution requires
+ASP.NET Core or Kestrel.

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderOutput.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderOutput.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Receives progressive server-rendered markup and exposes the host's flush boundary without
+/// introducing a web-framework response type.
+/// </summary>
+/// <remarks>
+/// The renderer borrows the output and never closes or disposes it. Each flush is awaited so the
+/// host's own buffering and backpressure policy remains authoritative. Specified by
+/// <c>[SSR-1]</c>, <c>[SSR-8]</c>, and <c>[SSR-11]</c>.
+/// </remarks>
+public interface IServerRenderOutput
+{
+    /// <summary>Writes one non-empty serialized markup chunk to the host response.</summary>
+    /// <param name="content">The serialized character content.</param>
+    /// <param name="cancellationToken">Cancellation propagated from the host request.</param>
+    /// <returns>A value task that completes when the host accepts the content.</returns>
+    ValueTask WriteAsync(
+        ReadOnlyMemory<char> content,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Flushes accepted content through the host's backpressure boundary.</summary>
+    /// <param name="cancellationToken">Cancellation propagated from the host request.</param>
+    /// <returns>A value task that completes only when the host completes the flush.</returns>
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderRequestScope.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderRequestScope.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Owns the application composition and server-render context created for exactly one host
+/// request.
+/// </summary>
+/// <remarks>
+/// The server adaptor disposes this scope after rendering, cancellation, or failure. The scope,
+/// application, and context must all be fresh for each factory invocation; the adaptor rejects
+/// reuse. Specified by <c>[SSR-8]</c>, <c>[SSR-9]</c>, and <c>[SSR-11]</c>.
+/// </remarks>
+public interface IServerRenderRequestScope : IAsyncDisposable
+{
+    /// <summary>Gets the request-owned server application composition.</summary>
+    ServerRenderApplication Application { get; }
+
+    /// <summary>Gets the request-owned teleport and hydration-state handoff context.</summary>
+    SsrContext RenderContext { get; }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderRequestScopeFactory{TContext}.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Abstraction/IServerRenderRequestScopeFactory{TContext}.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>Creates a fresh, owned server-render scope for each typed host request.</summary>
+/// <typeparam name="TContext">The host-defined request context type.</typeparam>
+/// <remarks>
+/// This is the structural per-request boundary: services, component registrations, and state may
+/// be composed from the host context without exposing that host's framework types to Viu.
+/// Specified by <c>[SSR-8]</c>, <c>[SSR-9]</c>, and <c>[SSR-11]</c>.
+/// </remarks>
+public interface IServerRenderRequestScopeFactory<TContext>
+    where TContext : notnull
+{
+    /// <summary>Creates the fresh scope used only for the supplied request.</summary>
+    /// <param name="request">The root component and host-defined request context.</param>
+    /// <param name="cancellationToken">Cancellation propagated from the host request.</param>
+    /// <returns>The request-owned scope that the adaptor will dispose.</returns>
+    ValueTask<IServerRenderRequestScope> CreateAsync(
+        ServerRenderRequest<TContext> request,
+        CancellationToken cancellationToken = default);
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Assimalign.Viu.ServerRenderer.csproj
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Assimalign.Viu.ServerRenderer.csproj
@@ -6,5 +6,6 @@
   <ItemGroup>
     <ViuProjectReference Include="Assimalign.Viu.Components" />
     <ViuProjectReference Include="Assimalign.Viu.Core" />
+    <ViuProjectReference Include="Assimalign.Viu.State" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Delegates/CompiledServerRender.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Delegates/CompiledServerRender.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Writes one compiler-produced server render body into a renderer-owned output state.
+/// </summary>
+/// <param name="state">
+/// The request-local output, application, cancellation, teleport, and component-render state.
+/// </param>
+/// <returns>A task that completes after the compiled body and all of its fallbacks complete.</returns>
+/// <remarks>
+/// The delegate is a build-time generated contract: it performs no runtime template compilation and
+/// is safe for trimming and NativeAOT. Direct writes and virtual-tree fallbacks share the same
+/// <see cref="SsrRenderState"/> so escaping, hydration markers, teleports, cancellation, and streaming
+/// boundaries remain one protocol. Specified by <c>[SSR-COMPILE-2]</c> and
+/// <c>[SSR-COMPILE-4]</c>.
+/// </remarks>
+public delegate Task CompiledServerRender(SsrRenderState state);

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderAdaptor{TContext}.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderAdaptor{TContext}.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Executes request-scoped server rendering over a framework-neutral factory and streaming output.
+/// </summary>
+/// <typeparam name="TContext">The host-defined request context type.</typeparam>
+/// <remarks>
+/// Every invocation obtains and disposes a new request scope. Reusing either a
+/// <see cref="ServerRenderApplication"/> or <see cref="SsrContext"/> is rejected, which prevents
+/// application, reactive-service, teleport, and hydration-state bleed between requests. Ordinary
+/// failures are returned for host mapping; request cancellation propagates. The renderer also
+/// selects fresh logical Core, Reactivity, State, and scheduler bookkeeping for every call.
+/// Specified by <c>[EXE-1]</c>, <c>[SSR-1]</c>, and <c>[SSR-8]</c> through <c>[SSR-12]</c>.
+/// </remarks>
+public sealed class ServerRenderAdaptor<TContext>
+    where TContext : notnull
+{
+    private readonly IServerRenderRequestScopeFactory<TContext> _requestScopeFactory;
+
+    /// <summary>Initializes the adaptor with the host's request-scope factory.</summary>
+    /// <param name="requestScopeFactory">The factory invoked exactly once per render request.</param>
+    public ServerRenderAdaptor(IServerRenderRequestScopeFactory<TContext> requestScopeFactory)
+    {
+        ArgumentNullException.ThrowIfNull(requestScopeFactory);
+        _requestScopeFactory = requestScopeFactory;
+    }
+
+    /// <summary>
+    /// Creates a fresh request scope, streams the render, and disposes the scope before reporting
+    /// the outcome to the host.
+    /// </summary>
+    /// <param name="request">The root component and host-defined request context.</param>
+    /// <param name="output">The borrowed host response output.</param>
+    /// <param name="cancellationToken">Cancellation propagated from the host request.</param>
+    /// <returns>
+    /// A completion or failure result the host maps to its own response policy. Cancellation throws
+    /// instead of becoming a failure result.
+    /// </returns>
+    public async ValueTask<ServerRenderResult> RenderAsync(
+        ServerRenderRequest<TContext> request,
+        IServerRenderOutput output,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(output);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IServerRenderRequestScope? scope = null;
+        SsrContext? context = null;
+        ServerRenderOutputTextWriter? writer = null;
+        Exception? failure = null;
+        ExceptionDispatchInfo? cancellation = null;
+
+        try
+        {
+            scope = await _requestScopeFactory.CreateAsync(
+                request,
+                cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException(
+                    "The server render request-scope factory returned null.");
+
+            ServerRenderApplication application = scope.Application
+                ?? throw new InvalidOperationException(
+                    "The server render request scope returned a null application.");
+            context = scope.RenderContext
+                ?? throw new InvalidOperationException(
+                    "The server render request scope returned a null render context.");
+
+            ServerRenderRequestIsolation.Track(application, context);
+
+            if (!ReferenceEquals(application.Context.RootComponent, request.RootComponent))
+            {
+                throw new InvalidOperationException(
+                    "The request-scope application must use the request's root component instance.");
+            }
+
+            writer = new ServerRenderOutputTextWriter(output);
+            await ServerRenderer.RenderToStreamAsync(
+                application,
+                writer,
+                context,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            cancellation = ExceptionDispatchInfo.Capture(exception);
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+        }
+        finally
+        {
+            if (scope is not null)
+            {
+                try
+                {
+                    await scope.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException exception)
+                    when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellation ??= ExceptionDispatchInfo.Capture(exception);
+                }
+                catch (Exception exception)
+                {
+                    failure = failure is null
+                        ? exception
+                        : new AggregateException(failure, exception);
+                }
+            }
+        }
+
+        cancellation?.Throw();
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ServerRenderResult(
+            context,
+            failure,
+            writer?.ResponseStarted ?? false);
+    }
+
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderRequest{TContext}.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderRequest{TContext}.cs
@@ -1,0 +1,33 @@
+using System;
+
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>Pairs one root render description with a host-defined per-request context.</summary>
+/// <typeparam name="TContext">The host-defined request context type.</typeparam>
+/// <remarks>
+/// The generic context keeps framework-specific request types in downstream host code while the
+/// ServerRenderer contract remains host-neutral. Specified by <c>[SSR-8]</c> and
+/// <c>[SSR-11]</c>.
+/// </remarks>
+public sealed class ServerRenderRequest<TContext>
+    where TContext : notnull
+{
+    /// <summary>Initializes one host render request.</summary>
+    /// <param name="rootComponent">The root value in Viu's virtual-node algebra.</param>
+    /// <param name="requestContext">The host-defined context for this request.</param>
+    public ServerRenderRequest(VirtualNode rootComponent, TContext requestContext)
+    {
+        ArgumentNullException.ThrowIfNull(rootComponent);
+        ArgumentNullException.ThrowIfNull(requestContext);
+        RootComponent = rootComponent;
+        RequestContext = requestContext;
+    }
+
+    /// <summary>Gets the immutable root render description.</summary>
+    public VirtualNode RootComponent { get; }
+
+    /// <summary>Gets the host-defined per-request context.</summary>
+    public TContext RequestContext { get; }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderResult.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/ServerRenderResult.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Reports completion or failure to the downstream host without prescribing an HTTP status,
+/// error page, or framework exception policy.
+/// </summary>
+/// <remarks>
+/// Cancellation is not converted to a result and propagates as <see cref="OperationCanceledException"/>.
+/// Specified by <c>[SSR-8]</c> and <c>[SSR-12]</c>.
+/// </remarks>
+public sealed class ServerRenderResult
+{
+    internal ServerRenderResult(
+        SsrContext? context,
+        Exception? failure,
+        bool responseStarted)
+    {
+        Context = context;
+        Failure = failure;
+        ResponseStarted = responseStarted;
+    }
+
+    /// <summary>Gets whether rendering and request-scope disposal both completed successfully.</summary>
+    public bool Succeeded => Failure is null;
+
+    /// <summary>Gets the render, output, validation, or disposal failure, when one occurred.</summary>
+    public Exception? Failure { get; }
+
+    /// <summary>
+    /// Gets whether the adaptor attempted to write any response content before completion or
+    /// failure was known.
+    /// </summary>
+    /// <remarks>A host uses this signal to decide whether its status and headers can still change.</remarks>
+    public bool ResponseStarted { get; }
+
+    /// <summary>
+    /// Gets the request-owned render context when scope creation reached that point, including
+    /// resolved teleport output available after successful rendering.
+    /// </summary>
+    public SsrContext? Context { get; }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/SsrStateIsland.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Hosting/SsrStateIsland.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Transports an explicitly serialized JSON payload between server rendering and a client host
+/// before hydration begins.
+/// </summary>
+/// <remarks>
+/// The codec depends only on raw JSON. State packages provide their own schema and source-generated
+/// serializers, while this transport validates the JSON, emits an inert script island, and requires
+/// a caller-supplied <see cref="JsonTypeInfo{T}"/> for typed restoration. Specified by
+/// <c>[SSR-7]</c> and <c>[EXE-4]</c>.
+/// </remarks>
+public static class SsrStateIsland
+{
+    /// <summary>Gets the host selector for locating the emitted state payload before hydration.</summary>
+    public const string Selector = "script[data-viu-state]";
+
+    /// <summary>Creates inert script markup containing normalized, HTML-safe JSON.</summary>
+    /// <param name="json">The explicitly serialized JSON payload.</param>
+    /// <returns>The complete state-island markup.</returns>
+    /// <exception cref="JsonException">The payload is not valid JSON.</exception>
+    public static string CreateMarkup(string json) =>
+        string.Concat(
+            "<script type=\"application/json\" data-viu-state>",
+            NormalizePayload(json),
+            "</script>");
+
+    /// <summary>Validates and normalizes a raw JSON payload with HTML-safe escaping.</summary>
+    /// <param name="json">The explicitly serialized JSON payload.</param>
+    /// <returns>The validated payload text used both for the island and client handoff.</returns>
+    /// <exception cref="JsonException">The payload is not valid JSON.</exception>
+    public static string NormalizePayload(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        using JsonDocument document = JsonDocument.Parse(json);
+        return JsonSerializer.Serialize(
+            document.RootElement,
+            SsrStateIslandJsonSerializerContext.Default.JsonElement);
+    }
+
+    /// <summary>Writes and flushes one state island through a borrowed text writer.</summary>
+    /// <param name="writer">The borrowed host or renderer writer.</param>
+    /// <param name="json">The explicitly serialized JSON payload.</param>
+    /// <param name="cancellationToken">Cancellation propagated from the host request.</param>
+    /// <returns>A task completing only after the destination flush completes.</returns>
+    public static async Task WriteAsync(
+        TextWriter writer,
+        string json,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        string markup = CreateMarkup(json);
+        await writer.WriteAsync(markup.AsMemory(), cancellationToken).ConfigureAwait(false);
+        await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deserializes extracted island text through caller-supplied source-generated metadata before
+    /// the client host begins hydration.
+    /// </summary>
+    /// <typeparam name="T">The explicitly registered payload schema.</typeparam>
+    /// <param name="json">The text content extracted through <see cref="Selector"/>.</param>
+    /// <param name="typeInformation">The source-generated JSON metadata for the payload.</param>
+    /// <returns>The restored payload value.</returns>
+    /// <exception cref="JsonException">The payload does not match the registered schema.</exception>
+    public static T? Deserialize<T>(string json, JsonTypeInfo<T> typeInformation)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        ArgumentNullException.ThrowIfNull(typeInformation);
+        return JsonSerializer.Deserialize(json, typeInformation);
+    }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerMarkupSerializer.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerMarkupSerializer.cs
@@ -149,6 +149,15 @@ internal static class ServerMarkupSerializer
         ComponentNode component,
         IComponentRenderScope? parent)
     {
+        HydrationStrategyKind hydrationStrategy =
+            component.Invocation.HydrationStrategy?.Kind
+            ?? HydrationStrategyKind.Immediate;
+        bool isDeferredHydration = hydrationStrategy != HydrationStrategyKind.Immediate;
+        if (isDeferredHydration)
+        {
+            state.Push(HydrationMarkers.GetLazyHydrationStart(hydrationStrategy));
+        }
+
         await using IComponentRenderScope scope = await state.ComponentHost.RenderAsync(
             new ComponentRenderRequest(component, parent),
             state.CancellationToken).ConfigureAwait(false);
@@ -160,6 +169,11 @@ internal static class ServerMarkupSerializer
         else
         {
             await RenderAsync(state, scope.Tree, scope).ConfigureAwait(false);
+        }
+
+        if (isDeferredHydration)
+        {
+            state.Push(HydrationMarkers.LazyHydrationEnd);
         }
 
         // A complete component subtree is the streaming boundary required by [SSR-1].

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderOutputTextWriter.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderOutputTextWriter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>Bridges the host output contract into the serializer's existing text writer seam.</summary>
+internal sealed class ServerRenderOutputTextWriter : TextWriter
+{
+    private readonly IServerRenderOutput _output;
+
+    internal ServerRenderOutputTextWriter(IServerRenderOutput output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        _output = output;
+    }
+
+    internal bool ResponseStarted { get; private set; }
+
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public override Task WriteAsync(
+        ReadOnlyMemory<char> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        if (buffer.Length > 0)
+        {
+            ResponseStarted = true;
+        }
+
+        return _output.WriteAsync(buffer, cancellationToken).AsTask();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        _output.FlushAsync(cancellationToken).AsTask();
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderRequestIsolation.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderRequestIsolation.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>Tracks request identities weakly across every typed server adaptor instance.</summary>
+internal static class ServerRenderRequestIsolation
+{
+    private static readonly object UsedMarker = new();
+    private static readonly ConditionalWeakTable<ServerRenderApplication, object> UsedApplications =
+        new();
+    private static readonly ConditionalWeakTable<SsrContext, object> UsedContexts = new();
+
+    internal static void Track(
+        ServerRenderApplication application,
+        SsrContext context)
+    {
+        ArgumentException? applicationReuse = null;
+        try
+        {
+            UsedApplications.Add(application, UsedMarker);
+        }
+        catch (ArgumentException exception)
+        {
+            applicationReuse = exception;
+        }
+
+        ArgumentException? contextReuse = null;
+        try
+        {
+            UsedContexts.Add(context, UsedMarker);
+        }
+        catch (ArgumentException exception)
+        {
+            contextReuse = exception;
+        }
+
+        if (applicationReuse is null && contextReuse is null)
+        {
+            return;
+        }
+
+        if (applicationReuse is not null && contextReuse is not null)
+        {
+            throw new InvalidOperationException(
+                "Server render application and SsrContext instances cannot be reused across host "
+                    + "requests.",
+                new AggregateException(applicationReuse, contextReuse));
+        }
+
+        throw applicationReuse is not null
+            ? new InvalidOperationException(
+                "A server render application instance cannot be reused across host requests.",
+                applicationReuse)
+            : new InvalidOperationException(
+                "An SsrContext instance cannot be reused across host requests.",
+                contextReuse);
+    }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderStatePayload.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Internal/ServerRenderStatePayload.cs
@@ -1,0 +1,36 @@
+using System;
+
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>
+/// Shares the post-traversal state capture and island emission contract between runtime-tree and
+/// compiler-produced server render bodies.
+/// </summary>
+internal static class ServerRenderStatePayload
+{
+    internal static void PrepareContext(SsrContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.State = null;
+    }
+
+    internal static void CaptureAndAppend(SsrRenderState renderState)
+    {
+        ArgumentNullException.ThrowIfNull(renderState);
+        if (renderState.Application.State is IStateStorePayloadRegistry payloadRegistry)
+        {
+            renderState.Context.State = payloadRegistry.CapturePayload();
+            renderState.Push(
+                SsrStateIsland.CreateMarkup(renderState.Context.State.Json));
+        }
+        else if (renderState.Application.State is { Count: > 0 })
+        {
+            throw new InvalidOperationException(
+                "The configured state registry materialized stores during server rendering but "
+                + "does not implement IStateStorePayloadRegistry. Use StateStoreRegistry or "
+                + "provide an explicit AOT-safe payload registry implementation.");
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/Internal/SsrStateIslandJsonSerializerContext.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/Internal/SsrStateIslandJsonSerializerContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <summary>Provides reflection-free metadata for raw state-island normalization.</summary>
+[JsonSourceGenerationOptions(WriteIndented = false)]
+[JsonSerializable(typeof(JsonElement))]
+internal sealed partial class SsrStateIslandJsonSerializerContext : JsonSerializerContext;

--- a/libraries/Assimalign.Viu.ServerRenderer/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,41 @@
 #nullable enable
+Assimalign.Viu.ServerRenderer.CompiledServerRender
+*REMOVED*Assimalign.Viu.ServerRenderer.SsrContext.State.get -> System.Collections.Generic.IDictionary<string!, object?>!
 *REMOVED*static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderAttr(string! key, object? value) -> string!
 *REMOVED*static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderAttrs(System.Collections.Generic.IReadOnlyList<Assimalign.Viu.Components.ElementBinding!>? bindings, Assimalign.Viu.Components.QualifiedName? elementName = null) -> string!
 *REMOVED*static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderDynamicAttr(string! key, object? value, string? tag = null) -> string!
+static Assimalign.Viu.ServerRenderer.ServerRender.IsModelValueSelected(object? modelValue, object? candidate, bool booleanModelIsSelection = false) -> bool
+static Assimalign.Viu.ServerRenderer.ServerRender.IsTruthy(object? value) -> bool
+static Assimalign.Viu.ServerRenderer.ServerRender.RenderCompiledToStreamAsync(Assimalign.Viu.ServerRenderer.ServerRenderApplication! application, Assimalign.Viu.ServerRenderer.CompiledServerRender! render, System.IO.TextWriter! writer, Assimalign.Viu.ServerRenderer.SsrContext? context = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Assimalign.Viu.ServerRenderer.ServerRender.RenderCompiledToStringAsync(Assimalign.Viu.ServerRenderer.ServerRenderApplication! application, Assimalign.Viu.ServerRenderer.CompiledServerRender! render, Assimalign.Viu.ServerRenderer.SsrContext? context = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderAttribute(string! key, object? value) -> string!
 static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderAttributes(System.Collections.Generic.IReadOnlyList<Assimalign.Viu.Components.ElementBinding!>? bindings, Assimalign.Viu.Components.QualifiedName? elementName = null) -> string!
 static Assimalign.Viu.ServerRenderer.ServerRender.SsrRenderDynamicAttribute(string! key, object? value, string? tag = null) -> string!
+Assimalign.Viu.ServerRenderer.SsrContext.State.get -> Assimalign.Viu.State.StateStorePayload?
+virtual Assimalign.Viu.ServerRenderer.CompiledServerRender.Invoke(Assimalign.Viu.ServerRenderer.SsrRenderState! state) -> System.Threading.Tasks.Task!
+Assimalign.Viu.ServerRenderer.IServerRenderOutput
+Assimalign.Viu.ServerRenderer.IServerRenderOutput.FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Assimalign.Viu.ServerRenderer.IServerRenderOutput.WriteAsync(System.ReadOnlyMemory<char> content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Assimalign.Viu.ServerRenderer.IServerRenderRequestScope
+Assimalign.Viu.ServerRenderer.IServerRenderRequestScope.Application.get -> Assimalign.Viu.ServerRenderer.ServerRenderApplication!
+Assimalign.Viu.ServerRenderer.IServerRenderRequestScope.RenderContext.get -> Assimalign.Viu.ServerRenderer.SsrContext!
+Assimalign.Viu.ServerRenderer.IServerRenderRequestScopeFactory<TContext>
+Assimalign.Viu.ServerRenderer.IServerRenderRequestScopeFactory<TContext>.CreateAsync(Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Assimalign.Viu.ServerRenderer.IServerRenderRequestScope!>
+Assimalign.Viu.ServerRenderer.ServerRenderAdaptor<TContext>
+Assimalign.Viu.ServerRenderer.ServerRenderAdaptor<TContext>.RenderAsync(Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>! request, Assimalign.Viu.ServerRenderer.IServerRenderOutput! output, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Assimalign.Viu.ServerRenderer.ServerRenderResult!>
+Assimalign.Viu.ServerRenderer.ServerRenderAdaptor<TContext>.ServerRenderAdaptor(Assimalign.Viu.ServerRenderer.IServerRenderRequestScopeFactory<TContext>! requestScopeFactory) -> void
+Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>
+Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>.RequestContext.get -> TContext
+Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>.RootComponent.get -> Assimalign.Viu.Components.VirtualNode!
+Assimalign.Viu.ServerRenderer.ServerRenderRequest<TContext>.ServerRenderRequest(Assimalign.Viu.Components.VirtualNode! rootComponent, TContext requestContext) -> void
+Assimalign.Viu.ServerRenderer.ServerRenderResult
+Assimalign.Viu.ServerRenderer.ServerRenderResult.Context.get -> Assimalign.Viu.ServerRenderer.SsrContext?
+Assimalign.Viu.ServerRenderer.ServerRenderResult.Failure.get -> System.Exception?
+Assimalign.Viu.ServerRenderer.ServerRenderResult.ResponseStarted.get -> bool
+Assimalign.Viu.ServerRenderer.ServerRenderResult.Succeeded.get -> bool
+Assimalign.Viu.ServerRenderer.SsrStateIsland
+const Assimalign.Viu.ServerRenderer.SsrStateIsland.Selector = "script[data-viu-state]" -> string!
+static Assimalign.Viu.ServerRenderer.SsrStateIsland.CreateMarkup(string! json) -> string!
+static Assimalign.Viu.ServerRenderer.SsrStateIsland.Deserialize<T>(string! json, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! typeInformation) -> T?
+static Assimalign.Viu.ServerRenderer.SsrStateIsland.NormalizePayload(string! json) -> string!
+static Assimalign.Viu.ServerRenderer.SsrStateIsland.WriteAsync(System.IO.TextWriter! writer, string! json, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/libraries/Assimalign.Viu.ServerRenderer/src/ServerRender.Compiled.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/ServerRender.Compiled.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Assimalign.Viu;
+
+namespace Assimalign.Viu.ServerRenderer;
+
+/// <content>
+/// Provides the invocation and normalization seam for compiler-produced server render bodies.
+/// </content>
+public static partial class ServerRender
+{
+    /// <summary>Renders one compiler-produced server body to a completed HTML string.</summary>
+    /// <param name="application">The immutable per-render application composition.</param>
+    /// <param name="render">The statically generated render body.</param>
+    /// <param name="context">The per-render state and teleport context, or null to create one.</param>
+    /// <param name="cancellationToken">Cancellation for direct writes and virtual-tree fallbacks.</param>
+    /// <returns>The completed WHATWG HTML serialization.</returns>
+    /// <remarks>
+    /// The compiled body owns root markup production; <paramref name="application"/> supplies the
+    /// borrowed component, service, state, and diagnostic composition used by fallback regions.
+    /// The final flush, teleport resolution, and fresh logical execution state are identical to
+    /// tree traversal. Specified by <c>[EXE-1]</c>, <c>[SSR-COMPILE-4]</c>, <c>[SSR-1]</c>, and
+    /// <c>[SSR-7]</c>.
+    /// </remarks>
+    public static async Task<string> RenderCompiledToStringAsync(
+        ServerRenderApplication application,
+        CompiledServerRender render,
+        SsrContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        ArgumentNullException.ThrowIfNull(render);
+
+        SsrWriter writer = new();
+        await RenderCompiledCoreAsync(
+            application,
+            render,
+            writer,
+            context ?? new SsrContext(),
+            cancellationToken).ConfigureAwait(false);
+        return writer.ToStringResult();
+    }
+
+    /// <summary>
+    /// Streams one compiler-produced server body and flushes its final direct-write chunk.
+    /// </summary>
+    /// <param name="application">The immutable per-render application composition.</param>
+    /// <param name="render">The statically generated render body.</param>
+    /// <param name="writer">The externally owned output destination.</param>
+    /// <param name="context">The per-render state and teleport context, or null to create one.</param>
+    /// <param name="cancellationToken">Cancellation for direct writes, fallbacks, and flushing.</param>
+    /// <returns>A task completing after the destination's final flush.</returns>
+    /// <remarks>
+    /// Component fallbacks keep their ordinary subtree flush boundaries; direct regions are drained by
+    /// the final flush and fresh logical execution state. The destination controls backpressure
+    /// under <c>[SSR-1]</c>. Specified by <c>[EXE-1]</c>, <c>[SSR-COMPILE-4]</c>, <c>[SSR-1]</c>,
+    /// and <c>[SSR-7]</c>.
+    /// </remarks>
+    public static Task RenderCompiledToStreamAsync(
+        ServerRenderApplication application,
+        CompiledServerRender render,
+        TextWriter writer,
+        SsrContext? context = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        ArgumentNullException.ThrowIfNull(render);
+        ArgumentNullException.ThrowIfNull(writer);
+        return RenderCompiledCoreAsync(
+            application,
+            render,
+            new SsrWriter(writer),
+            context ?? new SsrContext(),
+            cancellationToken);
+    }
+
+    /// <summary>Tests a value using the truth contract shared by class, style, and server directives.</summary>
+    /// <param name="value">The value to test.</param>
+    /// <returns>Whether the value participates as truthy server-render input.</returns>
+    /// <remarks>
+    /// Compiler-produced <c>v-show</c> branches use this helper so their style output follows the same
+    /// scalar truth rules as runtime normalization. Specified by <c>[SSR-COMPILE-3]</c> and
+    /// <c>[SSR-6]</c>.
+    /// </remarks>
+    public static bool IsTruthy(object? value) => StyleAndClassNormalization.IsTruthy(value);
+
+    /// <summary>Tests whether one candidate is selected by a scalar or collection model value.</summary>
+    /// <param name="modelValue">The current model value.</param>
+    /// <param name="candidate">The input or option value being rendered.</param>
+    /// <param name="booleanModelIsSelection">
+    /// Whether a boolean model selects directly, as it does for a checkbox.
+    /// </param>
+    /// <returns>
+    /// For a boolean checkbox model, its boolean value; for a non-string enumerable, whether any item
+    /// equals <paramref name="candidate"/>; otherwise whether the scalar values are equal.
+    /// </returns>
+    /// <remarks>
+    /// This explicit, reflection-free comparison is the compile-time server-rendering contract for
+    /// <c>checked</c> and <c>selected</c> attributes. Specified by <c>[SSR-COMPILE-3]</c> and
+    /// <c>[SSR-6]</c>.
+    /// </remarks>
+    public static bool IsModelValueSelected(
+        object? modelValue,
+        object? candidate,
+        bool booleanModelIsSelection = false)
+    {
+        if (booleanModelIsSelection && modelValue is bool booleanValue)
+        {
+            return booleanValue;
+        }
+
+        if (modelValue is IEnumerable values && modelValue is not string)
+        {
+            foreach (object? value in values)
+            {
+                if (Equals(value, candidate))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return Equals(modelValue, candidate);
+    }
+
+    private static async Task RenderCompiledCoreAsync(
+        ServerRenderApplication application,
+        CompiledServerRender render,
+        SsrWriter writer,
+        SsrContext context,
+        CancellationToken cancellationToken)
+    {
+        using IDisposable executionIsolation = CoreExecutionIsolation.Enter();
+        cancellationToken.ThrowIfCancellationRequested();
+        IApplicationContext applicationContext = application.Context;
+        ServerRenderStatePayload.PrepareContext(context);
+        ComponentHost componentHost = new(
+            new ComponentRuntimeOptions(
+                applicationContext.Components,
+                new ApplicationWatchScheduler(),
+                applicationContext.Services,
+                applicationContext.ErrorHandler,
+                applicationContext.WarnHandler,
+                applicationContext.EventObserver));
+        SsrRenderState state = new(
+            writer,
+            context,
+            applicationContext,
+            componentHost,
+            cancellationToken);
+
+        await render(state).ConfigureAwait(false);
+        ServerRenderStatePayload.CaptureAndAppend(state);
+        await state.FlushAsync().ConfigureAwait(false);
+        context.ResolveTeleports();
+    }
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/src/ServerRenderer.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/ServerRenderer.cs
@@ -13,9 +13,11 @@ namespace Assimalign.Viu.ServerRenderer;
 /// JavaScript interop boundary.
 /// </summary>
 /// <remarks>
-/// Each call owns its write state and component render leases. Applications should be composed per
-/// request when their borrowed services or state are request-scoped. Specified by
-/// <c>[SSR-1]</c> through <c>[SSR-10]</c>.
+/// Each call owns its write state and component render leases and selects fresh logical Core,
+/// Reactivity, State, and scheduler execution state. Distinct request-owned application graphs may
+/// therefore render concurrently, but an individual graph remains single-event-loop and must not be
+/// shared. Applications should be composed per request when their borrowed services or state are
+/// request-scoped. Specified by <c>[EXE-1]</c> and <c>[SSR-1]</c> through <c>[SSR-10]</c>.
 /// </remarks>
 public static class ServerRenderer
 {
@@ -128,8 +130,10 @@ public static class ServerRenderer
         SsrContext context,
         CancellationToken cancellationToken)
     {
+        using IDisposable executionIsolation = CoreExecutionIsolation.Enter();
         cancellationToken.ThrowIfCancellationRequested();
         IApplicationContext applicationContext = application.Context;
+        ServerRenderStatePayload.PrepareContext(context);
         ComponentHost componentHost = new(
             new ComponentRuntimeOptions(
                 applicationContext.Components,
@@ -149,6 +153,7 @@ public static class ServerRenderer
             state,
             applicationContext.RootComponent,
             null).ConfigureAwait(false);
+        ServerRenderStatePayload.CaptureAndAppend(state);
         await state.FlushAsync().ConfigureAwait(false);
         context.ResolveTeleports();
     }

--- a/libraries/Assimalign.Viu.ServerRenderer/src/SsrContext.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/src/SsrContext.cs
@@ -2,16 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using Assimalign.Viu.State;
+
 namespace Assimalign.Viu.ServerRenderer;
 
 /// <summary>
-/// Carries per-render teleport output and free-form state handed from server application code to
-/// the surrounding document host.
+/// Carries per-render teleport output and the versioned state-store payload handed to the
+/// surrounding document host.
 /// </summary>
 /// <remarks>
-/// One instance belongs to one render and is not thread-safe. The renderer never interprets or
-/// serializes <see cref="State"/> itself. Specified by <c>[SSR-7]</c>,
-/// <c>[SSR-MARKERS-2]</c>, and <c>[HYD-6]</c>.
+/// One instance belongs to one render and is not thread-safe. Store state is captured only through
+/// explicit serializers after component traversal, then emitted through the inert state island.
+/// Specified by <c>[SSR-7]</c>, <c>[SSR-MARKERS-2]</c>, <c>[HYD-6]</c>, and
+/// <c>[STA-9]</c>.
 /// </remarks>
 public sealed class SsrContext
 {
@@ -27,10 +30,16 @@ public sealed class SsrContext
     /// </remarks>
     public IReadOnlyDictionary<string, string> Teleports => _teleports;
 
-    /// <summary>Gets the deliberately unschematized per-render state handoff bag.</summary>
-    /// <remarks>The renderer leaves values untouched as required by <c>[SSR-7]</c>.</remarks>
-    public IDictionary<string, object?> State { get; } =
-        new Dictionary<string, object?>(StringComparer.Ordinal);
+    /// <summary>
+    /// Gets the versioned payload captured from the request's materialized state stores, or
+    /// <see langword="null"/> when the application has no payload-capable state registry.
+    /// </summary>
+    /// <remarks>
+    /// The payload schema is <c>{"version":1,"stores":{"store-key":state}}</c>. Values are
+    /// produced by each definition's explicit serializer and are safe to embed in a JSON island.
+    /// Specified by <c>[SSR-7]</c> and <c>[STA-9]</c>; constrained by <c>[EXE-4]</c>.
+    /// </remarks>
+    public StateStorePayload? State { get; internal set; }
 
     internal void AppendTeleport(string target, string content)
     {

--- a/libraries/Assimalign.Viu.ServerRenderer/test/Assimalign.Viu.ServerRenderer.Tests.csproj
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/Assimalign.Viu.ServerRenderer.Tests.csproj
@@ -8,6 +8,7 @@
     <None Remove="Assimalign.Viu.ServerRenderer.DomKnowledgeFixture/**" />
   </ItemGroup>
   <ItemGroup>
+    <ViuPackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <ViuPackageReference Include="Microsoft.NET.Test.Sdk" />
     <ViuPackageReference Include="xunit" />
     <ViuPackageReference Include="xunit.runner.visualstudio" />
@@ -19,5 +20,7 @@
     <ViuProjectReference Include="Assimalign.Viu.Reactivity" />
     <ViuProjectReference Include="Assimalign.Viu.ServerRenderer" />
     <ViuProjectReference Include="Assimalign.Viu.ServerRenderer.DomKnowledgeFixture" />
+    <ViuProjectReference Include="Assimalign.Viu.State" />
+    <ViuProjectReference Include="Assimalign.Viu.Syntax.Templates" />
   </ItemGroup>
 </Project>

--- a/libraries/Assimalign.Viu.ServerRenderer/test/CompiledServerRenderDifferentialTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/CompiledServerRenderDifferentialTests.cs
@@ -1,0 +1,426 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+using Assimalign.Viu.State;
+using Assimalign.Viu.Syntax.Templates;
+
+using ComponentCommentNode = Assimalign.Viu.Components.CommentNode;
+using ComponentElementNode = Assimalign.Viu.Components.ElementNode;
+using ComponentFragmentNode = Assimalign.Viu.Components.FragmentNode;
+using ComponentTextNode = Assimalign.Viu.Components.TextNode;
+using ComponentVirtualNode = Assimalign.Viu.Components.VirtualNode;
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+
+namespace Assimalign.Viu.ServerRenderer.Tests;
+
+/// <summary>
+/// Executes [V01.01.07.02]'s generated server body and the existing virtual-tree serializer over
+/// equivalent fixtures. Every comparison is byte equality, including hydration markers.
+/// </summary>
+public sealed class CompiledServerRenderDifferentialTests
+{
+    /// <summary>Gets the templates exercised by the byte-equality differential test.</summary>
+    public static IEnumerable<object[]> FixtureSource =>
+    [
+        ["<section id=\"root\"><h1>{{ title }}</h1><p :class=\"classes\" :style=\"styles\" :title=\"title\">{{ body }}</p><!--safe--></section>", ""],
+        ["<span>{{ title }}</span><input disabled :title=\"body\">", ""],
+        ["<textarea :value=\"body\">ignored</textarea>", ""],
+        ["<div v-if=\"visible\">yes</div>", ""],
+        ["<ul><li v-for=\"item in items\">{{ item }}</li></ul>", ""],
+        ["<input v-model=\"modelText\">", ""],
+        ["<input type=\"checkbox\" value=\"yes\" v-model=\"checkboxModel\">", ""],
+        ["<textarea v-model=\"body\">ignored</textarea>", ""],
+        ["<select v-model=\"choice\"><option value=\"one\">One</option><option :value=\"second\">Two</option></select>", ""],
+        ["<select v-model=\"choice\"><option>{{ choice }}</option></select>", ""],
+        ["<div :style=\"styles\" v-show=\"visible\">hidden</div>", ""],
+        ["<main><h1>heading</h1><p>body</p></main>", "data-v-c0ffee00"],
+        ["<template v-if=\"!visible\"><span>one</span><span>two</span></template>", ""],
+        ["<component :is=\"viewName\"><span>{{ body }}</span></component>", ""],
+        ["<div v-bind=\"attributes\"><span>{{ body }}</span></div>", "data-v-fallback00"],
+        ["<input :value.prop=\"body\">", ""],
+    ];
+
+    [Theory]
+    [MemberData(nameof(FixtureSource))]
+    public async Task CompiledMarkup_EquivalentVirtualTree_IsByteIdentical(
+        string source,
+        string scopeId)
+    {
+        MethodInfo renderMethod = CompileServerRender(
+            source,
+            out object component,
+            string.IsNullOrEmpty(scopeId) ? null : scopeId);
+        ComponentVirtualNode referenceTree = CreateReferenceTree(source);
+        ComponentFactory components = new();
+        ServerRenderApplication compiledApplication = new(new ComponentTextNode("unused"), components);
+
+        string compiled = await ServerRender.RenderCompiledToStringAsync(
+            compiledApplication,
+            state => (Task)renderMethod.Invoke(
+                null,
+                [state, component, new ComponentRenderFrame(), null])!);
+        string traversed = await ServerRender.RenderToStringAsync(referenceTree);
+
+        compiled.ShouldBe(traversed);
+    }
+
+    [Fact]
+    public async Task CompiledMarkup_Teleport_UsesUnchangedMarkerAndTargetProtocol()
+    {
+        const string source = "<Teleport to=\"#target\"><span>{{ body }}</span></Teleport>";
+        MethodInfo renderMethod = CompileServerRender(source, out object component);
+        ComponentFactory components = new();
+        SsrContext context = new();
+
+        string compiled = await ServerRender.RenderCompiledToStringAsync(
+            new ServerRenderApplication(new ComponentTextNode("unused"), components),
+            state => (Task)renderMethod.Invoke(
+                null,
+                [state, component, new ComponentRenderFrame(), null])!,
+            context);
+
+        compiled.ShouldBe(HydrationMarkers.TeleportStart + HydrationMarkers.TeleportEnd);
+        context.Teleports["#target"].ShouldBe(
+            "<span>body &amp; text</span>" + HydrationMarkers.TeleportAnchor);
+    }
+
+    [Fact]
+    public async Task CompiledMarkup_StreamPath_FlushesDirectWrites()
+    {
+        ComponentFactory components = new();
+        using StringWriter writer = new();
+
+        await ServerRender.RenderCompiledToStreamAsync(
+            new ServerRenderApplication(new ComponentTextNode("unused"), components),
+            state =>
+            {
+                state.Push("<p>streamed</p>");
+                return Task.CompletedTask;
+            },
+            writer);
+
+        writer.ToString().ShouldBe("<p>streamed</p>");
+    }
+
+    [Fact]
+    public async Task CompiledMarkup_PreCancelledRequest_DoesNotInvokeGeneratedBody()
+    {
+        ComponentFactory components = new();
+        using CancellationTokenSource cancellationSource = new();
+        cancellationSource.Cancel();
+        bool invoked = false;
+
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await ServerRender.RenderCompiledToStringAsync(
+                new ServerRenderApplication(new ComponentTextNode("unused"), components),
+                _ =>
+                {
+                    invoked = true;
+                    return Task.CompletedTask;
+                },
+                cancellationToken: cancellationSource.Token));
+
+        invoked.ShouldBeFalse();
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "This test deliberately compiles and loads ephemeral generated code; shipping code does not.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "The test-owned generated type has the public constructor and method declared below.")]
+    private static MethodInfo CompileServerRender(
+        string source,
+        out object component,
+        string? scopeId = null)
+    {
+        RootNode root = TemplateParser.Parse(source, ParserOptions.CreateHtml());
+        TransformOptions transformOptions = TransformOptions.CreateDom();
+        transformOptions.PrefixIdentifiers = true;
+        transformOptions.BindingMetadata = BindingMetadata.Empty;
+        transformOptions.IsServerRendering = true;
+        transformOptions.ScopeId = scopeId;
+        TransformResult transformed = Transformer.Transform(root, transformOptions);
+        RenderFunctionEmitterResult emitted = RenderFunctionEmitter.Emit(
+            transformed,
+            new RenderFunctionEmitterOptions
+            {
+                IndentLevel = 2,
+                TargetProfile = RenderFunctionTargetProfile.ServerMarkup,
+            });
+
+        string generatedSource =
+            "#nullable enable\n" +
+            "public sealed class CompiledRenderProbe\n" +
+            "{\n" +
+            "    public string title = \"<heading>\";\n" +
+            "    public string body = \"body & text\";\n" +
+            "    public object? classes = new object?[] { \"hero\", " +
+            "new global::System.Collections.Generic.Dictionary<string, object?> { [\"active\"] = true } };\n" +
+            "    public object? styles = new global::System.Collections.Generic.Dictionary<string, object?> " +
+            "{ [\"fontSize\"] = \"12px\", [\"color\"] = \"red\" };\n" +
+            "    public bool visible = false;\n" +
+            "    public string[] items = new string[] { \"one\", \"<two>\" };\n" +
+            "    public string modelText = \"typed & ready\";\n" +
+            "    public object? checkboxModel = new string[] { \"yes\" };\n" +
+            "    public string choice = \"two\";\n" +
+            "    public string second = \"two\";\n" +
+            "    public object? viewName = \"aside\";\n" +
+            "    public object? attributes = new global::System.Collections.Generic.Dictionary<string, object?> " +
+            "{ [\"title\"] = \"<fallback>\" };\n" +
+            "    public static async global::System.Threading.Tasks.Task RenderAsync(\n" +
+            "        global::Assimalign.Viu.ServerRenderer.SsrRenderState state,\n" +
+            "        CompiledRenderProbe component,\n" +
+            "        global::Assimalign.Viu.Components.ComponentRenderFrame frame,\n" +
+            "        global::Assimalign.Viu.IComponentRenderScope? parent)\n" +
+            "    {\n" +
+            emitted.Code +
+            "        await global::System.Threading.Tasks.Task.CompletedTask;\n" +
+            "    }\n" +
+            "}\n";
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "CompiledServerRenderDifferential_" + Guid.NewGuid().ToString("N"),
+            [CSharpSyntaxTree.ParseText(
+                generatedSource,
+                new CSharpParseOptions(LanguageVersion.Preview))],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        using MemoryStream assemblyStream = new();
+        EmitResult result = compilation.Emit(assemblyStream);
+        result.Diagnostics
+            .Where(diagnostic => diagnostic.Severity == RoslynDiagnosticSeverity.Error)
+            .ShouldBeEmpty(customMessage: generatedSource);
+
+        assemblyStream.Position = 0;
+        Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(assemblyStream);
+        Type probeType = assembly.GetType("CompiledRenderProbe", throwOnError: true)!;
+        component = probeType.GetConstructor(Type.EmptyTypes)!.Invoke(null);
+        return probeType.GetMethod("RenderAsync", BindingFlags.Public | BindingFlags.Static)!;
+    }
+
+    [UnconditionalSuppressMessage(
+        "SingleFile",
+        "IL3000",
+        Justification = "The non-published test runner supplies physical reference assemblies.")]
+    private static IEnumerable<MetadataReference> RuntimeReferences()
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? platformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (!string.IsNullOrEmpty(platformAssemblies))
+        {
+            foreach (string path in platformAssemblies!.Split(Path.PathSeparator))
+            {
+                if (!string.Equals(
+                    Path.GetFileNameWithoutExtension(path),
+                    "Assimalign.Viu.Syntax.Templates",
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    paths.Add(path);
+                }
+            }
+        }
+
+        paths.Add(typeof(ComponentVirtualNode).Assembly.Location);
+        paths.Add(typeof(IApplicationContext).Assembly.Location);
+        paths.Add(typeof(ServerRender).Assembly.Location);
+        paths.Add(typeof(StateStoreRegistry).Assembly.Location);
+        return paths.Select(static path =>
+            (MetadataReference)MetadataReference.CreateFromFile(path));
+    }
+
+    private static ComponentVirtualNode CreateReferenceTree(string source)
+    {
+        object? classes = new object?[]
+        {
+            "hero",
+            new Dictionary<string, object?> { ["active"] = true },
+        };
+        object? styles = new Dictionary<string, object?>
+        {
+            ["fontSize"] = "12px",
+            ["color"] = "red",
+        };
+
+        return source switch
+        {
+            "<section id=\"root\"><h1>{{ title }}</h1><p :class=\"classes\" :style=\"styles\" :title=\"title\">{{ body }}</p><!--safe--></section>" =>
+                Element(
+                    "section",
+                    [ElementBinding.Attribute(new QualifiedName("id"), "root")],
+                    [
+                        Element("h1", children: [new ComponentTextNode("<heading>")]),
+                        Element(
+                            "p",
+                            [
+                                ElementBinding.Attribute(new QualifiedName("class"), classes),
+                                ElementBinding.Attribute(new QualifiedName("style"), styles),
+                                ElementBinding.Attribute(new QualifiedName("title"), "<heading>"),
+                            ],
+                            [new ComponentTextNode("body & text")]),
+                        new ComponentCommentNode("safe"),
+                    ]),
+            "<span>{{ title }}</span><input disabled :title=\"body\">" =>
+                new ComponentFragmentNode(
+                [
+                    Element("span", children: [new ComponentTextNode("<heading>")]),
+                    Element(
+                        "input",
+                        [
+                            ElementBinding.Attribute(new QualifiedName("disabled"), string.Empty),
+                            ElementBinding.Attribute(new QualifiedName("title"), "body & text"),
+                        ]),
+                ]),
+            "<textarea :value=\"body\">ignored</textarea>" =>
+                Element(
+                    "textarea",
+                    [ElementBinding.Property("value", "body & text")],
+                    [new ComponentTextNode("ignored")]),
+            "<div v-if=\"visible\">yes</div>" => new ComponentCommentNode("v-if"),
+            "<ul><li v-for=\"item in items\">{{ item }}</li></ul>" =>
+                Element(
+                    "ul",
+                    children:
+                    [
+                        new ComponentFragmentNode(
+                        [
+                            Element("li", children: [new ComponentTextNode("one")]),
+                            Element("li", children: [new ComponentTextNode("<two>")]),
+                        ]),
+                    ]),
+            "<input v-model=\"modelText\">" =>
+                Element(
+                    "input",
+                    [ElementBinding.Attribute(new QualifiedName("value"), "typed & ready")]),
+            "<input type=\"checkbox\" value=\"yes\" v-model=\"checkboxModel\">" =>
+                Element(
+                    "input",
+                    [
+                        ElementBinding.Attribute(new QualifiedName("type"), "checkbox"),
+                        ElementBinding.Attribute(new QualifiedName("value"), "yes"),
+                        ElementBinding.Attribute(new QualifiedName("checked"), true),
+                    ]),
+            "<textarea v-model=\"body\">ignored</textarea>" =>
+                Element(
+                    "textarea",
+                    [ElementBinding.Property("value", "body & text")],
+                    [new ComponentTextNode("ignored")]),
+            "<select v-model=\"choice\"><option value=\"one\">One</option><option :value=\"second\">Two</option></select>" =>
+                Element(
+                    "select",
+                    children:
+                    [
+                        Element(
+                            "option",
+                            [ElementBinding.Attribute(new QualifiedName("value"), "one")],
+                            [new ComponentTextNode("One")]),
+                        Element(
+                            "option",
+                            [
+                                ElementBinding.Attribute(new QualifiedName("value"), "two"),
+                                ElementBinding.Attribute(new QualifiedName("selected"), true),
+                            ],
+                            [new ComponentTextNode("Two")]),
+                    ]),
+            "<select v-model=\"choice\"><option>{{ choice }}</option></select>" =>
+                Element(
+                    "select",
+                    children:
+                    [
+                        Element(
+                            "option",
+                            [ElementBinding.Attribute(new QualifiedName("selected"), true)],
+                            [new ComponentTextNode("two")]),
+                    ]),
+            "<div :style=\"styles\" v-show=\"visible\">hidden</div>" =>
+                Element(
+                    "div",
+                    [
+                        ElementBinding.Attribute(
+                            new QualifiedName("style"),
+                            "font-size:12px;color:red;display:none;"),
+                    ],
+                    [new ComponentTextNode("hidden")]),
+            "<main><h1>heading</h1><p>body</p></main>" =>
+                Element(
+                    "main",
+                    [ElementBinding.Attribute(new QualifiedName("data-v-c0ffee00"), string.Empty)],
+                    [
+                        Element(
+                            "h1",
+                            [ElementBinding.Attribute(
+                                new QualifiedName("data-v-c0ffee00"),
+                                string.Empty)],
+                            [new ComponentTextNode("heading")]),
+                        Element(
+                            "p",
+                            [ElementBinding.Attribute(
+                                new QualifiedName("data-v-c0ffee00"),
+                                string.Empty)],
+                            [new ComponentTextNode("body")]),
+                    ]),
+            "<template v-if=\"!visible\"><span>one</span><span>two</span></template>" =>
+                new ComponentFragmentNode(
+                [
+                    Element("span", children: [new ComponentTextNode("one")]),
+                    Element("span", children: [new ComponentTextNode("two")]),
+                ]),
+            "<component :is=\"viewName\"><span>{{ body }}</span></component>" =>
+                Element(
+                    "aside",
+                    children:
+                    [
+                        Element("span", children: [new ComponentTextNode("body & text")]),
+                    ]),
+            "<div v-bind=\"attributes\"><span>{{ body }}</span></div>" =>
+                Element(
+                    "div",
+                    [
+                        ElementBinding.Attribute(new QualifiedName("title"), "<fallback>"),
+                        ElementBinding.Attribute(
+                            new QualifiedName("data-v-fallback00"),
+                            string.Empty),
+                    ],
+                    children:
+                    [
+                        Element(
+                            "span",
+                            [ElementBinding.Attribute(
+                                new QualifiedName("data-v-fallback00"),
+                                string.Empty)],
+                            [new ComponentTextNode("body & text")]),
+                    ]),
+            "<input :value.prop=\"body\">" =>
+                Element(
+                    "input",
+                    [ElementBinding.Property("value", "body & text")]),
+            _ => throw new InvalidOperationException("Unknown differential fixture."),
+        };
+    }
+
+    private static ComponentElementNode Element(
+        string name,
+        IReadOnlyList<ElementBinding>? bindings = null,
+        IReadOnlyList<ComponentVirtualNode>? children = null) =>
+        new(new QualifiedName(name), bindings, children);
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/test/ServerRenderAdaptorTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/ServerRenderAdaptorTests.cs
@@ -1,0 +1,762 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu.Components;
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu.ServerRenderer.Tests;
+
+public sealed class ServerRenderAdaptorTests
+{
+    [Fact]
+    public async Task RenderAsync_ParallelRequests_FreshScopesKeepReactiveAndSsrContextStateIsolated()
+    {
+        ComponentReference componentReference = ComponentReference.ForName("request-root");
+        ParallelArrival arrival = new(2);
+        DelegateRequestScopeFactory<string> factory = new((request, _) =>
+        {
+            Reference<string> requestState = Reactive.Reference(request.RequestContext);
+            ComponentFactory components = new();
+            components.Register(Registration(
+                componentReference,
+                context =>
+                {
+                    context.Lifecycle.OnServerPrefetch(arrival.ArriveAsync);
+                    return _ => new FragmentNode(
+                    [
+                        new TextNode(requestState.Value),
+                        new TeleportNode("#request-state", [new TextNode(requestState.Value)]),
+                    ]);
+                }));
+            return CreateScope(request, components);
+        });
+        FakeServerHost<string> host = new(factory);
+        RecordingServerRenderOutput firstOutput = new();
+        RecordingServerRenderOutput secondOutput = new();
+        ServerRenderRequest<string> firstRequest = new(
+            new ComponentNode(componentReference),
+            "first-request");
+        ServerRenderRequest<string> secondRequest = new(
+            new ComponentNode(componentReference),
+            "second-request");
+
+        Task<ServerRenderResult> firstRendering = host.RenderAsync(
+            firstRequest,
+            firstOutput).AsTask();
+        Task<ServerRenderResult> secondRendering = host.RenderAsync(
+            secondRequest,
+            secondOutput).AsTask();
+        ServerRenderResult[] results = await Task.WhenAll(firstRendering, secondRendering);
+
+        results.ShouldAllBe(result => result.Succeeded);
+        firstOutput.Text.ShouldContain("first-request");
+        firstOutput.Text.ShouldNotContain("second-request");
+        secondOutput.Text.ShouldContain("second-request");
+        secondOutput.Text.ShouldNotContain("first-request");
+        results[0].Context.ShouldNotBeSameAs(results[1].Context);
+        results[0].Context!.Teleports["#request-state"].ShouldContain("first-request");
+        results[1].Context!.Teleports["#request-state"].ShouldContain("second-request");
+        factory.CreatedScopes.Count.ShouldBe(2);
+        factory.CreatedScopes.ShouldAllBe(scope => scope.DisposeCount == 1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_OverlappingStoreSetup_IsolatesAmbientScopeRegistryAndCleanup()
+    {
+        ComponentReference componentReference = ComponentReference.ForName("request-store-root");
+        TaskCompletionSource firstSetupEntered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource secondSetupEntered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource firstSetupObserved = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        ConcurrentDictionary<string, IReactiveEffectScope> observedScopes = new();
+        ConcurrentDictionary<string, IStateStoreRegistry> expectedRegistries = new();
+        ConcurrentDictionary<string, IStateStoreRegistry> observedRegistries = new();
+        ConcurrentDictionary<string, int> cleanupCounts = new();
+        DelegateRequestScopeFactory<string> factory = new((request, _) =>
+        {
+            string requestName = request.RequestContext;
+            IStateStoreRegistry registry = StateStores.CreateRegistry();
+            expectedRegistries[requestName] = registry;
+            StateStoreDefinition<RequestSetupStore> definition = StateStores.Define(
+                "request-store",
+                context =>
+                {
+                    if (string.Equals(requestName, "first-request", StringComparison.Ordinal))
+                    {
+                        firstSetupEntered.TrySetResult();
+                        if (!secondSetupEntered.Task.Wait(TimeSpan.FromSeconds(5)))
+                        {
+                            throw new TimeoutException("The second request did not enter store setup.");
+                        }
+                    }
+                    else
+                    {
+                        secondSetupEntered.TrySetResult();
+                        if (!firstSetupObserved.Task.Wait(TimeSpan.FromSeconds(5)))
+                        {
+                            throw new TimeoutException("The first request did not observe its setup state.");
+                        }
+                    }
+
+                    IReactiveEffectScope currentScope = Reactive.CurrentScope
+                        ?? throw new InvalidOperationException(
+                            "Store setup did not run inside its registry-owned reactive scope.");
+                    if (!ReferenceEquals(currentScope, context.Scope))
+                    {
+                        throw new InvalidOperationException(
+                            "Store setup observed another request's reactive scope.");
+                    }
+
+                    observedScopes[requestName] = currentScope;
+                    observedRegistries[requestName] = StateStores.ActiveRegistry
+                        ?? throw new InvalidOperationException(
+                            "Store setup lost its request's ambient registry.");
+                    Reactive.OnScopeDispose(
+                        () => cleanupCounts.AddOrUpdate(requestName, 1, static (_, count) => count + 1));
+                    if (string.Equals(requestName, "first-request", StringComparison.Ordinal))
+                    {
+                        firstSetupObserved.TrySetResult();
+                    }
+
+                    return new RequestSetupStore(requestName);
+                });
+            ComponentFactory components = new();
+            components.Register(Registration(
+                componentReference,
+                _ =>
+                {
+                    StateStores.SetActiveRegistry(registry);
+                    RequestSetupStore store = definition.Use();
+                    return _ => new TextNode(store.RequestName);
+                }));
+            return CreateScope(
+                request,
+                components,
+                () =>
+                {
+                    registry.Dispose();
+                    return ValueTask.CompletedTask;
+                });
+        });
+        FakeServerHost<string> host = new(factory);
+        ServerRenderRequest<string> firstRequest = new(
+            new ComponentNode(componentReference),
+            "first-request");
+        ServerRenderRequest<string> secondRequest = new(
+            new ComponentNode(componentReference),
+            "second-request");
+        RecordingServerRenderOutput firstOutput = new();
+        RecordingServerRenderOutput secondOutput = new();
+
+        Task<ServerRenderResult> firstRendering = Task.Run(
+            () => host.RenderAsync(firstRequest, firstOutput).AsTask());
+        await firstSetupEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task<ServerRenderResult> secondRendering = Task.Run(
+            () => host.RenderAsync(secondRequest, secondOutput).AsTask());
+        ServerRenderResult[] results = await Task.WhenAll(firstRendering, secondRendering)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        results.ShouldAllBe(result => result.Succeeded);
+        firstOutput.Text.ShouldBe("first-request");
+        secondOutput.Text.ShouldBe("second-request");
+        observedScopes["first-request"].ShouldNotBeSameAs(observedScopes["second-request"]);
+        observedRegistries["first-request"].ShouldBeSameAs(expectedRegistries["first-request"]);
+        observedRegistries["second-request"].ShouldBeSameAs(expectedRegistries["second-request"]);
+        cleanupCounts["first-request"].ShouldBe(1);
+        cleanupCounts["second-request"].ShouldBe(1);
+        factory.CreatedScopes.ShouldAllBe(scope => scope.DisposeCount == 1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_ReusedRequestScope_ReturnsFailureBeforeSecondResponseStarts()
+    {
+        ServerRenderRequest<string> request = new(new TextNode("fresh-once"), "request");
+        TestRequestScope reusedScope = CreateScope(request, new ComponentFactory());
+        DelegateRequestScopeFactory<string> factory = new((_, _) => reusedScope);
+        FakeServerHost<string> host = new(factory);
+        RecordingServerRenderOutput firstOutput = new();
+        RecordingServerRenderOutput secondOutput = new();
+
+        ServerRenderResult first = await host.RenderAsync(request, firstOutput);
+        ServerRenderResult second = await host.RenderAsync(request, secondOutput);
+
+        first.Succeeded.ShouldBeTrue();
+        firstOutput.Text.ShouldBe("fresh-once");
+        second.Succeeded.ShouldBeFalse();
+        second.ResponseStarted.ShouldBeFalse();
+        second.Failure.ShouldBeOfType<InvalidOperationException>();
+        second.Failure!.Message.ShouldContain("cannot be reused");
+        secondOutput.Text.ShouldBeEmpty();
+        reusedScope.DisposeCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task RenderAsync_ReusedSsrContextWithFreshApplication_ReturnsIsolationFailure()
+    {
+        ServerRenderRequest<string> request = new(new TextNode("context"), "request");
+        SsrContext reusedContext = new();
+        DelegateRequestScopeFactory<string> factory = new((createdRequest, _) =>
+            new TestRequestScope(
+                new ServerRenderApplication(
+                    createdRequest.RootComponent,
+                    new ComponentFactory()),
+                reusedContext,
+                dispose: null));
+        FakeServerHost<string> host = new(factory);
+
+        ServerRenderResult first = await host.RenderAsync(
+            request,
+            new RecordingServerRenderOutput());
+        ServerRenderResult second = await host.RenderAsync(
+            request,
+            new RecordingServerRenderOutput());
+
+        first.Succeeded.ShouldBeTrue();
+        second.Succeeded.ShouldBeFalse();
+        second.ResponseStarted.ShouldBeFalse();
+        second.Failure.ShouldBeOfType<InvalidOperationException>();
+        second.Failure!.Message.ShouldContain("SsrContext");
+        factory.CreatedScopes.Count.ShouldBe(2);
+        factory.CreatedScopes.ShouldAllBe(scope => scope.DisposeCount == 1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_MismatchedRoot_ConsumesBothApplicationAndContextIdentities()
+    {
+        TextNode requestedRoot = new("requested");
+        TextNode ownedRoot = new("owned");
+        ServerRenderApplication firstApplication = new(ownedRoot, new ComponentFactory());
+        SsrContext firstContext = new();
+        TestRequestScope firstScope = new(firstApplication, firstContext, dispose: null);
+        TestRequestScope reusedApplicationScope = new(
+            firstApplication,
+            new SsrContext(),
+            dispose: null);
+        TestRequestScope reusedContextScope = new(
+            new ServerRenderApplication(ownedRoot, new ComponentFactory()),
+            firstContext,
+            dispose: null);
+        ConcurrentQueue<TestRequestScope> scopes = new(
+            [firstScope, reusedApplicationScope, reusedContextScope]);
+        DelegateRequestScopeFactory<string> factory = new((_, _) =>
+            scopes.TryDequeue(out TestRequestScope? scope)
+                ? scope
+                : throw new InvalidOperationException("No request scope remained."));
+        FakeServerHost<string> host = new(factory);
+
+        ServerRenderResult mismatch = await host.RenderAsync(
+            new ServerRenderRequest<string>(requestedRoot, "mismatch"),
+            new RecordingServerRenderOutput());
+        ServerRenderResult applicationReuse = await host.RenderAsync(
+            new ServerRenderRequest<string>(ownedRoot, "application-reuse"),
+            new RecordingServerRenderOutput());
+        ServerRenderResult contextReuse = await host.RenderAsync(
+            new ServerRenderRequest<string>(ownedRoot, "context-reuse"),
+            new RecordingServerRenderOutput());
+
+        mismatch.Succeeded.ShouldBeFalse();
+        mismatch.Failure!.Message.ShouldContain("root component");
+        applicationReuse.Succeeded.ShouldBeFalse();
+        applicationReuse.Failure!.Message.ShouldContain("application");
+        contextReuse.Succeeded.ShouldBeFalse();
+        contextReuse.Failure!.Message.ShouldContain("SsrContext");
+        firstScope.DisposeCount.ShouldBe(1);
+        reusedApplicationScope.DisposeCount.ShouldBe(1);
+        reusedContextScope.DisposeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_FirstComponentBoundary_WritesBeforeCompletionAndAwaitsBackpressure()
+    {
+        ComponentReference rootReference = ComponentReference.ForName("stream-root");
+        ComponentReference firstReference = ComponentReference.ForName("stream-first");
+        ComponentReference secondReference = ComponentReference.ForName("stream-second");
+        ComponentFactory components = new();
+        components.Register(Registration(
+            rootReference,
+            _ => _ => Element(
+                "main",
+                [
+                    new ComponentNode(firstReference),
+                    new ComponentNode(secondReference),
+                ])));
+        components.Register(Registration(
+            firstReference,
+            _ => _ => Element("span", [new TextNode("first")])));
+        components.Register(Registration(
+            secondReference,
+            _ => _ => Element("span", [new TextNode("second")])));
+        DelegateRequestScopeFactory<string> factory = new(
+            (request, _) => CreateScope(request, components));
+        FakeServerHost<string> host = new(factory);
+        TaskCompletionSource releaseFirstFlush = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        RecordingServerRenderOutput output = new(releaseFirstFlush);
+        ServerRenderRequest<string> request = new(
+            new ComponentNode(rootReference),
+            "streaming");
+
+        Task<ServerRenderResult> rendering = host.RenderAsync(request, output).AsTask();
+        await output.FirstWrite.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        output.Text.ShouldBe("<main><span>first</span>");
+        output.FlushCount.ShouldBe(1);
+        rendering.IsCompleted.ShouldBeFalse();
+
+        releaseFirstFlush.SetResult();
+        ServerRenderResult result = await rendering.WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Succeeded.ShouldBeTrue();
+        output.Text.ShouldBe("<main><span>first</span><span>second</span></main>");
+        output.FlushCount.ShouldBe(3);
+        factory.CreatedScopes.ShouldHaveSingleItem().DisposeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_RequestCancellation_PropagatesAndDisposesEveryLease()
+    {
+        ComponentReference componentReference = ComponentReference.ForName("cancel-request");
+        TaskCompletionSource prefetchStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource componentDisposed = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        ComponentFactory components = new();
+        components.Register(new ComponentRegistration(
+            componentReference,
+            new ComponentContract(),
+            _ => new InlineComponent(
+                context =>
+                {
+                    context.Lifecycle.OnServerPrefetch(async cancellationToken =>
+                    {
+                        prefetchStarted.SetResult();
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    });
+                    return _ => new TextNode("never");
+                },
+                () => componentDisposed.TrySetResult())));
+        DelegateRequestScopeFactory<string> factory = new(
+            (request, _) => CreateScope(request, components));
+        FakeServerHost<string> host = new(factory);
+        RecordingServerRenderOutput output = new();
+        using CancellationTokenSource cancellationSource = new();
+        ServerRenderRequest<string> request = new(
+            new ComponentNode(componentReference),
+            "cancel");
+
+        Task<ServerRenderResult> rendering = host.RenderAsync(
+            request,
+            output,
+            cancellationSource.Token).AsTask();
+        await prefetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationSource.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            async () => await rendering.WaitAsync(TimeSpan.FromSeconds(5)));
+        await componentDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        factory.CreatedScopes.ShouldHaveSingleItem().DisposeCount.ShouldBe(1);
+        output.Text.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RenderAsync_RenderFailureAfterProgress_ReturnsHostMappableFailureAndDisposesScope()
+    {
+        ComponentReference rootReference = ComponentReference.ForName("failure-root");
+        ComponentReference firstReference = ComponentReference.ForName("failure-first");
+        ComponentReference failingReference = ComponentReference.ForName("failure-second");
+        ComponentFactory components = new();
+        components.Register(Registration(
+            rootReference,
+            _ => _ => Element(
+                "main",
+                [
+                    new ComponentNode(firstReference),
+                    new ComponentNode(failingReference),
+                ])));
+        components.Register(Registration(
+            firstReference,
+            _ => _ => new TextNode("progress")));
+        components.Register(Registration(
+            failingReference,
+            _ => _ => throw new InvalidOperationException("render failure")));
+        DelegateRequestScopeFactory<string> factory = new(
+            (request, _) => CreateScope(request, components));
+        FakeServerHost<string> host = new(factory);
+        RecordingServerRenderOutput output = new();
+        ServerRenderRequest<string> request = new(
+            new ComponentNode(rootReference),
+            "failure");
+
+        ServerRenderResult result = await host.RenderAsync(request, output);
+
+        result.Succeeded.ShouldBeFalse();
+        result.ResponseStarted.ShouldBeTrue();
+        result.Failure.ShouldBeOfType<InvalidOperationException>();
+        result.Failure!.Message.ShouldBe("render failure");
+        output.Text.ShouldBe("<main>progress");
+        factory.CreatedScopes.ShouldHaveSingleItem().DisposeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RenderAsync_RequestScopeDisposalFailure_ReturnsFailureAfterContent()
+    {
+        ServerRenderRequest<string> request = new(new TextNode("content"), "dispose");
+        DelegateRequestScopeFactory<string> factory = new((createdRequest, _) =>
+            CreateScope(
+                createdRequest,
+                new ComponentFactory(),
+                () => ValueTask.FromException(
+                    new InvalidOperationException("scope disposal failure"))));
+        FakeServerHost<string> host = new(factory);
+        RecordingServerRenderOutput output = new();
+
+        ServerRenderResult result = await host.RenderAsync(request, output);
+
+        result.Succeeded.ShouldBeFalse();
+        result.ResponseStarted.ShouldBeTrue();
+        result.Failure.ShouldBeOfType<InvalidOperationException>();
+        result.Failure!.Message.ShouldBe("scope disposal failure");
+        output.Text.ShouldBe("content");
+        factory.CreatedScopes.ShouldHaveSingleItem().DisposeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void SsrStateIsland_RawPayload_UsesSafeMarkupAndSourceGeneratedRestore()
+    {
+        const string hostileJson = "{\"value\":\"</script><div>\"}";
+
+        string markup = SsrStateIsland.CreateMarkup(hostileJson);
+        StateIslandTestPayload? payload = SsrStateIsland.Deserialize(
+            "{\"message\":\"restored\"}",
+            StateIslandTestJsonSerializerContext.Default.StateIslandTestPayload);
+
+        markup.ShouldStartWith(
+            "<script type=\"application/json\" data-viu-state>");
+        markup.ShouldContain("\\u003C/script\\u003E\\u003Cdiv\\u003E");
+        markup.ShouldEndWith("</script>");
+        payload.ShouldNotBeNull();
+        payload.Message.ShouldBe("restored");
+    }
+
+    [Fact]
+    public async Task RenderAsync_TcpListenerHost_ServesMarkupWithoutAWebFramework()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        DelegateRequestScopeFactory<string> factory = new(
+            (request, _) => CreateScope(request, new ComponentFactory()));
+        FakeServerHost<string> host = new(factory);
+        using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(10));
+        Task server = ServeSingleRequestAsync(listener, host, timeout.Token);
+        using HttpClient client = new();
+
+        string response;
+        try
+        {
+            response = await client.GetStringAsync(
+                new Uri($"http://127.0.0.1:{port}/smoke", UriKind.Absolute),
+                timeout.Token);
+            await server.WaitAsync(timeout.Token);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+
+        response.ShouldBe("<main>http-smoke</main>");
+        factory.CreatedScopes.ShouldHaveSingleItem().DisposeCount.ShouldBe(1);
+    }
+
+    private static async Task ServeSingleRequestAsync(
+        TcpListener listener,
+        FakeServerHost<string> host,
+        CancellationToken cancellationToken)
+    {
+        using TcpClient client = await listener.AcceptTcpClientAsync(cancellationToken);
+        await using NetworkStream stream = client.GetStream();
+        using StreamReader reader = new(
+            stream,
+            Encoding.ASCII,
+            detectEncodingFromByteOrderMarks: false,
+            bufferSize: 1024,
+            leaveOpen: true);
+        string requestLine = await reader.ReadLineAsync(cancellationToken)
+            ?? throw new InvalidOperationException("The test HTTP request had no request line.");
+        string? line;
+        do
+        {
+            line = await reader.ReadLineAsync(cancellationToken);
+        }
+        while (!string.IsNullOrEmpty(line));
+
+        using StreamWriter writer = new(
+            stream,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            bufferSize: 1024,
+            leaveOpen: true);
+        await writer.WriteAsync(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n"
+                .AsMemory(),
+            cancellationToken);
+        await writer.FlushAsync(cancellationToken);
+
+        TextWriterServerRenderOutput output = new(writer);
+        ServerRenderResult result = await host.RenderAsync(
+            new ServerRenderRequest<string>(
+                Element("main", [new TextNode("http-smoke")]),
+                requestLine),
+            output,
+            cancellationToken);
+        result.Succeeded.ShouldBeTrue(result.Failure?.ToString());
+    }
+
+    private static TestRequestScope CreateScope<TContext>(
+        ServerRenderRequest<TContext> request,
+        ComponentFactory components,
+        Func<ValueTask>? dispose = null)
+        where TContext : notnull =>
+        new(
+            new ServerRenderApplication(request.RootComponent, components),
+            new SsrContext(),
+            dispose);
+
+    private static ComponentRegistration Registration(
+        ComponentReference reference,
+        Func<ComponentContext, ComponentRenderer> setup) =>
+        new(
+            reference,
+            new ComponentContract(),
+            _ => new InlineComponent(setup));
+
+    private static ElementNode Element(
+        string name,
+        IReadOnlyList<VirtualNode>? children = null) =>
+        new(new QualifiedName(name), children: children);
+
+    private sealed class FakeServerHost<TContext>
+        where TContext : notnull
+    {
+        private readonly ServerRenderAdaptor<TContext> _adaptor;
+
+        internal FakeServerHost(IServerRenderRequestScopeFactory<TContext> requestScopeFactory)
+        {
+            _adaptor = new ServerRenderAdaptor<TContext>(requestScopeFactory);
+        }
+
+        internal ValueTask<ServerRenderResult> RenderAsync(
+            ServerRenderRequest<TContext> request,
+            IServerRenderOutput output,
+            CancellationToken cancellationToken = default) =>
+            _adaptor.RenderAsync(request, output, cancellationToken);
+    }
+
+    private sealed class DelegateRequestScopeFactory<TContext> :
+        IServerRenderRequestScopeFactory<TContext>
+        where TContext : notnull
+    {
+        private readonly Func<
+            ServerRenderRequest<TContext>,
+            CancellationToken,
+            IServerRenderRequestScope> _create;
+
+        internal DelegateRequestScopeFactory(
+            Func<
+                ServerRenderRequest<TContext>,
+                CancellationToken,
+                IServerRenderRequestScope> create)
+        {
+            _create = create;
+        }
+
+        internal ConcurrentBag<TestRequestScope> CreatedScopes { get; } = [];
+
+        public ValueTask<IServerRenderRequestScope> CreateAsync(
+            ServerRenderRequest<TContext> request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IServerRenderRequestScope scope = _create(request, cancellationToken);
+            CreatedScopes.Add((TestRequestScope)scope);
+            return ValueTask.FromResult(scope);
+        }
+    }
+
+    private sealed class TestRequestScope : IServerRenderRequestScope
+    {
+        private readonly Func<ValueTask>? _dispose;
+        private int _disposeCount;
+
+        internal TestRequestScope(
+            ServerRenderApplication application,
+            SsrContext renderContext,
+            Func<ValueTask>? dispose)
+        {
+            Application = application;
+            RenderContext = renderContext;
+            _dispose = dispose;
+        }
+
+        internal int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public ServerRenderApplication Application { get; }
+
+        public SsrContext RenderContext { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            if (_dispose is not null)
+            {
+                await _dispose().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class RecordingServerRenderOutput : IServerRenderOutput
+    {
+        private readonly object _synchronization = new();
+        private readonly StringBuilder _text = new();
+        private readonly TaskCompletionSource? _releaseFirstFlush;
+        private int _flushCount;
+
+        internal RecordingServerRenderOutput(TaskCompletionSource? releaseFirstFlush = null)
+        {
+            _releaseFirstFlush = releaseFirstFlush;
+        }
+
+        internal TaskCompletionSource FirstWrite { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int FlushCount => Volatile.Read(ref _flushCount);
+
+        internal string Text
+        {
+            get
+            {
+                lock (_synchronization)
+                {
+                    return _text.ToString();
+                }
+            }
+        }
+
+        public ValueTask WriteAsync(
+            ReadOnlyMemory<char> content,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_synchronization)
+            {
+                _text.Append(content.Span);
+            }
+
+            FirstWrite.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask FlushAsync(CancellationToken cancellationToken = default)
+        {
+            int count = Interlocked.Increment(ref _flushCount);
+            if (count == 1 && _releaseFirstFlush is not null)
+            {
+                return new ValueTask(_releaseFirstFlush.Task.WaitAsync(cancellationToken));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TextWriterServerRenderOutput : IServerRenderOutput
+    {
+        private readonly TextWriter _writer;
+
+        internal TextWriterServerRenderOutput(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public ValueTask WriteAsync(
+            ReadOnlyMemory<char> content,
+            CancellationToken cancellationToken = default) =>
+            new(_writer.WriteAsync(content, cancellationToken));
+
+        public ValueTask FlushAsync(CancellationToken cancellationToken = default) =>
+            new(_writer.FlushAsync(cancellationToken));
+    }
+
+    private sealed class ParallelArrival
+    {
+        private readonly int _requiredCount;
+        private readonly TaskCompletionSource _arrived = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrivalCount;
+
+        internal ParallelArrival(int requiredCount)
+        {
+            _requiredCount = requiredCount;
+        }
+
+        internal async Task ArriveAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _arrivalCount) == _requiredCount)
+            {
+                _arrived.TrySetResult();
+            }
+
+            await _arrived.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class InlineComponent : IComponent, IDisposable
+    {
+        private readonly Func<ComponentContext, ComponentRenderer> _setup;
+        private readonly Action? _dispose;
+
+        internal InlineComponent(
+            Func<ComponentContext, ComponentRenderer> setup,
+            Action? dispose = null)
+        {
+            _setup = setup;
+            _dispose = dispose;
+        }
+
+        public ComponentRenderer Setup(ComponentContext context) => _setup(context);
+
+        public void Dispose() => _dispose?.Invoke();
+    }
+
+    private sealed class RequestSetupStore
+    {
+        internal RequestSetupStore(string requestName)
+        {
+            RequestName = requestName;
+        }
+
+        internal string RequestName { get; }
+    }
+}
+
+internal sealed class StateIslandTestPayload
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(StateIslandTestPayload))]
+internal sealed partial class StateIslandTestJsonSerializerContext : JsonSerializerContext;

--- a/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererContextAndStreamingTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererContextAndStreamingTests.cs
@@ -68,16 +68,14 @@ public sealed class ServerRendererContextAndStreamingTests
     }
 
     [Fact]
-    public async Task SsrContext_StateBag_RemainsApplicationOwnedAndUninterpreted()
+    public async Task SsrContext_NoComposedStateRegistry_LeavesPayloadAbsent()
     {
         SsrContext context = new();
-        object state = new();
-        context.State["application"] = state;
 
         string html = await ServerRenderer.RenderToStringAsync(new TextNode("content"), context);
 
         html.ShouldBe("content");
-        context.State["application"].ShouldBeSameAs(state);
+        context.State.ShouldBeNull();
         context.Teleports.ShouldBeEmpty();
     }
 

--- a/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererStateHydrationTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererStateHydrationTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+using Assimalign.Viu.Reactivity;
+using Assimalign.Viu.State;
+
+namespace Assimalign.Viu.ServerRenderer.Tests;
+
+public sealed class ServerRendererStateHydrationTests
+{
+    private static readonly StateStoreDefinition<SsrPayloadStore> StoreDefinition =
+        StateStores.Define(
+            "request-state",
+            static context => new SsrPayloadStore
+            {
+                State = new SsrPayloadState
+                {
+                    Message = (string?)context.Services?.GetService(typeof(string))
+                        ?? "server-default",
+                },
+            },
+            new StateStoreJsonSerializer<SsrPayloadStore, SsrPayloadState>(
+                static stateStore => stateStore.State,
+                static (stateStore, state) => stateStore.State = state,
+                ServerRendererStateJsonContext.Default.SsrPayloadState));
+
+    [Fact]
+    public async Task RenderToStringAsync_MaterializedState_EmitsIslandAndRestoresBeforeFirstRender()
+    {
+        ComponentFactory components = CreateComponents();
+        using StateStoreRegistry serverRegistry = CreateRegistry("server-value");
+        SsrContext serverContext = new();
+
+        string serverHtml = await ServerRenderer.RenderToStringAsync(
+            CreateApplication(components, serverRegistry),
+            serverContext);
+
+        (string serverMarkup, string islandJson) = SplitStateIsland(serverHtml);
+        serverMarkup.ShouldBe("<p>server-value</p>");
+        serverContext.State.ShouldNotBeNull();
+        serverContext.State.StoreKeys.ShouldBe(["request-state"]);
+        islandJson.ShouldBe(serverContext.State.Json);
+
+        using StateStoreRegistry clientRegistry = CreateRegistry("client-default");
+        clientRegistry.RestorePayload(StateStorePayload.Parse(islandJson));
+        string firstClientHtml = await ServerRenderer.RenderToStringAsync(
+            CreateApplication(components, clientRegistry));
+        (string firstClientMarkup, _) = SplitStateIsland(firstClientHtml);
+
+        firstClientMarkup.ShouldBe(serverMarkup);
+        clientRegistry.GetOrCreate(StoreDefinition).State.Message.ShouldBe("server-value");
+    }
+
+    [Fact]
+    public async Task RenderToStringAsync_HtmlSensitiveState_IslandIsSafeAndRoundTrips()
+    {
+        const string dangerous = "</script>\u2028\u2029<&>";
+        using StateStoreRegistry serverRegistry = CreateRegistry(dangerous);
+
+        string html = await ServerRenderer.RenderToStringAsync(
+            CreateApplication(CreateComponents(), serverRegistry));
+        (_, string islandJson) = SplitStateIsland(html);
+
+        islandJson.ShouldNotContain("</script>");
+        islandJson.ShouldNotContain("<");
+        islandJson.ShouldNotContain(">");
+        islandJson.ShouldNotContain("&");
+        islandJson.ShouldNotContain("\u2028");
+        islandJson.ShouldNotContain("\u2029");
+
+        using StateStoreRegistry clientRegistry = CreateRegistry("client-default");
+        clientRegistry.RestorePayload(StateStorePayload.Parse(islandJson));
+        clientRegistry.GetOrCreate(StoreDefinition).State.Message.ShouldBe(dangerous);
+    }
+
+    [Fact]
+    public async Task RenderToStringAsync_ConcurrentRequestRegistries_DoNotBleedPayloadState()
+    {
+        ConcurrentRenderBarrier barrier = new();
+        ComponentFactory components = CreateComponents(barrier);
+        using StateStoreRegistry firstRegistry = CreateRegistry("first-request");
+        using StateStoreRegistry secondRegistry = CreateRegistry("second-request");
+        SsrContext firstContext = new();
+        SsrContext secondContext = new();
+
+        Task<string> firstRender = ServerRenderer.RenderToStringAsync(
+            CreateApplication(components, firstRegistry),
+            firstContext);
+        Task<string> secondRender = ServerRenderer.RenderToStringAsync(
+            CreateApplication(components, secondRegistry),
+            secondContext);
+        string[] outputs = await Task.WhenAll(firstRender, secondRender);
+
+        outputs[0].ShouldContain("first-request");
+        outputs[0].ShouldNotContain("second-request");
+        outputs[1].ShouldContain("second-request");
+        outputs[1].ShouldNotContain("first-request");
+        firstContext.State!.Json.ShouldContain("first-request");
+        firstContext.State.Json.ShouldNotContain("second-request");
+        secondContext.State!.Json.ShouldContain("second-request");
+        secondContext.State.Json.ShouldNotContain("first-request");
+    }
+
+    private static ComponentFactory CreateComponents(
+        ConcurrentRenderBarrier? barrier = null)
+    {
+        ComponentFactory components = new();
+        components.Register(
+            new ComponentRegistration(
+                ComponentReference.ForName("state-payload"),
+                new ComponentContract(),
+                _ => new SsrStateComponent(StoreDefinition, barrier)));
+        return components;
+    }
+
+    private static ServerRenderApplication CreateApplication(
+        IComponentFactory components,
+        IStateStoreRegistry registry) =>
+        ServerRenderApplication
+            .CreateBuilder(
+                new ComponentNode(ComponentReference.ForName("state-payload")),
+                components)
+            .ConfigureApplication(options => options.State = registry)
+            .Build();
+
+    private static StateStoreRegistry CreateRegistry(string message) =>
+        new(
+            new StringServiceProvider(message),
+            new ReactiveEffectScopeFactory());
+
+    private static (string Markup, string Json) SplitStateIsland(string html)
+    {
+        const string start = "<script type=\"application/json\" data-viu-state>";
+        const string end = "</script>";
+        int startIndex = html.IndexOf(start, StringComparison.Ordinal);
+        startIndex.ShouldBeGreaterThanOrEqualTo(0);
+        int jsonStart = startIndex + start.Length;
+        int endIndex = html.IndexOf(end, jsonStart, StringComparison.Ordinal);
+        endIndex.ShouldBeGreaterThanOrEqualTo(jsonStart);
+        (endIndex + end.Length).ShouldBe(html.Length);
+        return (
+            html[..startIndex],
+            html.Substring(jsonStart, endIndex - jsonStart));
+    }
+
+    private sealed class SsrStateComponent : IComponent
+    {
+        private readonly ConcurrentRenderBarrier? _barrier;
+        private readonly StateStoreDefinition<SsrPayloadStore> _definition;
+
+        internal SsrStateComponent(
+            StateStoreDefinition<SsrPayloadStore> definition,
+            ConcurrentRenderBarrier? barrier)
+        {
+            _definition = definition;
+            _barrier = barrier;
+        }
+
+        public ComponentRenderer Setup(ComponentContext context)
+        {
+            SsrPayloadStore stateStore = _definition.Use(context);
+            if (_barrier is not null)
+            {
+                context.Lifecycle.OnServerPrefetch(_barrier.WaitAsync);
+            }
+
+            return _ => new ElementNode(
+                new QualifiedName("p"),
+                children: [new TextNode(stateStore.State.Message)]);
+        }
+    }
+
+    private sealed class StringServiceProvider : IServiceProvider
+    {
+        private readonly string _value;
+
+        internal StringServiceProvider(string value)
+        {
+            _value = value;
+        }
+
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(string) ? _value : null;
+    }
+
+    private sealed class ConcurrentRenderBarrier
+    {
+        private readonly TaskCompletionSource _bothEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _entered;
+
+        internal async Task WaitAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _entered) == 2)
+            {
+                _bothEntered.TrySetResult();
+            }
+
+            await _bothEntered.Task.WaitAsync(cancellationToken);
+        }
+    }
+}
+
+internal sealed class SsrPayloadStore
+{
+    internal SsrPayloadState State { get; set; } = new();
+}
+
+internal sealed class SsrPayloadState
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+[JsonSerializable(typeof(SsrPayloadState))]
+internal sealed partial class ServerRendererStateJsonContext : JsonSerializerContext
+{
+}

--- a/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererTests.cs
+++ b/libraries/Assimalign.Viu.ServerRenderer/test/ServerRendererTests.cs
@@ -103,6 +103,70 @@ public sealed class ServerRendererTests
     }
 
     [Fact]
+    public async Task RenderToStringAsync_DeferredHydrationStrategies_EmitStableMarkerBoundaries()
+    {
+        ComponentReference reference = ComponentReference.ForName("lazy-markers");
+        ComponentFactory components = new();
+        components.Register(
+            new ComponentRegistration(
+                reference,
+                new ComponentContract(),
+                _ => new InlineComponent(
+                    _ => _ => Element("button", children: [new TextNode("ready")]))));
+        HydrationStrategy[] strategies =
+        [
+            HydrationStrategy.OnIdle(),
+            HydrationStrategy.OnVisible(),
+            HydrationStrategy.OnMediaQuery("(min-width: 1px)"),
+            HydrationStrategy.OnInteraction("click"),
+        ];
+
+        foreach (HydrationStrategy strategy in strategies)
+        {
+            ComponentNode root = new(
+                reference,
+                new ComponentInvocation(hydrationStrategy: strategy));
+
+            string html = await ServerRenderer.RenderToStringAsync(
+                new ServerRenderApplication(root, components));
+
+            html.ShouldBe(
+                HydrationMarkers.GetLazyHydrationStart(strategy.Kind)
+                + "<button>ready</button>"
+                + HydrationMarkers.LazyHydrationEnd);
+        }
+    }
+
+    [Fact]
+    public async Task RenderToStringAsync_LazyAsynchronousDefinition_EmitsOneBoundary()
+    {
+        AsynchronousComponentDefinition definition =
+            AsynchronousComponents.Define<AsynchronousWrapperIdentity>(
+                new AsynchronousComponentOptions
+                {
+                    Loader = _ => Task.FromResult(
+                        AsynchronousComponentTarget.From<AsynchronousTargetIdentity>()),
+                    HydrationStrategy = HydrationStrategy.OnIdle(),
+                });
+        ComponentFactory components = new();
+        components.Register(definition.Registration);
+        components.Register(
+            new ComponentRegistration(
+                ComponentReference.ForType(typeof(AsynchronousTargetIdentity)),
+                new ComponentContract(),
+                _ => new InlineComponent(
+                    _ => _ => Element("button", children: [new TextNode("ready")]))));
+
+        string html = await ServerRenderer.RenderToStringAsync(
+            new ServerRenderApplication(definition.CreateComponent(), components));
+
+        html.ShouldBe(
+            HydrationMarkers.GetLazyHydrationStart(HydrationStrategyKind.Idle)
+            + "<button>ready</button>"
+            + HydrationMarkers.LazyHydrationEnd);
+    }
+
+    [Fact]
     public async Task RenderToStringAsync_ServerPrefetch_CompletesBeforeSingleRender()
     {
         ComponentReference reference = ComponentReference.ForName("prefetch");
@@ -233,5 +297,15 @@ public sealed class ServerRendererTests
         }
 
         public ComponentRenderer Setup(ComponentContext context) => _setup(context);
+    }
+
+    private sealed class AsynchronousWrapperIdentity : IComponent
+    {
+        public ComponentRenderer Setup(ComponentContext context) => static _ => null;
+    }
+
+    private sealed class AsynchronousTargetIdentity : IComponent
+    {
+        public ComponentRenderer Setup(ComponentContext context) => static _ => null;
     }
 }

--- a/libraries/Assimalign.Viu.State/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.State/docs/DESIGN.md
@@ -64,3 +64,26 @@ not corrupt the current pass ([STA-8]).
 Store activation and state copying use typed delegates. Deep watching traverses the
 source-generated `IReactiveObject` contract. State performs no dynamic code generation, runtime
 constructor discovery, or reflection-based state serialization.
+
+## Server payload and pre-mount restore
+
+Payload participation is definition-local and explicit. `IStateStoreSerializer<TStore>` writes one
+state value to a registry-owned `Utf8JsonWriter` and restores one `JsonElement` value. The standard
+`StateStoreJsonSerializer<TStore,TState>` reaches only the caller's `JsonTypeInfo<TState>` plus
+typed access and restore delegates, so trimming cannot select a reflection overload
+([V01.01.09.03], [STA-6], [EXE-4]).
+
+`StateStoreRegistry.CapturePayload()` serializes the current ordinal entry map. Definitions never
+resolved in that registry are absent; a resolved definition without a serializer is an actionable
+error instead of a silent omission. The resulting schema is exactly:
+
+```json
+{"version":1,"stores":{"store-key":{"shape":"belongs to the registered serializer"}}}
+```
+
+`RestorePayload` applies matching live entries immediately and retains the immutable payload for
+later definitions. `GetOrCreate` constructs the store in its ordinary registry-owned scope, applies
+the matching value before adding or returning the entry, and disposes the new store plus its scope
+if restoration fails. Browser invokes this operation after its bridge initializes but before mount;
+ServerRenderer also selects request-local setup and active-registry ambient state, so separately
+owned payload maps and reactive lifetimes cannot cross concurrent requests [EXE-1].

--- a/libraries/Assimalign.Viu.State/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.State/docs/OVERVIEW.md
@@ -23,4 +23,16 @@ restores the ambient setup context even when setup fails. Removing a definition 
 lifetime; disposing the registry ends every store lifetime and clears the ambient registry when it
 points to that registry ([STA-2], [STA-3]).
 
+SSR state uses an explicit `IStateStoreSerializer<TStore>` on each participating definition.
+`StateStoreJsonSerializer<TStore,TState>` accepts state-access and restore delegates plus a
+source-generated `JsonTypeInfo<TState>`; no reflection serializer fallback exists. A capture
+contains only materialized stores and fails actionably if one lacks registration. Restore updates
+an already materialized store immediately and stages unmatched keys so a later `GetOrCreate`
+applies server state before returning the store ([V01.01.09.03], [EXE-4]).
+
+`StateStorePayload` uses the fixed schema
+`{"version":1,"stores":{"store-key":state}}`. It validates version, member shape, and ordinal
+store-key uniqueness, then exposes normalized JSON with HTML-sensitive characters and Unicode line
+separators escaped for inert script-island transport.
+
 See [DESIGN.md](DESIGN.md) for lifetime, scheduler, and AOT boundaries.

--- a/libraries/Assimalign.Viu.State/src/Abstraction/IStateStorePayloadRegistry.cs
+++ b/libraries/Assimalign.Viu.State/src/Abstraction/IStateStorePayloadRegistry.cs
@@ -1,0 +1,32 @@
+namespace Assimalign.Viu.State;
+
+/// <summary>
+/// Captures and restores the explicitly registered state of a registry's materialized stores.
+/// Payload operations use only each definition's typed serializer and never inspect a state shape.
+/// Specified by <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.
+/// </summary>
+public interface IStateStorePayloadRegistry
+{
+    /// <summary>
+    /// Captures one immutable, versioned payload containing exactly the stores currently
+    /// materialized in this registry. Every included definition must have an explicitly
+    /// registered serializer.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.</remarks>
+    /// <returns>The captured state-store payload.</returns>
+    /// <exception cref="System.InvalidOperationException">
+    /// A materialized store has no serializer registration.
+    /// </exception>
+    StateStorePayload CapturePayload();
+
+    /// <summary>
+    /// Restores matching materialized stores immediately and stages the remaining entries so a
+    /// matching store created later is restored before <c>GetOrCreate</c> returns it.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c>.</remarks>
+    /// <param name="payload">The validated state-store payload.</param>
+    /// <exception cref="System.InvalidOperationException">
+    /// A matching materialized store has no serializer registration.
+    /// </exception>
+    void RestorePayload(StateStorePayload payload);
+}

--- a/libraries/Assimalign.Viu.State/src/Abstraction/IStateStoreSerializer{TStore}.cs
+++ b/libraries/Assimalign.Viu.State/src/Abstraction/IStateStoreSerializer{TStore}.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace Assimalign.Viu.State;
+
+/// <summary>
+/// Serializes and restores one state-store type through an explicitly registered, AOT-safe
+/// contract. Implementations must not use reflection-backed serialization. Specified by
+/// <c>[STA-9]</c> and <c>[EXE-4]</c>.
+/// </summary>
+/// <typeparam name="TStore">The state-store type.</typeparam>
+public interface IStateStoreSerializer<in TStore>
+    where TStore : class
+{
+    /// <summary>
+    /// Writes only the registered state value for one store. Specified by
+    /// <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.
+    /// </summary>
+    /// <param name="writer">The payload-owned JSON writer.</param>
+    /// <param name="stateStore">The materialized state store.</param>
+    void Serialize(Utf8JsonWriter writer, TStore stateStore);
+
+    /// <summary>
+    /// Applies one validated payload value to an already materialized store before first render.
+    /// Specified by <c>[STA-9]</c>.
+    /// </summary>
+    /// <param name="stateStore">The materialized state store.</param>
+    /// <param name="state">The JSON value captured for the store's key.</param>
+    void Restore(TStore stateStore, JsonElement state);
+}

--- a/libraries/Assimalign.Viu.State/src/Internal/StateExecutionIsolation.cs
+++ b/libraries/Assimalign.Viu.State/src/Internal/StateExecutionIsolation.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+
+namespace Assimalign.Viu.State;
+
+/// <summary>
+/// Selects request-local ambient store state without changing the shared Browser event-loop default.
+/// </summary>
+internal static class StateExecutionIsolation
+{
+    private static readonly AsyncLocal<StateExecutionState?> IsolatedState = new();
+    private static readonly StateExecutionState SharedState = new();
+
+    internal static StateExecutionState Current => IsolatedState.Value ?? SharedState;
+
+    internal static IDisposable Enter()
+    {
+        StateExecutionState? previous = IsolatedState.Value;
+        IsolatedState.Value = new StateExecutionState();
+        return new IsolationLease(previous);
+    }
+
+    private sealed class IsolationLease : IDisposable
+    {
+        private readonly StateExecutionState? _previous;
+        private bool _isDisposed;
+
+        internal IsolationLease(StateExecutionState? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            IsolatedState.Value = _previous;
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.State/src/Internal/StateExecutionState.cs
+++ b/libraries/Assimalign.Viu.State/src/Internal/StateExecutionState.cs
@@ -1,0 +1,9 @@
+namespace Assimalign.Viu.State;
+
+/// <summary>Owns ambient state-store values for one logical execution flow.</summary>
+internal sealed class StateExecutionState
+{
+    internal IStateContext? SetupContext { get; set; }
+
+    internal IStateStoreRegistry? ActiveRegistry { get; set; }
+}

--- a/libraries/Assimalign.Viu.State/src/Internal/StateStoreEntry.cs
+++ b/libraries/Assimalign.Viu.State/src/Internal/StateStoreEntry.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Buffers;
 using System.Runtime.ExceptionServices;
+using System.Text.Json;
 
 using Assimalign.Viu.Reactivity;
 
@@ -8,22 +10,59 @@ namespace Assimalign.Viu.State;
 internal sealed class StateStoreEntry : IDisposable
 {
     private bool _isDisposed;
+    private readonly Action<Utf8JsonWriter>? _serializeState;
+    private readonly Action<JsonElement>? _restoreState;
 
     internal StateStoreEntry(
+        string key,
         object definition,
         object instance,
-        IReactiveEffectScope scope)
+        IReactiveEffectScope scope,
+        Action<Utf8JsonWriter>? serializeState,
+        Action<JsonElement>? restoreState)
     {
+        Key = key;
         Definition = definition;
         Instance = instance;
         Scope = scope;
+        _serializeState = serializeState;
+        _restoreState = restoreState;
     }
 
     internal object Definition { get; }
 
+    internal string Key { get; }
+
     internal object Instance { get; }
 
     internal IReactiveEffectScope Scope { get; }
+
+    internal JsonElement SerializeState()
+    {
+        if (_serializeState is null)
+        {
+            throw CreateMissingSerializerException();
+        }
+
+        ArrayBufferWriter<byte> buffer = new();
+        using (Utf8JsonWriter writer = new(buffer))
+        {
+            _serializeState(writer);
+        }
+
+        using JsonDocument document = JsonDocument.Parse(buffer.WrittenMemory);
+        return document.RootElement.Clone();
+    }
+
+    internal void RestoreState(JsonElement state)
+    {
+        if (_restoreState is null)
+        {
+            throw CreateMissingSerializerException();
+        }
+
+        _restoreState(state);
+    }
 
     public void Dispose()
     {
@@ -57,4 +96,10 @@ internal sealed class StateStoreEntry : IDisposable
 
         error?.Throw();
     }
+
+    private InvalidOperationException CreateMissingSerializerException() =>
+        new(
+            $"State store \"{Key}\" is materialized but has no AOT-safe "
+            + "serializer registration. Supply an IStateStoreSerializer<TStore> when defining "
+            + "the store before capturing or restoring an SSR state payload.");
 }

--- a/libraries/Assimalign.Viu.State/src/Internal/StateStoreSetupRuntime.cs
+++ b/libraries/Assimalign.Viu.State/src/Internal/StateStoreSetupRuntime.cs
@@ -2,9 +2,14 @@ namespace Assimalign.Viu.State;
 
 /// <summary>
 /// Carries the current registry setup context into an optional <see cref="StateStore{TState}"/>
-/// base constructor. Ambient state is deliberate under Viu's single-threaded event-loop model.
+/// base constructor. Browser execution shares one event-loop value; request-oriented hosts isolate
+/// it by logical execution flow.
 /// </summary>
 internal static class StateStoreSetupRuntime
 {
-    internal static IStateContext? Current { get; set; }
+    internal static IStateContext? Current
+    {
+        get => StateExecutionIsolation.Current.SetupContext;
+        set => StateExecutionIsolation.Current.SetupContext = value;
+    }
 }

--- a/libraries/Assimalign.Viu.State/src/Properties/AssemblyInfo.cs
+++ b/libraries/Assimalign.Viu.State/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Assimalign.Viu.Core")]
+[assembly: InternalsVisibleTo("Assimalign.Viu.State.Tests")]

--- a/libraries/Assimalign.Viu.State/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.State/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,25 @@
 #nullable enable
 *REMOVED*Assimalign.Viu.State.StateStoreDefinition<TStore>.Dispose(Assimalign.Viu.State.IStateStoreRegistry! registry) -> bool
+Assimalign.Viu.State.IStateStorePayloadRegistry
+Assimalign.Viu.State.IStateStorePayloadRegistry.CapturePayload() -> Assimalign.Viu.State.StateStorePayload!
+Assimalign.Viu.State.IStateStorePayloadRegistry.RestorePayload(Assimalign.Viu.State.StateStorePayload! payload) -> void
+Assimalign.Viu.State.IStateStoreSerializer<TStore>
+Assimalign.Viu.State.IStateStoreSerializer<TStore>.Restore(TStore! stateStore, System.Text.Json.JsonElement state) -> void
+Assimalign.Viu.State.IStateStoreSerializer<TStore>.Serialize(System.Text.Json.Utf8JsonWriter! writer, TStore! stateStore) -> void
 Assimalign.Viu.State.StateStoreDefinition<TStore>.Remove(Assimalign.Viu.State.IStateStoreRegistry! registry) -> bool
+Assimalign.Viu.State.StateStoreDefinition<TStore>.Serializer.get -> Assimalign.Viu.State.IStateStoreSerializer<TStore!>?
+Assimalign.Viu.State.StateStoreDefinition<TStore>.StateStoreDefinition(string! key, Assimalign.Viu.State.StateStoreActivator<TStore!>! setup, Assimalign.Viu.State.IStateStoreSerializer<TStore!>! serializer) -> void
+Assimalign.Viu.State.StateStoreJsonSerializer<TStore, TState>
+Assimalign.Viu.State.StateStoreJsonSerializer<TStore, TState>.Restore(TStore! stateStore, System.Text.Json.JsonElement state) -> void
+Assimalign.Viu.State.StateStoreJsonSerializer<TStore, TState>.Serialize(System.Text.Json.Utf8JsonWriter! writer, TStore! stateStore) -> void
+Assimalign.Viu.State.StateStoreJsonSerializer<TStore, TState>.StateStoreJsonSerializer(System.Func<TStore!, TState>! getState, System.Action<TStore!, TState>! restoreState, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TState>! jsonTypeInformation) -> void
+Assimalign.Viu.State.StateStorePayload
+Assimalign.Viu.State.StateStorePayload.Json.get -> string!
+Assimalign.Viu.State.StateStorePayload.StoreKeys.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Assimalign.Viu.State.StateStorePayload.Version.get -> int
+Assimalign.Viu.State.StateStoreRegistry.CapturePayload() -> Assimalign.Viu.State.StateStorePayload!
+Assimalign.Viu.State.StateStoreRegistry.RestorePayload(Assimalign.Viu.State.StateStorePayload! payload) -> void
+const Assimalign.Viu.State.StateStorePayload.CurrentVersion = 1 -> int
+static Assimalign.Viu.State.StateStorePayload.Parse(string! json) -> Assimalign.Viu.State.StateStorePayload!
+static Assimalign.Viu.State.StateStores.Define<TStore>(string! key, Assimalign.Viu.State.StateStoreActivator<TStore!>! setup, Assimalign.Viu.State.IStateStoreSerializer<TStore!>! serializer) -> Assimalign.Viu.State.StateStoreDefinition<TStore!>!
+static Assimalign.Viu.State.StateStores.Define<TStore>(string! key, System.Func<TStore!>! setup, Assimalign.Viu.State.IStateStoreSerializer<TStore!>! serializer) -> Assimalign.Viu.State.StateStoreDefinition<TStore!>!

--- a/libraries/Assimalign.Viu.State/src/Serialization/StateStoreJsonSerializer{TStore,TState}.cs
+++ b/libraries/Assimalign.Viu.State/src/Serialization/StateStoreJsonSerializer{TStore,TState}.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Assimalign.Viu.State;
+
+/// <summary>
+/// Implements state-store payload serialization with caller-supplied state access, restore, and
+/// source-generated JSON metadata. No reflection serializer overload is reachable through this
+/// type. Specified by <c>[STA-9]</c> and <c>[EXE-4]</c>.
+/// </summary>
+/// <typeparam name="TStore">The state-store type.</typeparam>
+/// <typeparam name="TState">The serialized state shape.</typeparam>
+public sealed class StateStoreJsonSerializer<TStore, TState> : IStateStoreSerializer<TStore>
+    where TStore : class
+{
+    private readonly Func<TStore, TState> _getState;
+    private readonly Action<TStore, TState> _restoreState;
+    private readonly JsonTypeInfo<TState> _jsonTypeInformation;
+
+    /// <summary>
+    /// Creates a serializer from explicit typed delegates and source-generated JSON metadata.
+    /// The delegates preserve arbitrary store implementations without member discovery.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.</remarks>
+    /// <param name="getState">Gets the state value to capture.</param>
+    /// <param name="restoreState">Applies a deserialized state value to the store.</param>
+    /// <param name="jsonTypeInformation">
+    /// The source-generated JSON metadata for <typeparamref name="TState"/>.
+    /// </param>
+    public StateStoreJsonSerializer(
+        Func<TStore, TState> getState,
+        Action<TStore, TState> restoreState,
+        JsonTypeInfo<TState> jsonTypeInformation)
+    {
+        ArgumentNullException.ThrowIfNull(getState);
+        ArgumentNullException.ThrowIfNull(restoreState);
+        ArgumentNullException.ThrowIfNull(jsonTypeInformation);
+        _getState = getState;
+        _restoreState = restoreState;
+        _jsonTypeInformation = jsonTypeInformation;
+    }
+
+    /// <inheritdoc />
+    public void Serialize(Utf8JsonWriter writer, TStore stateStore)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(stateStore);
+        JsonSerializer.Serialize(
+            writer,
+            _getState(stateStore),
+            _jsonTypeInformation);
+    }
+
+    /// <inheritdoc />
+    public void Restore(TStore stateStore, JsonElement state)
+    {
+        ArgumentNullException.ThrowIfNull(stateStore);
+        TState? restoredState = state.Deserialize(_jsonTypeInformation);
+        _restoreState(stateStore, restoredState!);
+    }
+}

--- a/libraries/Assimalign.Viu.State/src/Serialization/StateStorePayload.cs
+++ b/libraries/Assimalign.Viu.State/src/Serialization/StateStorePayload.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Assimalign.Viu.State;
+
+/// <summary>
+/// Carries a validated, immutable snapshot of registry-owned state using schema
+/// <c>{"version":1,"stores":{"store-key":state}}</c>. Store keys compare ordinally and each
+/// state value is produced only by its registered serializer. Specified by <c>[STA-9]</c> and
+/// constrained by <c>[EXE-4]</c>.
+/// </summary>
+public sealed class StateStorePayload
+{
+    /// <summary>
+    /// Gets the only schema version accepted by this release. Specified by
+    /// <c>[STA-9]</c>.
+    /// </summary>
+    public const int CurrentVersion = 1;
+
+    private readonly IReadOnlyDictionary<string, JsonElement> _stores;
+
+    private StateStorePayload(
+        string json,
+        IReadOnlyDictionary<string, JsonElement> stores)
+    {
+        Json = json;
+        _stores = stores;
+        string[] keys = new string[stores.Count];
+        int index = 0;
+        foreach (string key in stores.Keys)
+        {
+            keys[index++] = key;
+        }
+
+        StoreKeys = new ReadOnlyCollection<string>(keys);
+    }
+
+    /// <summary>
+    /// Gets this payload's fixed schema version. Specified by <c>[STA-9]</c>.
+    /// </summary>
+    public int Version => CurrentVersion;
+
+    /// <summary>
+    /// Gets the ordinal keys of the stores represented by the payload. Specified by
+    /// <c>[STA-9]</c>.
+    /// </summary>
+    public IReadOnlyList<string> StoreKeys { get; }
+
+    /// <summary>
+    /// Gets the normalized JSON document. HTML-sensitive characters and Unicode line separators
+    /// are escaped, so the value cannot terminate a JSON script island when embedded verbatim.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.</remarks>
+    public string Json { get; }
+
+    /// <summary>
+    /// Parses and validates the versioned payload without reflection-backed deserialization.
+    /// Unknown or duplicate schema members and duplicate or empty store keys are rejected.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c>.</remarks>
+    /// <param name="json">The complete payload JSON.</param>
+    /// <returns>A validated, normalized payload.</returns>
+    /// <exception cref="JsonException">The input does not conform to the payload schema.</exception>
+    public static StateStorePayload Parse(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("A Viu state payload must be a JSON object.");
+        }
+
+        int? version = null;
+        Dictionary<string, JsonElement>? stores = null;
+        foreach (JsonProperty property in root.EnumerateObject())
+        {
+            if (property.NameEquals("version"))
+            {
+                if (version is not null
+                    || property.Value.ValueKind != JsonValueKind.Number
+                    || !property.Value.TryGetInt32(out int parsedVersion))
+                {
+                    throw new JsonException(
+                        "A Viu state payload must contain one integer version member.");
+                }
+
+                version = parsedVersion;
+            }
+            else if (property.NameEquals("stores"))
+            {
+                if (stores is not null || property.Value.ValueKind != JsonValueKind.Object)
+                {
+                    throw new JsonException(
+                        "A Viu state payload must contain one object-valued stores member.");
+                }
+
+                stores = ReadStores(property.Value);
+            }
+            else
+            {
+                throw new JsonException(
+                    $"Unknown Viu state payload member \"{property.Name}\".");
+            }
+        }
+
+        if (version != CurrentVersion)
+        {
+            throw new JsonException(
+                $"Unsupported Viu state payload version {version?.ToString() ?? "<missing>"}; "
+                + $"expected {CurrentVersion}.");
+        }
+
+        if (stores is null)
+        {
+            throw new JsonException("A Viu state payload requires a stores member.");
+        }
+
+        return Create(stores);
+    }
+
+    internal static StateStorePayload Create(
+        IReadOnlyDictionary<string, StateStoreEntry> entries)
+    {
+        Dictionary<string, JsonElement> stores = new(
+            entries.Count,
+            StringComparer.Ordinal);
+        foreach (KeyValuePair<string, StateStoreEntry> entry in entries)
+        {
+            stores.Add(entry.Key, entry.Value.SerializeState());
+        }
+
+        return Create(stores);
+    }
+
+    internal bool TryGetState(string key, out JsonElement state) =>
+        _stores.TryGetValue(key, out state);
+
+    private static StateStorePayload Create(
+        IReadOnlyDictionary<string, JsonElement> stores)
+    {
+        ArrayBufferWriter<byte> buffer = new();
+        using (Utf8JsonWriter writer = new(
+            buffer,
+            new JsonWriterOptions
+            {
+                Encoder = JavaScriptEncoder.Default,
+            }))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("version", CurrentVersion);
+            writer.WriteStartObject("stores");
+            foreach (KeyValuePair<string, JsonElement> store in stores)
+            {
+                writer.WritePropertyName(store.Key);
+                store.Value.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        string json = Encoding.UTF8.GetString(buffer.WrittenSpan);
+        Dictionary<string, JsonElement> copies = new(
+            stores.Count,
+            StringComparer.Ordinal);
+        foreach (KeyValuePair<string, JsonElement> store in stores)
+        {
+            copies.Add(store.Key, store.Value.Clone());
+        }
+
+        return new StateStorePayload(
+            EscapeForJsonIsland(json),
+            new ReadOnlyDictionary<string, JsonElement>(copies));
+    }
+
+    private static Dictionary<string, JsonElement> ReadStores(JsonElement storesElement)
+    {
+        Dictionary<string, JsonElement> stores = new(StringComparer.Ordinal);
+        foreach (JsonProperty store in storesElement.EnumerateObject())
+        {
+            if (store.Name.Length == 0)
+            {
+                throw new JsonException("A Viu state payload cannot contain an empty store key.");
+            }
+
+            if (!stores.TryAdd(store.Name, store.Value.Clone()))
+            {
+                throw new JsonException(
+                    $"A Viu state payload contains duplicate store key \"{store.Name}\".");
+            }
+        }
+
+        return stores;
+    }
+
+    private static string EscapeForJsonIsland(string json)
+    {
+        StringBuilder? builder = null;
+        for (int index = 0; index < json.Length; index++)
+        {
+            string? replacement = json[index] switch
+            {
+                '<' => "\\u003C",
+                '>' => "\\u003E",
+                '&' => "\\u0026",
+                '\u2028' => "\\u2028",
+                '\u2029' => "\\u2029",
+                _ => null,
+            };
+            if (replacement is null)
+            {
+                builder?.Append(json[index]);
+                continue;
+            }
+
+            if (builder is null)
+            {
+                builder = new StringBuilder(json.Length + 16);
+                builder.Append(json, 0, index);
+            }
+
+            builder.Append(replacement);
+        }
+
+        return builder?.ToString() ?? json;
+    }
+}

--- a/libraries/Assimalign.Viu.State/src/StateStoreDefinition{TStore}.cs
+++ b/libraries/Assimalign.Viu.State/src/StateStoreDefinition{TStore}.cs
@@ -28,6 +28,24 @@ public sealed class StateStoreDefinition<TStore>
     }
 
     /// <summary>
+    /// Creates reusable metadata for a serializable state store. The serializer is invoked only
+    /// for registry payload capture and restore and must remain reflection-free. Specified by
+    /// <c>[STA-9]</c> and <c>[EXE-4]</c>.
+    /// </summary>
+    /// <param name="key">The non-empty application-unique state-store key.</param>
+    /// <param name="setup">The explicit AOT-safe store setup delegate.</param>
+    /// <param name="serializer">The explicit AOT-safe state serializer.</param>
+    public StateStoreDefinition(
+        string key,
+        StateStoreActivator<TStore> setup,
+        IStateStoreSerializer<TStore> serializer)
+        : this(key, setup)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        Serializer = serializer;
+    }
+
+    /// <summary>
     /// Gets the application-unique store key used for ordinal collision detection. Specified by
     /// <c>[STA-1]</c> and <c>[STA-2]</c>.
     /// </summary>
@@ -45,6 +63,13 @@ public sealed class StateStoreDefinition<TStore>
     /// Specified by <c>[STA-1]</c>.
     /// </summary>
     public StateStoreActivator<TStore> Setup { get; }
+
+    /// <summary>
+    /// Gets the optional explicit serializer used by registry payload capture and restore. A
+    /// materialized definition without one fails actionably when a payload operation includes it.
+    /// </summary>
+    /// <remarks>Specified by <c>[STA-9]</c> and constrained by <c>[EXE-4]</c>.</remarks>
+    public IStateStoreSerializer<TStore>? Serializer { get; }
 
     /// <summary>
     /// Gets the registry-owned store for this definition, creating it on first use. Different

--- a/libraries/Assimalign.Viu.State/src/StateStoreRegistry.cs
+++ b/libraries/Assimalign.Viu.State/src/StateStoreRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
+using System.Text.Json;
 
 using Assimalign.Viu.Reactivity;
 
@@ -17,7 +18,7 @@ namespace Assimalign.Viu.State;
 /// while an asynchronous-only store remains responsible for an explicit host-owned lifetime. The
 /// registry never blocks the host loop waiting for asynchronous disposal.
 /// </remarks>
-public sealed class StateStoreRegistry : IStateStoreRegistry
+public sealed class StateStoreRegistry : IStateStoreRegistry, IStateStorePayloadRegistry
 {
     private readonly Dictionary<string, StateStoreEntry> _entries =
         new(StringComparer.Ordinal);
@@ -25,6 +26,7 @@ public sealed class StateStoreRegistry : IStateStoreRegistry
     private readonly IReactiveEffectScope _rootScope;
     private readonly IServiceProvider? _services;
     private readonly IReactiveWatchScheduler? _watchScheduler;
+    private StateStorePayload? _restorePayload;
 
     /// <summary>
     /// Creates a registry with an explicit reactive scope factory. The factory creates one detached
@@ -79,6 +81,7 @@ public sealed class StateStoreRegistry : IStateStoreRegistry
 
         IReactiveEffectScope scope =
             _rootScope.Run(() => _effectScopes.Create(isDetached: false));
+        StateStoreEntry? createdEntry = null;
         try
         {
             StateContext context = new(
@@ -92,9 +95,27 @@ public sealed class StateStoreRegistry : IStateStoreRegistry
                 TStore store = scope.Run(() => definition.Setup(context))
                     ?? throw new InvalidOperationException(
                         $"State store setup for \"{definition.Key}\" returned null.");
-                _entries.Add(
+                IStateStoreSerializer<TStore>? serializer = definition.Serializer;
+                createdEntry = new StateStoreEntry(
                     definition.Key,
-                    new StateStoreEntry(definition, store, scope));
+                    definition,
+                    store,
+                    scope,
+                    serializer is null
+                        ? null
+                        : writer => serializer.Serialize(writer, store),
+                    serializer is null
+                        ? null
+                        : state => serializer.Restore(store, state));
+                if (_restorePayload is { } restorePayload
+                    && restorePayload.TryGetState(
+                        definition.Key,
+                        out JsonElement state))
+                {
+                    createdEntry.RestoreState(state);
+                }
+
+                _entries.Add(definition.Key, createdEntry);
                 return store;
             }
             finally
@@ -102,9 +123,26 @@ public sealed class StateStoreRegistry : IStateStoreRegistry
                 StateStoreSetupRuntime.Current = previousContext;
             }
         }
-        catch
+        catch (Exception exception)
         {
-            scope.Stop();
+            ExceptionDispatchInfo failure = ExceptionDispatchInfo.Capture(exception);
+            try
+            {
+                if (createdEntry is null)
+                {
+                    scope.Stop();
+                }
+                else
+                {
+                    createdEntry.Dispose();
+                }
+            }
+            catch
+            {
+                // Preserve the setup or restore failure after completing best-effort teardown.
+            }
+
+            failure.Throw();
             throw;
         }
     }
@@ -125,6 +163,30 @@ public sealed class StateStoreRegistry : IStateStoreRegistry
         _entries.Remove(definition.Key);
         entry.Dispose();
         return true;
+    }
+
+    /// <inheritdoc />
+    public StateStorePayload CapturePayload()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        return StateStorePayload.Create(_entries);
+    }
+
+    /// <inheritdoc />
+    public void RestorePayload(StateStorePayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+        foreach (KeyValuePair<string, StateStoreEntry> entry in _entries)
+        {
+            if (payload.TryGetState(entry.Key, out JsonElement state))
+            {
+                entry.Value.RestoreState(state);
+            }
+        }
+
+        _restorePayload = payload;
     }
 
     /// <summary>

--- a/libraries/Assimalign.Viu.State/src/StateStores.cs
+++ b/libraries/Assimalign.Viu.State/src/StateStores.cs
@@ -9,21 +9,21 @@ namespace Assimalign.Viu.State;
 /// ambient application registry. Specified by <c>[STA-1]</c> through <c>[STA-4]</c>.
 /// </summary>
 /// <remarks>
-/// Ambient registry state is not thread-safe and targets Viu's single-threaded event-loop model.
-/// Server and multi-request hosts should pass an explicit request-owned registry.
+/// An individual registry remains single-event-loop and is not thread-safe. Browser uses one shared
+/// ambient value; ServerRenderer selects a logical-flow-local value for each request. Other
+/// multi-request hosts should pass an explicit request-owned registry. Specified by
+/// <c>[EXE-1]</c>.
 /// </remarks>
 public static class StateStores
 {
-    private static IStateStoreRegistry? _activeRegistry;
-
     /// <summary>
     /// Gets or sets the ambient registry used by argument-less resolution and as the fallback after
     /// component services. It is <see langword="null"/> by default. Specified by <c>[STA-4]</c>.
     /// </summary>
     public static IStateStoreRegistry? ActiveRegistry
     {
-        get => _activeRegistry;
-        set => _activeRegistry = value;
+        get => StateExecutionIsolation.Current.ActiveRegistry;
+        set => StateExecutionIsolation.Current.ActiveRegistry = value;
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public static class StateStores
     /// </summary>
     /// <param name="registry">The registry to make active, or <see langword="null"/>.</param>
     public static void SetActiveRegistry(IStateStoreRegistry? registry)
-        => _activeRegistry = registry;
+        => StateExecutionIsolation.Current.ActiveRegistry = registry;
 
     /// <summary>
     /// Defines a context-aware state store without reflection-backed activation. Specified by
@@ -49,6 +49,25 @@ public static class StateStores
         => new(key, setup);
 
     /// <summary>
+    /// Defines a context-aware state store with an explicit AOT-safe payload serializer. Specified
+    /// by <c>[STA-9]</c> and <c>[EXE-4]</c>.
+    /// </summary>
+    /// <typeparam name="TStore">The state store type.</typeparam>
+    /// <param name="key">The non-empty application-unique state-store key.</param>
+    /// <param name="setup">The explicit AOT-safe setup delegate.</param>
+    /// <param name="serializer">The explicit AOT-safe state serializer.</param>
+    /// <returns>Reusable registry-independent store metadata.</returns>
+    public static StateStoreDefinition<TStore> Define<TStore>(
+        string key,
+        StateStoreActivator<TStore> setup,
+        IStateStoreSerializer<TStore> serializer)
+        where TStore : class
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        return new StateStoreDefinition<TStore>(key, setup, serializer);
+    }
+
+    /// <summary>
     /// Defines a parameterless state store without reflection-backed activation. Specified by
     /// <c>[STA-1]</c>.
     /// </summary>
@@ -63,6 +82,26 @@ public static class StateStores
     {
         ArgumentNullException.ThrowIfNull(setup);
         return new StateStoreDefinition<TStore>(key, _ => setup());
+    }
+
+    /// <summary>
+    /// Defines a parameterless state store with an explicit AOT-safe payload serializer. Specified
+    /// by <c>[STA-9]</c> and <c>[EXE-4]</c>.
+    /// </summary>
+    /// <typeparam name="TStore">The state store type.</typeparam>
+    /// <param name="key">The non-empty application-unique state-store key.</param>
+    /// <param name="setup">The explicit AOT-safe setup delegate.</param>
+    /// <param name="serializer">The explicit AOT-safe state serializer.</param>
+    /// <returns>Reusable registry-independent store metadata.</returns>
+    public static StateStoreDefinition<TStore> Define<TStore>(
+        string key,
+        Func<TStore> setup,
+        IStateStoreSerializer<TStore> serializer)
+        where TStore : class
+    {
+        ArgumentNullException.ThrowIfNull(setup);
+        ArgumentNullException.ThrowIfNull(serializer);
+        return new StateStoreDefinition<TStore>(key, _ => setup(), serializer);
     }
 
     /// <summary>

--- a/libraries/Assimalign.Viu.State/test/StateStorePayloadTests.cs
+++ b/libraries/Assimalign.Viu.State/test/StateStorePayloadTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Shouldly;
+using Xunit;
+
+namespace Assimalign.Viu.State.Tests;
+
+public sealed class StateStorePayloadTests
+{
+    [Fact]
+    public void CapturePayload_OnlyOneDefinitionMaterialized_ContainsOnlyThatStoreKey()
+    {
+        using StateStoreRegistry registry = StateStoreTestSupport.CreateRegistry();
+        StateStoreDefinition<PayloadStore> used = CreateDefinition("used");
+        _ = CreateDefinition("unused");
+        registry.GetOrCreate(used).State.Count = 42;
+
+        StateStorePayload payload = registry.CapturePayload();
+
+        payload.Version.ShouldBe(StateStorePayload.CurrentVersion);
+        payload.StoreKeys.ShouldBe(["used"]);
+        payload.Json.ShouldContain("\"stores\":{\"used\":");
+        payload.Json.ShouldNotContain("unused");
+    }
+
+    [Fact]
+    public void CapturePayload_MaterializedDefinitionHasNoSerializer_ThrowsActionableError()
+    {
+        using StateStoreRegistry registry = StateStoreTestSupport.CreateRegistry();
+        StateStoreDefinition<PayloadStore> definition = new(
+            "missing-serializer",
+            static _ => new PayloadStore());
+        registry.GetOrCreate(definition);
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(
+            () => registry.CapturePayload());
+
+        exception.Message.ShouldContain("missing-serializer");
+        exception.Message.ShouldContain("IStateStoreSerializer<TStore>");
+    }
+
+    [Fact]
+    public void RestorePayload_StoreCreatedAfterRestore_InitializesBeforeResolutionReturns()
+    {
+        StateStoreDefinition<PayloadStore> definition = CreateDefinition("counter");
+        StateStorePayload payload;
+        using (StateStoreRegistry serverRegistry = StateStoreTestSupport.CreateRegistry())
+        {
+            PayloadStore serverStore = serverRegistry.GetOrCreate(definition);
+            serverStore.State.Count = 37;
+            serverStore.State.Message = "server";
+            payload = serverRegistry.CapturePayload();
+        }
+
+        using StateStoreRegistry clientRegistry = StateStoreTestSupport.CreateRegistry();
+        clientRegistry.RestorePayload(StateStorePayload.Parse(payload.Json));
+
+        PayloadStore clientStore = clientRegistry.GetOrCreate(definition);
+
+        clientStore.State.Count.ShouldBe(37);
+        clientStore.State.Message.ShouldBe("server");
+    }
+
+    [Fact]
+    public void RestorePayload_StoreAlreadyMaterialized_RestoresImmediately()
+    {
+        StateStoreDefinition<PayloadStore> definition = CreateDefinition("counter");
+        StateStorePayload payload;
+        using (StateStoreRegistry serverRegistry = StateStoreTestSupport.CreateRegistry())
+        {
+            serverRegistry.GetOrCreate(definition).State.Count = 81;
+            payload = serverRegistry.CapturePayload();
+        }
+
+        using StateStoreRegistry clientRegistry = StateStoreTestSupport.CreateRegistry();
+        PayloadStore clientStore = clientRegistry.GetOrCreate(definition);
+        clientStore.State.Count.ShouldBe(0);
+
+        clientRegistry.RestorePayload(payload);
+
+        clientStore.State.Count.ShouldBe(81);
+    }
+
+    [Fact]
+    public void CaptureAndRestore_HtmlSensitiveState_ProducesSafeIslandJsonAndRoundTrips()
+    {
+        const string message = "</script>\u2028\u2029<&>";
+        StateStoreDefinition<PayloadStore> definition = CreateDefinition("unsafe");
+        StateStorePayload payload;
+        using (StateStoreRegistry serverRegistry = StateStoreTestSupport.CreateRegistry())
+        {
+            serverRegistry.GetOrCreate(definition).State.Message = message;
+            payload = serverRegistry.CapturePayload();
+        }
+
+        payload.Json.ShouldNotContain("</script>");
+        payload.Json.ShouldNotContain("<");
+        payload.Json.ShouldNotContain(">");
+        payload.Json.ShouldNotContain("&");
+        payload.Json.ShouldNotContain("\u2028");
+        payload.Json.ShouldNotContain("\u2029");
+        payload.Json.ShouldContain("\\u003C");
+        payload.Json.ShouldContain("\\u2028");
+        payload.Json.ShouldContain("\\u2029");
+
+        using StateStoreRegistry clientRegistry = StateStoreTestSupport.CreateRegistry();
+        clientRegistry.RestorePayload(StateStorePayload.Parse(payload.Json));
+        clientRegistry.GetOrCreate(definition).State.Message.ShouldBe(message);
+    }
+
+    [Fact]
+    public void Registries_DifferentStateValues_CaptureIndependentPayloads()
+    {
+        StateStoreDefinition<PayloadStore> definition = CreateDefinition("request");
+        using StateStoreRegistry firstRegistry = StateStoreTestSupport.CreateRegistry();
+        using StateStoreRegistry secondRegistry = StateStoreTestSupport.CreateRegistry();
+        firstRegistry.GetOrCreate(definition).State.Message = "first";
+        secondRegistry.GetOrCreate(definition).State.Message = "second";
+
+        StateStorePayload firstPayload = firstRegistry.CapturePayload();
+        StateStorePayload secondPayload = secondRegistry.CapturePayload();
+
+        firstPayload.Json.ShouldContain("first");
+        firstPayload.Json.ShouldNotContain("second");
+        secondPayload.Json.ShouldContain("second");
+        secondPayload.Json.ShouldNotContain("first");
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"version\":2,\"stores\":{}}")]
+    [InlineData("{\"version\":1,\"stores\":{},\"extra\":true}")]
+    [InlineData("{\"version\":1,\"stores\":{\"same\":{},\"same\":{}}}")]
+    public void Parse_InvalidSchema_ThrowsJsonException(string json)
+    {
+        Should.Throw<JsonException>(() => StateStorePayload.Parse(json));
+    }
+
+    private static StateStoreDefinition<PayloadStore> CreateDefinition(string key) =>
+        StateStores.Define(
+            key,
+            static () => new PayloadStore(),
+            new StateStoreJsonSerializer<PayloadStore, PayloadState>(
+                static stateStore => stateStore.State,
+                static (stateStore, state) => stateStore.State = state,
+                StateStorePayloadJsonContext.Default.PayloadState));
+}
+
+internal sealed class PayloadStore
+{
+    internal PayloadState State { get; set; } = new();
+}
+
+internal sealed class PayloadState
+{
+    public int Count { get; set; }
+
+    public string Message { get; set; } = string.Empty;
+}
+
+[JsonSerializable(typeof(PayloadState))]
+internal sealed partial class StateStorePayloadJsonContext : JsonSerializerContext
+{
+}

--- a/libraries/Assimalign.Viu.State/test/StateStoreRegistryTests.cs
+++ b/libraries/Assimalign.Viu.State/test/StateStoreRegistryTests.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Shouldly;
 using Xunit;
@@ -160,6 +164,84 @@ public sealed class StateStoreRegistryTests
     }
 
     [Fact]
+    public async Task GetOrCreate_ConcurrentIsolatedSetups_RestoreAmbientStateAndDisposeOnlyOwnedStores()
+    {
+        using Barrier setupBarrier = new(2);
+        ConcurrentQueue<string> disposedStores = new();
+        TaskCompletionSource firstReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource secondReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseFirst = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseSecond = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task RunRequestAsync(
+            string requestName,
+            TaskCompletionSource ready,
+            Task release)
+        {
+            using IDisposable isolation = StateExecutionIsolation.Enter();
+            using StateStoreRegistry registry = StateStoreTestSupport.CreateRegistry();
+            StateStores.ActiveRegistry = registry;
+            StateStoreDefinition<ConcurrentDisposableStore> definition = StateStores.Define(
+                requestName,
+                context =>
+                {
+                    setupBarrier.SignalAndWait(TimeSpan.FromSeconds(5));
+                    StateStoreSetupRuntime.Current.ShouldBeSameAs(context);
+                    StateStores.ActiveRegistry.ShouldBeSameAs(registry);
+                    return new ConcurrentDisposableStore(requestName, disposedStores);
+                });
+
+            definition.Use(registry);
+            ready.SetResult();
+            await release.ConfigureAwait(false);
+        }
+
+        Task first = Task.Run(
+            () => RunRequestAsync("first", firstReady, releaseFirst.Task));
+        Task second = Task.Run(
+            () => RunRequestAsync("second", secondReady, releaseSecond.Task));
+        await Task.WhenAll(firstReady.Task, secondReady.Task)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        releaseFirst.SetResult();
+        await first.WaitAsync(TimeSpan.FromSeconds(10));
+        disposedStores.ToArray().ShouldBe(["first"]);
+
+        releaseSecond.SetResult();
+        await second.WaitAsync(TimeSpan.FromSeconds(10));
+        disposedStores.ToArray().ShouldBe(["first", "second"]);
+        StateStores.ActiveRegistry.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetOrCreate_StagedRestoreThrows_DisposesNewStoreAndPreservesRestoreFailure()
+    {
+        TestReactiveEffectScopeFactory effectScopes = new();
+        using StateStoreRegistry registry = new(
+            services: null,
+            effectScopes);
+        StateStorePayload payload = StateStorePayload.Parse(
+            "{\"version\":1,\"stores\":{\"restore-failure\":{}}}");
+        ThrowingDisposableStore? createdStore = null;
+        StateStoreDefinition<ThrowingDisposableStore> definition = StateStores.Define(
+            "restore-failure",
+            () => createdStore = new ThrowingDisposableStore(),
+            new ThrowingRestoreSerializer());
+        registry.RestorePayload(payload);
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(
+            () => definition.Use(registry));
+
+        exception.Message.ShouldBe("restore failure");
+        createdStore.ShouldNotBeNull();
+        createdStore.DisposeCount.ShouldBe(1);
+        registry.Count.ShouldBe(0);
+        effectScopes.CreatedScopes.Count.ShouldBe(2);
+        effectScopes.CreatedScopes[0].IsActive.ShouldBeTrue();
+        effectScopes.CreatedScopes[1].IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
     public void Remove_StopsOnlySelectedStoreAndNextUseCreatesFreshInstance()
     {
         using StateStoreRegistry registry =
@@ -244,6 +326,46 @@ public sealed class StateStoreRegistryTests
         internal bool IsDisposed { get; private set; }
 
         public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class ConcurrentDisposableStore : IDisposable
+    {
+        private readonly ConcurrentQueue<string> _disposedStores;
+        private readonly string _requestName;
+
+        internal ConcurrentDisposableStore(
+            string requestName,
+            ConcurrentQueue<string> disposedStores)
+        {
+            _requestName = requestName;
+            _disposedStores = disposedStores;
+        }
+
+        public void Dispose() => _disposedStores.Enqueue(_requestName);
+    }
+
+    private sealed class ThrowingDisposableStore : IDisposable
+    {
+        internal int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            throw new InvalidOperationException("dispose failure");
+        }
+    }
+
+    private sealed class ThrowingRestoreSerializer :
+        IStateStoreSerializer<ThrowingDisposableStore>
+    {
+        public void Serialize(Utf8JsonWriter writer, ThrowingDisposableStore stateStore)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+
+        public void Restore(ThrowingDisposableStore stateStore, JsonElement state) =>
+            throw new InvalidOperationException("restore failure");
     }
 
     private sealed class MessageService

--- a/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
+++ b/libraries/Assimalign.Viu.Testing/docs/DESIGN.md
@@ -41,6 +41,12 @@ models browser-visible text and attribute values. `TestHydrationReader` exposes 
 `FrozenTestHydrationReader` captures a complete immutable pre-walk so recovery remains readable
 after host mutations, matching the browser's one-snapshot read budget (`[HYD-2]`, `[RND-IO-1]`).
 
+`TestHydrationTriggers` implements the same optional capability Browser supplies, but exposes
+explicit idle, visibility, media-query, and interaction trigger methods. Firing one invokes Core's
+request callback; the scheduler pump still controls the post-flush activation. Disposal removes a
+dormant registration, and completion counters distinguish activation from replay
+(`[HYD-LAZY-3]` through `[HYD-LAZY-5]`).
+
 ## Non-goals
 
 - Browser event propagation, layout, accessibility-tree, and CSS-engine simulation.

--- a/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
+++ b/libraries/Assimalign.Viu.Testing/docs/OVERVIEW.md
@@ -24,6 +24,10 @@ plain CoreCLR test host with no DOM, browser, WASM toolchain, or JavaScript inte
   pre-walk matching a one-read browser snapshot.
 - `TestSchedulerPump` installs through `Scheduler.UseFlushDispatcher` and restores through its
   returned lease. `ComponentTest` also uses `Scheduler.Reset` at mount boundaries.
+- `TestHydrationTriggers` is the deterministic host seam for idle, visible, media-query, and
+  interaction activation. Trigger methods enter Core's ordinary post-flush path; counters expose
+  completion and interaction replay without a DOM or wall clock (`[HYD-LAZY-3]` through
+  `[HYD-LAZY-5]`).
 
 ## Public-seam boundary
 

--- a/libraries/Assimalign.Viu.Testing/src/Hydration/TestHydrationTriggers.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Hydration/TestHydrationTriggers.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+
+namespace Assimalign.Viu.Testing;
+
+/// <summary>Provides deterministic host triggers for deferred hydration tests.</summary>
+/// <remarks>
+/// Trigger methods invoke Core's request callback; the test scheduler still controls when the
+/// queued post-flush activation runs. This host is not thread-safe. Specified by
+/// <c>[HYD-LAZY-3]</c> through <c>[HYD-LAZY-5]</c>.
+/// </remarks>
+public sealed class TestHydrationTriggers
+{
+    private readonly List<Registration> _pending = [];
+
+    /// <summary>Gets the number of unfired and undisposed trigger registrations.</summary>
+    public int PendingCount => _pending.Count;
+
+    /// <summary>Gets the number of activations completed by Core.</summary>
+    public int CompletedCount { get; private set; }
+
+    /// <summary>Gets the number of captured interaction events replayed after activation.</summary>
+    public int ReplayedInteractionCount { get; private set; }
+
+    /// <summary>Fires the first pending idle trigger.</summary>
+    public void TriggerIdle() => TriggerFirst(HydrationStrategyKind.Idle, null);
+
+    /// <summary>Fires the first pending visibility trigger.</summary>
+    public void TriggerVisible() => TriggerFirst(HydrationStrategyKind.Visible, null);
+
+    /// <summary>Fires the pending trigger for a matching media condition.</summary>
+    /// <param name="mediaQuery">The exact declared media condition.</param>
+    public void TriggerMediaQuery(string mediaQuery)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(mediaQuery);
+        TriggerFirst(HydrationStrategyKind.MediaQuery, mediaQuery);
+    }
+
+    /// <summary>Captures and fires the first pending trigger configured for an event.</summary>
+    /// <param name="eventName">The exact declared event name.</param>
+    public void TriggerInteraction(string eventName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(eventName);
+        TriggerFirst(HydrationStrategyKind.Interaction, eventName);
+    }
+
+    internal IHydrationTriggerRegistration Schedule(
+        HydrationTriggerRequest<TestNode> request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Registration registration = new(this, request);
+        _pending.Add(registration);
+        return registration;
+    }
+
+    private void TriggerFirst(HydrationStrategyKind kind, string? condition)
+    {
+        for (int index = 0; index < _pending.Count; index++)
+        {
+            Registration registration = _pending[index];
+            if (registration.Request.Strategy.Kind != kind
+                || !MatchesCondition(registration.Request.Strategy, condition))
+            {
+                continue;
+            }
+
+            _pending.RemoveAt(index);
+            registration.Fire(condition);
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"No pending {kind} hydration trigger matched the requested condition.");
+    }
+
+    private static bool MatchesCondition(
+        HydrationStrategy strategy,
+        string? condition) => strategy.Kind switch
+    {
+        HydrationStrategyKind.MediaQuery => string.Equals(
+            strategy.MediaQuery,
+            condition,
+            StringComparison.Ordinal),
+        HydrationStrategyKind.Interaction => Contains(
+            strategy.InteractionEvents,
+            condition),
+        _ => condition is null,
+    };
+
+    private static bool Contains(IReadOnlyList<string> values, string? value)
+    {
+        for (int index = 0; index < values.Count; index++)
+        {
+            if (string.Equals(values[index], value, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class Registration : IHydrationTriggerRegistration
+    {
+        private TestHydrationTriggers? _owner;
+        private bool _fired;
+        private bool _isInteraction;
+
+        internal Registration(
+            TestHydrationTriggers owner,
+            HydrationTriggerRequest<TestNode> request)
+        {
+            _owner = owner;
+            Request = request;
+        }
+
+        internal HydrationTriggerRequest<TestNode> Request { get; }
+
+        internal void Fire(string? condition)
+        {
+            if (_owner is null || _fired)
+            {
+                return;
+            }
+
+            _fired = true;
+            _isInteraction = Request.Strategy.Kind == HydrationStrategyKind.Interaction
+                && condition is not null;
+            Request.Trigger();
+        }
+
+        public void Complete()
+        {
+            if (_owner is not { } owner || !_fired)
+            {
+                return;
+            }
+
+            owner.CompletedCount++;
+            if (_isInteraction)
+            {
+                owner.ReplayedInteractionCount++;
+            }
+
+            _owner = null;
+        }
+
+        public void Dispose()
+        {
+            if (_owner is not { } owner)
+            {
+                return;
+            }
+
+            _ = owner._pending.Remove(this);
+            _owner = null;
+        }
+    }
+}

--- a/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
+++ b/libraries/Assimalign.Viu.Testing/src/Nodes/TestNodeOperations.cs
@@ -177,6 +177,9 @@ public static class TestNodeOperations
             CreateHydrationReader = options.SnapshotSemantics
                 ? root => new FrozenTestHydrationReader(root)
                 : _ => TestHydrationReader.Instance,
+            ScheduleHydrationTrigger = options.HydrationTriggers is null
+                ? null
+                : options.HydrationTriggers.Schedule,
         };
     }
 

--- a/libraries/Assimalign.Viu.Testing/src/PublicAPI.Unshipped.txt
+++ b/libraries/Assimalign.Viu.Testing/src/PublicAPI.Unshipped.txt
@@ -30,6 +30,8 @@ Assimalign.Viu.Testing.TestRendererOptions.SnapshotSemantics.get -> bool
 Assimalign.Viu.Testing.TestRendererOptions.SnapshotSemantics.init -> void
 Assimalign.Viu.Testing.TestRendererOptions.StrictRemoval.get -> bool
 Assimalign.Viu.Testing.TestRendererOptions.StrictRemoval.init -> void
+Assimalign.Viu.Testing.TestRendererOptions.HydrationTriggers.get -> Assimalign.Viu.Testing.TestHydrationTriggers?
+Assimalign.Viu.Testing.TestRendererOptions.HydrationTriggers.init -> void
 Assimalign.Viu.Testing.TestRendererOptions.TestRendererOptions() -> void
 override Assimalign.Viu.Testing.TestRendererOptions.Equals(object? obj) -> bool
 override Assimalign.Viu.Testing.TestRendererOptions.GetHashCode() -> int
@@ -40,3 +42,12 @@ static Assimalign.Viu.Testing.ComponentTest.Mount(Assimalign.Viu.Components.Virt
 static Assimalign.Viu.Testing.TestNodeOperations.Create(Assimalign.Viu.Testing.TestNodeOperationLog! operationLog, System.Collections.Generic.IReadOnlyList<Assimalign.Viu.Testing.TestElement!>? queryRoots = null, Assimalign.Viu.Testing.TestRendererOptions? options = null) -> Assimalign.Viu.RendererOptions<Assimalign.Viu.Testing.TestNode!>!
 static Assimalign.Viu.Testing.TestRendererOptions.operator !=(Assimalign.Viu.Testing.TestRendererOptions? left, Assimalign.Viu.Testing.TestRendererOptions? right) -> bool
 static Assimalign.Viu.Testing.TestRendererOptions.operator ==(Assimalign.Viu.Testing.TestRendererOptions? left, Assimalign.Viu.Testing.TestRendererOptions? right) -> bool
+Assimalign.Viu.Testing.TestHydrationTriggers
+Assimalign.Viu.Testing.TestHydrationTriggers.CompletedCount.get -> int
+Assimalign.Viu.Testing.TestHydrationTriggers.PendingCount.get -> int
+Assimalign.Viu.Testing.TestHydrationTriggers.ReplayedInteractionCount.get -> int
+Assimalign.Viu.Testing.TestHydrationTriggers.TestHydrationTriggers() -> void
+Assimalign.Viu.Testing.TestHydrationTriggers.TriggerIdle() -> void
+Assimalign.Viu.Testing.TestHydrationTriggers.TriggerInteraction(string! eventName) -> void
+Assimalign.Viu.Testing.TestHydrationTriggers.TriggerMediaQuery(string! mediaQuery) -> void
+Assimalign.Viu.Testing.TestHydrationTriggers.TriggerVisible() -> void

--- a/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
+++ b/libraries/Assimalign.Viu.Testing/src/TestRenderer.cs
@@ -29,6 +29,7 @@ public sealed class TestRenderer
                 {
                     SnapshotSemantics = options.SnapshotSemantics,
                     StrictRemoval = options.StrictRemoval || options.SnapshotSemantics,
+                    HydrationTriggers = options.HydrationTriggers,
                 }));
     }
 

--- a/libraries/Assimalign.Viu.Testing/src/TestRendererOptions.cs
+++ b/libraries/Assimalign.Viu.Testing/src/TestRendererOptions.cs
@@ -12,4 +12,7 @@ public sealed record TestRendererOptions
 
     /// <summary>Gets whether removing the same host node more than once throws.</summary>
     public bool StrictRemoval { get; init; }
+
+    /// <summary>Gets the optional deterministic deferred-hydration trigger host.</summary>
+    public TestHydrationTriggers? HydrationTriggers { get; init; }
 }

--- a/libraries/Assimalign.Viu.Testing/test/LazyHydrationTests.cs
+++ b/libraries/Assimalign.Viu.Testing/test/LazyHydrationTests.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Shouldly;
+using Xunit;
+
+using Assimalign.Viu;
+using Assimalign.Viu.Components;
+using Assimalign.Viu.Testing;
+
+namespace Assimalign.Viu.Testing.Tests;
+
+/// <summary>Pins deterministic host triggers for [V01.01.07.03.01].</summary>
+public sealed class LazyHydrationTests
+{
+    [Fact]
+    public void TriggerIdle_AdoptedComponent_ActivatesOnPostFlush()
+    {
+        AssertDeferredActivation(
+            HydrationStrategy.OnIdle(500),
+            static triggers => triggers.TriggerIdle());
+    }
+
+    [Fact]
+    public void TriggerVisible_AdoptedComponent_ActivatesOnPostFlush()
+    {
+        AssertDeferredActivation(
+            HydrationStrategy.OnVisible("100px"),
+            static triggers => triggers.TriggerVisible());
+    }
+
+    [Fact]
+    public void TriggerMediaQuery_AdoptedComponent_ActivatesOnPostFlush()
+    {
+        AssertDeferredActivation(
+            HydrationStrategy.OnMediaQuery("(min-width: 60rem)"),
+            static triggers => triggers.TriggerMediaQuery("(min-width: 60rem)"));
+    }
+
+    [Fact]
+    public void TriggerInteraction_AdoptedComponent_ReplaysAfterActivation()
+    {
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        Scenario scenario = CreateScenario(
+            HydrationStrategy.OnInteraction("click", "keydown"),
+            triggers);
+
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+        triggers.TriggerInteraction("click");
+
+        scenario.Component.SetupCount.ShouldBe(0);
+        triggers.ReplayedInteractionCount.ShouldBe(0);
+        pump.RunUntilIdle();
+        scenario.Component.SetupCount.ShouldBe(1);
+        triggers.ReplayedInteractionCount.ShouldBe(1);
+        triggers.CompletedCount.ShouldBe(1);
+        scenario.Renderer.Render(null, scenario.Container);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void RenderNull_BeforeTrigger_CancelsActivationAndHostRegistration()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        List<object?> referenceValues = [];
+        Scenario scenario = CreateScenario(
+            HydrationStrategy.OnIdle(),
+            triggers,
+            referenceValues.Add);
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+
+        scenario.Renderer.Render(null, scenario.Container);
+
+        triggers.PendingCount.ShouldBe(0);
+        Should.Throw<InvalidOperationException>(triggers.TriggerIdle);
+        pump.RunUntilIdle();
+        scenario.Component.SetupCount.ShouldBe(0);
+        referenceValues.ShouldBeEmpty();
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void TriggerThenRenderNull_BeforePostFlush_CancelsQueuedActivation()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        Scenario scenario = CreateScenario(HydrationStrategy.OnIdle(), triggers);
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+        triggers.TriggerIdle();
+
+        scenario.Renderer.Render(null, scenario.Container);
+        pump.RunUntilIdle();
+
+        scenario.Component.SetupCount.ShouldBe(0);
+        triggers.CompletedCount.ShouldBe(0);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void PatchDormantStrategyData_ReplacesTheHostRegistration()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        Scenario scenario = CreateScenario(
+            HydrationStrategy.OnMediaQuery("(width < 40rem)"),
+            triggers);
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+        ComponentNode next = new(
+            scenario.Root.Component,
+            new ComponentInvocation(
+                hydrationStrategy: HydrationStrategy.OnMediaQuery("(width >= 40rem)")));
+
+        scenario.Renderer.Render(next, scenario.Container);
+
+        Should.Throw<InvalidOperationException>(
+            () => triggers.TriggerMediaQuery("(width < 40rem)"));
+        triggers.TriggerMediaQuery("(width >= 40rem)");
+        pump.RunUntilIdle();
+        scenario.Component.SetupCount.ShouldBe(1);
+        scenario.Renderer.Render(null, scenario.Container);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void ActivatedLazyMountReference_PublishesAndClearsExactlyOnce()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        List<object?> values = [];
+        Scenario scenario = CreateScenario(
+            HydrationStrategy.OnVisible(),
+            triggers,
+            values.Add);
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+
+        triggers.TriggerVisible();
+        pump.RunUntilIdle();
+        scenario.Renderer.Render(null, scenario.Container);
+
+        values.Count.ShouldBe(2);
+        values[0].ShouldBeSameAs(scenario.Component);
+        values[1].ShouldBeNull();
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public async Task AsynchronousDefinition_PendingLoader_PreservesMarkupUntilOneTriggerCompletes()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        TaskCompletionSource<AsynchronousComponentTarget> load = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        AsynchronousComponentDefinition definition =
+            AsynchronousComponents.Define<AsynchronousWrapperIdentity>(
+                new AsynchronousComponentOptions
+                {
+                    Loader = _ => load.Task,
+                    Delay = 0,
+                    HydrationStrategy = HydrationStrategy.OnIdle(),
+                });
+        LazyTargetComponent target = new();
+        ComponentFactory components = new();
+        components.Register(definition.Registration);
+        components.Register(
+            new ComponentRegistration(
+                ComponentReference.ForType(typeof(LazyTargetComponent)),
+                new ComponentContract(),
+                _ => target));
+        ComponentNode root = definition.CreateComponent();
+        ApplicationContext application = CreateApplication(root, components);
+        TestRenderer renderer = CreateRenderer(triggers);
+        TestElement container = TestServerMarkup.Parse(
+            Marker(HydrationStrategyKind.Idle)
+                + "<button>ready</button>"
+                + HydrationMarkers.LazyHydrationEnd);
+        TestNode adopted = container.Children[1];
+
+        renderer.Hydrate(root, container, application);
+        triggers.TriggerIdle();
+        pump.RunUntilIdle();
+
+        target.SetupCount.ShouldBe(0);
+        container.Children[1].ShouldBeSameAs(adopted);
+
+        load.SetResult(AsynchronousComponentTarget.From<LazyTargetComponent>());
+        for (int attempt = 0; attempt < 5000 && pump.PendingFlushCount == 0; attempt++)
+        {
+            await Task.Yield();
+        }
+        pump.PendingFlushCount.ShouldBeGreaterThan(0);
+        pump.RunUntilIdle();
+
+        target.SetupCount.ShouldBe(1);
+        triggers.CompletedCount.ShouldBe(1);
+        container.Children[1].ShouldBeSameAs(adopted);
+        renderer.Render(null, container);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public async Task AsynchronousDefinition_NeverCompletingLoader_TimeoutActivatesErrorPresentation()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        TaskCompletionSource<AsynchronousComponentTarget> load = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<Exception> routed = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        AsynchronousComponentDefinition definition =
+            AsynchronousComponents.Define<AsynchronousWrapperIdentity>(
+                new AsynchronousComponentOptions
+                {
+                    Loader = _ => load.Task,
+                    Delay = 0,
+                    Timeout = 20,
+                    ErrorComponent = error => new ElementNode(
+                        new QualifiedName("p"),
+                        children: [new TextNode(error.Message)]),
+                    HydrationStrategy = HydrationStrategy.OnIdle(),
+                });
+        ComponentFactory components = new();
+        components.Register(definition.Registration);
+        ComponentNode root = definition.CreateComponent();
+        ApplicationContext application = new(
+            new ApplicationOptions
+            {
+                RootComponent = root,
+                Components = components,
+                ErrorHandler = (error, _, _) => routed.TrySetResult(error),
+            });
+        TestRenderer renderer = CreateRenderer(triggers);
+        TestElement container = TestServerMarkup.Parse(
+            Marker(HydrationStrategyKind.Idle)
+                + "<p>server</p>"
+                + HydrationMarkers.LazyHydrationEnd);
+        TestNode adopted = container.Children[1];
+
+        renderer.Hydrate(root, container, application);
+        triggers.TriggerIdle();
+        pump.RunUntilIdle();
+
+        load.Task.IsCompleted.ShouldBeFalse();
+        container.Children[1].ShouldBeSameAs(adopted);
+
+        Exception routedError = await routed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        for (int attempt = 0; attempt < 5000 && pump.PendingFlushCount == 0; attempt++)
+        {
+            await Task.Yield();
+        }
+        pump.PendingFlushCount.ShouldBeGreaterThan(0);
+        pump.RunUntilIdle();
+
+        routedError.ShouldBeOfType<TimeoutException>();
+        TestElement errorPresentation = container.Children[1].ShouldBeOfType<TestElement>();
+        errorPresentation.ShouldBeSameAs(adopted);
+        errorPresentation.Tag.ShouldBe("p");
+        errorPresentation.Children.Count.ShouldBe(1);
+        errorPresentation.Children[0]
+            .ShouldBeOfType<TestText>()
+            .Text.ShouldBe("Asynchronous component timed out after 20ms.");
+        load.Task.IsCompleted.ShouldBeFalse();
+        triggers.CompletedCount.ShouldBe(1);
+        renderer.Render(null, container);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void NestedLazyBoundaries_OuterActivationSchedulesInnerIndependently()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        TestRenderer renderer = CreateRenderer(triggers);
+        CountingComponent inner = new(
+            () => new ElementNode(
+                new QualifiedName("span"),
+                children: [new TextNode("ready")]));
+        ComponentFactory components = new();
+        ComponentNode innerNode = Register(
+            components,
+            "inner",
+            inner,
+            HydrationStrategy.OnVisible());
+        CountingComponent outer = new(() => innerNode);
+        ComponentNode root = Register(
+            components,
+            "outer",
+            outer,
+            HydrationStrategy.OnIdle());
+        ApplicationContext application = CreateApplication(root, components);
+        TestElement container = TestServerMarkup.Parse(
+            Marker(HydrationStrategyKind.Idle)
+                + Marker(HydrationStrategyKind.Visible)
+                + "<span>ready</span>"
+                + HydrationMarkers.LazyHydrationEnd
+                + HydrationMarkers.LazyHydrationEnd);
+
+        renderer.Hydrate(root, container, application);
+        triggers.PendingCount.ShouldBe(1);
+        outer.SetupCount.ShouldBe(0);
+        inner.SetupCount.ShouldBe(0);
+
+        triggers.TriggerIdle();
+        pump.RunUntilIdle();
+        outer.SetupCount.ShouldBe(1);
+        inner.SetupCount.ShouldBe(0);
+        triggers.PendingCount.ShouldBe(1);
+
+        triggers.TriggerVisible();
+        pump.RunUntilIdle();
+        inner.SetupCount.ShouldBe(1);
+        triggers.CompletedCount.ShouldBe(2);
+        renderer.Render(null, container);
+        Scheduler.Reset();
+    }
+
+    [Fact]
+    public void EagerParentWithLazyChild_ActivatesOnlyTheParentDuringInitialWalk()
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        TestRenderer renderer = CreateRenderer(triggers);
+        CountingComponent child = new(
+            () => new ElementNode(
+                new QualifiedName("strong"),
+                children: [new TextNode("child")]));
+        ComponentFactory components = new();
+        ComponentNode childNode = Register(
+            components,
+            "child",
+            child,
+            HydrationStrategy.OnVisible());
+        CountingComponent parent = new(() => childNode);
+        ComponentNode root = Register(components, "parent", parent, null);
+        ApplicationContext application = CreateApplication(root, components);
+        TestElement container = TestServerMarkup.Parse(
+            Marker(HydrationStrategyKind.Visible)
+                + "<strong>child</strong>"
+                + HydrationMarkers.LazyHydrationEnd);
+
+        renderer.Hydrate(root, container, application);
+
+        parent.SetupCount.ShouldBe(1);
+        child.SetupCount.ShouldBe(0);
+        triggers.PendingCount.ShouldBe(1);
+        triggers.TriggerVisible();
+        pump.RunUntilIdle();
+        child.SetupCount.ShouldBe(1);
+        renderer.Render(null, container);
+        Scheduler.Reset();
+    }
+
+    private static void AssertDeferredActivation(
+        HydrationStrategy strategy,
+        Action<TestHydrationTriggers> trigger)
+    {
+        Scheduler.Reset();
+        TestHydrationTriggers triggers = new();
+        using TestSchedulerPump pump = TestSchedulerPump.Install();
+        Scenario scenario = CreateScenario(strategy, triggers);
+        TestNode adopted = scenario.Container.Children[1];
+
+        scenario.Renderer.Hydrate(
+            scenario.Root,
+            scenario.Container,
+            scenario.Application);
+
+        scenario.Component.SetupCount.ShouldBe(0);
+        triggers.PendingCount.ShouldBe(1);
+        trigger(triggers);
+        scenario.Component.SetupCount.ShouldBe(0);
+        pump.PendingFlushCount.ShouldBe(1);
+        pump.RunUntilIdle();
+
+        scenario.Component.SetupCount.ShouldBe(1);
+        triggers.PendingCount.ShouldBe(0);
+        triggers.CompletedCount.ShouldBe(1);
+        scenario.Container.Children[1].ShouldBeSameAs(adopted);
+        scenario.Renderer.Render(null, scenario.Container);
+        Scheduler.Reset();
+    }
+
+    private static Scenario CreateScenario(
+        HydrationStrategy strategy,
+        TestHydrationTriggers triggers,
+        MountReference? mountReference = null)
+    {
+        TestRenderer renderer = CreateRenderer(triggers);
+        CountingComponent component = new(
+            () => new ElementNode(
+                new QualifiedName("button"),
+                children: [new TextNode("ready")]));
+        ComponentFactory components = new();
+        ComponentNode root = Register(
+            components,
+            "target",
+            component,
+            strategy,
+            mountReference);
+        ApplicationContext application = CreateApplication(root, components);
+        TestElement container = TestServerMarkup.Parse(
+            Marker(strategy.Kind)
+                + "<button>ready</button>"
+                + HydrationMarkers.LazyHydrationEnd);
+        return new Scenario(renderer, container, root, application, component);
+    }
+
+    private static TestRenderer CreateRenderer(TestHydrationTriggers triggers) => new(
+        new TestRendererOptions
+        {
+            SnapshotSemantics = true,
+            HydrationTriggers = triggers,
+        });
+
+    private static ComponentNode Register(
+        ComponentFactory components,
+        string name,
+        CountingComponent component,
+        HydrationStrategy? strategy,
+        MountReference? mountReference = null)
+    {
+        ComponentReference reference = ComponentReference.ForName(name);
+        components.Register(
+            new ComponentRegistration(
+                reference,
+                new ComponentContract(displayName: name),
+                _ => component));
+        return new ComponentNode(
+            reference,
+            new ComponentInvocation(hydrationStrategy: strategy),
+            mountReference: mountReference);
+    }
+
+    private static ApplicationContext CreateApplication(
+        ComponentNode root,
+        ComponentFactory components) => new(
+        new ApplicationOptions
+        {
+            RootComponent = root,
+            Components = components,
+        });
+
+    private static string Marker(HydrationStrategyKind kind) =>
+        HydrationMarkers.GetLazyHydrationStart(kind);
+
+    private sealed record Scenario(
+        TestRenderer Renderer,
+        TestElement Container,
+        ComponentNode Root,
+        ApplicationContext Application,
+        CountingComponent Component);
+
+    private sealed class CountingComponent : IComponent
+    {
+        private readonly Func<VirtualNode> _render;
+
+        internal CountingComponent(Func<VirtualNode> render)
+        {
+            _render = render;
+        }
+
+        internal int SetupCount { get; private set; }
+
+        public ComponentRenderer Setup(ComponentContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            SetupCount++;
+            return _ => _render();
+        }
+    }
+
+    private sealed class LazyTargetComponent : IComponent
+    {
+        internal int SetupCount { get; private set; }
+
+        public ComponentRenderer Setup(ComponentContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            SetupCount++;
+            return static _ => new ElementNode(
+                new QualifiedName("button"),
+                children: [new TextNode("ready")]);
+        }
+    }
+
+    private sealed class AsynchronousWrapperIdentity : IComponent
+    {
+        public ComponentRenderer Setup(ComponentContext context) => static _ => null;
+    }
+}

--- a/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentModel.cs
+++ b/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentModel.cs
@@ -39,9 +39,8 @@ namespace Assimalign.Viu.Compiler.SingleFileComponent;
 /// </param>
 /// <param name="ScopeId">
 /// The scoped-CSS scope id (<c>data-v-&lt;hash&gt;</c>) when the component declares at least one
-/// <c>scoped</c> style block, otherwise <see langword="null"/> ([V01.01.06.04]). Retained as style-
-/// compilation metadata; runtime scope-identifier emission is deferred during the component-model
-/// migration.
+/// <c>scoped</c> style block, otherwise <see langword="null"/> ([V01.01.06.04]). The template transform
+/// stamps this identifier on every emitted native element, keeping client and server output aligned.
 /// </param>
 /// <param name="ExtractedStyles">
 /// The component's compiled CSS — scoped style blocks rewritten with <see cref="ScopeId"/> and

--- a/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentProjection.cs
+++ b/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentProjection.cs
@@ -188,7 +188,14 @@ public static class SingleFileComponentProjection
         };
 
         var cssModules = BuildCssModuleAccessors(moduleClasses, moduleTemplateNames);
-        var render = CompileRenderFunction(input, parse, bindingMetadata, cssModules, diagnostics, cancellationToken);
+        var render = CompileRenderFunction(
+            input,
+            parse,
+            bindingMetadata,
+            cssModules,
+            scopeId,
+            diagnostics,
+            cancellationToken);
         model = model with { RenderBody = render.Body, RenderCacheSize = render.CacheSize };
 
         var array = diagnostics.Count == 0
@@ -423,6 +430,7 @@ public static class SingleFileComponentProjection
         AggregateSyntaxParserResult<SingleFileComponentBlock> parse,
         BindingMetadata bindingMetadata,
         CssModuleAccessors cssModules,
+        string? scopeId,
         List<DiagnosticInfo> diagnostics,
         CancellationToken cancellationToken)
     {
@@ -440,6 +448,10 @@ public static class SingleFileComponentProjection
             var transformOptions = TransformOptions.CreateDom();
             transformOptions.PrefixIdentifiers = true;
             transformOptions.BindingMetadata = bindingMetadata;
+            // Scoped styles ([V01.01.06.04], [V01.01.07.02]): the style compiler and render compiler share
+            // one path-derived identifier, so every client-rendered element carries the same attribute that
+            // the server-markup target emits for hydration.
+            transformOptions.ScopeId = scopeId;
             // CSS Modules accessors ([V01.01.05.04.01]): resolve `$style.<class>` (and named-module) references
             // against the emitted accessor class. The map is complete (every declared class), so an access to an
             // undeclared member is reported on the .viu coordinate.

--- a/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentSourceEmitter.cs
+++ b/tooling/Assimalign.Viu.Compiler.SingleFileComponent/src/Projection/SingleFileComponentSourceEmitter.cs
@@ -850,9 +850,9 @@ public static class SingleFileComponentSourceEmitter
         builder.Append("#line default\n");
     }
 
-    // [V01.01.06.04] Style extraction remains a build-time channel. Runtime scoped-CSS identifiers and
-    // v-bind application are deliberately absent during the component-model migration; CSS Modules
-    // accessors and the extracted text consumed by bundling remain.
+    // [V01.01.06.04] Style extraction remains a build-time channel. Scoped-CSS identifiers are applied
+    // by the template transform; runtime v-bind application remains absent during the component-model
+    // migration. CSS Modules accessors and the extracted text consumed by bundling remain.
     private static void AppendStyleSeam(StringBuilder builder, int indent, in SingleFileComponentModel model)
     {
         if (model.ExtractedStyles is not { } styles)
@@ -868,7 +868,7 @@ public static class SingleFileComponentSourceEmitter
         AppendIndent(builder, indent);
         builder.Append("// [V01.01.06.04] Compiled style blocks retained for static asset bundling; scoped-CSS\n");
         AppendIndent(builder, indent);
-        builder.Append("// runtime application is deferred.\n");
+        builder.Append("// identifiers are already stamped by the generated render function.\n");
 
         AppendIndent(builder, indent);
         builder.Append("/// <summary>\n");

--- a/tooling/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
+++ b/tooling/Assimalign.Viu.Syntax.Templates/docs/DESIGN.md
@@ -234,6 +234,45 @@ The template compiler remains a runtime-reference-free `netstandard2.0` assembly
 names occur only in emitted source. `FrameRenderCodeWriter`, generator snapshots, and the compiled-fixture
 suite jointly pin the contract.
 
+### Direct server-markup target ([V01.01.07.02])
+
+`RenderFunctionEmitterOptions.TargetProfile` selects a second build-time lowering over the same parsed
+template. `VirtualNodeTree` remains the default and preserves the interactive contract. `ServerMarkup`
+requires a transform with `IsServerRendering=true`, then emits an asynchronous method body over the
+enclosing method's `state`, `component`, `frame`, and `parent` parameters.
+
+`ServerRenderCodeWriter` keeps native, provably serializable structure on a direct path:
+
+- literal markup is HTML-escaped at compile time and coalesced into `state.Push(...)` calls;
+- interpolations and dynamic attributes call the public ServerRenderer normalizers, preserving the
+  current WHATWG escaping, Boolean-attribute, class, style, and property rules;
+- `v-model` writes input values/check state, textarea content, and option selection; `v-show` composes
+  `display:none;` into the authored style position; a scoped-style id is written on every native
+  element;
+- fragments and structural branches use Core's named `HydrationMarkers`, never duplicated marker
+  literals; Teleport, Suspense, and Transition lower to the ServerRenderer helper protocol, default
+  content, and pass-through children respectively.
+
+A dynamic component or property shape the direct writer cannot prove serializable invokes a local
+`FrameRenderCodeWriter` body and passes its resulting subtree to `SsrRenderComponentAsync`. The fallback
+therefore shares one `SsrRenderState` with adjacent direct output: cancellation, component ownership,
+escaping, markers, streaming, state handoff, and teleport resolution stay in the renderer-owned
+protocol. The compiler assembly still references no runtime assembly; all runtime names exist only in
+the emitted consumer source.
+
+`ServerRenderFunctionEmitterTests` snapshot the allocation-free direct body, form/show/scope transforms,
+built-ins, and fallback source. `CompiledServerRenderDifferentialTests` compile the emitted body in the
+test host and execute it through the production compiled-body seam against equivalent virtual trees,
+including escaping, attribute order, forms, scope ids, structural markers, and both dynamic-component
+and property-spread fallbacks.
+
+The profile is currently an explicit compiler facade rather than the default single-file-component
+projection. Automatic dual emission needs a server-targeting SDK/reference contract first: the base and
+Browser targeting frameworks intentionally do not expose `Assimalign.Viu.ServerRenderer`, so emitting
+server helper references unconditionally would break otherwise valid component libraries and add the
+server serializer to Browser applications. That integration must select the server profile only where
+the generated runtime helper contract is present.
+
 ### Browser directive integration ([V01.01.04.09])
 
 Browser behavior remains Browser-owned. The template compiler recognizes the structural helper tokens in

--- a/tooling/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
+++ b/tooling/Assimalign.Viu.Syntax.Templates/docs/OVERVIEW.md
@@ -2,7 +2,8 @@
 
 The Viu template language front end: it tokenizes
 and parses template markup into a located AST, runs the transform pipeline (structural and
-directive transforms, expression binding, static optimization), and generates a **C# render method**.
+directive transforms, expression binding, static optimization), and generates **C# render method
+bodies** for either the interactive virtual-node tree or direct server markup.
 The platform-neutral template language and its DOM directive set live in this one project.
 It is a build-time library that runs inside the source generator ([V01.01.05.05]/[V01.01.06.02]);
 there is no runtime compilation (`[SFC-1]`, and see
@@ -27,16 +28,19 @@ detailed in [DESIGN.md](DESIGN.md); this page is the surface map.
 - **Binding** (`Binding/`) — `BindingMetadata`, `BindingType`, `BindingRewriteMode`, and the CSS
   module accessors (`CssModuleAccessor`, `CssModuleAccessors`) that let the compiler resolve
   `$style.x`.
-- **Code generation** (`CodeGeneration/`) — `RenderFunctionEmitter`, its
-  options/result, `RenderSourceMapping` (the `#line` correspondence), and the code-generation IR.
+- **Code generation** (`CodeGeneration/`) — `RenderFunctionEmitter`, its options/result,
+  `RenderFunctionTargetProfile` (`VirtualNodeTree` or `ServerMarkup`), `RenderSourceMapping` (the
+  `#line` correspondence), and the code-generation IR. The server profile writes static structure and
+  interpolations directly to `SsrRenderState`; subtrees it cannot prove safe retain a local
+  virtual-node fallback.
 - **Diagnostics** (`Diagnostics/`) — `CompilerError` and `CompilerErrorCode`, whose numeric bands are
   a frozen contract.
 
 ## Boundaries
 
 - Roots on **`Assimalign.Viu.Syntax`** only. It does **not** reference the runtime: emitted render
-  statements name the Components frame/node contracts and typed Browser operations directly, so the
-  contract flows one way (see
+  statements name the Components frame/node contracts, typed Browser operations, and public
+  ServerRenderer serialization helpers directly, so the contract flows one way (see
   [`Assimalign.Viu.Core/docs/OVERVIEW.md`](../../Assimalign.Viu.Core/docs/OVERVIEW.md)).
 - Build-time library on the netstandard2.0 analyzer TFM; runs in Roslyn generator hosts.
 - Everything a parse or transform produces is value-equatable to preserve the incremental-generator

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionEmitter.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionEmitter.cs
@@ -5,17 +5,18 @@ namespace Assimalign.Viu.Syntax.Templates;
 
 /// <summary>
 /// Serializes a <see cref="TransformResult"/>'s code-generation tree into a C# render-function body.
-/// Every render node becomes ordered statements against a caller-provided component instance and
-/// <c>ComponentRenderFrame</c>, with direct construction of the closed virtual-node algebra. This
-/// analyzer-host library still does not reference runtime assemblies: adopted runtime types are written
-/// as fully qualified names into consumer code. Specified by <c>[SFC-CG-1]</c> and <c>[SFC-CG-2]</c>.
+/// The selected target either constructs the closed virtual-node algebra against a
+/// <c>ComponentRenderFrame</c> or writes server markup directly with subtree-local virtual-node
+/// fallbacks. This analyzer-host library does not reference runtime assemblies: runtime type names are
+/// written as fully qualified names into consumer code. Specified by <c>[SFC-CG-1]</c>,
+/// <c>[SFC-CG-2]</c>, and <c>[SSR-COMPILE-1]</c>.
 /// </summary>
 /// <remarks>
 /// The emission is deterministic — ordinal string handling, invariant-culture numbers, LF newlines — and
-/// pure: equal input produces an equal <see cref="RenderFunctionEmitterResult"/>. Block assembly is an
-/// explicit sequence: <c>frame.OpenBlock()</c>, descendant construction and tracking, then
-/// <c>frame.CloseBlock()</c> in the owning node's render plan. This makes lifetime and nesting visible
-/// without ambient state. Specified by <c>[RND-BLOCK-3]</c>.
+/// pure: equal input produces an equal <see cref="RenderFunctionEmitterResult"/>. Virtual-node block
+/// assembly remains an explicit open, descendant construction/tracking, and close sequence; the server
+/// target preserves that sequence only in fallback regions and emits ordered buffer writes elsewhere.
+/// Specified by <c>[RND-BLOCK-3]</c> and <c>[SSR-COMPILE-2]</c>.
 /// </remarks>
 public static class RenderFunctionEmitter
 {
@@ -43,9 +44,33 @@ public static class RenderFunctionEmitter
             throw new ArgumentNullException(nameof(options));
         }
 
-        var writer = new FrameRenderCodeWriter(result, options.IndentLevel, options.IndentText);
-        var code = writer.EmitRenderBody();
-        var mappings = writer.SourceMappings;
+        string code;
+        IReadOnlyList<RenderSourceMapping> mappings;
+        switch (options.TargetProfile)
+        {
+            case RenderFunctionTargetProfile.VirtualNodeTree:
+                var frameWriter = new FrameRenderCodeWriter(result, options.IndentLevel, options.IndentText);
+                code = frameWriter.EmitRenderBody();
+                mappings = frameWriter.SourceMappings;
+                break;
+            case RenderFunctionTargetProfile.ServerMarkup:
+                if (!result.IsServerRendering)
+                {
+                    throw new InvalidOperationException(
+                        "The server-markup target requires a transform with IsServerRendering enabled.");
+                }
+
+                var serverWriter = new ServerRenderCodeWriter(result, options.IndentLevel, options.IndentText);
+                code = serverWriter.EmitRenderBody();
+                mappings = serverWriter.SourceMappings;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    options.TargetProfile,
+                    "Unknown render-function target profile.");
+        }
+
         return new RenderFunctionEmitterResult
         {
             Code = code,

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionEmitterOptions.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionEmitterOptions.cs
@@ -1,14 +1,27 @@
 namespace Assimalign.Viu.Syntax.Templates;
 
 /// <summary>
-/// Configures <see cref="RenderFunctionEmitter"/>. The surface is deliberately tiny — indentation only —
-/// because the emitter produces a method <em>body</em>, nothing more: the composition root (the source
-/// generator, [V01.01.06.02]) owns the method declaration, its component and frame parameters, and the
-/// enclosing partial class. Generated runtime references are fully qualified, so no import contract is
-/// required. Specified by <c>[SFC-CG-1]</c> and <c>[SFC-CG-2]</c>.
+/// Configures <see cref="RenderFunctionEmitter"/>'s target profile and statement indentation. The
+/// emitter produces a method <em>body</em>, nothing more: a composition root owns the method declaration,
+/// its profile-specific parameters, and the enclosing partial class. Generated runtime references are
+/// fully qualified, so no import contract is required. Specified by <c>[SFC-CG-1]</c>,
+/// <c>[SFC-CG-2]</c>, and <c>[SSR-COMPILE-1]</c>.
 /// </summary>
 public sealed class RenderFunctionEmitterOptions
 {
+    /// <summary>
+    /// Gets or sets the generated body's target profile. Defaults to the host-neutral virtual-node
+    /// tree, preserving the existing interactive compiler path.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RenderFunctionTargetProfile.ServerMarkup"/> produces an asynchronous body whose
+    /// enclosing method supplies <c>component</c>, <c>frame</c>, <c>state</c>, and <c>parent</c> locals.
+    /// The template must have been transformed with <see cref="TransformOptions.IsServerRendering"/>
+    /// so browser-only operations never enter fallback code. Specified by
+    /// <c>[SSR-COMPILE-1]</c> and <c>[SSR-COMPILE-2]</c>.
+    /// </remarks>
+    public RenderFunctionTargetProfile TargetProfile { get; set; }
+
     /// <summary>
     /// The indentation level the emitted statements start at (the number of <see cref="IndentText"/>
     /// repetitions prefixed to each line). The generator passes the nesting depth of the render method's

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionTargetProfile.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/CodeGeneration/RenderFunctionTargetProfile.cs
@@ -1,0 +1,22 @@
+namespace Assimalign.Viu.Syntax.Templates;
+
+/// <summary>
+/// Selects the runtime shape produced by <see cref="RenderFunctionEmitter"/>.
+/// </summary>
+/// <remarks>
+/// Both profiles consume one transformed template at build time. The virtual-node profile is the
+/// host-neutral interactive path; the server-markup profile writes provably serializable regions
+/// directly and retains the same virtual-node algebra only as an explicit fallback. Specified by
+/// <c>[SSR-COMPILE-1]</c> through <c>[SSR-COMPILE-3]</c>.
+/// </remarks>
+public enum RenderFunctionTargetProfile
+{
+    /// <summary>Emits the host-neutral virtual-node render body used by interactive renderers.</summary>
+    VirtualNodeTree = 0,
+
+    /// <summary>
+    /// Emits an asynchronous server-markup body over <c>SsrRenderState</c>, with virtual-node
+    /// construction limited to fallback regions.
+    /// </summary>
+    ServerMarkup = 1,
+}

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/FrameRenderCodeWriter.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/FrameRenderCodeWriter.cs
@@ -51,14 +51,23 @@ internal sealed class FrameRenderCodeWriter
 
     /// <summary>Emits one frame-taking render-method body.</summary>
     public string EmitRenderBody()
+        => EmitRenderBody(result.CodegenNode);
+
+    /// <summary>
+    /// Emits a frame-taking render-method body for one subtree. Server code generation uses this
+    /// narrow seam for regions that must preserve virtual-tree behavior.
+    /// </summary>
+    /// <param name="root">The transformed subtree or its code-generation node.</param>
+    /// <returns>The complete local-function body, including its return statement.</returns>
+    internal string EmitRenderBody(object? root)
     {
-        CodeExpression root = result.CodegenNode is null
+        CodeExpression value = root is null
             ? CodeExpression.Literal("null")
-            : EmitVirtualValue(result.CodegenNode);
+            : EmitVirtualValue(root);
 
         BeginLine();
         Push("return ");
-        AppendExpression(root);
+        AppendExpression(value);
         Push(";");
         EndLine();
 
@@ -140,6 +149,7 @@ internal sealed class FrameRenderCodeWriter
     private CodeExpression EmitElementNode(VirtualNodeCall node, VirtualNodeTag tag)
     {
         ElementPropertyEmission properties = EmitElementProperties(node.Properties);
+        AppendScopeBinding(properties);
         CodeExpression children = EmitChildren(node.Children);
         CodeExpression directives = EmitDirectiveInvocations(node.Directives);
         CodeExpression dynamicBindingIndices = EmitDynamicBindingIndices(
@@ -299,11 +309,12 @@ internal sealed class FrameRenderCodeWriter
     private CodeExpression EmitDynamicNode(VirtualNodeCall node, VirtualNodeTag tag)
     {
         ElementPropertyEmission elementProperties = EmitElementProperties(node.Properties);
+        AppendScopeBinding(elementProperties);
         ComponentInvocationEmission componentInvocation = EmitComponentInvocation(
             node.Properties,
             node.Children,
             node.Directives);
-        CodeExpression children = EmitChildren(node.Children);
+        CodeExpression children = EmitDynamicElementChildren(node.Children);
         CodeExpression directives = EmitDirectiveInvocations(node.Directives);
         CodeExpression renderPlan = EmitRenderPlan(node, CodeExpression.Literal("null"));
         string nodeName = NextName("node");
@@ -334,6 +345,67 @@ internal sealed class FrameRenderCodeWriter
 
         TrackIfRequired(node, nodeName);
         return CodeExpression.Literal(nodeName);
+    }
+
+    private CodeExpression EmitDynamicElementChildren(object? slotsNode)
+    {
+        if (TryGetDefaultSlotFunction(slotsNode, out FunctionExpression defaultSlot))
+        {
+            return EmitChildren(defaultSlot.Returns);
+        }
+
+        // A dynamic selector can resolve to a native element or a component. Slot objects describe
+        // component invocation and are not themselves virtual children; only their default slot has
+        // an element-child spelling.
+        return slotsNode is ObjectExpression
+            ? CodeExpression.Literal("null")
+            : EmitChildren(slotsNode);
+    }
+
+    private static bool TryGetDefaultSlotFunction(
+        object? slotsNode,
+        out FunctionExpression defaultSlot)
+    {
+        if (slotsNode is CallExpression call
+            && call.Callee is RuntimeHelper helper
+            && helper == HelperNames.CreateSlots
+            && call.Arguments.Count > 0)
+        {
+            slotsNode = call.Arguments[0];
+        }
+
+        if (slotsNode is ObjectExpression slots)
+        {
+            for (int index = 0; index < slots.Properties.Count; index++)
+            {
+                ObjectProperty property = slots.Properties[index];
+                if (property.Key is SimpleExpressionNode
+                    {
+                        IsStatic: true,
+                        Content: "default",
+                    }
+                    && property.Value is FunctionExpression function)
+                {
+                    defaultSlot = function;
+                    return true;
+                }
+            }
+        }
+
+        defaultSlot = null!;
+        return false;
+    }
+
+    private void AppendScopeBinding(ElementPropertyEmission properties)
+    {
+        if (string.IsNullOrEmpty(result.ScopeId))
+        {
+            return;
+        }
+
+        AppendStatement(
+            $"{properties.BindingsName}.Add({ComponentsNamespace}.ElementBinding.Attribute(new "
+            + $"{ComponentsNamespace}.QualifiedName({StringLiteral(result.ScopeId!)}), string.Empty));");
     }
 
     private CodeExpression EmitCallAsVirtualValue(CallExpression call)
@@ -2303,7 +2375,7 @@ internal sealed class FrameRenderCodeWriter
         return name;
     }
 
-    private static string MapRawLiteral(string raw)
+    internal static string MapRawLiteral(string raw)
     {
         switch (raw)
         {
@@ -2511,7 +2583,7 @@ internal sealed class FrameRenderCodeWriter
     private static bool IsQuotedString(string value) =>
         value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"';
 
-    private static string StringLiteral(string value) =>
+    internal static string StringLiteral(string value) =>
         SymbolDisplay.FormatLiteral(value, quote: true);
 
     private enum PropertyValuePurpose

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/ServerRenderCodeWriter.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/Internal/ServerRenderCodeWriter.cs
@@ -1,0 +1,1314 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Assimalign.Viu.Syntax.Templates;
+
+/// <summary>
+/// Lowers a server-transformed template to ordered writes over the public ServerRenderer compiler
+/// contract. Native markup stays on the string path; components and unsupported property shapes use
+/// subtree-local virtual-node fallbacks emitted by <see cref="FrameRenderCodeWriter"/>.
+/// </summary>
+internal sealed class ServerRenderCodeWriter
+{
+    private const string ComponentsNamespace = "global::Assimalign.Viu.Components";
+    private const string CoreNamespace = "global::Assimalign.Viu";
+    private const string ServerNamespace = "global::Assimalign.Viu.ServerRenderer";
+
+    private readonly TransformResult result;
+    private readonly StringBuilder builder = new();
+    private readonly StringBuilder staticMarkup = new();
+    private readonly string indentText;
+    private readonly List<(int Offset, SourceLocation Location)> mappingSites = new();
+    private IReadOnlyList<RenderSourceMapping> sourceMappings = Array.Empty<RenderSourceMapping>();
+    private string staticStateName = "state";
+    private int indentLevel;
+    private int generatedNameIndex;
+
+    internal ServerRenderCodeWriter(
+        TransformResult result,
+        int indentLevel,
+        string indentText)
+    {
+        this.result = result;
+        this.indentLevel = indentLevel;
+        this.indentText = indentText;
+    }
+
+    /// <summary>Gets the source map produced by the latest server-body emission.</summary>
+    internal IReadOnlyList<RenderSourceMapping> SourceMappings => sourceMappings;
+
+    /// <summary>Emits one asynchronous compiled-server-render method body.</summary>
+    internal string EmitRenderBody()
+    {
+        EmitChildrenAsRoot(result.Children, "state", selectModel: null);
+        FlushStaticMarkup();
+        string code = builder.ToString();
+        sourceMappings = BuildSourceMappings(code);
+        return code;
+    }
+
+    private void EmitChildrenAsRoot(
+        IReadOnlyList<TemplateChildNode> children,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        if (children.Count > 1)
+        {
+            AppendMarker(stateName, "FragmentStart");
+        }
+
+        EmitChildren(children, stateName, selectModel);
+
+        if (children.Count > 1)
+        {
+            AppendMarker(stateName, "FragmentEnd");
+        }
+    }
+
+    private void EmitChildren(
+        IReadOnlyList<TemplateChildNode> children,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        for (int index = 0; index < children.Count; index++)
+        {
+            EmitNode(children[index], stateName, selectModel);
+        }
+    }
+
+    private void EmitNode(
+        TemplateChildNode node,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        switch (node)
+        {
+            case TextNode text:
+                AppendStaticMarkup(stateName, EscapeHtml(text.Content));
+                break;
+            case InterpolationNode interpolation:
+                AppendStateHelper(
+                    stateName,
+                    "SsrInterpolate",
+                    EmitExpression(interpolation.Content));
+                break;
+            case TextCallNode textCall:
+                EmitTextCall(textCall, stateName);
+                break;
+            case CommentNode comment:
+                AppendStateHelper(
+                    stateName,
+                    "SsrRenderComment",
+                    CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral(comment.Content)));
+                break;
+            case ElementNode element:
+                EmitElement(element, stateName, selectModel);
+                break;
+            case IfNode conditional:
+                EmitIf(conditional, stateName, selectModel);
+                break;
+            case ForNode loop:
+                EmitFor(loop, stateName, selectModel);
+                break;
+            default:
+                EmitFallback(node, stateName);
+                break;
+        }
+    }
+
+    private void EmitTextCall(TextCallNode textCall, string stateName)
+    {
+        switch (textCall.Content)
+        {
+            case TextNode text:
+                AppendStaticMarkup(stateName, EscapeHtml(text.Content));
+                break;
+            case InterpolationNode interpolation:
+                AppendStateHelper(
+                    stateName,
+                    "SsrInterpolate",
+                    EmitExpression(interpolation.Content));
+                break;
+            case CompoundExpressionNode compound:
+                AppendStateHelper(stateName, "SsrInterpolate", EmitExpression(compound));
+                break;
+            default:
+                AppendStateHelper(stateName, "SsrInterpolate", EmitExpression(textCall.Content));
+                break;
+        }
+    }
+
+    private void EmitElement(
+        ElementNode element,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        if (element.ElementType == ElementType.Template)
+        {
+            EmitChildrenAsRoot(ChildrenOf(element), stateName, selectModel);
+            return;
+        }
+
+        if (element.ElementType != ElementType.Element)
+        {
+            if (IsTeleport(element.Tag))
+            {
+                EmitTeleport(element, stateName);
+            }
+            else if (IsSuspense(element.Tag))
+            {
+                EmitSuspense(element, stateName);
+            }
+            else if (IsTransition(element.Tag) || IsKeepAlive(element.Tag))
+            {
+                EmitChildrenAsRoot(DefaultContentOf(element), stateName, selectModel: null);
+            }
+            else
+            {
+                EmitFallback(element, stateName);
+            }
+
+            return;
+        }
+
+        if (!CanRenderElementDirectly(element))
+        {
+            EmitFallback(element, stateName);
+            return;
+        }
+
+        AppendStaticMarkup(stateName, "<" + element.Tag);
+        EmitElementAttributes(element, stateName, selectModel);
+        AppendStaticMarkup(stateName, ">");
+
+        if (element.Namespace == ElementNamespace.Html
+            && CompilerDomKnowledge.IsVoidTag(element.Tag))
+        {
+            return;
+        }
+
+        ElementContentOverride? contentOverride = FindContentOverride(element);
+        DirectiveNode? model = FindDirective(element, "model");
+        CodeExpression? textAreaValue = model?.Expression is { } textAreaModel
+            ? EmitExpression(textAreaModel)
+            : FindStaticPropertyValue(element, "value")?.Value;
+        if (contentOverride is not null)
+        {
+            if (contentOverride.IsRaw)
+            {
+                AppendStateExpression(
+                    stateName,
+                    QualifiedCall(
+                        CoreNamespace + ".DisplayStringFormatter.ToDisplayString",
+                        contentOverride.Value));
+            }
+            else
+            {
+                AppendStateHelper(stateName, "SsrInterpolate", contentOverride.Value);
+            }
+        }
+        else if (string.Equals(element.Tag, "textarea", StringComparison.OrdinalIgnoreCase)
+            && textAreaValue is not null)
+        {
+            AppendStateHelper(stateName, "SsrInterpolate", textAreaValue);
+        }
+        else
+        {
+            CodeExpression? childSelectModel = string.Equals(
+                    element.Tag,
+                    "select",
+                    StringComparison.OrdinalIgnoreCase)
+                && model?.Expression is { } selectExpression
+                    ? EmitExpression(selectExpression)
+                    : selectModel;
+            EmitChildren(ChildrenOf(element), stateName, childSelectModel);
+        }
+
+        AppendStaticMarkup(stateName, "</" + element.Tag + ">");
+    }
+
+    private void EmitElementAttributes(
+        ElementNode element,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        DirectiveNode? model = FindDirective(element, "model");
+        DirectiveNode? show = FindDirective(element, "show");
+        ElementValue? style = FindStaticPropertyValue(element, "style");
+
+        for (int index = 0; index < element.Properties.Count; index++)
+        {
+            PropertyNode property = element.Properties[index];
+            switch (property)
+            {
+                case AttributeNode attribute:
+                    if (string.Equals(attribute.Name, "style", StringComparison.Ordinal))
+                    {
+                        EmitStyleAttribute(stateName, style, show);
+                        continue;
+                    }
+
+                    if (ShouldSkipSerializedProperty(element, attribute.Name, model))
+                    {
+                        continue;
+                    }
+
+                    EmitNamedAttribute(
+                        stateName,
+                        element.Tag,
+                        attribute.Name,
+                        CodeExpression.Literal(
+                            FrameRenderCodeWriter.StringLiteral(attribute.Value?.Content ?? string.Empty)));
+                    break;
+                case DirectiveNode directive when directive.Name == "bind":
+                    if (directive.Argument is not SimpleExpressionNode { IsStatic: true } argument
+                        || directive.Expression is null
+                        || HasModifier(directive, "prop"))
+                    {
+                        continue;
+                    }
+
+                    if (string.Equals(argument.Content, "style", StringComparison.Ordinal))
+                    {
+                        EmitStyleAttribute(stateName, style, show);
+                        continue;
+                    }
+
+                    if (ShouldSkipSerializedProperty(element, argument.Content, model))
+                    {
+                        continue;
+                    }
+
+                    EmitNamedAttribute(
+                        stateName,
+                        element.Tag,
+                        argument.Content,
+                        EmitExpression(directive.Expression));
+                    break;
+                case DirectiveNode directive when directive.Name == "show":
+                    if (style is null && ReferenceEquals(directive, show))
+                    {
+                        EmitStyleAttribute(stateName, style: null, show: show);
+                    }
+
+                    break;
+                case DirectiveNode directive when directive.Name == "model":
+                    if (ReferenceEquals(directive, model))
+                    {
+                        EmitModelAttribute(element, stateName, model);
+                    }
+
+                    break;
+            }
+        }
+
+        if (selectModel is not null
+            && string.Equals(element.Tag, "option", StringComparison.OrdinalIgnoreCase))
+        {
+            ElementValue? optionValue = FindStaticPropertyValue(element, "value");
+            CodeExpression candidate = optionValue?.Value
+                ?? OptionTextValue(element);
+            EmitSelectionAttribute(
+                stateName,
+                element.Tag,
+                "selected",
+                selectModel,
+                candidate,
+                booleanModelIsSelection: false);
+        }
+
+        if (!string.IsNullOrEmpty(result.ScopeId))
+        {
+            EmitNamedAttribute(
+                stateName,
+                element.Tag,
+                result.ScopeId!,
+                CodeExpression.Literal("string.Empty"));
+        }
+    }
+
+    private void EmitStyleAttribute(
+        string stateName,
+        ElementValue? style,
+        DirectiveNode? show)
+    {
+        if (style is null && show?.Expression is null)
+        {
+            return;
+        }
+
+        if (style is null)
+        {
+            FlushStaticMarkup();
+            BeginLine();
+            Push("if (!");
+            AppendExpression(QualifiedCall(
+                ServerNamespace + ".ServerRender.IsTruthy",
+                EmitExpression(show!.Expression!)));
+            Push(")");
+            EndLine();
+            AppendLine("{");
+            indentLevel++;
+            AppendLine(stateName + ".Push(\" style=\\\"display:none;\\\"\");");
+            indentLevel--;
+            AppendLine("}");
+            return;
+        }
+
+        AppendStaticMarkup(stateName, " style=\"");
+        AppendStateHelper(stateName, "SsrRenderStyle", style.Value);
+        if (show?.Expression is not null)
+        {
+            FlushStaticMarkup();
+            BeginLine();
+            Push("if (!");
+            AppendExpression(QualifiedCall(
+                ServerNamespace + ".ServerRender.IsTruthy",
+                EmitExpression(show.Expression)));
+            Push(")");
+            EndLine();
+            AppendLine("{");
+            indentLevel++;
+            AppendLine(stateName + ".Push(\"display:none;\");");
+            indentLevel--;
+            AppendLine("}");
+        }
+
+        AppendStaticMarkup(stateName, "\"");
+    }
+
+    private void EmitModelAttribute(
+        ElementNode element,
+        string stateName,
+        DirectiveNode? model)
+    {
+        if (model?.Expression is null)
+        {
+            return;
+        }
+
+        CodeExpression modelValue = EmitExpression(model.Expression);
+        if (string.Equals(element.Tag, "input", StringComparison.OrdinalIgnoreCase))
+        {
+            string inputType = StaticAttributeValue(element, "type") ?? "text";
+            if (string.Equals(inputType, "checkbox", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(inputType, "radio", StringComparison.OrdinalIgnoreCase))
+            {
+                ElementValue? candidateValue = FindStaticPropertyValue(element, "value");
+                EmitSelectionAttribute(
+                    stateName,
+                    element.Tag,
+                    "checked",
+                    modelValue,
+                    candidateValue?.Value
+                        ?? CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral("on")),
+                    booleanModelIsSelection: string.Equals(
+                        inputType,
+                        "checkbox",
+                        StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                EmitNamedAttribute(stateName, element.Tag, "value", modelValue);
+            }
+        }
+    }
+
+    private void EmitSelectionAttribute(
+        string stateName,
+        string tag,
+        string name,
+        CodeExpression modelValue,
+        CodeExpression candidate,
+        bool booleanModelIsSelection)
+    {
+        var selected = new CodeExpression();
+        selected.Append(ServerNamespace);
+        selected.Append(".ServerRender.IsModelValueSelected(");
+        selected.Append(modelValue);
+        selected.Append(", ");
+        selected.Append(candidate);
+        selected.Append(booleanModelIsSelection ? ", true)" : ", false)");
+        EmitNamedAttribute(stateName, tag, name, selected);
+    }
+
+    private void EmitNamedAttribute(
+        string stateName,
+        string tag,
+        string name,
+        CodeExpression value)
+    {
+        if (string.Equals(name, "class", StringComparison.Ordinal))
+        {
+            AppendStaticMarkup(stateName, " class=\"");
+            AppendStateHelper(stateName, "SsrRenderClass", value);
+            AppendStaticMarkup(stateName, "\"");
+            return;
+        }
+
+        FlushStaticMarkup();
+        BeginLine();
+        Push(stateName);
+        Push(".Push(");
+        Push(ServerNamespace);
+        Push(".ServerRender.SsrRenderDynamicAttribute(");
+        Push(FrameRenderCodeWriter.StringLiteral(name));
+        Push(", ");
+        AppendExpression(value);
+        Push(", ");
+        Push(FrameRenderCodeWriter.StringLiteral(tag));
+        Push("));");
+        EndLine();
+    }
+
+    private void EmitIf(
+        IfNode conditional,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        FlushStaticMarkup();
+        bool hasElse = false;
+        for (int index = 0; index < conditional.Branches.Count; index++)
+        {
+            IfBranchNode branch = conditional.Branches[index];
+            if (branch.Condition is null)
+            {
+                AppendLine(index == 0 ? "if (true)" : "else");
+                hasElse = true;
+            }
+            else
+            {
+                BeginLine();
+                Push(index == 0 ? "if (" : "else if (");
+                AppendExpression(EmitExpression(branch.Condition));
+                Push(")");
+                EndLine();
+            }
+
+            AppendLine("{");
+            indentLevel++;
+            EmitChildrenAsRoot(branch.Children, stateName, selectModel);
+            FlushStaticMarkup();
+            indentLevel--;
+            AppendLine("}");
+        }
+
+        if (!hasElse)
+        {
+            AppendLine("else");
+            AppendLine("{");
+            indentLevel++;
+            AppendStateHelper(
+                stateName,
+                "SsrRenderComment",
+                CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral("v-if")));
+            FlushStaticMarkup();
+            indentLevel--;
+            AppendLine("}");
+        }
+    }
+
+    private void EmitFor(
+        ForNode loop,
+        string stateName,
+        CodeExpression? selectModel)
+    {
+        AppendMarker(stateName, "FragmentStart");
+        FlushStaticMarkup();
+        string sourceName = NextName("listSource");
+        string itemName = NextName("listItem");
+        string indexName = NextName("listIndex");
+
+        BeginLine();
+        Push("var ");
+        Push(sourceName);
+        Push(" = ");
+        AppendExpression(EmitExpression(loop.Source));
+        Push(";");
+        EndLine();
+        AppendLine("int " + indexName + " = 0;");
+        AppendLine("foreach (var " + itemName + " in " + sourceName + ")");
+        AppendLine("{");
+        indentLevel++;
+        AppendForAliases(loop, itemName, indexName);
+        EmitChildrenAsRoot(loop.Children, stateName, selectModel);
+        FlushStaticMarkup();
+        AppendLine(indexName + "++;");
+        indentLevel--;
+        AppendLine("}");
+        AppendMarker(stateName, "FragmentEnd");
+    }
+
+    private void AppendForAliases(ForNode loop, string itemName, string indexName)
+    {
+        if (loop.ValueAlias is null)
+        {
+            return;
+        }
+
+        string valueName = ParameterName(loop.ValueAlias, "item");
+        if (loop.ObjectIndexAlias is not null)
+        {
+            AppendLine("var " + valueName + " = " + itemName + ".Value;");
+            AppendLine(
+                "var " + ParameterName(loop.KeyAlias, "key") + " = " + itemName + ".Key;");
+            AppendLine(
+                "var " + ParameterName(loop.ObjectIndexAlias, "index") + " = " + indexName + ";");
+            return;
+        }
+
+        AppendLine("var " + valueName + " = " + itemName + ";");
+        if (loop.KeyAlias is not null)
+        {
+            AppendLine(
+                "var " + ParameterName(loop.KeyAlias, "index") + " = " + indexName + ";");
+        }
+    }
+
+    private void EmitTeleport(ElementNode element, string stateName)
+    {
+        ElementValue? target = FindStaticPropertyValue(element, "to");
+        ElementValue? disabled = FindStaticPropertyValue(element, "disabled");
+        FlushStaticMarkup();
+        string teleportState = NextName("teleportState");
+        BeginLine();
+        Push("await ");
+        Push(ServerNamespace);
+        Push(".ServerRender.SsrRenderTeleportAsync(");
+        Push(stateName);
+        Push(", async ");
+        Push(teleportState);
+        Push(" =>");
+        EndLine();
+        AppendLine("{");
+        indentLevel++;
+        EmitChildren(ChildrenOf(element), teleportState, selectModel: null);
+        FlushStaticMarkup();
+        AppendLine("await global::System.Threading.Tasks.Task.CompletedTask;");
+        indentLevel--;
+        AppendLine("},");
+        BeginLine();
+        Push("global::System.Convert.ToString(");
+        AppendExpression(target?.Value ?? CodeExpression.Literal("null"));
+        Push(", global::System.Globalization.CultureInfo.InvariantCulture),");
+        EndLine();
+        BeginLine();
+        AppendExpression(disabled is null
+            ? CodeExpression.Literal("false")
+            : QualifiedCall(ServerNamespace + ".ServerRender.IsTruthy", disabled.Value));
+        Push(");");
+        EndLine();
+    }
+
+    private void EmitSuspense(ElementNode element, string stateName)
+    {
+        FlushStaticMarkup();
+        string suspenseState = NextName("suspenseState");
+        BeginLine();
+        Push("await ");
+        Push(ServerNamespace);
+        Push(".ServerRender.SsrRenderSuspenseAsync(");
+        Push(stateName);
+        Push(", async ");
+        Push(suspenseState);
+        Push(" =>");
+        EndLine();
+        AppendLine("{");
+        indentLevel++;
+        EmitChildrenAsRoot(DefaultContentOf(element), suspenseState, selectModel: null);
+        FlushStaticMarkup();
+        AppendLine("await global::System.Threading.Tasks.Task.CompletedTask;");
+        indentLevel--;
+        AppendLine("});");
+    }
+
+    private void EmitFallback(TemplateChildNode node, string stateName)
+    {
+        FlushStaticMarkup();
+        string fallbackName = NextName("RenderFallback");
+        AppendLine(ComponentsNamespace + ".VirtualNode? " + fallbackName + "()");
+        AppendLine("{");
+        indentLevel++;
+        var fallbackWriter = new FrameRenderCodeWriter(result, indentLevel, indentText);
+        string fallbackCode = fallbackWriter.EmitRenderBody(node);
+        int fallbackOffset = builder.Length;
+        builder.Append(fallbackCode);
+        for (int index = 0; index < fallbackWriter.SourceMappings.Count; index++)
+        {
+            RenderSourceMapping mapping = fallbackWriter.SourceMappings[index];
+            mappingSites.Add((
+                fallbackOffset + OffsetAtLineColumn(
+                    fallbackCode,
+                    mapping.GeneratedLine,
+                    mapping.GeneratedColumn),
+                mapping.TemplateLocation));
+        }
+        indentLevel--;
+        AppendLine("}");
+        BeginLine();
+        Push("await ");
+        Push(ServerNamespace);
+        Push(".ServerRender.SsrRenderComponentAsync(");
+        Push(stateName);
+        Push(", ");
+        Push(fallbackName);
+        Push("(), parent);");
+        EndLine();
+    }
+
+    private bool CanRenderElementDirectly(ElementNode element)
+    {
+        int styleCount = 0;
+        for (int index = 0; index < element.Properties.Count; index++)
+        {
+            if (element.Properties[index] is AttributeNode attribute)
+            {
+                if (string.Equals(attribute.Name, "style", StringComparison.Ordinal))
+                {
+                    styleCount++;
+                }
+
+                continue;
+            }
+
+            if (element.Properties[index] is not DirectiveNode directive)
+            {
+                continue;
+            }
+
+            if (directive.Name == "bind")
+            {
+                if (directive.Argument is not SimpleExpressionNode { IsStatic: true } argument)
+                {
+                    return false;
+                }
+
+                if (HasModifier(directive, "prop"))
+                {
+                    return false;
+                }
+
+                if (string.Equals(argument.Content, "style", StringComparison.Ordinal))
+                {
+                    styleCount++;
+                }
+            }
+
+            if (directive.Name == "model"
+                && string.Equals(element.Tag, "input", StringComparison.OrdinalIgnoreCase)
+                && FindStaticPropertyValue(element, "type") is { IsStatic: false })
+            {
+                return false;
+            }
+        }
+
+        return styleCount <= 1;
+    }
+
+    private ElementContentOverride? FindContentOverride(ElementNode element)
+    {
+        ElementContentOverride? resultOverride = null;
+        for (int index = 0; index < element.Properties.Count; index++)
+        {
+            PropertyNode property = element.Properties[index];
+            if (property is AttributeNode attribute
+                && IsContentOverrideName(attribute.Name))
+            {
+                resultOverride = new ElementContentOverride(
+                    CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral(
+                        attribute.Value?.Content ?? string.Empty)),
+                    string.Equals(attribute.Name, "innerHTML", StringComparison.Ordinal));
+            }
+            else if (property is DirectiveNode directive)
+            {
+                if (directive.Name == "html" && directive.Expression is not null)
+                {
+                    resultOverride = new ElementContentOverride(
+                        EmitExpression(directive.Expression),
+                        isRaw: true);
+                }
+                else if (directive.Name == "text" && directive.Expression is not null)
+                {
+                    resultOverride = new ElementContentOverride(
+                        EmitExpression(directive.Expression),
+                        isRaw: false);
+                }
+                else if (directive.Name == "bind"
+                    && directive.Argument is SimpleExpressionNode { IsStatic: true } argument
+                    && IsContentOverrideName(argument.Content)
+                    && directive.Expression is not null)
+                {
+                    resultOverride = new ElementContentOverride(
+                        EmitExpression(directive.Expression),
+                        string.Equals(argument.Content, "innerHTML", StringComparison.Ordinal));
+                }
+            }
+        }
+
+        return resultOverride;
+    }
+
+    private ElementValue? FindStaticPropertyValue(ElementNode element, string name)
+    {
+        ElementValue? value = null;
+        for (int index = 0; index < element.Properties.Count; index++)
+        {
+            PropertyNode property = element.Properties[index];
+            if (property is AttributeNode attribute
+                && string.Equals(attribute.Name, name, StringComparison.Ordinal))
+            {
+                value = new ElementValue(
+                    CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral(
+                        attribute.Value?.Content ?? string.Empty)),
+                    isStatic: true);
+            }
+            else if (property is DirectiveNode { Name: "bind" } directive
+                && directive.Argument is SimpleExpressionNode { IsStatic: true } argument
+                && string.Equals(argument.Content, name, StringComparison.Ordinal)
+                && directive.Expression is not null)
+            {
+                value = new ElementValue(EmitExpression(directive.Expression), isStatic: false);
+            }
+        }
+
+        return value;
+    }
+
+    private static DirectiveNode? FindDirective(ElementNode element, string name)
+    {
+        for (int index = element.Properties.Count - 1; index >= 0; index--)
+        {
+            if (element.Properties[index] is DirectiveNode directive
+                && string.Equals(directive.Name, name, StringComparison.Ordinal))
+            {
+                return directive;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ShouldSkipSerializedProperty(
+        ElementNode element,
+        string name,
+        DirectiveNode? model)
+    {
+        if (name is "key" or "ref" or "innerHTML" or "textContent")
+        {
+            return true;
+        }
+
+        if (string.Equals(element.Tag, "textarea", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(name, "value", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (model is not null
+            && string.Equals(element.Tag, "input", StringComparison.OrdinalIgnoreCase))
+        {
+            if (name == "checked")
+            {
+                return true;
+            }
+
+            if (name == "value" && !IsCheckableInput(element))
+            {
+                return true;
+            }
+        }
+
+        return name.Length > 2
+            && name[0] == 'o'
+            && name[1] == 'n'
+            && !char.IsLower(name[2]);
+    }
+
+    private static bool IsContentOverrideName(string name) =>
+        name is "innerHTML" or "textContent";
+
+    private static bool IsCheckableInput(ElementNode element)
+    {
+        string? inputType = StaticAttributeValue(element, "type");
+        return string.Equals(inputType, "checkbox", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(inputType, "radio", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasModifier(DirectiveNode directive, string name)
+    {
+        for (int index = 0; index < directive.Modifiers.Count; index++)
+        {
+            if (string.Equals(directive.Modifiers[index].Content, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? StaticAttributeValue(ElementNode element, string name)
+    {
+        for (int index = element.Properties.Count - 1; index >= 0; index--)
+        {
+            if (element.Properties[index] is AttributeNode attribute
+                && string.Equals(attribute.Name, name, StringComparison.Ordinal))
+            {
+                return attribute.Value?.Content ?? string.Empty;
+            }
+        }
+
+        return null;
+    }
+
+    private CodeExpression OptionTextValue(ElementNode element)
+    {
+        IReadOnlyList<TemplateChildNode> children = ChildrenOf(element);
+        var parts = new List<CodeExpression>();
+        for (int index = 0; index < children.Count; index++)
+        {
+            switch (children[index])
+            {
+                case TextNode text:
+                    parts.Add(CodeExpression.Literal(
+                        FrameRenderCodeWriter.StringLiteral(text.Content)));
+                    break;
+                case InterpolationNode interpolation:
+                    parts.Add(QualifiedCall(
+                        CoreNamespace + ".DisplayStringFormatter.ToDisplayString",
+                        EmitExpression(interpolation.Content)));
+                    break;
+                case TextCallNode textCall:
+                    parts.Add(QualifiedCall(
+                        CoreNamespace + ".DisplayStringFormatter.ToDisplayString",
+                        EmitExpression(textCall.Content)));
+                    break;
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return CodeExpression.Literal("string.Empty");
+        }
+
+        if (parts.Count == 1)
+        {
+            return parts[0];
+        }
+
+        var combined = new CodeExpression();
+        combined.Append("(");
+        for (int index = 0; index < parts.Count; index++)
+        {
+            if (index > 0)
+            {
+                combined.Append(" + ");
+            }
+
+            combined.Append(parts[index]);
+        }
+
+        combined.Append(")");
+        return combined;
+    }
+
+    private IReadOnlyList<TemplateChildNode> ChildrenOf(ElementNode element) =>
+        result.GetTransformedChildren(element);
+
+    private IReadOnlyList<TemplateChildNode> DefaultContentOf(ElementNode element)
+    {
+        IReadOnlyList<TemplateChildNode> children = ChildrenOf(element);
+        ElementNode? namedDefault = null;
+        bool hasSlotTemplate = false;
+        for (int index = 0; index < children.Count; index++)
+        {
+            if (children[index] is not ElementNode
+                {
+                    ElementType: ElementType.Template,
+                } template)
+            {
+                continue;
+            }
+
+            DirectiveNode? slot = FindDirective(template, "slot");
+            if (slot is null)
+            {
+                continue;
+            }
+
+            hasSlotTemplate = true;
+            if (slot.Argument is null
+                || slot.Argument is SimpleExpressionNode
+                {
+                    IsStatic: true,
+                    Content: "default",
+                })
+            {
+                namedDefault = template;
+                break;
+            }
+        }
+
+        if (namedDefault is not null)
+        {
+            return ChildrenOf(namedDefault);
+        }
+
+        if (!hasSlotTemplate)
+        {
+            return children;
+        }
+
+        var implicitDefault = new List<TemplateChildNode>();
+        for (int index = 0; index < children.Count; index++)
+        {
+            TemplateChildNode child = children[index];
+            if (child is CommentNode)
+            {
+                continue;
+            }
+
+            if (child is ElementNode
+                {
+                    ElementType: ElementType.Template,
+                } template
+                && FindDirective(template, "slot") is not null)
+            {
+                continue;
+            }
+
+            implicitDefault.Add(child);
+        }
+
+        return implicitDefault;
+    }
+
+    private static bool IsTeleport(string tag) =>
+        tag is "Teleport" or "teleport";
+
+    private static bool IsSuspense(string tag) =>
+        tag is "Suspense" or "suspense";
+
+    private static bool IsKeepAlive(string tag) =>
+        tag is "KeepAlive" or "keep-alive";
+
+    private static bool IsTransition(string tag) =>
+        tag is "Transition" or "transition" or "BaseTransition" or "base-transition";
+
+    private CodeExpression EmitExpression(object? node)
+    {
+        switch (node)
+        {
+            case null:
+                return CodeExpression.Literal("null");
+            case string raw:
+                return CodeExpression.Literal(FrameRenderCodeWriter.MapRawLiteral(raw));
+            case TextNode text:
+                return CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral(text.Content));
+            case SimpleExpressionNode simple:
+                return EmitSimpleExpression(simple);
+            case InterpolationNode interpolation:
+                return EmitExpression(interpolation.Content);
+            case CompoundExpressionNode compound:
+                var compoundExpression = new CodeExpression();
+                for (int index = 0; index < compound.Parts.Count; index++)
+                {
+                    object part = compound.Parts[index];
+                    compoundExpression.Append(part is string partText
+                        ? CodeExpression.Literal(FrameRenderCodeWriter.MapRawLiteral(partText))
+                        : EmitExpression(part));
+                }
+
+                return compoundExpression;
+            default:
+                throw new InvalidOperationException(
+                    "Unsupported direct server expression '" + node.GetType().Name + "'.");
+        }
+    }
+
+    private CodeExpression EmitSimpleExpression(SimpleExpressionNode simple)
+    {
+        if (simple.IsStatic)
+        {
+            return CodeExpression.Literal(FrameRenderCodeWriter.StringLiteral(simple.Content));
+        }
+
+        string text = FrameRenderCodeWriter.MapRawLiteral(simple.Content);
+        CodeExpression expression = CodeExpression.Literal(text);
+        string source = simple.Location.Source;
+        if (!string.IsNullOrEmpty(source))
+        {
+            int sourceOffset = text.IndexOf(source, StringComparison.Ordinal);
+            if (sourceOffset >= 0)
+            {
+                expression.AddMapping(sourceOffset, simple.Location);
+            }
+        }
+
+        return expression;
+    }
+
+    private static CodeExpression QualifiedCall(string name, CodeExpression argument)
+    {
+        var expression = new CodeExpression();
+        expression.Append(name);
+        expression.Append("(");
+        expression.Append(argument);
+        expression.Append(")");
+        return expression;
+    }
+
+    private void AppendStateHelper(
+        string stateName,
+        string helperName,
+        CodeExpression value)
+    {
+        AppendStateExpression(
+            stateName,
+            QualifiedCall(ServerNamespace + ".ServerRender." + helperName, value));
+    }
+
+    private void AppendStateExpression(string stateName, CodeExpression value)
+    {
+        FlushStaticMarkup();
+        BeginLine();
+        Push(stateName);
+        Push(".Push(");
+        AppendExpression(value);
+        Push(");");
+        EndLine();
+    }
+
+    private void AppendMarker(string stateName, string markerName)
+    {
+        FlushStaticMarkup();
+        AppendLine(
+            stateName + ".Push(" + CoreNamespace + ".HydrationMarkers." + markerName + ");");
+    }
+
+    private void AppendStaticMarkup(string stateName, string value)
+    {
+        if (!string.Equals(staticStateName, stateName, StringComparison.Ordinal))
+        {
+            FlushStaticMarkup();
+            staticStateName = stateName;
+        }
+
+        staticMarkup.Append(value);
+    }
+
+    private void FlushStaticMarkup()
+    {
+        if (staticMarkup.Length == 0)
+        {
+            return;
+        }
+
+        AppendLine(
+            staticStateName + ".Push(" + FrameRenderCodeWriter.StringLiteral(staticMarkup.ToString()) + ");");
+        staticMarkup.Clear();
+    }
+
+    private static string EscapeHtml(string value)
+    {
+        StringBuilder? escaped = null;
+        int copyStart = 0;
+        for (int index = 0; index < value.Length; index++)
+        {
+            string? entity = value[index] switch
+            {
+                '"' => "&quot;",
+                '&' => "&amp;",
+                '\'' => "&#39;",
+                '<' => "&lt;",
+                '>' => "&gt;",
+                _ => null,
+            };
+            if (entity is null)
+            {
+                continue;
+            }
+
+            escaped ??= new StringBuilder(value.Length + 16);
+            escaped.Append(value, copyStart, index - copyStart);
+            escaped.Append(entity);
+            copyStart = index + 1;
+        }
+
+        if (escaped is null)
+        {
+            return value;
+        }
+
+        escaped.Append(value, copyStart, value.Length - copyStart);
+        return escaped.ToString();
+    }
+
+    private static string ParameterName(ExpressionNode? expression, string fallback)
+    {
+        if (expression is not SimpleExpressionNode simple)
+        {
+            return fallback;
+        }
+
+        string name = simple.Content;
+        return string.IsNullOrEmpty(name) || name[0] == '_'
+            ? fallback
+            : name;
+    }
+
+    private string NextName(string prefix)
+    {
+        string name = prefix + generatedNameIndex.ToString(CultureInfo.InvariantCulture);
+        generatedNameIndex++;
+        return name;
+    }
+
+    private void AppendExpression(CodeExpression expression)
+    {
+        for (int index = 0; index < expression.Mappings.Count; index++)
+        {
+            (int offset, SourceLocation location) = expression.Mappings[index];
+            mappingSites.Add((builder.Length + offset, location));
+        }
+
+        builder.Append(expression.Text);
+    }
+
+    private void AppendLine(string text)
+    {
+        BeginLine();
+        Push(text);
+        EndLine();
+    }
+
+    private void BeginLine()
+    {
+        for (int level = 0; level < indentLevel; level++)
+        {
+            builder.Append(indentText);
+        }
+    }
+
+    private void EndLine() => builder.Append('\n');
+
+    private void Push(string text) => builder.Append(text);
+
+    private IReadOnlyList<RenderSourceMapping> BuildSourceMappings(string code)
+    {
+        if (mappingSites.Count == 0)
+        {
+            return Array.Empty<RenderSourceMapping>();
+        }
+
+        var mappings = new List<RenderSourceMapping>(mappingSites.Count);
+        for (int index = 0; index < mappingSites.Count; index++)
+        {
+            (int offset, SourceLocation location) = mappingSites[index];
+            (int line, int column) = LineColumnAt(code, offset);
+            mappings.Add(new RenderSourceMapping
+            {
+                GeneratedLine = line,
+                GeneratedColumn = column,
+                TemplateLocation = location,
+            });
+        }
+
+        return mappings;
+    }
+
+    private static (int Line, int Column) LineColumnAt(string text, int offset)
+    {
+        int line = 0;
+        int lineStart = 0;
+        int limit = offset < text.Length ? offset : text.Length;
+        for (int index = 0; index < limit; index++)
+        {
+            if (text[index] == '\n')
+            {
+                line++;
+                lineStart = index + 1;
+            }
+        }
+
+        return (line, offset - lineStart);
+    }
+
+    private static int OffsetAtLineColumn(string text, int line, int column)
+    {
+        int currentLine = 0;
+        int offset = 0;
+        while (currentLine < line && offset < text.Length)
+        {
+            if (text[offset] == '\n')
+            {
+                currentLine++;
+            }
+
+            offset++;
+        }
+
+        return Math.Min(offset + column, text.Length);
+    }
+
+    private sealed class ElementContentOverride
+    {
+        internal ElementContentOverride(CodeExpression value, bool isRaw)
+        {
+            Value = value;
+            IsRaw = isRaw;
+        }
+
+        internal CodeExpression Value { get; }
+
+        internal bool IsRaw { get; }
+    }
+
+    private sealed class ElementValue
+    {
+        internal ElementValue(CodeExpression value, bool isStatic)
+        {
+            Value = value;
+            IsStatic = isStatic;
+        }
+
+        internal CodeExpression Value { get; }
+
+        internal bool IsStatic { get; }
+    }
+
+    private sealed class CodeExpression
+    {
+        private readonly StringBuilder text = new();
+        private readonly List<(int Offset, SourceLocation Location)> mappings = new();
+
+        internal string Text => text.ToString();
+
+        internal IReadOnlyList<(int Offset, SourceLocation Location)> Mappings => mappings;
+
+        internal static CodeExpression Literal(string value)
+        {
+            var expression = new CodeExpression();
+            expression.Append(value);
+            return expression;
+        }
+
+        internal void Append(string value) => text.Append(value);
+
+        internal void Append(CodeExpression expression)
+        {
+            int offset = text.Length;
+            text.Append(expression.Text);
+            for (int index = 0; index < expression.mappings.Count; index++)
+            {
+                (int mappingOffset, SourceLocation location) = expression.mappings[index];
+                mappings.Add((offset + mappingOffset, location));
+            }
+        }
+
+        internal void AddMapping(int offset, SourceLocation location) =>
+            mappings.Add((offset, location));
+    }
+}

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/Transforms/TransformResult.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/Transforms/TransformResult.cs
@@ -59,6 +59,22 @@ public sealed record TransformResult
     public IReadOnlyList<CacheExpression?> Cached { get; }
 
     /// <summary>
+    /// Gets whether the transform omitted client-only operations for a server-markup target.
+    /// </summary>
+    /// <remarks>
+    /// The server render emitter requires this mode so any virtual-node fallback remains free of
+    /// browser-only event and directive dependencies. Specified by
+    /// <c>[SSR-COMPILE-1]</c> and <c>[SSR-COMPILE-2]</c>.
+    /// </remarks>
+    public bool IsServerRendering => context.IsServerRendering;
+
+    /// <summary>
+    /// Gets the scoped-style attribute stamped on every directly rendered native element, or null.
+    /// </summary>
+    /// <remarks>Specified by <c>[V01.01.06.04]</c> and <c>[SSR-COMPILE-3]</c>.</remarks>
+    public string? ScopeId => context.ScopeId;
+
+    /// <summary>
     /// Resolves the code-generation node of <paramref name="node"/>: a container carries it directly, while an
     /// element's node is looked up from the transform's side table.
     /// </summary>
@@ -70,4 +86,21 @@ public sealed record TransformResult
         TextCallNode textCall => textCall.CodegenNode,
         _ => context.GetCodegenNode(node),
     };
+
+    /// <summary>
+    /// Returns the transform's current child list for an element instead of its immutable parse-time
+    /// snapshot. The server writer consumes this list so expression-prefix and structural replacements
+    /// are identical to the virtual-node writer's inputs.
+    /// </summary>
+    /// <param name="element">The transformed element.</param>
+    /// <returns>The element's frozen transformed children.</returns>
+    internal IReadOnlyList<TemplateChildNode> GetTransformedChildren(ElementNode element)
+    {
+        if (!context.TryGetWorkingChildren(element, out List<TemplateSyntaxNode>? children))
+        {
+            return element.Children;
+        }
+
+        return TransformFreeze.FreezeChildren(children);
+    }
 }

--- a/tooling/Assimalign.Viu.Syntax.Templates/test/ServerRenderFunctionEmitterTests.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/test/ServerRenderFunctionEmitterTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Shouldly;
+using Xunit;
+
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
+
+namespace Assimalign.Viu.Syntax.Templates;
+
+/// <summary>
+/// Pins [V01.01.07.02]'s build-time server-markup target independently of the interactive
+/// virtual-node target. Runtime byte equality is covered in ServerRenderer's differential suite.
+/// </summary>
+public sealed class ServerRenderFunctionEmitterTests
+{
+    [Fact]
+    public void ServerMarkup_StaticWithInterpolation_EmitsOnlyWritesAndSerializationHelpers()
+    {
+        RenderFunctionEmitterResult emitted = Emit(
+            "<section class=\"hero\"><h1>{{ title }}</h1><p>ready</p></section>");
+
+        emitted.Code.ShouldContain("state.Push(\"<section");
+        emitted.Code.ShouldContain("ServerRender.SsrInterpolate(component.title)");
+        emitted.Code.ShouldContain("ready</p></section>");
+        emitted.Code.ShouldNotContain("new global::Assimalign.Viu.Components.");
+        emitted.Code.ShouldNotContain("VirtualNode");
+    }
+
+    [Fact]
+    public void ServerMarkup_ModelControlsAndShow_EmitSerializedState()
+    {
+        string input = Emit("<input v-model=\"name\">").Code;
+        string checkbox = Emit("<input type=\"checkbox\" value=\"yes\" v-model=\"choices\">").Code;
+        string textArea = Emit("<textarea v-model=\"notes\">ignored</textarea>").Code;
+        string select = Emit(
+            "<select v-model=\"choice\"><option value=\"a\">A</option><option :value=\"other\">B</option></select>").Code;
+        string implicitOptionValue = Emit(
+            "<select v-model=\"choice\"><option>{{ choice }}</option></select>").Code;
+        string show = Emit("<div :style=\"styles\" v-show=\"visible\">shown</div>").Code;
+
+        input.ShouldContain("SsrRenderDynamicAttribute(\"value\", component.name, \"input\")");
+        checkbox.ShouldContain("SsrRenderDynamicAttribute(\"value\", \"yes\", \"input\")");
+        checkbox.ShouldContain("IsModelValueSelected(component.choices, \"yes\", true)");
+        checkbox.ShouldContain("SsrRenderDynamicAttribute(\"checked\"");
+        textArea.ShouldContain("ServerRender.SsrInterpolate(component.notes)");
+        textArea.ShouldNotContain("SsrRenderDynamicAttribute(\"value\"");
+        select.OccurrencesOf("IsModelValueSelected(component.choice").ShouldBe(2);
+        select.OccurrencesOf("SsrRenderDynamicAttribute(\"selected\"").ShouldBe(2);
+        implicitOptionValue.ShouldContain(
+            "IsModelValueSelected(component.choice, " +
+            "global::Assimalign.Viu.DisplayStringFormatter.ToDisplayString(component.choice), false)");
+        show.ShouldContain("ServerRender.SsrRenderStyle(component.styles)");
+        show.ShouldContain("if (!global::Assimalign.Viu.ServerRenderer.ServerRender.IsTruthy(component.visible))");
+        show.ShouldContain("state.Push(\"display:none;\")");
+    }
+
+    [Fact]
+    public void ServerMarkup_ScopedStyleIdentifier_IsWrittenOnEveryNativeElement()
+    {
+        string code = Emit(
+            "<main><h1>heading</h1><p>body</p></main>",
+            scopeId: "data-v-c0ffee00").Code;
+
+        code.OccurrencesOf("SsrRenderDynamicAttribute(\"data-v-c0ffee00\"")
+            .ShouldBe(3);
+    }
+
+    [Fact]
+    public void VirtualNodeTree_ScopedStyleIdentifier_IsBoundOnEveryNativeElement()
+    {
+        RootNode root = TemplateParser.Parse(
+            "<main><h1>heading</h1><p>body</p></main>",
+            ParserOptions.CreateHtml());
+        TransformOptions options = TransformOptions.CreateDom();
+        options.PrefixIdentifiers = true;
+        options.BindingMetadata = BindingMetadata.Empty;
+        options.ScopeId = "data-v-c0ffee00";
+
+        string code = RenderFunctionEmitter.Emit(Transformer.Transform(root, options)).Code;
+
+        code.OccurrencesOf("new global::Assimalign.Viu.Components.QualifiedName(\"data-v-c0ffee00\")")
+            .ShouldBe(3);
+    }
+
+    [Fact]
+    public void ServerMarkup_DynamicComponent_UsesSubtreeLocalVirtualNodeFallback()
+    {
+        string code = Emit("<component :is=\"viewName\"></component>").Code;
+
+        code.ShouldContain("VirtualNode? RenderFallback");
+        code.ShouldContain("DynamicComponents.Create(");
+        code.ShouldContain("ServerRender.SsrRenderComponentAsync(state, RenderFallback");
+    }
+
+    [Fact]
+    public void ServerMarkup_DynamicAttributeSubtree_UsesVirtualNodeFallback()
+    {
+        string code = Emit(
+            "<div v-bind=\"attributes\"><span>{{ body }}</span></div>").Code;
+
+        code.ShouldContain("VirtualNode? RenderFallback");
+        code.ShouldContain("ElementBinding.Attribute");
+        code.ShouldContain("ServerRender.SsrRenderComponentAsync(state, RenderFallback");
+    }
+
+    [Fact]
+    public void ServerMarkup_PropertyBinding_UsesMappedSubtreeLocalVirtualNodeFallback()
+    {
+        RenderFunctionEmitterResult emitted = Emit("<input :value.prop=\"body\">");
+
+        emitted.Code.ShouldContain("VirtualNode? RenderFallback");
+        emitted.Code.ShouldContain("ElementBinding.Property(");
+        emitted.Code.ShouldContain("component.body");
+        emitted.Code.ShouldContain("ServerRender.SsrRenderComponentAsync(state, RenderFallback");
+        emitted.SourceMappings.Any(mapping => mapping.TemplateLocation.Source == "body")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ServerMarkup_FragmentTemplate_PreservesHydrationMarkers()
+    {
+        string code = Emit(
+            "<template v-if=\"!visible\"><span>one</span><span>two</span></template>").Code;
+
+        code.ShouldContain("HydrationMarkers.FragmentStart");
+        code.ShouldContain("HydrationMarkers.FragmentEnd");
+    }
+
+    [Fact]
+    public void ServerMarkup_BuiltIns_UseMarkerPreservingServerHelpers()
+    {
+        string teleport = Emit("<Teleport to=\"#target\"><span>away</span></Teleport>").Code;
+        string suspense = Emit(
+            "<Suspense><template #default><strong>ready</strong></template>" +
+            "<template #fallback><em>wait</em></template></Suspense>").Code;
+        string transition = Emit("<Transition><div>shown</div></Transition>").Code;
+
+        teleport.ShouldContain("ServerRender.SsrRenderTeleportAsync(");
+        teleport.ShouldNotContain("teleport start");
+        suspense.ShouldContain("ServerRender.SsrRenderSuspenseAsync(");
+        suspense.ShouldContain("<strong>ready</strong>");
+        suspense.ShouldNotContain("<em>wait</em>");
+        transition.ShouldContain("state.Push(\"<div>shown</div>\")");
+        transition.ShouldNotContain("TransitionNode");
+    }
+
+    [Theory]
+    [InlineData("<div :id=\"identifier\">{{ message }}</div>")]
+    [InlineData("<div v-if=\"visible\">yes</div><p v-else>no</p>")]
+    [InlineData("<ul><li v-for=\"item in items\">{{ item }}</li></ul>")]
+    [InlineData("<component :is=\"viewName\"><span>{{ body }}</span></component>")]
+    [InlineData("<div v-bind=\"attributes\"><span>{{ body }}</span></div>")]
+    [InlineData("<Teleport to=\"body\"><div>away</div></Teleport>")]
+    [InlineData("<input v-model=\"name\">")]
+    [InlineData("<select v-model=\"choice\"><option>{{ choice }}</option></select>")]
+    public void ServerMarkup_EmittedBody_ParsesAsValidCSharp(string source)
+    {
+        string code = Emit(source).Code;
+        string unit =
+            "internal sealed class RenderProbe {\n" +
+            "    private static async global::System.Threading.Tasks.Task Render(" +
+            "global::Assimalign.Viu.ServerRenderer.SsrRenderState state, RenderProbe component, " +
+            "global::Assimalign.Viu.Components.ComponentRenderFrame frame, " +
+            "global::Assimalign.Viu.IComponentRenderScope? parent) {\n" +
+            code +
+            "    }\n" +
+            "}";
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            unit,
+            new CSharpParseOptions(LanguageVersion.Preview));
+        tree.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == RoslynDiagnosticSeverity.Error)
+            .ShouldBeEmpty(customMessage: code);
+    }
+
+    [Fact]
+    public void ServerMarkup_ProfileRequiresServerTransform()
+    {
+        RootNode root = TemplateParser.Parse("<div>text</div>", ParserOptions.CreateHtml());
+        TransformResult transformed = Transformer.Transform(root, TransformOptions.CreateDom());
+
+        InvalidOperationException exception = Should.Throw<InvalidOperationException>(() =>
+            RenderFunctionEmitter.Emit(
+                transformed,
+                new RenderFunctionEmitterOptions
+                {
+                    TargetProfile = RenderFunctionTargetProfile.ServerMarkup,
+                }));
+
+        exception.Message.ShouldContain("IsServerRendering");
+    }
+
+    private static RenderFunctionEmitterResult Emit(string source, string? scopeId = null)
+    {
+        RootNode root = TemplateParser.Parse(source, ParserOptions.CreateHtml());
+        TransformOptions transformOptions = TransformOptions.CreateDom();
+        transformOptions.PrefixIdentifiers = true;
+        transformOptions.BindingMetadata = BindingMetadata.Empty;
+        transformOptions.IsServerRendering = true;
+        transformOptions.ScopeId = scopeId;
+        TransformResult transformed = Transformer.Transform(root, transformOptions);
+        return RenderFunctionEmitter.Emit(
+            transformed,
+            new RenderFunctionEmitterOptions
+            {
+                TargetProfile = RenderFunctionTargetProfile.ServerMarkup,
+            });
+    }
+}
+
+internal static class ServerRenderCodeStringExtensions
+{
+    internal static int OccurrencesOf(this string value, string fragment)
+    {
+        int count = 0;
+        int offset = 0;
+        while ((offset = value.IndexOf(fragment, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += fragment.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

Completes the server-rendering story on the redesigned model — the four remaining `[V01.01.07]`/`[V01.01.09]` features. Stacked on #324 (segmentation); diff shows only this train.

## What's here

**Compiled server markup (#65).** A `ServerMarkup` compiler profile lowers static template regions to direct string writes — zero virtual nodes — with subtree-local fallback to tree rendering for dynamic regions. Proven by **16/16 byte-identical differential fixtures** against the tree walker (escaping, class/style, fragments, conditions/loops, every v-model form, scope stamping, fallback regions). ShortRun benchmark: **3.56× faster at 0.32× the allocations**. `[SSR-COMPILE-1..4]`.

**Host-agnostic server adaptor (#67).** Typed request/scope/output/result contracts through which *any* web framework hosts Viu SSR — the deliberate inversion of a framework-specific integration package. No ASP.NET Core/Kestrel reference (scanned); awaited write/flush for progressive output and backpressure; per-request isolation proven under deterministic overlap (ambient scope, registry, scheduler queues, teleports do not cross requests — 231/231 ×11 runs); raw `TcpListener` HTTP smoke as the test-only host proof. `[SSR-11..12]`.

**SSR state round-trip (#78).** Explicit, AOT-safe store serializer + payload registry contracts (typed `JsonTypeInfo`, no reachable reflection path), a schema-validated payload (`{"version":1,"stores":{...}}`) replacing the unschematized bag, one inert `script[data-viu-state]` island consumed by Browser before mount, and staged restore for stores created after hydration. XSS and concurrent-isolation tests included. `[STA-9]`.

**Lazy hydration (#229).** `Immediate`/`Idle`/`Visible`/`MediaQuery`/`Interaction` strategies declared at the invocation, carried through SSR markers, adopted before activation; Core owns neutral trigger scheduling, Browser supplies the platform triggers, Testing gets deterministic fakes. Decision recorded: the first configured interaction is captured and **replayed after activation** (cloned event, async, dropped on cancellation). Covers trigger-before-navigation-away, nested boundaries, eager-parent/lazy-child, pending async loaders. `[HYD-LAZY-1..5]`, `[HYD-8]`.

## Scope note

The byte-equality gate on scoped fixtures forced the **compile-time half of scoped CSS** back in: `[STY-1]` is un-deferred — the `data-v-*` hash is emitted as an *ordinary attribute binding*, needing zero runtime support (exactly why the redesign called reintroduction additive). The reactive `v-bind()` runtime (`[STY-6..8]`) remains deferred under #319, which narrows to that scope.

## Verification

- Build 0/0 under `-warnaserror`; **2,717 tests, 0 failures** (+84 over the base branch)
- Differential suite 16/16; scheduler race hardening re-run 10× clean
- AOT scans: zero forbidden reflection/activation; all 4 JSON call sites use generated context metadata

Closes #65
Closes #67
Closes #78
Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
