### PR TITLE
feat(tooling): Visual Studio editor enhancements for .viu files [V01.01.12.07]

### DIFF
--- a/build/Targets/Build.References.Packages.targets
+++ b/build/Targets/Build.References.Packages.targets
@@ -104,22 +104,45 @@
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>runtime</ExcludeAssets>
         </_ViuPackage>
+        <!-- The documented Async Completion contracts used by the Visual Studio swatch adapter:
+             its item manager delegates the stock manager and changes only CompletionItem.Icon.
+             Pinned to the same 17.14 editor floor as CoreUtility/Text; Visual Studio supplies the
+             implementation, so this remains compile-only. -->
+        <_ViuPackage Include="Microsoft.VisualStudio.Language" Version="17.14.249">
+            <PrivateAssets>all</PrivateAssets>
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </_ViuPackage>
+        <!-- IVsManagedImageService turns each server-computed color into a custom image moniker;
+             SVsImageService is the documented shell service contract used to obtain it. Both are
+             host contracts only and never enter the VSIX container. -->
+        <_ViuPackage Include="Microsoft.VisualStudio.Shell.Framework" Version="17.14.40264">
+            <PrivateAssets>all</PrivateAssets>
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </_ViuPackage>
+        <_ViuPackage Include="Microsoft.VisualStudio.Interop" Version="17.14.40260">
+            <PrivateAssets>all</PrivateAssets>
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </_ViuPackage>
         <!-- AsyncEventHandler<T>, the type of ILanguageClient's StartAsync/StopAsync events, which
              ViuLanguageClient declares and raises. A transitive dependency of the client package,
-             pinned explicitly because it is compiled against directly. -->
-        <_ViuPackage Include="Microsoft.VisualStudio.Threading" Version="17.13.2">
+             pinned explicitly because it is compiled against directly. Floor raised with
+             Shell.Framework 17.14.40264 (the swatch adapter), which requires >= 17.14.15. -->
+        <_ViuPackage Include="Microsoft.VisualStudio.Threading" Version="17.14.15">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>runtime</ExcludeAssets>
         </_ViuPackage>
         <!-- Two more transitive dependencies of the client package whose requested builds were never
              published, so NuGet resolves upward and warns (NU1603) - the same situation as
              Imaging.Interop above. Pinned at the builds NuGet picks anyway, which makes the
-             resolution explicit rather than approximate. -->
-        <_ViuPackage Include="Microsoft.VisualStudio.Telemetry" Version="17.14.2">
+             resolution explicit rather than approximate. Telemetry's floor is raised by
+             Shell.Framework 17.14.40264, which requires >= 17.14.18. -->
+        <_ViuPackage Include="Microsoft.VisualStudio.Telemetry" Version="17.14.18">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>runtime</ExcludeAssets>
         </_ViuPackage>
-        <_ViuPackage Include="Microsoft.VisualStudio.Utilities" Version="17.13.40008">
+        <!-- Floor raised with Shell.Framework 17.14.40264 (the swatch adapter), which requires
+             Utilities at the same 17.14.40264 build. -->
+        <_ViuPackage Include="Microsoft.VisualStudio.Utilities" Version="17.14.40264">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>runtime</ExcludeAssets>
         </_ViuPackage>

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/docs/DESIGN.md
@@ -39,14 +39,17 @@ load-bearing half of the original decision:
 
 - the language server remains a separate stdio process, so the Viu parsers and Roslyn never load
   into `devenv.exe` and a parser fault or dependency conflict cannot destabilize the IDE;
-- the server stays editor-neutral — it speaks the Language Server Protocol and reads file paths, and
-  knows nothing about Visual Studio;
+- the server stays editor-neutral — it speaks the Language Server Protocol plus an opt-in,
+  data-only exact-classification notification, reads file paths, and references no Visual Studio
+  assembly;
 - the Visual Studio Code extension consumes the identical binary, published by the identical shared
   target (`build/Targets/Build.LanguageServer.targets`), so the two hosts cannot drift.
 
 Only the client crossed the boundary, and the client is exactly the layer the original decision
 described as "document registration, process lifetime, and editor presentation". No server change
-was required by the migration and none was made.
+was required by that migration. The later exact C# classification bridge ([V01.01.12.07.11]) adds
+one opt-in notification, but leaves every semantic decision and dependency below the process
+boundary.
 
 **Revisit condition.** If `VisualStudio.Extensibility` ships stable editor classification — custom
 classification types with user-editable format definitions — together with a pkgdef-equivalent file
@@ -61,7 +64,7 @@ Visual Studio (devenv.exe)
   -> Assimalign.Viu.VisualStudio  (classic VSSDK package, in process)
        -> Assimalign.Viu.VisualStudio.pkgdef   claims .viu for the Source Code (Text) Editor
        -> viu content type    MEF; bases: code, code-languageserver-preview
-       -> ViuClassifier       MEF; the Viu palette over ViuLexicalClassifier
+       -> ViuClassifier       MEF; lexical fallback plus exact server-authored C# classifications
        -> ViuLanguageClient   MEF ILanguageClient; starts the server, hands Visual Studio its streams
             -> stdio Language Server Protocol connection
                  -> Assimalign.Viu.LanguageServer  (separate process)
@@ -84,7 +87,11 @@ during the migration window.
 
 `Assimalign.Viu.LanguageServer` owns protocol framing and translates protocol values into
 editor-neutral contracts. It writes protocol messages only to standard output; standard error is
-reserved for diagnostics.
+reserved for diagnostics. Visual Studio opts into `viu/publishSemanticClassifications`, a custom
+notification containing only a URI, document version, text checksum, authored ranges, and exact C#
+classification-type names. The client's non-null StreamJsonRpc custom-message target receives that
+server-to-client notification; the message middle layer is reserved for outgoing requests and their
+responses. Other clients receive only the standard semantic-token response.
 
 `Assimalign.Viu.LanguageService` caches the current text and the format-appropriate immutable
 container parse for each open `.viu` or accepted `.vue` document. It exposes block diagnostics,
@@ -96,23 +103,42 @@ workspace), semantic `@script` completion when the host feeds a restored project
 project-defined utilities and variants, and generated-CSS hover documentation. It never loads a
 Roslyn workspace.
 
+Color utility completions carry their computed CSS value in the Language Server Protocol item's
+opaque `data.colorValue`. The Visual Studio message middle layer captures the completed response,
+and a Viu-only Async Completion item-manager wrapper delegates filtering and sorting to the editor's
+default manager. It matches the complete candidate identity within one completion-source group,
+then changes only that candidate's icon. Custom images are registered on the UI thread through
+`IVsManagedImageService`, their handles remain alive with the catalog, and the current document path
+is read for every list so Save As cannot strand a response under an old path. [V01.01.12.07.13]
+
 ## The Viu color theme
 
 Classification splits by ownership, specified by `[TOOL-3]`.
 
-**Embedded C# resolves the editor's own classification types.** Every kind a C# token pass can emit —
-keyword, string, number, comment, operator, punctuation, identifier, class name, method name —
-resolves the name the editor and Roslyn already register, so the `@script` block, interpolation
-interiors, and binding-expression interiors color exactly as the user's chosen C# theme colors C#.
-Viu registers none of those names and expresses no opinion about them: the theme applies 1:1.
+**Embedded C# resolves the editor's own classification types.** The immediate lexical fallback maps
+every kind its C# token pass can emit — keyword, string, number, comment, operator, punctuation,
+identifier, class name, method name — to the name the editor and Roslyn already register. It colors
+the `@script` block, interpolation interiors, and binding-expression interiors without waiting for
+the server.
 
-Resolution is defensive, because three of those names (`punctuation`, `class name`, `method name`)
-come from Roslyn's editor features rather than the core editor. Each buffer resolves every kind once
-and walks a fixed fallback chain when a name is absent: `method name` and `class name` fall back to
-`identifier`, `punctuation` falls back to `operator`, and a kind that resolves to nothing at all is
-dropped rather than mis-colored. A Visual Studio without a managed-language workload therefore still
-colors Viu templates in full, and script spans degrade to plain identifiers instead of vanishing.
-The chain lives in `ViuClassificationTypeNames.GetFallbackClassificationTypeName`.
+When project semantics are available, the server overlays authored `@script` identifiers with the
+exact names produced for the identical plain-C# construct: namespace, class, delegate, enum,
+interface, struct, type parameter, method, property, field, constant, enum member, event, parameter,
+local, and label names. The client resolves those strings through
+`IClassificationTypeRegistryService`; it neither loads Roslyn nor recomputes a classification in
+`devenv.exe`. Each publication carries the editor document version and a SHA-256 checksum of its
+UTF-8 text. A classifier uses it only when the checksum matches its current immutable snapshot, and
+removes every intersecting lexical span before adding the exact span, so one identifier never has
+two competing classifications. Missing, invalid, delayed, or cleared semantic data leaves the
+lexical result unchanged. [V01.01.12.07.11]
+
+Resolution is defensive because punctuation and semantic C# names come from Roslyn's editor features
+rather than the core editor. Each buffer caches each resolved name and walks a fixed fallback chain
+when a name is absent: every class/member/variable semantic name falls back to `identifier`,
+`punctuation` falls back to `operator`, and a name that resolves to nothing at all is dropped rather
+than mis-colored. A Visual Studio without a managed-language workload therefore still colors Viu
+templates in full, and script spans degrade to plain identifiers instead of vanishing. The chain
+lives in `ViuClassificationTypeNames.GetFallbackClassificationTypeName`.
 
 **Template, markup, and style constructs resolve ten Viu-owned classification types.**
 `ViuClassificationTypes` registers each one with `text` as its base definition, and each has exactly
@@ -169,7 +195,8 @@ general C#; a binding value is the one position where the leading name is a memb
 
 ### Classification caching
 
-`ViuClassifier` lexes the **whole document** and caches the result on the snapshot. A line's
+`ViuClassifier` lexes the **whole document**, merges any checksum-matching semantic publication, and
+caches the result on the snapshot. A line's
 classification depends on the container section enclosing it — the lexer has to see the `<template>`
 above line three hundred to color line three hundred — so asking for a range would cost exactly what
 asking for everything costs. Every `GetClassificationSpans` call is therefore answered by filtering
@@ -182,9 +209,11 @@ how line three hundred is colored, so no narrower invalidation would be correct.
 re-requests only the ranges it is actually displaying, so the cost of the wide notification is
 bounded by the visible text rather than by the document.
 
-The classifier is stored in the buffer's property collection and subscribes to that same buffer, so
-the subscription is a self-reference that dies with the buffer; `IClassifier` offers no disposal point
-to unsubscribe from.
+The classifier is stored in the buffer's property collection and subscribes to that same buffer.
+The process-wide semantic state holds listeners weakly because `IClassifier` offers no disposal
+point; a publication cannot retain a closed buffer. Closing a document removes its publication, and
+starting a language-server session clears every prior publication so a restarted version sequence
+cannot inherit stale ordering.
 
 The out-of-process tagger this replaces reported the whole document too, but for a different reason:
 each report was a JSON-RPC round trip, and reporting only the requested lines left every unscrolled
@@ -585,7 +614,7 @@ too, and because it costs a static field read when it is off.
   computation of *what* indentation it uses are both pure, and only the buffer edit is runtime-only.
 - **Expanding a `{ }` block on Return in a `<style>` section.** A CSS rule is a block and Visual
   Studio's CSS editor does expand it, so this is a plausible follow-up; it is out of scope here so
-  that [V01.01.12.07.09] carries exactly the C#-parity behavior it specifies. Template sections are
+  that [V01.01.12.07.09] carries exactly the C#-matching behavior it specifies. Template sections are
   not a candidate: a template brace is usually an interpolation.
 
 ## Activation, and where `.vue` stands in Visual Studio

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Assimalign.Viu.VisualStudio.csproj
@@ -76,6 +76,12 @@
     <!-- The classic in-process language-server client API (ILanguageClient, Connection) and the
          threading primitives its events are typed with. -->
     <ViuPackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" />
+    <!-- Async Completion supplies the presentation-only item-manager seam. The shell contracts
+         register runtime color images and expose their monikers; no completion semantics or parser
+         dependency moves into devenv.exe. -->
+    <ViuPackageReference Include="Microsoft.VisualStudio.Language" />
+    <ViuPackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
+    <ViuPackageReference Include="Microsoft.VisualStudio.Interop" />
     <ViuPackageReference Include="Microsoft.VisualStudio.Threading" />
     <!-- Transitive dependencies of the client package pinned to silence NU1603, exactly as
          Imaging.Interop is above. -->

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifier.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
@@ -7,16 +8,23 @@ using Microsoft.VisualStudio.Text.Classification;
 namespace Assimalign.Viu.VisualStudio;
 
 /// <summary>
-/// Colors one Viu single-file-component buffer from <see cref="ViuLexicalClassifier"/>.
+/// Colors one Viu single-file-component buffer from the lexical fallback and exact server-authored
+/// semantic classifications.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Whole-document lexing, cached per snapshot.</b> A line's classification depends on the
+/// <b>Whole-document classification, cached per snapshot.</b> A line's classification depends on the
 /// container section enclosing it, so the lexer has to see the whole document to color any part of
 /// it; asking it for a range would cost the same as asking it for everything. The result is therefore
 /// computed once per snapshot and every <see cref="GetClassificationSpans(SnapshotSpan)"/> call is
 /// answered by filtering that one result. Exactly one snapshot's spans are held at a time — this is a
 /// reuse cache, not a history.
+/// </para>
+/// <para>
+/// <b>Semantic overlay.</b> The language server publishes authored ranges with the exact C# editor
+/// classification-type names. A publication is used only when its text checksum matches this
+/// snapshot; otherwise the lexical result remains intact. Exact spans replace intersecting lexical
+/// identifier spans, so the editor never receives two competing classifications for one token.
 /// </para>
 /// <para>
 /// <b>Change notification is whole-buffer</b> for the same reason: adding a <c>&lt;/template&gt;</c>
@@ -30,38 +38,69 @@ namespace Assimalign.Viu.VisualStudio;
 /// <see cref="IClassifier"/> has no disposal point to unsubscribe from.
 /// </para>
 /// </remarks>
-internal sealed class ViuClassifier : IClassifier
+internal sealed class ViuClassifier : IClassifier, IViuSemanticClassificationListener
 {
     private readonly ITextBuffer textBuffer;
+    private readonly IClassificationTypeRegistryService classificationTypeRegistry;
+    private readonly ViuSemanticClassificationState semanticClassificationState;
+    private readonly ITextDocumentFactoryService textDocumentFactory;
+    private ITextDocument? textDocument;
+    private string? documentIdentifier;
 
     /// <summary>
     /// The resolved classification type for each <see cref="ViuClassificationKind"/>, indexed by the
     /// enum value. An entry is <see langword="null"/> only when neither the name nor its fallback
     /// chain is registered, in which case spans of that kind are dropped rather than mis-colored.
     /// </summary>
-    private readonly IClassificationType?[] classificationTypes;
+    private readonly Dictionary<string, IClassificationType?> classificationTypes =
+        new(StringComparer.Ordinal);
 
     private readonly object classificationLock = new();
+    private readonly object classificationTypeLock = new();
 
     private ITextSnapshot? classifiedSnapshot;
     private IReadOnlyList<ClassificationSpan>? classifiedSpans;
+    private long classificationGeneration;
 
     /// <summary>
     /// Initializes a classifier over one buffer.
     /// </summary>
     /// <param name="textBuffer">The buffer to classify.</param>
     /// <param name="classificationTypeRegistry">The editor's classification type registry.</param>
+    /// <param name="semanticClassificationState">The server publication state.</param>
+    /// <param name="textDocumentFactory">
+    /// The document service used only to associate the buffer with the URI published by the server.
+    /// </param>
     public ViuClassifier(
         ITextBuffer textBuffer,
-        IClassificationTypeRegistryService classificationTypeRegistry)
+        IClassificationTypeRegistryService classificationTypeRegistry,
+        ViuSemanticClassificationState semanticClassificationState,
+        ITextDocumentFactoryService textDocumentFactory)
     {
-        this.textBuffer = textBuffer;
-        this.classificationTypes = ResolveClassificationTypes(classificationTypeRegistry);
+        this.textBuffer = textBuffer ?? throw new ArgumentNullException(nameof(textBuffer));
+        this.classificationTypeRegistry = classificationTypeRegistry ??
+            throw new ArgumentNullException(nameof(classificationTypeRegistry));
+        this.semanticClassificationState = semanticClassificationState ??
+            throw new ArgumentNullException(nameof(semanticClassificationState));
+        this.textDocumentFactory = textDocumentFactory ??
+            throw new ArgumentNullException(nameof(textDocumentFactory));
+        this.PrimeLexicalClassificationTypes();
         this.textBuffer.Changed += this.OnTextBufferChanged;
+        this.EnsureDocumentIdentifier();
     }
 
     /// <inheritdoc />
     public event EventHandler<ClassificationChangedEventArgs>? ClassificationChanged;
+
+    /// <inheritdoc />
+    public void OnSemanticClassificationsChanged(string changedDocumentIdentifier)
+    {
+        this.InvalidateClassificationCache();
+        ITextSnapshot snapshot = this.textBuffer.CurrentSnapshot;
+        this.ClassificationChanged?.Invoke(
+            this,
+            new ClassificationChangedEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length)));
+    }
 
     /// <inheritdoc />
     public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span)
@@ -85,11 +124,7 @@ internal sealed class ViuClassifier : IClassifier
 
     private void OnTextBufferChanged(object sender, TextContentChangedEventArgs arguments)
     {
-        lock (this.classificationLock)
-        {
-            this.classifiedSnapshot = null;
-            this.classifiedSpans = null;
-        }
+        this.InvalidateClassificationCache();
 
         ITextSnapshot snapshot = arguments.After;
         this.ClassificationChanged?.Invoke(
@@ -99,6 +134,8 @@ internal sealed class ViuClassifier : IClassifier
 
     private IReadOnlyList<ClassificationSpan> GetSnapshotSpans(ITextSnapshot snapshot)
     {
+        this.EnsureDocumentIdentifier();
+        long generation;
         lock (this.classificationLock)
         {
             if (ReferenceEquals(this.classifiedSnapshot, snapshot) &&
@@ -106,14 +143,21 @@ internal sealed class ViuClassifier : IClassifier
             {
                 return this.classifiedSpans;
             }
+
+            generation = this.classificationGeneration;
         }
 
         IReadOnlyList<ClassificationSpan> snapshotSpans = this.ClassifySnapshot(snapshot);
 
         lock (this.classificationLock)
         {
-            this.classifiedSnapshot = snapshot;
-            this.classifiedSpans = snapshotSpans;
+            // A server publication can arrive while classification runs. Do not let an older result
+            // repopulate the cache after that publication invalidated it.
+            if (generation == this.classificationGeneration)
+            {
+                this.classifiedSnapshot = snapshot;
+                this.classifiedSpans = snapshotSpans;
+            }
         }
 
         return snapshotSpans;
@@ -123,27 +167,50 @@ internal sealed class ViuClassifier : IClassifier
     {
         IReadOnlyList<ViuLexicalSpan> lexicalSpans =
             ViuLexicalClassifier.Classify(ViuSnapshotLines.Read(snapshot));
-        List<ClassificationSpan> snapshotSpans = new(lexicalSpans.Count);
+        IReadOnlyList<ViuSemanticClassification> semanticClassifications =
+            Array.Empty<ViuSemanticClassification>();
+        string? associatedDocumentIdentifier = Volatile.Read(ref this.documentIdentifier);
+        if (associatedDocumentIdentifier is not null)
+        {
+            string checksum = ViuDocumentTextChecksum.Compute(snapshot.GetText());
+            this.semanticClassificationState.TryGetClassifications(
+                associatedDocumentIdentifier,
+                checksum,
+                out semanticClassifications);
+        }
 
-        foreach (ViuLexicalSpan lexicalSpan in lexicalSpans)
+        IReadOnlyList<ViuResolvedClassificationSpan> resolvedSpans =
+            ViuClassificationMerge.Merge(lexicalSpans, semanticClassifications);
+        List<ClassificationSpan> snapshotSpans = new(resolvedSpans.Count);
+
+        foreach (ViuResolvedClassificationSpan resolvedSpan in resolvedSpans)
         {
             IClassificationType? classificationType =
-                this.classificationTypes[(int)lexicalSpan.ClassificationKind];
+                this.GetOrResolveClassificationType(resolvedSpan.ClassificationTypeName);
             if (classificationType is null)
             {
                 continue;
             }
 
-            ITextSnapshotLine line = snapshot.GetLineFromLineNumber(lexicalSpan.LineNumber);
-            int start = line.Start.Position + lexicalSpan.Start;
-            if (start + lexicalSpan.Length > snapshot.Length)
+            if (resolvedSpan.LineNumber < 0 ||
+                resolvedSpan.LineNumber >= snapshot.LineCount ||
+                resolvedSpan.Start < 0 ||
+                resolvedSpan.Length <= 0)
             {
                 continue;
             }
 
+            ITextSnapshotLine line = snapshot.GetLineFromLineNumber(resolvedSpan.LineNumber);
+            if (resolvedSpan.Start + resolvedSpan.Length > line.Length)
+            {
+                continue;
+            }
+
+            int start = line.Start.Position + resolvedSpan.Start;
+
             snapshotSpans.Add(
                 new ClassificationSpan(
-                    new SnapshotSpan(snapshot, start, lexicalSpan.Length),
+                    new SnapshotSpan(snapshot, start, resolvedSpan.Length),
                     classificationType));
         }
 
@@ -160,49 +227,92 @@ internal sealed class ViuClassifier : IClassifier
     /// present in any installation with a managed-language workload but are not part of the core
     /// editor, and Viu templates must still color without one.
     /// </remarks>
-    private static IClassificationType?[] ResolveClassificationTypes(
-        IClassificationTypeRegistryService classificationTypeRegistry)
+    private void PrimeLexicalClassificationTypes()
     {
         ViuClassificationKind[] classificationKinds =
             (ViuClassificationKind[])Enum.GetValues(typeof(ViuClassificationKind));
-
-        int highestKindValue = 0;
         foreach (ViuClassificationKind classificationKind in classificationKinds)
         {
-            if ((int)classificationKind > highestKindValue)
-            {
-                highestKindValue = (int)classificationKind;
-            }
-        }
-
-        IClassificationType?[] resolved = new IClassificationType?[highestKindValue + 1];
-        foreach (ViuClassificationKind classificationKind in classificationKinds)
-        {
-            resolved[(int)classificationKind] = ResolveClassificationType(
-                classificationTypeRegistry,
+            this.GetOrResolveClassificationType(
                 ViuClassificationTypeNames.GetClassificationTypeName(classificationKind));
         }
-
-        return resolved;
     }
 
-    private static IClassificationType? ResolveClassificationType(
-        IClassificationTypeRegistryService classificationTypeRegistry,
-        string classificationTypeName)
+    private IClassificationType? GetOrResolveClassificationType(string classificationTypeName)
     {
-        string? candidateName = classificationTypeName;
-        while (candidateName is not null)
+        lock (this.classificationTypeLock)
         {
-            IClassificationType? classificationType =
-                classificationTypeRegistry.GetClassificationType(candidateName);
-            if (classificationType is not null)
+            if (this.classificationTypes.TryGetValue(classificationTypeName, out var cached))
             {
-                return classificationType;
+                return cached;
             }
 
-            candidateName = ViuClassificationTypeNames.GetFallbackClassificationTypeName(candidateName);
+            string? candidateName = classificationTypeName;
+            while (candidateName is not null)
+            {
+                IClassificationType? classificationType =
+                    this.classificationTypeRegistry.GetClassificationType(candidateName);
+                if (classificationType is not null)
+                {
+                    this.classificationTypes.Add(classificationTypeName, classificationType);
+                    return classificationType;
+                }
+
+                candidateName =
+                    ViuClassificationTypeNames.GetFallbackClassificationTypeName(candidateName);
+            }
+
+            this.classificationTypes.Add(classificationTypeName, null);
+            return null;
+        }
+    }
+
+    private void InvalidateClassificationCache()
+    {
+        lock (this.classificationLock)
+        {
+            this.classificationGeneration++;
+            this.classifiedSnapshot = null;
+            this.classifiedSpans = null;
+        }
+    }
+
+    private void EnsureDocumentIdentifier()
+    {
+        ITextDocument? associatedDocument = Volatile.Read(ref this.textDocument);
+        if (associatedDocument is null)
+        {
+            if (!this.textDocumentFactory.TryGetTextDocument(
+                    this.textBuffer,
+                    out ITextDocument discoveredDocument))
+            {
+                return;
+            }
+
+            associatedDocument = Interlocked.CompareExchange(
+                    ref this.textDocument,
+                    discoveredDocument,
+                    null) ??
+                discoveredDocument;
         }
 
-        return null;
+        string filePath = associatedDocument.FilePath;
+        if (string.IsNullOrWhiteSpace(filePath) ||
+            string.Equals(
+                Volatile.Read(ref this.documentIdentifier),
+                filePath,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string? previous = Interlocked.Exchange(ref this.documentIdentifier, filePath);
+        if (string.Equals(previous, filePath, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        this.semanticClassificationState.Subscribe(filePath, this);
+        this.InvalidateClassificationCache();
     }
 }

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifierProvider.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Classification/ViuClassifierProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Assimalign.Viu.VisualStudio;
 
 /// <summary>
-/// Supplies the lexical classifier for buffers carrying the <c>viu</c> content type.
+/// Supplies the lexical-plus-semantic classifier for buffers carrying the <c>viu</c> content type.
 /// </summary>
 /// <remarks>
 /// One classifier per buffer, held in the buffer's own property collection so it lives and dies with
@@ -18,17 +18,30 @@ namespace Assimalign.Viu.VisualStudio;
 internal sealed class ViuClassifierProvider : IClassifierProvider
 {
     private readonly IClassificationTypeRegistryService classificationTypeRegistry;
+    private readonly ITextDocumentFactoryService textDocumentFactory;
 
     /// <summary>
     /// Initializes the provider with the registry the classifier resolves classification types from.
     /// </summary>
     /// <param name="classificationTypeRegistry">The editor's classification type registry.</param>
+    /// <param name="textDocumentFactory">
+    /// The document service used only to associate the buffer with the URI published by the server.
+    /// </param>
     [ImportingConstructor]
-    public ViuClassifierProvider(IClassificationTypeRegistryService classificationTypeRegistry) =>
+    public ViuClassifierProvider(
+        IClassificationTypeRegistryService classificationTypeRegistry,
+        ITextDocumentFactoryService textDocumentFactory)
+    {
         this.classificationTypeRegistry = classificationTypeRegistry;
+        this.textDocumentFactory = textDocumentFactory;
+    }
 
     /// <inheritdoc />
     public IClassifier GetClassifier(ITextBuffer textBuffer) =>
         textBuffer.Properties.GetOrCreateSingletonProperty(
-            () => new ViuClassifier(textBuffer, this.classificationTypeRegistry));
+            () => new ViuClassifier(
+                textBuffer,
+                this.classificationTypeRegistry,
+                ViuSemanticClassificationState.Shared,
+                this.textDocumentFactory));
 }

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/IViuSemanticClassificationListener.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/IViuSemanticClassificationListener.cs
@@ -1,0 +1,8 @@
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>Receives weakly held semantic-classification state changes for one editor buffer.</summary>
+internal interface IViuSemanticClassificationListener
+{
+    /// <summary>Invalidates the buffer after its semantic classification publication changes.</summary>
+    void OnSemanticClassificationsChanged(string documentIdentifier);
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuClassificationMerge.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuClassificationMerge.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Overlays exact server classifications on the lexical fallback without producing overlapping
+/// editor spans. Only lexical tokens intersecting an exact semantic span are replaced.
+/// </summary>
+internal static class ViuClassificationMerge
+{
+    /// <summary>Merges lexical and semantic spans in authored document order.</summary>
+    internal static IReadOnlyList<ViuResolvedClassificationSpan> Merge(
+        IReadOnlyList<ViuLexicalSpan> lexicalSpans,
+        IReadOnlyList<ViuSemanticClassification> semanticClassifications)
+    {
+        if (lexicalSpans is null)
+        {
+            throw new ArgumentNullException(nameof(lexicalSpans));
+        }
+
+        if (semanticClassifications is null)
+        {
+            throw new ArgumentNullException(nameof(semanticClassifications));
+        }
+
+        var semanticByLine = new Dictionary<int, List<ViuSemanticClassification>>();
+        var merged = new List<ViuResolvedClassificationSpan>(
+            lexicalSpans.Count + semanticClassifications.Count);
+        foreach (var semantic in semanticClassifications)
+        {
+            if (!semantic.IsValid)
+            {
+                continue;
+            }
+
+            if (!semanticByLine.TryGetValue(semantic.StartLine, out var lineClassifications))
+            {
+                lineClassifications = [];
+                semanticByLine.Add(semantic.StartLine, lineClassifications);
+            }
+
+            lineClassifications.Add(semantic);
+            merged.Add(
+                new ViuResolvedClassificationSpan(
+                    semantic.StartLine,
+                    semantic.StartCharacter,
+                    semantic.EndCharacter - semantic.StartCharacter,
+                    semantic.ClassificationTypeName));
+        }
+
+        foreach (var lexical in lexicalSpans)
+        {
+            if (lexical.Length <= 0 ||
+                IntersectsSemanticSpan(lexical, semanticByLine))
+            {
+                continue;
+            }
+
+            merged.Add(
+                new ViuResolvedClassificationSpan(
+                    lexical.LineNumber,
+                    lexical.Start,
+                    lexical.Length,
+                    ViuClassificationTypeNames.GetClassificationTypeName(
+                        lexical.ClassificationKind)));
+        }
+
+        merged.Sort(
+            static (left, right) =>
+            {
+                var lineComparison = left.LineNumber.CompareTo(right.LineNumber);
+                return lineComparison != 0
+                    ? lineComparison
+                    : left.Start.CompareTo(right.Start);
+            });
+        return merged;
+    }
+
+    private static bool IntersectsSemanticSpan(
+        ViuLexicalSpan lexical,
+        IReadOnlyDictionary<int, List<ViuSemanticClassification>> semanticByLine)
+    {
+        if (!semanticByLine.TryGetValue(lexical.LineNumber, out var classifications))
+        {
+            return false;
+        }
+
+        var lexicalEnd = lexical.Start + lexical.Length;
+        foreach (var semantic in classifications)
+        {
+            if (lexical.Start < semantic.EndCharacter &&
+                semantic.StartCharacter < lexicalEnd)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionCandidateIdentity.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionCandidateIdentity.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Identifies one completion candidate using the fields preserved by Visual Studio's LSP adapter.
+/// </summary>
+internal readonly struct ViuCompletionCandidateIdentity :
+    IEquatable<ViuCompletionCandidateIdentity>
+{
+    /// <summary>Initializes a normalized completion candidate identity.</summary>
+    internal ViuCompletionCandidateIdentity(
+        string displayText,
+        string insertText,
+        string sortText,
+        string filterText)
+    {
+        this.DisplayText = displayText ?? throw new ArgumentNullException(nameof(displayText));
+        this.InsertText = insertText ?? throw new ArgumentNullException(nameof(insertText));
+        this.SortText = sortText ?? throw new ArgumentNullException(nameof(sortText));
+        this.FilterText = filterText ?? throw new ArgumentNullException(nameof(filterText));
+    }
+
+    /// <summary>Gets the candidate's displayed label.</summary>
+    internal string DisplayText { get; }
+
+    /// <summary>Gets the text committed by the candidate.</summary>
+    internal string InsertText { get; }
+
+    /// <summary>Gets the candidate's sorting identity.</summary>
+    internal string SortText { get; }
+
+    /// <summary>Gets the candidate's filtering identity.</summary>
+    internal string FilterText { get; }
+
+    /// <inheritdoc />
+    public bool Equals(ViuCompletionCandidateIdentity other) =>
+        string.Equals(this.DisplayText, other.DisplayText, StringComparison.Ordinal) &&
+        string.Equals(this.InsertText, other.InsertText, StringComparison.Ordinal) &&
+        string.Equals(this.SortText, other.SortText, StringComparison.Ordinal) &&
+        string.Equals(this.FilterText, other.FilterText, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? value) =>
+        value is ViuCompletionCandidateIdentity other && this.Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        int hash = StringComparer.Ordinal.GetHashCode(this.DisplayText);
+        hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(this.InsertText);
+        hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(this.SortText);
+        return (hash * 397) ^ StringComparer.Ordinal.GetHashCode(this.FilterText);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColor.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColor.cs
@@ -1,0 +1,489 @@
+using System;
+using System.Globalization;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Represents the device-sRGB color used to draw one completion swatch.
+/// </summary>
+internal readonly struct ViuCompletionColor : IEquatable<ViuCompletionColor>
+{
+    private const double OklchPercentageChromaScale = 0.4;
+
+    /// <summary>Initializes a color from its eight-bit channels.</summary>
+    internal ViuCompletionColor(byte red, byte green, byte blue, byte alpha)
+    {
+        this.Red = red;
+        this.Green = green;
+        this.Blue = blue;
+        this.Alpha = alpha;
+    }
+
+    /// <summary>Gets the red channel.</summary>
+    internal byte Red { get; }
+
+    /// <summary>Gets the green channel.</summary>
+    internal byte Green { get; }
+
+    /// <summary>Gets the blue channel.</summary>
+    internal byte Blue { get; }
+
+    /// <summary>Gets the alpha channel.</summary>
+    internal byte Alpha { get; }
+
+    /// <summary>
+    /// Parses the concrete CSS color value transported in a completion payload.
+    /// </summary>
+    internal static bool TryParse(string? value, out ViuCompletionColor color)
+    {
+        color = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string text = value!.Trim();
+        if (TryParseHex(text, out color) ||
+            TryParseRgb(text, out color) ||
+            TryParseHsl(text, out color) ||
+            TryParseOklch(text, out color))
+        {
+            return true;
+        }
+
+        switch (text.ToLowerInvariant())
+        {
+            case "black":
+                color = new ViuCompletionColor(0, 0, 0, 255);
+                return true;
+            case "white":
+                color = new ViuCompletionColor(255, 255, 255, 255);
+                return true;
+            case "red":
+                color = new ViuCompletionColor(255, 0, 0, 255);
+                return true;
+            case "green":
+                color = new ViuCompletionColor(0, 128, 0, 255);
+                return true;
+            case "blue":
+                color = new ViuCompletionColor(0, 0, 255, 255);
+                return true;
+            case "rebeccapurple":
+                color = new ViuCompletionColor(102, 51, 153, 255);
+                return true;
+            case "transparent":
+                color = new ViuCompletionColor(0, 0, 0, 0);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Equals(ViuCompletionColor other) =>
+        this.Red == other.Red &&
+        this.Green == other.Green &&
+        this.Blue == other.Blue &&
+        this.Alpha == other.Alpha;
+
+    /// <inheritdoc />
+    public override bool Equals(object? value) =>
+        value is ViuCompletionColor other && this.Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        (((this.Red * 397) ^ this.Green) * 397 ^ this.Blue) * 397 ^ this.Alpha;
+
+    private static bool TryParseHex(string text, out ViuCompletionColor color)
+    {
+        color = default;
+        if (text.Length < 4 || text[0] != '#')
+        {
+            return false;
+        }
+
+        string digits = text.Substring(1);
+        byte red;
+        byte green;
+        byte blue;
+        byte alpha = 255;
+
+        if (digits.Length is 3 or 4)
+        {
+            if (!TryParseHexByte(new string(digits[0], 2), out red) ||
+                !TryParseHexByte(new string(digits[1], 2), out green) ||
+                !TryParseHexByte(new string(digits[2], 2), out blue) ||
+                (digits.Length == 4 &&
+                 !TryParseHexByte(new string(digits[3], 2), out alpha)))
+            {
+                return false;
+            }
+        }
+        else if (digits.Length is 6 or 8)
+        {
+            if (!TryParseHexByte(digits.Substring(0, 2), out red) ||
+                !TryParseHexByte(digits.Substring(2, 2), out green) ||
+                !TryParseHexByte(digits.Substring(4, 2), out blue) ||
+                (digits.Length == 8 && !TryParseHexByte(digits.Substring(6, 2), out alpha)))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        color = new ViuCompletionColor(red, green, blue, alpha);
+        return true;
+    }
+
+    private static bool TryParseRgb(string text, out ViuCompletionColor color)
+    {
+        color = default;
+        if (!TryGetFunctionBody(text, "rgb", out string body) &&
+            !TryGetFunctionBody(text, "rgba", out body))
+        {
+            return false;
+        }
+
+        SplitFunctionBody(body, out string componentsText, out string? alphaText);
+        string[] components = SplitComponents(componentsText);
+        if (components.Length == 4 && alphaText is null)
+        {
+            alphaText = components[3];
+        }
+
+        if (components.Length is not (3 or 4) ||
+            !TryParseRgbChannel(components[0], out byte red) ||
+            !TryParseRgbChannel(components[1], out byte green) ||
+            !TryParseRgbChannel(components[2], out byte blue) ||
+            !TryParseAlpha(alphaText, out byte alpha))
+        {
+            return false;
+        }
+
+        color = new ViuCompletionColor(red, green, blue, alpha);
+        return true;
+    }
+
+    private static bool TryParseHsl(string text, out ViuCompletionColor color)
+    {
+        color = default;
+        if (!TryGetFunctionBody(text, "hsl", out string body) &&
+            !TryGetFunctionBody(text, "hsla", out body))
+        {
+            return false;
+        }
+
+        SplitFunctionBody(body, out string componentsText, out string? alphaText);
+        string[] components = SplitComponents(componentsText);
+        if (components.Length == 4 && alphaText is null)
+        {
+            alphaText = components[3];
+        }
+
+        if (components.Length is not (3 or 4) ||
+            !TryParseHue(components[0], out double hue) ||
+            !TryParsePercentage(components[1], out double saturation) ||
+            !TryParsePercentage(components[2], out double lightness) ||
+            !TryParseAlpha(alphaText, out byte alpha))
+        {
+            return false;
+        }
+
+        double chroma = (1 - Math.Abs((2 * lightness) - 1)) * saturation;
+        double sector = hue / 60;
+        double intermediate = chroma * (1 - Math.Abs((sector % 2) - 1));
+        double redComponent;
+        double greenComponent;
+        double blueComponent;
+
+        if (sector < 1)
+        {
+            redComponent = chroma;
+            greenComponent = intermediate;
+            blueComponent = 0;
+        }
+        else if (sector < 2)
+        {
+            redComponent = intermediate;
+            greenComponent = chroma;
+            blueComponent = 0;
+        }
+        else if (sector < 3)
+        {
+            redComponent = 0;
+            greenComponent = chroma;
+            blueComponent = intermediate;
+        }
+        else if (sector < 4)
+        {
+            redComponent = 0;
+            greenComponent = intermediate;
+            blueComponent = chroma;
+        }
+        else if (sector < 5)
+        {
+            redComponent = intermediate;
+            greenComponent = 0;
+            blueComponent = chroma;
+        }
+        else
+        {
+            redComponent = chroma;
+            greenComponent = 0;
+            blueComponent = intermediate;
+        }
+
+        double match = lightness - (chroma / 2);
+        color = new ViuCompletionColor(
+            ToByte(redComponent + match),
+            ToByte(greenComponent + match),
+            ToByte(blueComponent + match),
+            alpha);
+        return true;
+    }
+
+    private static bool TryParseOklch(string text, out ViuCompletionColor color)
+    {
+        color = default;
+        if (!TryGetFunctionBody(text, "oklch", out string body))
+        {
+            return false;
+        }
+
+        SplitFunctionBody(body, out string componentsText, out string? alphaText);
+        string[] components = SplitComponents(componentsText);
+        if (components.Length != 3 ||
+            !TryParseLightness(components[0], out double lightness) ||
+            !TryParseChroma(components[1], out double chroma) ||
+            !TryParseHue(components[2], out double hue) ||
+            !TryParseAlpha(alphaText, out byte alpha))
+        {
+            return false;
+        }
+
+        double radians = hue * Math.PI / 180;
+        double a = chroma * Math.Cos(radians);
+        double b = chroma * Math.Sin(radians);
+
+        double lBase = lightness + (0.3963377774 * a) + (0.2158037573 * b);
+        double mBase = lightness - (0.1055613458 * a) - (0.0638541728 * b);
+        double sBase = lightness - (0.0894841775 * a) - (1.2914855480 * b);
+        double l = lBase * lBase * lBase;
+        double m = mBase * mBase * mBase;
+        double s = sBase * sBase * sBase;
+
+        double redLinear = (4.0767416621 * l) - (3.3077115913 * m) + (0.2309699292 * s);
+        double greenLinear = (-1.2684380046 * l) + (2.6097574011 * m) - (0.3413193965 * s);
+        double blueLinear = (-0.0041960863 * l) - (0.7034186147 * m) + (1.7076147010 * s);
+
+        color = new ViuCompletionColor(
+            ToByte(LinearToSrgb(redLinear)),
+            ToByte(LinearToSrgb(greenLinear)),
+            ToByte(LinearToSrgb(blueLinear)),
+            alpha);
+        return true;
+    }
+
+    private static bool TryGetFunctionBody(string text, string name, out string body)
+    {
+        body = string.Empty;
+        string prefix = name + "(";
+        if (!text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+            text[text.Length - 1] != ')')
+        {
+            return false;
+        }
+
+        body = text.Substring(prefix.Length, text.Length - prefix.Length - 1).Trim();
+        return body.Length > 0;
+    }
+
+    private static void SplitFunctionBody(
+        string body,
+        out string components,
+        out string? alpha)
+    {
+        int separator = body.IndexOf('/');
+        if (separator < 0)
+        {
+            components = body;
+            alpha = null;
+            return;
+        }
+
+        components = body.Substring(0, separator).Trim();
+        alpha = body.Substring(separator + 1).Trim();
+    }
+
+    private static string[] SplitComponents(string text) =>
+        text.Replace(',', ' ').Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries);
+
+    private static bool TryParseHexByte(string text, out byte value) =>
+        byte.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+
+    private static bool TryParseRgbChannel(string text, out byte value)
+    {
+        value = 0;
+        if (text.EndsWith("%", StringComparison.Ordinal))
+        {
+            if (!TryParseNumber(text.Substring(0, text.Length - 1), out double percentage))
+            {
+                return false;
+            }
+
+            value = ToByte(percentage / 100);
+            return true;
+        }
+
+        if (!TryParseNumber(text, out double channel))
+        {
+            return false;
+        }
+
+        value = ToByte(channel / 255);
+        return true;
+    }
+
+    private static bool TryParseAlpha(string? text, out byte alpha)
+    {
+        alpha = 255;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return true;
+        }
+
+        if (text!.EndsWith("%", StringComparison.Ordinal))
+        {
+            if (!TryParseNumber(text.Substring(0, text.Length - 1), out double percentage))
+            {
+                return false;
+            }
+
+            alpha = ToByte(percentage / 100);
+            return true;
+        }
+
+        if (!TryParseNumber(text, out double value))
+        {
+            return false;
+        }
+
+        alpha = ToByte(value);
+        return true;
+    }
+
+    private static bool TryParseLightness(string text, out double value)
+    {
+        if (text.EndsWith("%", StringComparison.Ordinal))
+        {
+            if (!TryParseNumber(text.Substring(0, text.Length - 1), out value))
+            {
+                return false;
+            }
+
+            value = Clamp(value / 100);
+            return true;
+        }
+
+        if (!TryParseNumber(text, out value))
+        {
+            return false;
+        }
+
+        value = Clamp(value);
+        return true;
+    }
+
+    private static bool TryParseChroma(string text, out double value)
+    {
+        if (text.EndsWith("%", StringComparison.Ordinal))
+        {
+            if (!TryParseNumber(text.Substring(0, text.Length - 1), out value))
+            {
+                return false;
+            }
+
+            value = Math.Max(0, value / 100 * OklchPercentageChromaScale);
+            return true;
+        }
+
+        if (!TryParseNumber(text, out value))
+        {
+            return false;
+        }
+
+        value = Math.Max(0, value);
+        return true;
+    }
+
+    private static bool TryParseHue(string text, out double degrees)
+    {
+        double multiplier = 1;
+        string number = text;
+        if (text.EndsWith("deg", StringComparison.OrdinalIgnoreCase))
+        {
+            number = text.Substring(0, text.Length - 3);
+        }
+        else if (text.EndsWith("grad", StringComparison.OrdinalIgnoreCase))
+        {
+            number = text.Substring(0, text.Length - 4);
+            multiplier = 0.9;
+        }
+        else if (text.EndsWith("rad", StringComparison.OrdinalIgnoreCase))
+        {
+            number = text.Substring(0, text.Length - 3);
+            multiplier = 180 / Math.PI;
+        }
+        else if (text.EndsWith("turn", StringComparison.OrdinalIgnoreCase))
+        {
+            number = text.Substring(0, text.Length - 4);
+            multiplier = 360;
+        }
+
+        if (!TryParseNumber(number, out degrees))
+        {
+            return false;
+        }
+
+        degrees = ((degrees * multiplier) % 360 + 360) % 360;
+        return true;
+    }
+
+    private static bool TryParsePercentage(string text, out double value)
+    {
+        value = 0;
+        if (!text.EndsWith("%", StringComparison.Ordinal) ||
+            !TryParseNumber(text.Substring(0, text.Length - 1), out double percentage))
+        {
+            return false;
+        }
+
+        value = Clamp(percentage / 100);
+        return true;
+    }
+
+    private static bool TryParseNumber(string text, out double value) =>
+        double.TryParse(
+            text,
+            NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint |
+                NumberStyles.AllowExponent,
+            CultureInfo.InvariantCulture,
+            out value) &&
+        !double.IsNaN(value) &&
+        !double.IsInfinity(value);
+
+    private static double LinearToSrgb(double value) =>
+        value <= 0.0031308
+            ? 12.92 * value
+            : (1.055 * Math.Pow(value, 1 / 2.4)) - 0.055;
+
+    private static byte ToByte(double value) =>
+        (byte)Math.Round(Clamp(value) * 255, MidpointRounding.AwayFromZero);
+
+    private static double Clamp(double value) => Math.Max(0, Math.Min(1, value));
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorImageCatalog.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorImageCatalog.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Registers frozen WPF swatches with Visual Studio's image service and retains their handles.
+/// </summary>
+internal sealed class ViuCompletionColorImageCatalog
+{
+    private const int ImageSize = 16;
+
+    private readonly object gate = new();
+    private readonly IVsManagedImageService? imageService;
+    private readonly Dictionary<string, RegisteredImage> images = new(StringComparer.Ordinal);
+
+    /// <summary>Initializes a catalog over the host image service.</summary>
+    internal ViuCompletionColorImageCatalog(IVsManagedImageService? imageService) =>
+        this.imageService = imageService;
+
+    /// <summary>Gets or registers the image for a concrete completion color.</summary>
+    internal ImageElement? GetOrCreate(ViuCompletionColorPresentation presentation)
+    {
+        if (this.imageService is null)
+        {
+            return null;
+        }
+
+        lock (this.gate)
+        {
+            if (this.images.TryGetValue(presentation.CssValue, out RegisteredImage? registered))
+            {
+                return registered.Element;
+            }
+
+            BitmapSource image = CreateImage(presentation.Color);
+            IImageHandle handle = this.imageService.AddCustomImage(image, canTheme: false);
+            ImageMoniker moniker = handle.Moniker;
+            var element = new ImageElement(
+                new ImageId(moniker.Guid, moniker.Id),
+                "Color " + presentation.CssValue);
+            registered = new RegisteredImage(handle, element);
+            this.images.Add(presentation.CssValue, registered);
+            return element;
+        }
+    }
+
+    private static BitmapSource CreateImage(ViuCompletionColor color)
+    {
+        int stride = ImageSize * 4;
+        var pixels = new byte[stride * ImageSize];
+        for (var y = 0; y < ImageSize; y++)
+        {
+            for (var x = 0; x < ImageSize; x++)
+            {
+                bool border = x == 0 || y == 0 || x == ImageSize - 1 || y == ImageSize - 1;
+                int offset = (y * stride) + (x * 4);
+                if (border)
+                {
+                    pixels[offset] = 96;
+                    pixels[offset + 1] = 96;
+                    pixels[offset + 2] = 96;
+                    pixels[offset + 3] = 255;
+                }
+                else
+                {
+                    pixels[offset] = color.Blue;
+                    pixels[offset + 1] = color.Green;
+                    pixels[offset + 2] = color.Red;
+                    pixels[offset + 3] = color.Alpha;
+                }
+            }
+        }
+
+        BitmapSource image = BitmapSource.Create(
+            ImageSize,
+            ImageSize,
+            96,
+            96,
+            PixelFormats.Bgra32,
+            palette: null,
+            pixels,
+            stride);
+        image.Freeze();
+        return image;
+    }
+
+    private sealed class RegisteredImage
+    {
+        // The handle is deliberately retained: Visual Studio documents it as the lifetime token for
+        // the custom image registered under Element.ImageId.
+        internal RegisteredImage(IImageHandle handle, ImageElement element)
+        {
+            this.Handle = handle;
+            this.Element = element;
+        }
+
+        internal IImageHandle Handle { get; }
+
+        internal ImageElement Element { get; }
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorMiddleLayer.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorMiddleLayer.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.LanguageServer.Client;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Captures the opaque Viu color payload after the server computes a completion response.
+/// </summary>
+internal sealed class ViuCompletionColorMiddleLayer :
+    ILanguageClientMiddleLayer2<JsonDocument>
+{
+    /// <summary>The standard Language Server Protocol completion request method.</summary>
+    internal const string CompletionMethodName = "textDocument/completion";
+
+    private readonly ViuCompletionColorState state;
+
+    /// <summary>Initializes the middle layer over the process-wide completion-color state.</summary>
+    internal ViuCompletionColorMiddleLayer(ViuCompletionColorState state) =>
+        this.state = state ?? throw new ArgumentNullException(nameof(state));
+
+    /// <inheritdoc />
+    public bool CanHandle(string methodName) =>
+        string.Equals(methodName, CompletionMethodName, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public async Task<JsonDocument?> HandleRequestAsync(
+        string methodName,
+        JsonDocument methodParameters,
+        Func<JsonDocument, Task<JsonDocument?>> sendRequest)
+    {
+        JsonDocument? response = await sendRequest(methodParameters).ConfigureAwait(false);
+        if (response is not null &&
+            CanHandle(methodName) &&
+            ViuCompletionColorPublication.TryParse(
+                methodParameters.RootElement,
+                response.RootElement,
+                out var publication))
+        {
+            this.state.Publish(publication!);
+        }
+
+        return response;
+    }
+
+    /// <inheritdoc />
+    public Task HandleNotificationAsync(
+        string methodName,
+        JsonDocument methodParameters,
+        Func<JsonDocument, Task> sendNotification)
+        => sendNotification(methodParameters);
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorPresentation.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorPresentation.cs
@@ -1,0 +1,20 @@
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Carries the authored CSS value and its parsed swatch color together.
+/// </summary>
+internal sealed class ViuCompletionColorPresentation
+{
+    /// <summary>Initializes a candidate-specific swatch presentation.</summary>
+    internal ViuCompletionColorPresentation(string cssValue, ViuCompletionColor color)
+    {
+        this.CssValue = cssValue;
+        this.Color = color;
+    }
+
+    /// <summary>Gets the concrete CSS value transported by the language server.</summary>
+    internal string CssValue { get; }
+
+    /// <summary>Gets the device-sRGB color used for the Visual Studio image.</summary>
+    internal ViuCompletionColor Color { get; }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorPublication.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorPublication.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Represents the color payloads from one Language Server Protocol completion response.
+/// </summary>
+internal sealed class ViuCompletionColorPublication
+{
+    private readonly IReadOnlyDictionary<ViuCompletionCandidateIdentity, int> candidateCounts;
+
+    private ViuCompletionColorPublication(
+        string documentUri,
+        IReadOnlyList<ViuCompletionCandidateIdentity> candidates,
+        IReadOnlyDictionary<ViuCompletionCandidateIdentity, ViuCompletionColorPresentation>
+            presentations)
+    {
+        this.DocumentUri = documentUri;
+        this.Candidates = candidates;
+        this.Presentations = presentations;
+        this.candidateCounts = CountCandidates(candidates);
+    }
+
+    /// <summary>Gets the document URI from the completion request.</summary>
+    internal string DocumentUri { get; }
+
+    /// <summary>Gets every candidate identity from the same completion response.</summary>
+    internal IReadOnlyList<ViuCompletionCandidateIdentity> Candidates { get; }
+
+    /// <summary>Gets parsed color presentations keyed by complete candidate identity.</summary>
+    internal IReadOnlyDictionary<ViuCompletionCandidateIdentity, ViuCompletionColorPresentation>
+        Presentations { get; }
+
+    /// <summary>
+    /// Reads the request document and the result returned by <c>textDocument/completion</c>.
+    /// </summary>
+    internal static bool TryParse(
+        JsonElement methodParameters,
+        JsonElement response,
+        out ViuCompletionColorPublication? publication)
+    {
+        publication = null;
+        if (!TryGetDocumentUri(methodParameters, out string? documentUri))
+        {
+            return false;
+        }
+
+        var candidates = new List<ViuCompletionCandidateIdentity>();
+        var presentations =
+            new Dictionary<ViuCompletionCandidateIdentity, ViuCompletionColorPresentation>();
+        if (TryGetItems(response, out JsonElement items))
+        {
+            foreach (JsonElement item in items.EnumerateArray())
+            {
+                if (!TryGetCandidateIdentity(item, out ViuCompletionCandidateIdentity identity))
+                {
+                    return false;
+                }
+
+                candidates.Add(identity);
+                if (!item.TryGetProperty("data", out JsonElement dataElement) ||
+                    dataElement.ValueKind != JsonValueKind.Object ||
+                    !dataElement.TryGetProperty("colorValue", out JsonElement valueElement) ||
+                    valueElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                string? value = valueElement.GetString();
+                if (ViuCompletionColor.TryParse(value, out ViuCompletionColor color))
+                {
+                    presentations[identity] = new ViuCompletionColorPresentation(value!, color);
+                }
+            }
+        }
+
+        publication = new ViuCompletionColorPublication(documentUri!, candidates, presentations);
+        return true;
+    }
+
+    /// <summary>Determines whether a source group is exactly this response's candidate multiset.</summary>
+    internal bool Matches(IReadOnlyList<ViuCompletionCandidateIdentity> candidates)
+    {
+        if (candidates.Count != this.Candidates.Count)
+        {
+            return false;
+        }
+
+        IReadOnlyDictionary<ViuCompletionCandidateIdentity, int> counts =
+            CountCandidates(candidates);
+        if (counts.Count != this.candidateCounts.Count)
+        {
+            return false;
+        }
+
+        foreach (KeyValuePair<ViuCompletionCandidateIdentity, int> candidate in
+                 this.candidateCounts)
+        {
+            if (!counts.TryGetValue(candidate.Key, out int count) || count != candidate.Value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static IReadOnlyDictionary<ViuCompletionCandidateIdentity, int> CountCandidates(
+        IReadOnlyList<ViuCompletionCandidateIdentity> candidates)
+    {
+        var counts = new Dictionary<ViuCompletionCandidateIdentity, int>();
+        foreach (ViuCompletionCandidateIdentity candidate in candidates)
+        {
+            counts.TryGetValue(candidate, out int count);
+            counts[candidate] = count + 1;
+        }
+
+        return counts;
+    }
+
+    private static bool TryGetCandidateIdentity(
+        JsonElement item,
+        out ViuCompletionCandidateIdentity identity)
+    {
+        identity = default;
+        if (item.ValueKind != JsonValueKind.Object ||
+            !item.TryGetProperty("label", out JsonElement labelElement) ||
+            labelElement.ValueKind != JsonValueKind.String ||
+            string.IsNullOrEmpty(labelElement.GetString()))
+        {
+            return false;
+        }
+
+        string label = labelElement.GetString()!;
+        string insertText = GetString(item, "insertText") ?? label;
+        if (item.TryGetProperty("textEdit", out JsonElement textEdit) &&
+            textEdit.ValueKind == JsonValueKind.Object)
+        {
+            insertText = GetString(textEdit, "newText") ?? insertText;
+        }
+
+        identity = new ViuCompletionCandidateIdentity(
+            label,
+            insertText,
+            GetString(item, "sortText") ?? label,
+            GetString(item, "filterText") ?? label);
+        return true;
+    }
+
+    private static string? GetString(JsonElement value, string propertyName) =>
+        value.TryGetProperty(propertyName, out JsonElement property) &&
+        property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static bool TryGetDocumentUri(JsonElement methodParameters, out string? documentUri)
+    {
+        documentUri = null;
+        return methodParameters.ValueKind == JsonValueKind.Object &&
+            methodParameters.TryGetProperty("textDocument", out JsonElement document) &&
+            document.ValueKind == JsonValueKind.Object &&
+            document.TryGetProperty("uri", out JsonElement uri) &&
+            uri.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(documentUri = uri.GetString());
+    }
+
+    private static bool TryGetItems(JsonElement response, out JsonElement items)
+    {
+        items = default;
+        if (response.ValueKind == JsonValueKind.Array)
+        {
+            items = response;
+            return true;
+        }
+
+        if (response.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (response.TryGetProperty("items", out items) &&
+            items.ValueKind == JsonValueKind.Array)
+        {
+            return true;
+        }
+
+        // Keeping this envelope form makes the parser independently testable with a raw JSON-RPC
+        // response as well as with the result-only JsonDocument supplied by Visual Studio's middle
+        // layer contract.
+        return response.TryGetProperty("result", out JsonElement result) &&
+            TryGetItems(result, out items);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorState.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionColorState.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Stores a bounded queue of color-bearing completion responses for each open document.
+/// </summary>
+internal sealed class ViuCompletionColorState
+{
+    private readonly object gate = new();
+    private const int MaximumPublicationsPerDocument = 8;
+
+    private readonly Dictionary<string, List<ViuCompletionColorPublication>> publicationsByDocument =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Gets the process-wide state shared by the client and completion adapter.</summary>
+    internal static ViuCompletionColorState Shared { get; } = new();
+
+    /// <summary>Queues one completed server response until its exact source list is presented.</summary>
+    internal void Publish(ViuCompletionColorPublication publication)
+    {
+        if (publication is null)
+        {
+            throw new ArgumentNullException(nameof(publication));
+        }
+
+        string key = NormalizeDocumentKey(publication.DocumentUri);
+        lock (this.gate)
+        {
+            if (!this.publicationsByDocument.TryGetValue(key, out var publications))
+            {
+                publications = new List<ViuCompletionColorPublication>();
+                this.publicationsByDocument.Add(key, publications);
+            }
+
+            publications.Add(publication);
+            if (publications.Count > MaximumPublicationsPerDocument)
+            {
+                publications.RemoveAt(0);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Consumes the newest response that exactly matches one and only one completion-source group.
+    /// </summary>
+    internal bool TryTakeMatchingPublication(
+        string documentPath,
+        IReadOnlyList<IReadOnlyList<ViuCompletionCandidateIdentity>> sourceGroups,
+        out int sourceGroupIndex,
+        out ViuCompletionColorPublication? publication)
+    {
+        sourceGroupIndex = -1;
+        publication = null;
+        if (string.IsNullOrWhiteSpace(documentPath) || sourceGroups.Count == 0)
+        {
+            return false;
+        }
+
+        string key = NormalizeDocumentKey(documentPath);
+        lock (this.gate)
+        {
+            if (!this.publicationsByDocument.TryGetValue(key, out var publications))
+            {
+                return false;
+            }
+
+            for (int publicationIndex = publications.Count - 1;
+                 publicationIndex >= 0;
+                 publicationIndex--)
+            {
+                ViuCompletionColorPublication candidate = publications[publicationIndex];
+                int matchingGroupIndex = -1;
+                int matchingGroupCount = 0;
+                for (var groupIndex = 0; groupIndex < sourceGroups.Count; groupIndex++)
+                {
+                    if (!candidate.Matches(sourceGroups[groupIndex]))
+                    {
+                        continue;
+                    }
+
+                    matchingGroupIndex = groupIndex;
+                    matchingGroupCount++;
+                }
+
+                if (matchingGroupCount == 0)
+                {
+                    continue;
+                }
+
+                publications.RemoveAt(publicationIndex);
+                if (publications.Count == 0)
+                {
+                    this.publicationsByDocument.Remove(key);
+                }
+
+                if (matchingGroupCount != 1)
+                {
+                    return false;
+                }
+
+                sourceGroupIndex = matchingGroupIndex;
+                publication = candidate;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>Clears response state when the language-server session is replaced.</summary>
+    internal void Clear()
+    {
+        lock (this.gate)
+        {
+            this.publicationsByDocument.Clear();
+        }
+    }
+
+    private static string NormalizeDocumentKey(string value)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+        {
+            return Path.GetFullPath(uri.LocalPath);
+        }
+
+        try
+        {
+            return Path.GetFullPath(value);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return value;
+        }
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionDocumentPath.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionDocumentPath.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Reads an editor document's current path without freezing its pre-Save-As identity.
+/// </summary>
+internal sealed class ViuCompletionDocumentPath
+{
+    private readonly Func<string> getCurrentPath;
+
+    /// <summary>Initializes a path reader over a live editor document.</summary>
+    internal ViuCompletionDocumentPath(Func<string> getCurrentPath) =>
+        this.getCurrentPath = getCurrentPath ??
+            throw new ArgumentNullException(nameof(getCurrentPath));
+
+    /// <summary>Gets the document path at the time the completion list is presented.</summary>
+    internal string Current => this.getCurrentPath();
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionItemManager.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionItemManager.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Adornments;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Delegates filtering and sorting to Visual Studio and changes only candidate-specific color icons.
+/// </summary>
+internal sealed class ViuCompletionItemManager : IAsyncCompletionItemManager
+{
+    private readonly IAsyncCompletionItemManager inner;
+    private readonly ViuCompletionDocumentPath documentPath;
+    private readonly ViuCompletionColorState state;
+    private readonly ViuCompletionColorImageCatalog imageCatalog;
+
+    /// <summary>Initializes a presentation-only wrapper around the stock manager.</summary>
+    internal ViuCompletionItemManager(
+        IAsyncCompletionItemManager inner,
+        ViuCompletionDocumentPath documentPath,
+        ViuCompletionColorState state,
+        ViuCompletionColorImageCatalog imageCatalog)
+    {
+        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        this.documentPath = documentPath ?? throw new ArgumentNullException(nameof(documentPath));
+        this.state = state ?? throw new ArgumentNullException(nameof(state));
+        this.imageCatalog = imageCatalog ?? throw new ArgumentNullException(nameof(imageCatalog));
+    }
+
+    /// <inheritdoc />
+    public async Task<ImmutableArray<CompletionItem>> SortCompletionListAsync(
+        IAsyncCompletionSession session,
+        AsyncCompletionSessionInitialDataSnapshot data,
+        CancellationToken token)
+    {
+        ImmutableArray<CompletionItem> sorted =
+            await this.inner.SortCompletionListAsync(session, data, token).ConfigureAwait(false);
+        List<CompletionSourceGroup> sourceGroups = CreateSourceGroups(sorted);
+        var candidateGroups = new List<IReadOnlyList<ViuCompletionCandidateIdentity>>(
+            sourceGroups.Count);
+        foreach (CompletionSourceGroup sourceGroup in sourceGroups)
+        {
+            candidateGroups.Add(sourceGroup.Candidates);
+        }
+
+        if (!this.state.TryTakeMatchingPublication(
+                this.documentPath.Current,
+                candidateGroups,
+                out int sourceGroupIndex,
+                out var publication))
+        {
+            return sorted;
+        }
+
+        CompletionSourceGroup matchingGroup = sourceGroups[sourceGroupIndex];
+        var decorations = new List<CompletionDecoration>();
+
+        for (var index = 0; index < sorted.Length; index++)
+        {
+            CompletionItem item = sorted[index];
+            if (!ReferenceEquals(item.Source, matchingGroup.Source) ||
+                !publication!.Presentations.TryGetValue(
+                    CreateIdentity(item),
+                    out var presentation))
+            {
+                continue;
+            }
+
+            decorations.Add(new CompletionDecoration(index, item, presentation));
+        }
+
+        if (decorations.Count == 0)
+        {
+            return sorted;
+        }
+
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);
+        ImmutableArray<CompletionItem>.Builder? decorated = null;
+        foreach (CompletionDecoration decoration in decorations)
+        {
+            ImageElement? image = this.imageCatalog.GetOrCreate(decoration.Presentation);
+            if (image is null)
+            {
+                continue;
+            }
+
+            decorated ??= sorted.ToBuilder();
+            decorated[decoration.Index] = CloneWithImage(decoration.Item, image);
+        }
+
+        return decorated?.MoveToImmutable() ?? sorted;
+    }
+
+    /// <inheritdoc />
+    public Task<FilteredCompletionModel> UpdateCompletionListAsync(
+        IAsyncCompletionSession session,
+        AsyncCompletionSessionDataSnapshot data,
+        CancellationToken token)
+        => this.inner.UpdateCompletionListAsync(session, data, token);
+
+    private static List<CompletionSourceGroup> CreateSourceGroups(
+        ImmutableArray<CompletionItem> items)
+    {
+        var groups = new List<CompletionSourceGroup>();
+        foreach (CompletionItem item in items)
+        {
+            CompletionSourceGroup? group = null;
+            foreach (CompletionSourceGroup candidate in groups)
+            {
+                if (ReferenceEquals(candidate.Source, item.Source))
+                {
+                    group = candidate;
+                    break;
+                }
+            }
+
+            if (group is null)
+            {
+                group = new CompletionSourceGroup(item.Source);
+                groups.Add(group);
+            }
+
+            group.Candidates.Add(CreateIdentity(item));
+        }
+
+        return groups;
+    }
+
+    private static ViuCompletionCandidateIdentity CreateIdentity(CompletionItem item) =>
+        new(
+            item.DisplayText,
+            item.InsertText,
+            item.SortText,
+            item.FilterText);
+
+    private static CompletionItem CloneWithImage(CompletionItem item, ImageElement image)
+    {
+        var clone = new CompletionItem(
+            item.DisplayText,
+            item.Source,
+            image,
+            item.Filters,
+            item.Suffix,
+            item.InsertText,
+            item.SortText,
+            item.FilterText,
+            item.AutomationText,
+            item.AttributeIcons,
+            item.CommitCharacters,
+            item.ApplicableToSpan,
+            item.IsCommittedAsSnippet,
+            item.IsPreselected);
+
+        foreach (KeyValuePair<object, object> property in item.Properties.PropertyList)
+        {
+            clone.Properties.AddProperty(property.Key, property.Value);
+        }
+
+        return clone;
+    }
+
+    private sealed class CompletionDecoration
+    {
+        internal CompletionDecoration(
+            int index,
+            CompletionItem item,
+            ViuCompletionColorPresentation presentation)
+        {
+            this.Index = index;
+            this.Item = item;
+            this.Presentation = presentation;
+        }
+
+        internal int Index { get; }
+
+        internal CompletionItem Item { get; }
+
+        internal ViuCompletionColorPresentation Presentation { get; }
+    }
+
+    private sealed class CompletionSourceGroup
+    {
+        internal CompletionSourceGroup(IAsyncCompletionSource source) => this.Source = source;
+
+        internal IAsyncCompletionSource Source { get; }
+
+        internal List<ViuCompletionCandidateIdentity> Candidates { get; } = new();
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionItemManagerProvider.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuCompletionItemManagerProvider.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Installs the Viu swatch wrapper ahead of Visual Studio's default Async Completion item manager.
+/// </summary>
+[Export(typeof(IAsyncCompletionItemManagerProvider))]
+[Name(nameof(ViuCompletionItemManagerProvider))]
+[ContentType(ViuContentTypes.Viu)]
+[TextViewRole(PredefinedTextViewRoles.Editable)]
+[Order(Before = PredefinedCompletionNames.DefaultCompletionItemManager)]
+internal sealed class ViuCompletionItemManagerProvider : IAsyncCompletionItemManagerProvider
+{
+    private static readonly object ManagerPropertyKey = new();
+
+    private readonly ITextDocumentFactoryService documentFactory;
+    private readonly Lazy<IAsyncCompletionItemManagerProvider, IOrderable> defaultProvider;
+    private readonly ViuCompletionColorImageCatalog imageCatalog;
+
+    /// <summary>Initializes the provider from editor and shell services supplied by Visual Studio.</summary>
+    [ImportingConstructor]
+    internal ViuCompletionItemManagerProvider(
+        ITextDocumentFactoryService documentFactory,
+        [Import(typeof(SVsServiceProvider))]
+        IServiceProvider serviceProvider,
+        [ImportMany]
+        IEnumerable<Lazy<IAsyncCompletionItemManagerProvider, IOrderable>> providers)
+    {
+        this.documentFactory = documentFactory ??
+            throw new ArgumentNullException(nameof(documentFactory));
+        this.defaultProvider = providers?.FirstOrDefault(provider =>
+                string.Equals(
+                    provider.Metadata.Name,
+                    PredefinedCompletionNames.DefaultCompletionItemManager,
+                    StringComparison.Ordinal)) ??
+            throw new InvalidOperationException(
+                "Visual Studio's default Async Completion item manager is unavailable.");
+
+        var imageService = serviceProvider?.GetService(typeof(SVsImageService)) as
+            IVsManagedImageService;
+        this.imageCatalog = new ViuCompletionColorImageCatalog(imageService);
+    }
+
+    /// <inheritdoc />
+    public IAsyncCompletionItemManager GetOrCreate(ITextView textView)
+    {
+        if (textView is null)
+        {
+            throw new ArgumentNullException(nameof(textView));
+        }
+
+        return textView.Properties.GetOrCreateSingletonProperty<IAsyncCompletionItemManager>(
+            ManagerPropertyKey,
+            () =>
+            {
+                IAsyncCompletionItemManager inner =
+                    this.defaultProvider.Value.GetOrCreate(textView);
+                if (!this.documentFactory.TryGetTextDocument(
+                        textView.TextBuffer,
+                        out ITextDocument document))
+                {
+                    return inner;
+                }
+
+                return new ViuCompletionItemManager(
+                    inner,
+                    new ViuCompletionDocumentPath(() => document.FilePath),
+                    ViuCompletionColorState.Shared,
+                    this.imageCatalog);
+            });
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuDocumentTextChecksum.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuDocumentTextChecksum.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>Computes the server-compatible identity of one editor text snapshot.</summary>
+internal static class ViuDocumentTextChecksum
+{
+    /// <summary>Computes a base-64 SHA-256 checksum over the text's UTF-8 representation.</summary>
+    internal static string Compute(string text)
+    {
+        if (text is null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        using (var algorithm = SHA256.Create())
+        {
+            return Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(text)));
+        }
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuLanguageClientCustomMessageTarget.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuLanguageClientCustomMessageTarget.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text.Json;
+
+using StreamJsonRpc;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Exposes Viu's server-to-client semantic-classification notification to StreamJsonRpc.
+/// </summary>
+internal sealed class ViuLanguageClientCustomMessageTarget
+{
+    private readonly ViuSemanticClassificationReceiver semanticClassificationReceiver;
+
+    /// <summary>Initializes the target over the editor-free notification receiver.</summary>
+    internal ViuLanguageClientCustomMessageTarget(
+        ViuSemanticClassificationReceiver semanticClassificationReceiver)
+    {
+        this.semanticClassificationReceiver = semanticClassificationReceiver ??
+            throw new ArgumentNullException(nameof(semanticClassificationReceiver));
+    }
+
+    /// <summary>Receives one exact semantic-classification publication from the language server.</summary>
+    /// <param name="parameters">The single JSON object carried by the custom notification.</param>
+    [JsonRpcMethod(
+        ViuSemanticClassificationReceiver.PublicationMethodName,
+        UseSingleObjectParameterDeserialization = true)]
+    public void PublishSemanticClassifications(JsonElement parameters) =>
+        this.semanticClassificationReceiver.Receive(parameters);
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuResolvedClassificationSpan.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuResolvedClassificationSpan.cs
@@ -1,0 +1,8 @@
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>One editor-free span paired with its final Visual Studio classification-type name.</summary>
+internal readonly record struct ViuResolvedClassificationSpan(
+    int LineNumber,
+    int Start,
+    int Length,
+    string ClassificationTypeName);

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassification.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassification.cs
@@ -1,0 +1,18 @@
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>One exact C# classification at an authored document range.</summary>
+internal readonly record struct ViuSemanticClassification(
+    int StartLine,
+    int StartCharacter,
+    int EndLine,
+    int EndCharacter,
+    string ClassificationTypeName)
+{
+    /// <summary>Gets whether the range is a non-empty single-line editor span.</summary>
+    internal bool IsValid =>
+        StartLine >= 0 &&
+        StartCharacter >= 0 &&
+        EndLine == StartLine &&
+        EndCharacter > StartCharacter &&
+        !string.IsNullOrWhiteSpace(ClassificationTypeName);
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationPublication.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationPublication.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// The editor-free representation of one custom semantic-classification notification.
+/// </summary>
+internal sealed record ViuSemanticClassificationPublication(
+    string DocumentIdentifier,
+    int? Version,
+    string? TextChecksum,
+    bool IsClosed,
+    IReadOnlyList<ViuSemanticClassification> Classifications)
+{
+    /// <summary>Parses the server's versioned publication without retaining the JSON document.</summary>
+    internal static bool TryParse(
+        JsonElement parameters,
+        out ViuSemanticClassificationPublication? publication)
+    {
+        publication = null;
+        if (parameters.ValueKind != JsonValueKind.Object ||
+            !TryGetString(parameters, "uri", out var documentIdentifier) ||
+            !TryGetBoolean(parameters, "isClosed", out var isClosed) ||
+            !parameters.TryGetProperty("classifications", out var classificationsElement) ||
+            classificationsElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        int? version = null;
+        if (parameters.TryGetProperty("version", out var versionElement) &&
+            versionElement.ValueKind != JsonValueKind.Null)
+        {
+            if (versionElement.ValueKind != JsonValueKind.Number ||
+                !versionElement.TryGetInt32(out var parsedVersion))
+            {
+                return false;
+            }
+
+            version = parsedVersion;
+        }
+
+        string? textChecksum = null;
+        if (parameters.TryGetProperty("textChecksum", out var checksumElement) &&
+            checksumElement.ValueKind != JsonValueKind.Null)
+        {
+            if (checksumElement.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(checksumElement.GetString()))
+            {
+                return false;
+            }
+
+            textChecksum = checksumElement.GetString();
+        }
+
+        if (!isClosed && textChecksum is null)
+        {
+            return false;
+        }
+
+        var classifications = new List<ViuSemanticClassification>();
+        foreach (var classificationElement in classificationsElement.EnumerateArray())
+        {
+            if (!TryParseClassification(classificationElement, out var classification))
+            {
+                return false;
+            }
+
+            classifications.Add(classification);
+        }
+
+        publication = new ViuSemanticClassificationPublication(
+            documentIdentifier,
+            version,
+            textChecksum,
+            isClosed,
+            classifications.ToArray());
+        return true;
+    }
+
+    private static bool TryParseClassification(
+        JsonElement element,
+        out ViuSemanticClassification classification)
+    {
+        classification = default;
+        if (element.ValueKind != JsonValueKind.Object ||
+            !TryGetString(element, "classificationTypeName", out var classificationTypeName) ||
+            !element.TryGetProperty("range", out var range) ||
+            range.ValueKind != JsonValueKind.Object ||
+            !range.TryGetProperty("start", out var start) ||
+            !range.TryGetProperty("end", out var end) ||
+            !TryGetPosition(start, out var startLine, out var startCharacter) ||
+            !TryGetPosition(end, out var endLine, out var endCharacter))
+        {
+            return false;
+        }
+
+        classification = new ViuSemanticClassification(
+            startLine,
+            startCharacter,
+            endLine,
+            endCharacter,
+            classificationTypeName);
+        return classification.IsValid;
+    }
+
+    private static bool TryGetPosition(JsonElement element, out int line, out int character)
+    {
+        line = -1;
+        character = -1;
+        return element.ValueKind == JsonValueKind.Object &&
+            element.TryGetProperty("line", out var lineElement) &&
+            lineElement.ValueKind == JsonValueKind.Number &&
+            lineElement.TryGetInt32(out line) &&
+            element.TryGetProperty("character", out var characterElement) &&
+            characterElement.ValueKind == JsonValueKind.Number &&
+            characterElement.TryGetInt32(out character) &&
+            line >= 0 &&
+            character >= 0;
+    }
+
+    private static bool TryGetString(
+        JsonElement element,
+        string propertyName,
+        out string value)
+    {
+        value = string.Empty;
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(property.GetString()))
+        {
+            return false;
+        }
+
+        value = property.GetString()!;
+        return true;
+    }
+
+    private static bool TryGetBoolean(
+        JsonElement element,
+        string propertyName,
+        out bool value)
+    {
+        value = false;
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            return false;
+        }
+
+        value = property.GetBoolean();
+        return true;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationReceiver.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationReceiver.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.Json;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Validates and publishes one exact semantic-classification notification received from the Viu
+/// language server.
+/// </summary>
+internal sealed class ViuSemanticClassificationReceiver
+{
+    /// <summary>The custom notification method published by the Viu language server.</summary>
+    internal const string PublicationMethodName = "viu/publishSemanticClassifications";
+
+    private readonly ViuSemanticClassificationState state;
+
+    /// <summary>Initializes the receiver over the process-wide classification state.</summary>
+    internal ViuSemanticClassificationReceiver(ViuSemanticClassificationState state) =>
+        this.state = state ?? throw new ArgumentNullException(nameof(state));
+
+    /// <summary>Publishes a valid notification and rejects malformed input without changing state.</summary>
+    internal bool Receive(JsonElement parameters)
+    {
+        if (!ViuSemanticClassificationPublication.TryParse(parameters, out var publication))
+        {
+            return false;
+        }
+
+        return this.state.Publish(publication!);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationState.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/Internal/ViuSemanticClassificationState.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Assimalign.Viu.VisualStudio;
+
+/// <summary>
+/// Stores exact semantic classifications outside any Visual Studio type. Publications are immutable,
+/// checksum-gated by consumers, and listeners are weak so the process-wide bridge cannot retain a
+/// closed editor buffer. Thread-safe: language-client callbacks and editor classification requests
+/// may arrive on different threads.
+/// </summary>
+internal sealed class ViuSemanticClassificationState
+{
+    private readonly object synchronization = new();
+    private readonly Dictionary<string, ViuSemanticClassificationPublication> publications =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<WeakReference<IViuSemanticClassificationListener>>> listeners =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Gets the process-wide state shared by the language client and classifiers.</summary>
+    internal static ViuSemanticClassificationState Shared { get; } = new();
+
+    /// <summary>Weakly subscribes one listener to a document's publications.</summary>
+    internal void Subscribe(
+        string documentIdentifier,
+        IViuSemanticClassificationListener listener)
+    {
+        if (string.IsNullOrWhiteSpace(documentIdentifier))
+        {
+            throw new ArgumentException("A document identifier is required.", nameof(documentIdentifier));
+        }
+
+        if (listener is null)
+        {
+            throw new ArgumentNullException(nameof(listener));
+        }
+
+        var key = NormalizeDocumentIdentifier(documentIdentifier);
+        lock (synchronization)
+        {
+            if (!listeners.TryGetValue(key, out var documentListeners))
+            {
+                documentListeners = [];
+                listeners.Add(key, documentListeners);
+            }
+
+            for (var index = documentListeners.Count - 1; index >= 0; index--)
+            {
+                if (!documentListeners[index].TryGetTarget(out var existing))
+                {
+                    documentListeners.RemoveAt(index);
+                }
+                else if (ReferenceEquals(existing, listener))
+                {
+                    return;
+                }
+            }
+
+            documentListeners.Add(new WeakReference<IViuSemanticClassificationListener>(listener));
+        }
+    }
+
+    /// <summary>
+    /// Publishes one server snapshot, rejecting only a version older than the last accepted snapshot.
+    /// The checksum is evaluated by the classifier against its current text.
+    /// </summary>
+    internal bool Publish(ViuSemanticClassificationPublication publication)
+    {
+        if (publication is null)
+        {
+            throw new ArgumentNullException(nameof(publication));
+        }
+
+        var key = NormalizeDocumentIdentifier(publication.DocumentIdentifier);
+        IViuSemanticClassificationListener[] liveListeners;
+        lock (synchronization)
+        {
+            if (publications.TryGetValue(key, out var current) &&
+                current.Version is int currentVersion &&
+                publication.Version is int nextVersion &&
+                nextVersion < currentVersion)
+            {
+                return false;
+            }
+
+            if (publication.IsClosed)
+            {
+                publications.Remove(key);
+            }
+            else
+            {
+                publications[key] = publication;
+            }
+
+            liveListeners = CaptureLiveListeners(key);
+        }
+
+        foreach (var listener in liveListeners)
+        {
+            listener.OnSemanticClassificationsChanged(key);
+        }
+
+        return true;
+    }
+
+    /// <summary>Gets classifications only when they describe the supplied editor text checksum.</summary>
+    internal bool TryGetClassifications(
+        string documentIdentifier,
+        string textChecksum,
+        out IReadOnlyList<ViuSemanticClassification> classifications)
+    {
+        if (string.IsNullOrWhiteSpace(documentIdentifier))
+        {
+            throw new ArgumentException("A document identifier is required.", nameof(documentIdentifier));
+        }
+
+        if (string.IsNullOrWhiteSpace(textChecksum))
+        {
+            throw new ArgumentException("A text checksum is required.", nameof(textChecksum));
+        }
+
+        var key = NormalizeDocumentIdentifier(documentIdentifier);
+        lock (synchronization)
+        {
+            if (publications.TryGetValue(key, out var publication) &&
+                string.Equals(publication.TextChecksum, textChecksum, StringComparison.Ordinal))
+            {
+                classifications = publication.Classifications;
+                return true;
+            }
+        }
+
+        classifications = Array.Empty<ViuSemanticClassification>();
+        return false;
+    }
+
+    /// <summary>
+    /// Removes every server-authored snapshot and invalidates affected listeners. A new language-
+    /// server session must not inherit version ordering or classifications from the previous one.
+    /// </summary>
+    internal void ClearPublications()
+    {
+        Dictionary<string, IViuSemanticClassificationListener[]> notifications;
+        lock (synchronization)
+        {
+            notifications = new Dictionary<string, IViuSemanticClassificationListener[]>(
+                publications.Count,
+                StringComparer.OrdinalIgnoreCase);
+            foreach (string key in publications.Keys)
+            {
+                notifications.Add(key, CaptureLiveListeners(key));
+            }
+
+            publications.Clear();
+        }
+
+        foreach (KeyValuePair<string, IViuSemanticClassificationListener[]> notification in
+                 notifications)
+        {
+            foreach (IViuSemanticClassificationListener listener in notification.Value)
+            {
+                listener.OnSemanticClassificationsChanged(notification.Key);
+            }
+        }
+    }
+
+    private IViuSemanticClassificationListener[] CaptureLiveListeners(string key)
+    {
+        if (!listeners.TryGetValue(key, out var documentListeners))
+        {
+            return Array.Empty<IViuSemanticClassificationListener>();
+        }
+
+        var liveListeners = new List<IViuSemanticClassificationListener>(documentListeners.Count);
+        for (var index = documentListeners.Count - 1; index >= 0; index--)
+        {
+            if (documentListeners[index].TryGetTarget(out var listener))
+            {
+                liveListeners.Add(listener);
+            }
+            else
+            {
+                documentListeners.RemoveAt(index);
+            }
+        }
+
+        if (documentListeners.Count == 0)
+        {
+            listeners.Remove(key);
+        }
+
+        return liveListeners.ToArray();
+    }
+
+    private static string NormalizeDocumentIdentifier(string documentIdentifier)
+    {
+        if (Uri.TryCreate(documentIdentifier, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            return NormalizeFilePath(uri.LocalPath);
+        }
+
+        return Path.IsPathRooted(documentIdentifier)
+            ? NormalizeFilePath(documentIdentifier)
+            : documentIdentifier;
+    }
+
+    private static string NormalizeFilePath(string filePath)
+        => filePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuClassificationTypeNames.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuClassificationTypeNames.cs
@@ -89,6 +89,48 @@ internal static class ViuClassificationTypeNames
     /// <summary>Roslyn's method-name classification.</summary>
     public const string MethodName = "method name";
 
+    /// <summary>Roslyn's namespace-name classification.</summary>
+    public const string NamespaceName = "namespace name";
+
+    /// <summary>Roslyn's delegate-name classification.</summary>
+    public const string DelegateName = "delegate name";
+
+    /// <summary>Roslyn's enum-name classification.</summary>
+    public const string EnumName = "enum name";
+
+    /// <summary>Roslyn's interface-name classification.</summary>
+    public const string InterfaceName = "interface name";
+
+    /// <summary>Roslyn's struct-name classification.</summary>
+    public const string StructName = "struct name";
+
+    /// <summary>Roslyn's type-parameter-name classification.</summary>
+    public const string TypeParameterName = "type parameter name";
+
+    /// <summary>Roslyn's property-name classification.</summary>
+    public const string PropertyName = "property name";
+
+    /// <summary>Roslyn's field-name classification.</summary>
+    public const string FieldName = "field name";
+
+    /// <summary>Roslyn's constant-name classification.</summary>
+    public const string ConstantName = "constant name";
+
+    /// <summary>Roslyn's enum-member-name classification.</summary>
+    public const string EnumMemberName = "enum member name";
+
+    /// <summary>Roslyn's event-name classification.</summary>
+    public const string EventName = "event name";
+
+    /// <summary>Roslyn's parameter-name classification.</summary>
+    public const string ParameterName = "parameter name";
+
+    /// <summary>Roslyn's local-name classification.</summary>
+    public const string LocalName = "local name";
+
+    /// <summary>Roslyn's label-name classification.</summary>
+    public const string LabelName = "label name";
+
     /// <summary>
     /// Returns the name of the classification type that colors <paramref name="classificationKind"/>.
     /// </summary>
@@ -147,8 +189,8 @@ internal static class ViuClassificationTypeNames
     /// <returns>The next name to try, or <see langword="null"/>.</returns>
     /// <remarks>
     /// In process these names are all present once the managed-language workload is installed:
-    /// <see cref="Punctuation"/>, <see cref="ClassName"/>, and <see cref="MethodName"/> are contributed
-    /// by Roslyn's editor features rather than by the core editor. Resolving defensively keeps the
+    /// <see cref="Punctuation"/> and the semantic name constants are contributed by Roslyn's editor
+    /// features rather than by the core editor. Resolving defensively keeps the
     /// VSIX independent of any particular workload — a Visual Studio installation without C# still
     /// colors Viu templates, and script spans degrade to plain identifiers instead of losing their
     /// spans entirely. The Viu-owned names need no fallback: this extension registers them itself.
@@ -156,7 +198,21 @@ internal static class ViuClassificationTypeNames
     public static string? GetFallbackClassificationTypeName(string classificationTypeName)
     {
         if (string.Equals(classificationTypeName, MethodName, StringComparison.Ordinal) ||
-            string.Equals(classificationTypeName, ClassName, StringComparison.Ordinal))
+            string.Equals(classificationTypeName, ClassName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, NamespaceName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, DelegateName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, EnumName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, InterfaceName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, StructName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, TypeParameterName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, PropertyName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, FieldName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, ConstantName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, EnumMemberName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, EventName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, ParameterName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, LocalName, StringComparison.Ordinal) ||
+            string.Equals(classificationTypeName, LabelName, StringComparison.Ordinal))
         {
             return Identifier;
         }

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuLanguageClient.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/src/ViuLanguageClient.cs
@@ -13,6 +13,8 @@ using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 
+using StreamJsonRpc;
+
 namespace Assimalign.Viu.VisualStudio;
 
 /// <summary>
@@ -21,10 +23,11 @@ namespace Assimalign.Viu.VisualStudio;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The client is the whole of what runs in process for semantic features: it resolves the packaged
-/// executable, starts it, and hands Visual Studio the two streams. Every language feature — completion,
-/// hover, document symbols, folding, code actions, and the diagnostics that reach the Error List — is
-/// computed in the server process, so the Viu parsers and Roslyn never load into <c>devenv.exe</c>.
+/// The client and its thin classification adapter are the whole of what runs in process for semantic
+/// features: they start the packaged executable, hand Visual Studio the two streams, and translate
+/// server-authored ranges to classification-type names already registered by the editor. Every
+/// language feature and every classification decision is computed in the server process, so the Viu
+/// parsers and Roslyn never load into <c>devenv.exe</c>.
 /// </para>
 /// <para>
 /// Activation is scoped to the <c>viu</c> content type alone. <c>.vue</c> is deliberately out of scope
@@ -32,19 +35,32 @@ namespace Assimalign.Viu.VisualStudio;
 /// carries a Viu content type — see <see cref="ViuContentTypes"/>.
 /// </para>
 /// <para>
-/// The server's <c>initialize</c> handling reads client capabilities and nothing else — no
-/// initialization options, no workspace folders, no root URI, and no custom handshake — so
-/// <see cref="InitializationOptions"/> is empty by contract rather than by omission. Every project
-/// fact the server needs is derived from the document's own file path: the owning project is found by
-/// walking up from the document, and the restore artifacts are read from there. Nothing about that
-/// path changes when the client moves in process, so the connection needs no compensating message.
+/// The one initialization option opts this client into exact C# classification-name publications.
+/// It carries no project fact: every project input still comes from the document's own file path and
+/// restore artifacts. The adapter stores only authored ranges, text checksums, and editor-owned type
+/// names; the standard semantic-token response remains available to every other client.
 /// </para>
 /// </remarks>
 [Export(typeof(ILanguageClient))]
 [ContentType(ViuContentTypes.Viu)]
-internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
+internal sealed class ViuLanguageClient :
+    ILanguageClient,
+    ILanguageClientCustomMessage2,
+    IDisposable
 {
+    private static readonly IReadOnlyDictionary<string, bool> ServerInitializationOptions =
+        new Dictionary<string, bool>(StringComparer.Ordinal)
+        {
+            ["semanticClassificationNotifications"] = true,
+        };
+
     private readonly object serverProcessGate = new();
+    private readonly ViuCompletionColorMiddleLayer middleLayer =
+        new(ViuCompletionColorState.Shared);
+    private readonly ViuLanguageClientCustomMessageTarget customMessageTarget =
+        new(
+            new ViuSemanticClassificationReceiver(
+                ViuSemanticClassificationState.Shared));
     private Process? serverProcess;
     private string? activationFailureMessage;
     private bool disposed;
@@ -65,11 +81,16 @@ internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
     /// Gets the value sent as the <c>initialize</c> request's <c>initializationOptions</c>.
     /// </summary>
     /// <remarks>
-    /// Empty by contract: the server's <c>initialize</c> handler captures client capabilities and
-    /// discards the rest of the parameters, and every document is placed in its project by file path
-    /// at open time. Sending options here would be sending a message nothing reads.
+    /// The option enables Viu's exact-classification notification. It deliberately carries no
+    /// project or workspace state; documents are still placed in projects from their file paths.
     /// </remarks>
-    public object? InitializationOptions => null;
+    public object InitializationOptions => ServerInitializationOptions;
+
+    /// <inheritdoc />
+    public object MiddleLayer => this.middleLayer;
+
+    /// <inheritdoc />
+    public object CustomMessageTarget => this.customMessageTarget;
 
     /// <summary>
     /// Gets the glob patterns Visual Studio watches on the server's behalf.
@@ -118,6 +139,8 @@ internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
     {
         token.ThrowIfCancellationRequested();
         Volatile.Write(ref this.activationFailureMessage, null);
+        ViuSemanticClassificationState.Shared.ClearPublications();
+        ViuCompletionColorState.Shared.Clear();
 
         string extensionDirectory = ViuLanguageServerConfiguration.GetExtensionDirectory(
             typeof(ViuLanguageClient).Assembly.Location);
@@ -214,6 +237,9 @@ internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
     /// <inheritdoc />
     public Task OnServerInitializedAsync() => Task.CompletedTask;
 
+    /// <inheritdoc />
+    public Task AttachForCustomMessageAsync(JsonRpc rpc) => Task.CompletedTask;
+
     /// <summary>
     /// Composes the message shown when the server never reached an initialized state.
     /// </summary>
@@ -252,6 +278,9 @@ internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
             this.disposed = true;
             this.TerminateCurrentServerProcess();
         }
+
+        ViuSemanticClassificationState.Shared.ClearPublications();
+        ViuCompletionColorState.Shared.Clear();
     }
 
     private void OnServerProcessExited(object sender, EventArgs arguments)
@@ -277,6 +306,8 @@ internal sealed class ViuLanguageClient : ILanguageClient, IDisposable
         // Process.Close deliberately leaves the redirected reader and writer alone, so releasing the
         // handle here cannot pull the streams out from under a connection Visual Studio still holds.
         process.Dispose();
+        ViuSemanticClassificationState.Shared.ClearPublications();
+        ViuCompletionColorState.Shared.Clear();
     }
 
     // Callers hold serverProcessGate.

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/Assimalign.Viu.VisualStudio.Tests.csproj
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/Assimalign.Viu.VisualStudio.Tests.csproj
@@ -5,9 +5,9 @@
   VSSDK package on the .NET Framework line, and its VSIX build tasks cannot load under `dotnet`.
   A `dotnet test` project therefore cannot reference it - referencing it would drag this project onto
   net48 and drag the VSSDK targets into every `dotnet build` of the repository solution. The sources
-  linked below are exactly the ones that touch no Visual Studio type: the lexer, its value types, and
-  the kind-to-classification-type-name mapping. Everything Viu decides about a document is decided in
-  those files, so this covers the behavior that matters without the editor in the way.
+  linked below are exactly the ones that touch no Visual Studio type: the lexer and value types,
+  classification-name mapping, semantic JSON/state/merge contract, and completion-color
+  payload/presentation contract. This covers the behavior that matters without the editor in the way.
 
   The consequence to keep in mind: this project compiles the sources a SECOND time, on the
   repository TFM. The extension's own build is what pins them to the .NET Framework surface it
@@ -42,6 +42,39 @@
     <Compile Include="..\src\ViuLexicalSpan.cs" Link="ViuLexicalSpan.cs" />
     <Compile Include="..\src\ViuSectionKind.cs" Link="ViuSectionKind.cs" />
     <Compile Include="..\src\ViuLanguageServerConfiguration.cs" Link="ViuLanguageServerConfiguration.cs" />
+    <!-- Exact semantic classifications cross the process boundary as plain JSON, paths, checksums,
+         and classification-type names. These sources deliberately touch no editor API so the
+         transport/state/merge contract can be exercised without launching Visual Studio. -->
+    <Compile Include="..\src\Internal\IViuSemanticClassificationListener.cs"
+             Link="Internal\IViuSemanticClassificationListener.cs" />
+    <Compile Include="..\src\Internal\ViuClassificationMerge.cs"
+             Link="Internal\ViuClassificationMerge.cs" />
+    <Compile Include="..\src\Internal\ViuDocumentTextChecksum.cs"
+             Link="Internal\ViuDocumentTextChecksum.cs" />
+    <Compile Include="..\src\Internal\ViuResolvedClassificationSpan.cs"
+             Link="Internal\ViuResolvedClassificationSpan.cs" />
+    <Compile Include="..\src\Internal\ViuSemanticClassification.cs"
+             Link="Internal\ViuSemanticClassification.cs" />
+    <Compile Include="..\src\Internal\ViuSemanticClassificationPublication.cs"
+             Link="Internal\ViuSemanticClassificationPublication.cs" />
+    <Compile Include="..\src\Internal\ViuSemanticClassificationReceiver.cs"
+             Link="Internal\ViuSemanticClassificationReceiver.cs" />
+    <Compile Include="..\src\Internal\ViuSemanticClassificationState.cs"
+             Link="Internal\ViuSemanticClassificationState.cs" />
+    <!-- Completion colors likewise remain plain JSON, paths, CSS values, and RGBA channels until
+         the thin host adapter turns them into an ImageElement. -->
+    <Compile Include="..\src\Internal\ViuCompletionCandidateIdentity.cs"
+             Link="Internal\ViuCompletionCandidateIdentity.cs" />
+    <Compile Include="..\src\Internal\ViuCompletionColor.cs"
+             Link="Internal\ViuCompletionColor.cs" />
+    <Compile Include="..\src\Internal\ViuCompletionColorPresentation.cs"
+             Link="Internal\ViuCompletionColorPresentation.cs" />
+    <Compile Include="..\src\Internal\ViuCompletionColorPublication.cs"
+             Link="Internal\ViuCompletionColorPublication.cs" />
+    <Compile Include="..\src\Internal\ViuCompletionColorState.cs"
+             Link="Internal\ViuCompletionColorState.cs" />
+    <Compile Include="..\src\Internal\ViuCompletionDocumentPath.cs"
+             Link="Internal\ViuCompletionDocumentPath.cs" />
     <!-- The same frozen-path link the extension takes, so the void-element table the auto-closing
          tests exercise is the repository's authoritative one and not a test fixture. -->
     <Compile Include="$(ViuRepositoryDirectory)libraries\Assimalign.Viu.ServerRenderer\src\Internal\DomKnowledgeData.cs"

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuClassificationMergeTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuClassificationMergeTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.VisualStudio;
+
+namespace Assimalign.Viu.VisualStudio.Tests;
+
+/// <summary>
+/// Pins the non-overlapping merge between lexical fallback spans and exact server-authored C#
+/// classifications. [V01.01.12.07.11]
+/// </summary>
+public class ViuClassificationMergeTests
+{
+    [Fact]
+    public void Merge_SemanticIdentifiers_ReplaceOnlyIntersectingLexicalSpans()
+    {
+        IReadOnlyList<ViuLexicalSpan> lexical =
+        [
+            new ViuLexicalSpan(0, 0, 6, ViuClassificationKind.Keyword),
+            new ViuLexicalSpan(1, 4, 5, ViuClassificationKind.Type),
+            new ViuLexicalSpan(1, 12, 5, ViuClassificationKind.Identifier),
+        ];
+        IReadOnlyList<ViuSemanticClassification> semantic =
+        [
+            new ViuSemanticClassification(1, 4, 1, 9, "property name"),
+            new ViuSemanticClassification(1, 12, 1, 17, "local name"),
+        ];
+
+        IReadOnlyList<ViuResolvedClassificationSpan> merged =
+            ViuClassificationMerge.Merge(lexical, semantic);
+
+        merged.Count.ShouldBe(3);
+        merged[0].ShouldBe(new ViuResolvedClassificationSpan(0, 0, 6, "keyword"));
+        merged[1].ShouldBe(new ViuResolvedClassificationSpan(1, 4, 5, "property name"));
+        merged[2].ShouldBe(new ViuResolvedClassificationSpan(1, 12, 5, "local name"));
+        merged.Count(span => span.LineNumber == 1 && span.Start == 4).ShouldBe(1);
+        merged.Count(span => span.LineNumber == 1 && span.Start == 12).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Merge_NoSemanticSnapshot_ReturnsEveryLexicalFallbackSpan()
+    {
+        IReadOnlyList<ViuLexicalSpan> lexical =
+        [
+            new ViuLexicalSpan(2, 4, 5, ViuClassificationKind.Type),
+            new ViuLexicalSpan(2, 10, 4, ViuClassificationKind.Method),
+        ];
+
+        IReadOnlyList<ViuResolvedClassificationSpan> merged =
+            ViuClassificationMerge.Merge(lexical, []);
+
+        merged.ShouldBe(
+        [
+            new ViuResolvedClassificationSpan(2, 4, 5, "class name"),
+            new ViuResolvedClassificationSpan(2, 10, 4, "method name"),
+        ]);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuClassificationTypeNamesTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuClassificationTypeNamesTests.cs
@@ -112,12 +112,26 @@ public class ViuClassificationTypeNamesTests
     [Theory]
     [InlineData("method name", "identifier")]
     [InlineData("class name", "identifier")]
+    [InlineData("namespace name", "identifier")]
+    [InlineData("delegate name", "identifier")]
+    [InlineData("enum name", "identifier")]
+    [InlineData("interface name", "identifier")]
+    [InlineData("struct name", "identifier")]
+    [InlineData("type parameter name", "identifier")]
+    [InlineData("property name", "identifier")]
+    [InlineData("field name", "identifier")]
+    [InlineData("constant name", "identifier")]
+    [InlineData("enum member name", "identifier")]
+    [InlineData("event name", "identifier")]
+    [InlineData("parameter name", "identifier")]
+    [InlineData("local name", "identifier")]
+    [InlineData("label name", "identifier")]
     [InlineData("punctuation", "operator")]
     public void GetFallbackClassificationTypeName_RoslynContributedNames_DegradeToCoreEditorNames(
         string classificationTypeName,
         string expectedFallback)
     {
-        // These three are contributed by Roslyn's editor features rather than the core editor, so an
+        // These are contributed by Roslyn's editor features rather than the core editor, so an
         // installation without a managed-language workload must still color Viu documents.
         ViuClassificationTypeNames.GetFallbackClassificationTypeName(classificationTypeName)
             .ShouldBe(expectedFallback);

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuCompletionColorPresentationTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuCompletionColorPresentationTests.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.VisualStudio.Tests;
+
+/// <summary>
+/// Pins the editor-free portion of the #334 Visual Studio completion-swatch contract.
+/// </summary>
+public class ViuCompletionColorPresentationTests
+{
+    [Fact]
+    public void TryParse_DefaultUtilityOklch_ProducesDeviceSrgbSwatch()
+    {
+        bool parsed = ViuCompletionColor.TryParse(
+            "oklch(62.3% 0.214 259.815)",
+            out ViuCompletionColor color);
+
+        parsed.ShouldBeTrue();
+        color.Red.ShouldBe((byte)43);
+        color.Green.ShouldBe((byte)127);
+        color.Blue.ShouldBe((byte)255);
+        color.Alpha.ShouldBe((byte)255);
+    }
+
+    [Theory]
+    [InlineData("#123456", 18, 52, 86, 255)]
+    [InlineData("#3698", 51, 102, 153, 136)]
+    [InlineData("rgb(25% 50% 100% / 40%)", 64, 128, 255, 102)]
+    [InlineData("hsl(270 50% 40%)", 102, 51, 153, 255)]
+    [InlineData("rebeccapurple", 102, 51, 153, 255)]
+    public void TryParse_ConcreteCssColor_ProducesExpectedChannels(
+        string value,
+        byte red,
+        byte green,
+        byte blue,
+        byte alpha)
+    {
+        bool parsed = ViuCompletionColor.TryParse(value, out ViuCompletionColor color);
+
+        parsed.ShouldBeTrue();
+        color.Red.ShouldBe(red);
+        color.Green.ShouldBe(green);
+        color.Blue.ShouldBe(blue);
+        color.Alpha.ShouldBe(alpha);
+    }
+
+    [Theory]
+    [InlineData("var(--application-brand)")]
+    [InlineData("color-mix(in oklab, red 50%, blue)")]
+    [InlineData("")]
+    public void TryParse_NonConcreteCssValue_DoesNotInventSwatch(string value)
+    {
+        ViuCompletionColor.TryParse(value, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParse_CompletionResponse_CarriesCandidateSpecificColorAndSkipsOtherItems()
+    {
+        using JsonDocument parameters = JsonDocument.Parse(
+            """
+            {"textDocument":{"uri":"file:///C:/Source/Card.viu"}}
+            """);
+        using JsonDocument response = JsonDocument.Parse(
+            """
+            {
+              "items": [
+                {
+                  "label": "bg-blue-500",
+                  "kind": 16,
+                  "data": {"colorValue": "oklch(62.3% 0.214 259.815)"}
+                },
+                {
+                  "label": "block",
+                  "kind": 21,
+                  "data": {"label": "block"}
+                }
+              ]
+            }
+            """);
+
+        bool parsed = ViuCompletionColorPublication.TryParse(
+            parameters.RootElement,
+            response.RootElement,
+            out var publication);
+
+        parsed.ShouldBeTrue();
+        publication.ShouldNotBeNull();
+        publication!.DocumentUri.ShouldBe("file:///C:/Source/Card.viu");
+        publication.Presentations.Count.ShouldBe(1);
+        var identity = new ViuCompletionCandidateIdentity(
+            "bg-blue-500",
+            "bg-blue-500",
+            "bg-blue-500",
+            "bg-blue-500");
+        ViuCompletionColorPresentation presentation = publication.Presentations[identity];
+        presentation.CssValue.ShouldBe("oklch(62.3% 0.214 259.815)");
+        presentation.Color.ShouldBe(new ViuCompletionColor(43, 127, 255, 255));
+    }
+
+    [Fact]
+    public void Publish_FileUri_CanBeReadByVisualStudioDocumentPathAndCleared()
+    {
+        using JsonDocument parameters = JsonDocument.Parse(
+            """
+            {"textDocument":{"uri":"file:///C:/Source/Card.viu"}}
+            """);
+        using JsonDocument response = JsonDocument.Parse(
+            """
+            [{"label":"text-red-500","data":{"colorValue":"#ef4444"}}]
+            """);
+        ViuCompletionColorPublication.TryParse(
+            parameters.RootElement,
+            response.RootElement,
+            out var publication).ShouldBeTrue();
+        var state = new ViuCompletionColorState();
+
+        state.Publish(publication!);
+        var identity = new ViuCompletionCandidateIdentity(
+            "text-red-500",
+            "text-red-500",
+            "text-red-500",
+            "text-red-500");
+        IReadOnlyList<IReadOnlyList<ViuCompletionCandidateIdentity>> sourceGroups =
+            new[] { new[] { identity } };
+        bool found = state.TryTakeMatchingPublication(
+            @"C:\Source\Card.viu",
+            sourceGroups,
+            out int sourceGroupIndex,
+            out var matchedPublication);
+
+        found.ShouldBeTrue();
+        sourceGroupIndex.ShouldBe(0);
+        matchedPublication.ShouldNotBeNull();
+        matchedPublication!.Presentations[identity].Color.ShouldBe(
+            new ViuCompletionColor(239, 68, 68, 255));
+
+        state.Clear();
+        state.TryTakeMatchingPublication(
+            @"C:\Source\Card.viu",
+            sourceGroups,
+            out _,
+            out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryTakeMatchingPublication_ConcurrentResponses_MatchesCompleteListIdentity()
+    {
+        ViuCompletionColorPublication first = ParsePublication(
+            "bg-red-500",
+            "bg-red-500",
+            "#ef4444");
+        ViuCompletionColorPublication second = ParsePublication(
+            "bg-blue-500",
+            "bg-blue-500",
+            "#3b82f6");
+        var state = new ViuCompletionColorState();
+        state.Publish(first);
+        state.Publish(second);
+        IReadOnlyList<IReadOnlyList<ViuCompletionCandidateIdentity>> sourceGroups =
+            new[] { first.Candidates };
+
+        bool found = state.TryTakeMatchingPublication(
+            @"C:\Source\Card.viu",
+            sourceGroups,
+            out int sourceGroupIndex,
+            out var matchedPublication);
+
+        found.ShouldBeTrue();
+        sourceGroupIndex.ShouldBe(0);
+        matchedPublication.ShouldBeSameAs(first);
+    }
+
+    [Fact]
+    public void TryTakeMatchingPublication_SameLabelFromOtherSource_MatchesFullCandidateIdentity()
+    {
+        ViuCompletionColorPublication publication = ParsePublication(
+            "bg-blue-500",
+            "bg-blue-500",
+            "#3b82f6");
+        var foreignIdentity = new ViuCompletionCandidateIdentity(
+            "bg-blue-500",
+            "different-insert-text",
+            "bg-blue-500",
+            "bg-blue-500");
+        var state = new ViuCompletionColorState();
+        state.Publish(publication);
+        IReadOnlyList<IReadOnlyList<ViuCompletionCandidateIdentity>> sourceGroups =
+            new[] { new[] { foreignIdentity }, publication.Candidates };
+
+        bool found = state.TryTakeMatchingPublication(
+            @"C:\Source\Card.viu",
+            sourceGroups,
+            out int sourceGroupIndex,
+            out var matchedPublication);
+
+        found.ShouldBeTrue();
+        sourceGroupIndex.ShouldBe(1);
+        matchedPublication.ShouldBeSameAs(publication);
+    }
+
+    [Fact]
+    public void Current_UntitledDocumentSavedAsFile_ReadsNewPathWithoutRecreatingManagerState()
+    {
+        string currentPath = string.Empty;
+        var documentPath = new ViuCompletionDocumentPath(() => currentPath);
+
+        documentPath.Current.ShouldBeEmpty();
+
+        currentPath = @"C:\Source\SavedCard.viu";
+
+        documentPath.Current.ShouldBe(@"C:\Source\SavedCard.viu");
+    }
+
+    private static ViuCompletionColorPublication ParsePublication(
+        string label,
+        string insertText,
+        string colorValue)
+    {
+        using JsonDocument parameters = JsonDocument.Parse(
+            """
+            {"textDocument":{"uri":"file:///C:/Source/Card.viu"}}
+            """);
+        using JsonDocument response = JsonDocument.Parse(
+            JsonSerializer.Serialize(
+                new[]
+                {
+                    new
+                    {
+                        label,
+                        insertText,
+                        data = new { colorValue },
+                    },
+                }));
+        ViuCompletionColorPublication.TryParse(
+            parameters.RootElement,
+            response.RootElement,
+            out var publication).ShouldBeTrue();
+        return publication!;
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSemanticClassificationPublicationTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSemanticClassificationPublicationTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Text.Json;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.VisualStudio;
+
+namespace Assimalign.Viu.VisualStudio.Tests;
+
+/// <summary>
+/// Pins the editor-free JSON contract used by the thin Visual Studio semantic-classification
+/// adapter. [V01.01.12.07.11]
+/// </summary>
+public class ViuSemanticClassificationPublicationTests
+{
+    [Fact]
+    public void TryParse_ExactServerPublication_PreservesVersionChecksumNameAndRange()
+    {
+        using JsonDocument document = JsonDocument.Parse(
+            """
+            {
+              "uri": "file:///C:/workspace/Card.viu",
+              "version": 7,
+              "textChecksum": "server-checksum",
+              "isClosed": false,
+              "classifications": [
+                {
+                  "classificationTypeName": "property name",
+                  "range": {
+                    "start": { "line": 4, "character": 11 },
+                    "end": { "line": 4, "character": 16 }
+                  }
+                }
+              ]
+            }
+            """);
+
+        bool parsed = ViuSemanticClassificationPublication.TryParse(
+            document.RootElement,
+            out ViuSemanticClassificationPublication? publication);
+
+        parsed.ShouldBeTrue();
+        publication.ShouldNotBeNull();
+        publication.DocumentIdentifier.ShouldBe("file:///C:/workspace/Card.viu");
+        publication.Version.ShouldBe(7);
+        publication.TextChecksum.ShouldBe("server-checksum");
+        publication.IsClosed.ShouldBeFalse();
+        publication.Classifications.ShouldBe(
+        [
+            new ViuSemanticClassification(4, 11, 4, 16, "property name"),
+        ]);
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        {"uri":"file:///Card.viu","version":1,"isClosed":false,"classifications":[]}
+        """)]
+    [InlineData(
+        """
+        {"uri":"file:///Card.viu","version":1,"textChecksum":"x","isClosed":false,"classifications":[{"classificationTypeName":"local name","range":{"start":{"line":1,"character":3},"end":{"line":2,"character":4}}}]}
+        """)]
+    [InlineData(
+        """
+        {"uri":"file:///Card.viu","version":1,"textChecksum":"x","isClosed":false,"classifications":[{"classificationTypeName":"","range":{"start":{"line":1,"character":3},"end":{"line":1,"character":4}}}]}
+        """)]
+    [InlineData(
+        """
+        {"uri":"file:///Card.viu","version":1,"textChecksum":"x","isClosed":false,"classifications":[{"classificationTypeName":"local name","range":{"start":{"line":"one","character":3},"end":{"line":1,"character":4}}}]}
+        """)]
+    public void TryParse_InvalidOrUnsafePublication_IsRejected(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+
+        ViuSemanticClassificationPublication.TryParse(document.RootElement, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Compute_KnownText_UsesServerCompatibleUtf8Sha256()
+    {
+        ViuDocumentTextChecksum.Compute("Viu\n")
+            .ShouldBe("cky5hMd4dzR9iJUWww+rP9qM9jfQl0FUB90suepnndI=");
+    }
+
+    [Fact]
+    public void Receive_ServerNotification_PublishesExactClassificationForMatchingEditorText()
+    {
+        using JsonDocument document = JsonDocument.Parse(
+            """
+            {
+              "uri": "file:///C:/workspace/Card.viu",
+              "version": 8,
+              "textChecksum": "matching-checksum",
+              "isClosed": false,
+              "classifications": [
+                {
+                  "classificationTypeName": "local name",
+                  "range": {
+                    "start": { "line": 7, "character": 12 },
+                    "end": { "line": 7, "character": 17 }
+                  }
+                }
+              ]
+            }
+            """);
+        var state = new ViuSemanticClassificationState();
+        var receiver = new ViuSemanticClassificationReceiver(state);
+
+        bool received = receiver.Receive(document.RootElement);
+        bool found = state.TryGetClassifications(
+            @"C:\workspace\Card.viu",
+            "matching-checksum",
+            out var classifications);
+
+        received.ShouldBeTrue();
+        found.ShouldBeTrue();
+        classifications.ShouldBe(
+        [
+            new ViuSemanticClassification(7, 12, 7, 17, "local name"),
+        ]);
+    }
+}

--- a/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSemanticClassificationStateTests.cs
+++ b/extensions/VisualStudio/Assimalign.Viu.VisualStudio/test/ViuSemanticClassificationStateTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.VisualStudio;
+
+namespace Assimalign.Viu.VisualStudio.Tests;
+
+/// <summary>
+/// Pins publication ordering, checksum gating, path matching, close teardown, and weak-listener
+/// notification without loading any Visual Studio editor assembly. [V01.01.12.07.11]
+/// </summary>
+public class ViuSemanticClassificationStateTests
+{
+    [Fact]
+    public void TryGetClassifications_MatchingPathAndChecksum_ReturnsExactNames()
+    {
+        var state = new ViuSemanticClassificationState();
+        IReadOnlyList<ViuSemanticClassification> expected =
+        [
+            new ViuSemanticClassification(2, 8, 2, 13, "local name"),
+        ];
+        state.Publish(
+            new ViuSemanticClassificationPublication(
+                "file:///C:/workspace/Card.viu",
+                3,
+                "checksum-3",
+                false,
+                expected));
+
+        bool found = state.TryGetClassifications(
+            @"c:\workspace\CARD.viu",
+            "checksum-3",
+            out IReadOnlyList<ViuSemanticClassification> classifications);
+
+        found.ShouldBeTrue();
+        classifications.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryGetClassifications_TextChangedBeforePublication_PreservesLexicalFallback()
+    {
+        var state = new ViuSemanticClassificationState();
+        state.Publish(
+            Publication(
+                version: 1,
+                checksum: "old-text",
+                classificationTypeName: "field name"));
+
+        bool found = state.TryGetClassifications(
+            @"C:\workspace\Card.viu",
+            "new-text",
+            out IReadOnlyList<ViuSemanticClassification> classifications);
+
+        found.ShouldBeFalse();
+        classifications.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Publish_OlderVersionArrivesLater_DoesNotReplaceNewestSnapshot()
+    {
+        var state = new ViuSemanticClassificationState();
+        state.Publish(Publication(5, "newest", "property name")).ShouldBeTrue();
+
+        bool accepted = state.Publish(Publication(4, "older", "field name"));
+
+        accepted.ShouldBeFalse();
+        state.TryGetClassifications(
+                @"C:\workspace\Card.viu",
+                "newest",
+                out IReadOnlyList<ViuSemanticClassification> classifications)
+            .ShouldBeTrue();
+        classifications.ShouldContain(classification =>
+            classification.ClassificationTypeName == "property name");
+    }
+
+    [Fact]
+    public void Publish_Close_RemovesSnapshotAndNotifiesDocumentListener()
+    {
+        var state = new ViuSemanticClassificationState();
+        var listener = new RecordingListener();
+        state.Subscribe(@"C:\workspace\Card.viu", listener);
+        state.Publish(Publication(2, "open", "parameter name"));
+
+        bool accepted = state.Publish(
+            new ViuSemanticClassificationPublication(
+                "file:///C:/workspace/Card.viu",
+                null,
+                null,
+                true,
+                []));
+
+        accepted.ShouldBeTrue();
+        state.TryGetClassifications(
+                @"C:\workspace\Card.viu",
+                "open",
+                out IReadOnlyList<ViuSemanticClassification> classifications)
+            .ShouldBeFalse();
+        classifications.ShouldBeEmpty();
+        listener.NotificationCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ClearPublications_NewServerSession_DropsOldVersionAndNotifiesListener()
+    {
+        var state = new ViuSemanticClassificationState();
+        var listener = new RecordingListener();
+        state.Subscribe(@"C:\workspace\Card.viu", listener);
+        state.Publish(Publication(42, "old-session", "property name"));
+
+        state.ClearPublications();
+        bool accepted = state.Publish(Publication(1, "new-session", "local name"));
+
+        accepted.ShouldBeTrue();
+        state.TryGetClassifications(
+                @"C:\workspace\Card.viu",
+                "old-session",
+                out IReadOnlyList<ViuSemanticClassification> stale)
+            .ShouldBeFalse();
+        stale.ShouldBeEmpty();
+        state.TryGetClassifications(
+                @"C:\workspace\Card.viu",
+                "new-session",
+                out IReadOnlyList<ViuSemanticClassification> current)
+            .ShouldBeTrue();
+        current.ShouldContain(classification =>
+            classification.ClassificationTypeName == "local name");
+        listener.NotificationCount.ShouldBe(3);
+    }
+
+    private static ViuSemanticClassificationPublication Publication(
+        int version,
+        string checksum,
+        string classificationTypeName)
+        => new(
+            "file:///C:/workspace/Card.viu",
+            version,
+            checksum,
+            false,
+            [new ViuSemanticClassification(1, 4, 1, 9, classificationTypeName)]);
+
+    private sealed class RecordingListener : IViuSemanticClassificationListener
+    {
+        internal int NotificationCount { get; private set; }
+
+        public void OnSemanticClassificationsChanged(string documentIdentifier) =>
+            this.NotificationCount++;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerClientCapabilities.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerClientCapabilities.cs
@@ -13,11 +13,16 @@ namespace Assimalign.Viu.LanguageServer;
 /// <param name="CompletionDocumentationSupportsMarkdown">Whether <c>textDocument.completion.completionItem.documentationFormat</c> includes <c>markdown</c>.</param>
 /// <param name="SupportsHierarchicalDocumentSymbols">Whether <c>textDocument.documentSymbol.hierarchicalDocumentSymbolSupport</c> is <see langword="true"/>.</param>
 /// <param name="SupportsCodeActionLiterals">Whether <c>textDocument.codeAction.codeActionLiteralSupport</c> is present.</param>
+/// <param name="SupportsViuSemanticClassificationNotifications">
+/// Whether the Viu client opted into exact C# classification-name publications through
+/// <c>initializationOptions.semanticClassificationNotifications</c>.
+/// </param>
 internal sealed record LanguageServerClientCapabilities(
     bool HoverSupportsMarkdown,
     bool CompletionDocumentationSupportsMarkdown,
     bool SupportsHierarchicalDocumentSymbols,
-    bool SupportsCodeActionLiterals)
+    bool SupportsCodeActionLiterals,
+    bool SupportsViuSemanticClassificationNotifications)
 {
     /// <summary>Gets the plaintext-only default used before (or without) an <c>initialize</c> request.</summary>
     internal static LanguageServerClientCapabilities Default { get; } =
@@ -25,17 +30,29 @@ internal sealed record LanguageServerClientCapabilities(
             HoverSupportsMarkdown: false,
             CompletionDocumentationSupportsMarkdown: false,
             SupportsHierarchicalDocumentSymbols: false,
-            SupportsCodeActionLiterals: false);
+            SupportsCodeActionLiterals: false,
+            SupportsViuSemanticClassificationNotifications: false);
 
     /// <summary>Reads the honored capabilities from the <c>initialize</c> request parameters.</summary>
     /// <param name="initializeParameters">The <c>initialize</c> request's <c>params</c> element.</param>
     /// <returns>The captured capabilities; missing properties at any level read as unsupported.</returns>
     internal static LanguageServerClientCapabilities Read(JsonElement initializeParameters)
     {
+        var supportsViuSemanticClassificationNotifications =
+            TryGetObject(initializeParameters, "initializationOptions", out var initializationOptions) &&
+            initializationOptions.TryGetProperty(
+                "semanticClassificationNotifications",
+                out var semanticClassificationNotifications) &&
+            semanticClassificationNotifications.ValueKind == JsonValueKind.True;
+
         if (!TryGetObject(initializeParameters, "capabilities", out var capabilities) ||
             !TryGetObject(capabilities, "textDocument", out var textDocument))
         {
-            return Default;
+            return Default with
+            {
+                SupportsViuSemanticClassificationNotifications =
+                    supportsViuSemanticClassificationNotifications,
+            };
         }
 
         var hoverSupportsMarkdown =
@@ -59,7 +76,8 @@ internal sealed record LanguageServerClientCapabilities(
             hoverSupportsMarkdown,
             completionDocumentationSupportsMarkdown,
             supportsHierarchicalDocumentSymbols,
-            supportsCodeActionLiterals);
+            supportsCodeActionLiterals,
+            supportsViuSemanticClassificationNotifications);
     }
 
     private static bool TryGetObject(

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerDocumentPublicationState.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerDocumentPublicationState.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Assimalign.Viu.LanguageServer;
+
+/// <summary>
+/// Coordinates cancellation and ordered writes for one document's asynchronous publication rounds.
+/// </summary>
+internal sealed class LanguageServerDocumentPublicationState
+{
+    private readonly object synchronization = new();
+    private long generation;
+    private CancellationTokenSource? currentCancellation;
+    private int activeFeatureRequests;
+    private TaskCompletionSource? featureRequestsCompleted;
+
+    /// <summary>Serializes the document's classification and diagnostic notification pair.</summary>
+    internal SemaphoreSlim WriteGate { get; } = new(1, 1);
+
+    /// <summary>Cancels the previous round and begins a new current generation.</summary>
+    internal (long Generation, CancellationTokenSource Cancellation) Begin(
+        CancellationToken hostCancellation)
+    {
+        var nextCancellation = CancellationTokenSource.CreateLinkedTokenSource(hostCancellation);
+        CancellationTokenSource? previousCancellation;
+        long nextGeneration;
+        lock (synchronization)
+        {
+            previousCancellation = currentCancellation;
+            currentCancellation = nextCancellation;
+            nextGeneration = ++generation;
+        }
+
+        Cancel(previousCancellation);
+        return (nextGeneration, nextCancellation);
+    }
+
+    /// <summary>Cancels any current round and invalidates its generation.</summary>
+    internal bool CancelCurrent()
+    {
+        CancellationTokenSource? cancellation;
+        lock (synchronization)
+        {
+            cancellation = currentCancellation;
+            if (cancellation is null)
+            {
+                return false;
+            }
+
+            currentCancellation = null;
+            generation++;
+        }
+
+        Cancel(cancellation);
+        return true;
+    }
+
+    /// <summary>
+    /// Invalidates the current publication and opens the latency-sensitive feature-request barrier.
+    /// </summary>
+    /// <returns><see langword="true"/> when a live publication needs replacement.</returns>
+    internal bool BeginFeatureRequest()
+    {
+        CancellationTokenSource? cancellation;
+        lock (synchronization)
+        {
+            activeFeatureRequests++;
+            if (activeFeatureRequests == 1)
+            {
+                featureRequestsCompleted = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            cancellation = currentCancellation;
+            if (cancellation is not null)
+            {
+                currentCancellation = null;
+                generation++;
+            }
+        }
+
+        Cancel(cancellation);
+        return cancellation is not null;
+    }
+
+    /// <summary>Closes one feature-request lease and releases a waiting publication when last.</summary>
+    internal void EndFeatureRequest()
+    {
+        TaskCompletionSource? completed = null;
+        lock (synchronization)
+        {
+            activeFeatureRequests--;
+            if (activeFeatureRequests == 0)
+            {
+                completed = featureRequestsCompleted;
+                featureRequestsCompleted = null;
+            }
+        }
+
+        completed?.TrySetResult();
+    }
+
+    /// <summary>Waits until every earlier semantic feature request has written its response.</summary>
+    internal Task WaitForFeatureRequestsAsync(CancellationToken cancellationToken)
+    {
+        Task? wait;
+        lock (synchronization)
+        {
+            wait = featureRequestsCompleted?.Task;
+        }
+
+        return wait is null
+            ? Task.CompletedTask
+            : wait.WaitAsync(cancellationToken);
+    }
+
+    /// <summary>Applies a short service mutation only while the candidate remains current.</summary>
+    internal bool TryApplyCurrent(
+        long candidateGeneration,
+        CancellationTokenSource cancellation,
+        Action apply)
+    {
+        ArgumentNullException.ThrowIfNull(apply);
+        lock (synchronization)
+        {
+            if (generation != candidateGeneration ||
+                !ReferenceEquals(currentCancellation, cancellation) ||
+                cancellation.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            apply();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Applies a short feature-request mutation only while its document request remains live.
+    /// Closing the document uses the same gate, so a mutation that wins the race is evicted by
+    /// close and a mutation that loses the race observes cancellation before it can repopulate.
+    /// </summary>
+    internal bool TryApplyFeatureRequest(CancellationToken cancellationToken, Action apply)
+    {
+        ArgumentNullException.ThrowIfNull(apply);
+        lock (synchronization)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            apply();
+            return true;
+        }
+    }
+
+    /// <summary>Serializes document-cache eviction with short feature-request mutations.</summary>
+    internal void ApplyDocumentClose(Action apply)
+    {
+        ArgumentNullException.ThrowIfNull(apply);
+        lock (synchronization)
+        {
+            apply();
+        }
+    }
+
+    /// <summary>Clears a successfully finished source without invalidating a newer generation.</summary>
+    internal void Complete(long candidateGeneration, CancellationTokenSource cancellation)
+    {
+        lock (synchronization)
+        {
+            if (generation == candidateGeneration &&
+                ReferenceEquals(currentCancellation, cancellation))
+            {
+                currentCancellation = null;
+            }
+        }
+    }
+
+    /// <summary>Reports whether a round remains the newest document generation.</summary>
+    internal bool IsCurrent(long candidateGeneration, CancellationTokenSource cancellation)
+    {
+        lock (synchronization)
+        {
+            return generation == candidateGeneration &&
+                   ReferenceEquals(currentCancellation, cancellation) &&
+                   !cancellation.IsCancellationRequested;
+        }
+    }
+
+    private static void Cancel(CancellationTokenSource? cancellation)
+    {
+        if (cancellation is null)
+        {
+            return;
+        }
+
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The completed prior round disposed its source before the loop advanced the document.
+        }
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerHost.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerHost.cs
@@ -13,6 +13,9 @@ namespace Assimalign.Viu.LanguageServer;
 
 internal sealed class LanguageServerHost
 {
+    private static readonly TimeSpan DocumentPublicationDebounceDelay =
+        TimeSpan.FromMilliseconds(75);
+
     private const int ParseErrorCode = -32700;
     private const int InvalidRequestCode = -32600;
     private const int MethodNotFoundCode = -32601;
@@ -36,11 +39,20 @@ internal sealed class LanguageServerHost
     // Keyed by the request identifier's raw JSON text (JsonElement.GetRawText()), so the numeric
     // identifier 1 and the string identifier "1" stay distinct per JSON-RPC. The loop thread adds
     // entries; request tasks remove their own entry from pool threads.
-    private readonly ConcurrentDictionary<string, CancellationTokenSource> pendingRequestCancellations =
+    private readonly ConcurrentDictionary<string, LanguageServerPendingRequestCancellation>
+        pendingRequestCancellations =
         new(StringComparer.Ordinal);
     // Loop-thread only: the dispatched request tasks. Completed tasks are pruned each iteration,
     // and the list is drained before the shutdown reply and before RunAsync returns.
     private readonly List<Task> inFlightRequests = new();
+    // Loop-thread only: every scheduled publication remains tracked even after a newer edit cancels
+    // it, so shutdown and stream teardown never leave a task writing to a disposed output stream.
+    private readonly List<Task> inFlightPublications = new();
+    // State objects survive close/reopen so an older canceled task and a newer inline close/open
+    // publication share the same write gate and can never reverse their notification order.
+    private readonly Dictionary<string, LanguageServerDocumentPublicationState> documentPublications =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<CancellationToken, Task> documentPublicationDelay;
     private LanguageServerClientCapabilities clientCapabilities =
         LanguageServerClientCapabilities.Default;
     private bool shutdownRequested;
@@ -51,7 +63,20 @@ internal sealed class LanguageServerHost
     }
 
     internal LanguageServerHost(ILanguageService languageService)
-        => this.languageService = languageService ?? throw new ArgumentNullException(nameof(languageService));
+        : this(
+            languageService,
+            cancellationToken => Task.Delay(DocumentPublicationDebounceDelay, cancellationToken))
+    {
+    }
+
+    internal LanguageServerHost(
+        ILanguageService languageService,
+        Func<CancellationToken, Task> documentPublicationDelay)
+    {
+        this.languageService = languageService ?? throw new ArgumentNullException(nameof(languageService));
+        this.documentPublicationDelay = documentPublicationDelay ??
+            throw new ArgumentNullException(nameof(documentPublicationDelay));
+    }
 
     /// <summary>
     /// Runs the JSON-RPC message loop. Notifications and lifecycle messages apply inline in
@@ -75,6 +100,7 @@ internal sealed class LanguageServerHost
         while (!cancellationToken.IsCancellationRequested)
         {
             inFlightRequests.RemoveAll(task => task.IsCompleted);
+            inFlightPublications.RemoveAll(task => task.IsCompleted);
 
             JsonDocument? document;
             try
@@ -108,7 +134,7 @@ internal sealed class LanguageServerHost
             {
                 // End of input without an exit message: drain so no request task is left writing
                 // to an output stream the caller disposes right after RunAsync returns.
-                await DrainInFlightRequestsAsync().ConfigureAwait(false);
+                await DrainInFlightOperationsAsync().ConfigureAwait(false);
                 return 0;
             }
 
@@ -181,7 +207,7 @@ internal sealed class LanguageServerHost
                     shutdownRequested = true;
                     // Draining before the reply preserves the contract that every response
                     // precedes the shutdown reply.
-                    await DrainInFlightRequestsAsync().ConfigureAwait(false);
+                    await DrainInFlightOperationsAsync().ConfigureAwait(false);
                     await WriteResultAsync(
                             writer,
                             RequireIdentifier(hasIdentifier, identifier),
@@ -191,11 +217,10 @@ internal sealed class LanguageServerHost
                     return false;
 
                 case "exit":
-                    // Deliberate deviation from the protocol's "exit immediately": every compute
-                    // is bounded synchronous CPU work, and draining without cancelling keeps
-                    // in-flight responses off an output stream the caller disposes right after
-                    // RunAsync returns.
-                    await DrainInFlightRequestsAsync().ConfigureAwait(false);
+                    // Deliberate deviation from the protocol's "exit immediately": publications
+                    // are canceled, while already-dispatched feature requests drain so no response
+                    // writes to an output stream the caller disposes right after RunAsync returns.
+                    await DrainInFlightOperationsAsync().ConfigureAwait(false);
                     return true;
 
                 case "textDocument/didOpen":
@@ -215,6 +240,7 @@ internal sealed class LanguageServerHost
                 case "completionItem/resolve":
                 case "textDocument/documentSymbol":
                 case "textDocument/foldingRange":
+                case "textDocument/semanticTokens/full":
                 case "textDocument/codeAction":
                     await DispatchFeatureRequestAsync(
                             method,
@@ -282,18 +308,25 @@ internal sealed class LanguageServerHost
 
         // An unknown identifier is silently ignored: the request either never dispatched or has
         // already answered, and cancellation of a finished request is a no-op per the protocol.
-        if (pendingRequestCancellations.TryGetValue(identifier.GetRawText(), out var requestCancellation))
+        if (pendingRequestCancellations.TryGetValue(identifier.GetRawText(), out var pendingCancellation))
         {
-            try
-            {
-                requestCancellation.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-                // Benign race: the request completed and disposed its source between the lookup
-                // and the cancel.
-            }
+            CancelRequest(pendingCancellation.Source);
         }
+    }
+
+    private async ValueTask DrainInFlightOperationsAsync()
+    {
+        CancelAllDocumentPublications();
+        await DrainInFlightRequestsAsync().ConfigureAwait(false);
+        if (inFlightPublications.Count == 0)
+        {
+            return;
+        }
+
+        // Publication tasks translate cancellation and compute failures into an omitted stale
+        // round, so the tracked task list has the same never-fault contract as feature requests.
+        await Task.WhenAll(inFlightPublications).ConfigureAwait(false);
+        inFlightPublications.Clear();
     }
 
     private async ValueTask DrainInFlightRequestsAsync()
@@ -329,7 +362,10 @@ internal sealed class LanguageServerHost
         }
 
         var requestCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        if (!pendingRequestCancellations.TryAdd(pending.IdentifierKey, requestCancellation))
+        var pendingCancellation = new LanguageServerPendingRequestCancellation(
+            pending.DocumentUri,
+            requestCancellation);
+        if (!pendingRequestCancellations.TryAdd(pending.IdentifierKey, pendingCancellation))
         {
             // A duplicate in-flight identifier would make $/cancelRequest ambiguous, so the
             // protocol-violating request is rejected instead of orphaning a cancellation source.
@@ -344,7 +380,45 @@ internal sealed class LanguageServerHost
             return;
         }
 
-        inFlightRequests.Add(RunRequestAsync(pending, requestCancellation, writer, cancellationToken));
+        LanguageServerDocumentPublicationState? publicationState = null;
+        var replacePublication = false;
+        if (IsSemanticFeatureRequest(pending.Method))
+        {
+            // Semantic feature requests are latency-sensitive. Invalidate the current background
+            // round before the request can enter the language service, then keep its replacement
+            // behind the per-document feature barrier until the response has been written.
+            publicationState = GetDocumentPublicationState(pending.DocumentUri);
+            replacePublication = publicationState.BeginFeatureRequest();
+        }
+
+        var requestTask = RunRequestAsync(
+            pending,
+            requestCancellation,
+            publicationState,
+            writer,
+            cancellationToken);
+        inFlightRequests.Add(
+            publicationState is null
+                ? requestTask
+                : CompleteFeatureRequestAsync(requestTask, publicationState));
+        if (replacePublication)
+        {
+            ScheduleDocumentPublication(writer, pending.DocumentUri, cancellationToken);
+        }
+    }
+
+    private static async Task CompleteFeatureRequestAsync(
+        Task requestTask,
+        LanguageServerDocumentPublicationState publicationState)
+    {
+        try
+        {
+            await requestTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            publicationState.EndFeatureRequest();
+        }
     }
 
     private LanguageServerPendingRequest? CreatePendingRequest(
@@ -423,12 +497,15 @@ internal sealed class LanguageServerHost
 
             case "textDocument/documentSymbol":
             case "textDocument/foldingRange":
+            case "textDocument/semanticTokens/full":
             {
                 var textDocument = GetRequiredObject(parameters, "textDocument");
                 var documentUri = GetRequiredString(textDocument, "uri");
                 if (!IsOpenAndSupported(documentUri))
                 {
-                    inlineResult = new JsonArray();
+                    inlineResult = method == "textDocument/semanticTokens/full"
+                        ? LanguageServerSemanticTokens.CreateResult([])
+                        : new JsonArray();
                     return null;
                 }
 
@@ -475,6 +552,7 @@ internal sealed class LanguageServerHost
     private async Task RunRequestAsync(
         LanguageServerPendingRequest request,
         CancellationTokenSource requestCancellation,
+        LanguageServerDocumentPublicationState? documentState,
         LanguageServerProtocolMessageWriter writer,
         CancellationToken hostCancellation)
     {
@@ -494,10 +572,16 @@ internal sealed class LanguageServerHost
                         // the reply.
                         if (IsSemanticFeatureRequest(request.Method))
                         {
-                            statusNotification = ConfigureProjectContext(request.DocumentUri);
+                            statusNotification = ConfigureProjectContext(
+                                request.DocumentUri,
+                                documentState!,
+                                requestCancellation.Token);
                         }
 
-                        return ComputeRequestResult(request, requestCancellation.Token);
+                        return ComputeRequestResult(
+                            request,
+                            documentState,
+                            requestCancellation.Token);
                     },
                     requestCancellation.Token)
                 .ConfigureAwait(false);
@@ -582,14 +666,25 @@ internal sealed class LanguageServerHost
 
     private JsonNode? ComputeRequestResult(
         LanguageServerPendingRequest request,
+        LanguageServerDocumentPublicationState? documentState,
         CancellationToken cancellationToken)
         => request.Method switch
         {
-            "textDocument/completion" => ComputeCompletionResult(request, cancellationToken),
-            "textDocument/hover" => ComputeHoverResult(request, cancellationToken),
-            "completionItem/resolve" => ComputeCompletionItemResolveResult(request, cancellationToken),
+            "textDocument/completion" => ComputeCompletionResult(
+                request,
+                documentState!,
+                cancellationToken),
+            "textDocument/hover" => ComputeHoverResult(
+                request,
+                documentState!,
+                cancellationToken),
+            "completionItem/resolve" => ComputeCompletionItemResolveResult(
+                request,
+                documentState!,
+                cancellationToken),
             "textDocument/documentSymbol" => ComputeDocumentSymbolResult(request, cancellationToken),
             "textDocument/foldingRange" => ComputeFoldingRangeResult(request, cancellationToken),
+            "textDocument/semanticTokens/full" => ComputeSemanticTokenResult(request, cancellationToken),
             _ => ComputeCodeActionResult(request, cancellationToken),
         };
 
@@ -604,29 +699,28 @@ internal sealed class LanguageServerHost
         var version = GetOptionalInteger(textDocument, "version");
 
         JsonObject? statusNotification = null;
-        if (ViuDocumentSupport.IsSupported(documentUri))
+        var isSupported = ViuDocumentSupport.IsSupported(documentUri);
+        if (isSupported)
         {
             openSupportedDocuments.Add(documentUri);
-            ConfigureUtilityStylesheet(documentUri);
-            statusNotification = ConfigureProjectContext(documentUri);
+            ConfigureUtilityStylesheet(documentUri, cancellationToken);
+            statusNotification = ConfigureProjectContext(documentUri, cancellationToken);
             languageService.OpenDocument(documentUri, text, version);
         }
         else if (openSupportedDocuments.Remove(documentUri))
         {
-            languageService.CloseDocument(documentUri);
+            CancelDocumentRequests(documentUri);
+            CloseLanguageDocument(documentUri);
         }
 
-        if (statusNotification is not null)
-        {
-            await WriteNotificationAsync(
-                    writer,
-                    "window/logMessage",
-                    statusNotification,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        await PublishDiagnosticsAsync(writer, documentUri, cancellationToken).ConfigureAwait(false);
+        CancelDocumentPublication(documentUri);
+        await PublishSynchronizedDocumentAsync(
+                writer,
+                documentUri,
+                isClosed: !isSupported,
+                statusNotification,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async ValueTask HandleDidChangeAsync(
@@ -640,7 +734,14 @@ internal sealed class LanguageServerHost
 
         if (!IsOpenAndSupported(documentUri))
         {
-            await PublishDiagnosticsAsync(writer, documentUri, cancellationToken).ConfigureAwait(false);
+            CancelDocumentPublication(documentUri);
+            await PublishSynchronizedDocumentAsync(
+                    writer,
+                    documentUri,
+                    isClosed: true,
+                    statusNotification: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
             return;
         }
 
@@ -665,8 +766,11 @@ internal sealed class LanguageServerHost
             changes.Add(new LanguageDocumentChange(range, text));
         }
 
+        // The next edit invalidates the current round before it mutates the live document. Project
+        // context resolution is part of the replacement task after its debounce, never this loop.
+        CancelDocumentPublication(documentUri);
         languageService.ChangeDocument(documentUri, version, changes);
-        await PublishDiagnosticsAsync(writer, documentUri, cancellationToken).ConfigureAwait(false);
+        ScheduleDocumentPublication(writer, documentUri, cancellationToken);
     }
 
     private async ValueTask HandleDidCloseAsync(
@@ -677,30 +781,33 @@ internal sealed class LanguageServerHost
         var textDocument = GetRequiredObject(parameters, "textDocument");
         var documentUri = GetRequiredString(textDocument, "uri");
 
+        CancelDocumentRequests(documentUri);
+        CancelDocumentPublication(documentUri);
         if (openSupportedDocuments.Remove(documentUri))
         {
-            languageService.CloseDocument(documentUri);
+            CloseLanguageDocument(documentUri);
         }
 
-        await WriteNotificationAsync(
+        await PublishSynchronizedDocumentAsync(
                 writer,
-                "textDocument/publishDiagnostics",
-                new JsonObject
-                {
-                    ["uri"] = documentUri,
-                    ["diagnostics"] = new JsonArray(),
-                },
+                documentUri,
+                isClosed: true,
+                statusNotification: null,
                 cancellationToken)
             .ConfigureAwait(false);
     }
 
     private JsonObject ComputeCompletionResult(
         LanguageServerPendingRequest request,
+        LanguageServerDocumentPublicationState documentState,
         CancellationToken cancellationToken)
     {
         // The stylesheet configuration (disk probing included) runs on the request task, mirroring
         // the previous per-request configure-then-compute order without blocking the loop thread.
-        ConfigureUtilityStylesheet(request.DocumentUri);
+        ConfigureUtilityStylesheet(
+            request.DocumentUri,
+            documentState,
+            cancellationToken);
         var completions = languageService.GetCompletions(
             request.DocumentUri,
             request.Position,
@@ -725,6 +832,14 @@ internal sealed class LanguageServerHost
                     ["label"] = completion.Label,
                 },
             };
+
+            if (completion.ColorValue is not null)
+            {
+                // CompletionItem.data is an opaque extension payload retained for a Viu-aware
+                // adapter. The standard Color kind selects stock client presentation; the computed
+                // value remains available without requiring an adapter to parse utility CSS.
+                ((JsonObject)item["data"]!)["colorValue"] = completion.ColorValue;
+            }
 
             // Deferred documentation (utility items) is omitted entirely and computed by
             // completionItem/resolve; inline one-liners keep shipping with the item.
@@ -761,9 +876,13 @@ internal sealed class LanguageServerHost
 
     private JsonNode? ComputeHoverResult(
         LanguageServerPendingRequest request,
+        LanguageServerDocumentPublicationState documentState,
         CancellationToken cancellationToken)
     {
-        ConfigureUtilityStylesheet(request.DocumentUri);
+        ConfigureUtilityStylesheet(
+            request.DocumentUri,
+            documentState,
+            cancellationToken);
         var hover = languageService.GetHover(
             request.DocumentUri,
             request.Position,
@@ -784,9 +903,13 @@ internal sealed class LanguageServerHost
 
     private JsonNode ComputeCompletionItemResolveResult(
         LanguageServerPendingRequest request,
+        LanguageServerDocumentPublicationState documentState,
         CancellationToken cancellationToken)
     {
-        ConfigureUtilityStylesheet(request.DocumentUri);
+        ConfigureUtilityStylesheet(
+            request.DocumentUri,
+            documentState,
+            cancellationToken);
         var documentation = languageService.ResolveCompletionDocumentation(
             request.DocumentUri,
             request.CompletionLabel!,
@@ -848,6 +971,12 @@ internal sealed class LanguageServerHost
 
         return results;
     }
+
+    private JsonObject ComputeSemanticTokenResult(
+        LanguageServerPendingRequest request,
+        CancellationToken cancellationToken)
+        => LanguageServerSemanticTokens.CreateResult(
+            languageService.GetClassifications(request.DocumentUri, cancellationToken));
 
     private JsonArray ComputeCodeActionResult(
         LanguageServerPendingRequest request,
@@ -942,18 +1071,179 @@ internal sealed class LanguageServerHost
         }
     }
 
-    private async ValueTask PublishDiagnosticsAsync(
+    private void ScheduleDocumentPublication(
         LanguageServerProtocolMessageWriter writer,
         string documentUri,
+        CancellationToken hostCancellation)
+    {
+        var state = GetDocumentPublicationState(documentUri);
+        var (generation, publicationCancellation) = state.Begin(hostCancellation);
+        var includeClassifications =
+            clientCapabilities.SupportsViuSemanticClassificationNotifications;
+        var task = Task.Run(
+            () => RunDocumentPublicationAsync(
+                writer,
+                documentUri,
+                state,
+                generation,
+                publicationCancellation,
+                includeClassifications,
+                hostCancellation));
+        inFlightPublications.Add(task);
+    }
+
+    private async Task RunDocumentPublicationAsync(
+        LanguageServerProtocolMessageWriter writer,
+        string documentUri,
+        LanguageServerDocumentPublicationState state,
+        long generation,
+        CancellationTokenSource publicationCancellation,
+        bool includeClassifications,
+        CancellationToken hostCancellation)
+    {
+        try
+        {
+            await documentPublicationDelay(publicationCancellation.Token).ConfigureAwait(false);
+            await state.WaitForFeatureRequestsAsync(publicationCancellation.Token)
+                .ConfigureAwait(false);
+
+            var (isCurrent, projectContextStatus) = ConfigureCurrentProjectContext(
+                documentUri,
+                state,
+                generation,
+                publicationCancellation,
+                publicationCancellation.Token);
+            if (!isCurrent)
+            {
+                return;
+            }
+
+            // This synchronous Roslyn work is intentionally reached from Task.Run, never from the
+            // protocol loop. One service call captures one document and shares its semantic fork.
+            var publication = languageService.GetDocumentPublication(
+                documentUri,
+                includeClassifications,
+                publicationCancellation.Token);
+            publicationCancellation.Token.ThrowIfCancellationRequested();
+
+            await state.WriteGate.WaitAsync(publicationCancellation.Token).ConfigureAwait(false);
+            try
+            {
+                if (!state.IsCurrent(generation, publicationCancellation))
+                {
+                    return;
+                }
+
+                // Output uses only the host token. Canceling a per-document source after a header
+                // write must never interrupt its payload and corrupt later JSON-RPC framing.
+                var statusNotification = projectContextStatus is null
+                    ? null
+                    : CreateProjectContextStatusNotification(projectContextStatus);
+                await WriteDocumentPublicationAsync(
+                        writer,
+                        documentUri,
+                        publication,
+                        includeClassifications,
+                        isClosed: false,
+                        statusNotification,
+                        hostCancellation)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                state.WriteGate.Release();
+            }
+        }
+        catch (Exception exception) when (
+            exception is OperationCanceledException or IOException or ObjectDisposedException)
+        {
+            // A superseding edit or host teardown omits this round. No partial publication state
+            // was committed before the document write gate/current-generation check.
+        }
+        catch
+        {
+            // Publication is additive; a semantic-engine miss must not fault the protocol loop.
+        }
+        finally
+        {
+            state.Complete(generation, publicationCancellation);
+            publicationCancellation.Dispose();
+        }
+    }
+
+    private async ValueTask PublishSynchronizedDocumentAsync(
+        LanguageServerProtocolMessageWriter writer,
+        string documentUri,
+        bool isClosed,
+        JsonObject? statusNotification,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new JsonArray();
-        if (IsOpenAndSupported(documentUri))
+        var state = GetDocumentPublicationState(documentUri);
+        await state.WriteGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            foreach (var diagnostic in languageService.GetDiagnostics(documentUri))
-            {
-                diagnostics.Add((JsonNode)ToJsonDiagnostic(diagnostic));
-            }
+            var includeClassifications =
+                clientCapabilities.SupportsViuSemanticClassificationNotifications;
+            var publication = isClosed
+                ? new LanguageDocumentPublication(
+                    ClassificationSnapshot: null,
+                    Diagnostics: Array.Empty<LanguageDiagnostic>())
+                : languageService.GetDocumentPublication(
+                    documentUri,
+                    includeClassifications,
+                    cancellationToken);
+            await WriteDocumentPublicationAsync(
+                    writer,
+                    documentUri,
+                    publication,
+                    includeClassifications,
+                    isClosed,
+                    statusNotification,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            state.WriteGate.Release();
+        }
+    }
+
+    private static async ValueTask WriteDocumentPublicationAsync(
+        LanguageServerProtocolMessageWriter writer,
+        string documentUri,
+        LanguageDocumentPublication publication,
+        bool includeClassifications,
+        bool isClosed,
+        JsonObject? statusNotification,
+        CancellationToken cancellationToken)
+    {
+        if (includeClassifications)
+        {
+            await WriteNotificationAsync(
+                    writer,
+                    LanguageServerSemanticClassificationPublication.MethodName,
+                    LanguageServerSemanticClassificationPublication.Create(
+                        documentUri,
+                        isClosed ? null : publication.ClassificationSnapshot,
+                        isClosed),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (statusNotification is not null)
+        {
+            await WriteNotificationAsync(
+                    writer,
+                    "window/logMessage",
+                    statusNotification,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var diagnostics = new JsonArray();
+        foreach (var diagnostic in publication.Diagnostics)
+        {
+            diagnostics.Add((JsonNode)ToJsonDiagnostic(diagnostic));
         }
 
         await WriteNotificationAsync(
@@ -966,6 +1256,61 @@ internal sealed class LanguageServerHost
                 },
                 cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private void CancelDocumentPublication(string documentUri)
+        => GetDocumentPublicationState(documentUri).CancelCurrent();
+
+    private void CloseLanguageDocument(string documentUri)
+        => GetDocumentPublicationState(documentUri).ApplyDocumentClose(
+            () => languageService.CloseDocument(documentUri));
+
+    private void CancelDocumentRequests(string documentUri)
+    {
+        foreach (var pendingCancellation in pendingRequestCancellations.Values)
+        {
+            if (string.Equals(
+                    pendingCancellation.DocumentUri,
+                    documentUri,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                CancelRequest(pendingCancellation.Source);
+            }
+        }
+    }
+
+    private static void CancelRequest(CancellationTokenSource requestCancellation)
+    {
+        try
+        {
+            requestCancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Benign race: the request completed and disposed its source between the lookup
+            // and cancellation.
+        }
+    }
+
+    private void CancelAllDocumentPublications()
+    {
+        foreach (var state in documentPublications.Values)
+        {
+            state.CancelCurrent();
+        }
+    }
+
+    // Loop-thread only: background tasks receive the resolved state object and never access this
+    // dictionary, so no concurrent collection or lock is required.
+    private LanguageServerDocumentPublicationState GetDocumentPublicationState(string documentUri)
+    {
+        if (!documentPublications.TryGetValue(documentUri, out var state))
+        {
+            state = new LanguageServerDocumentPublicationState();
+            documentPublications.Add(documentUri, state);
+        }
+
+        return state;
     }
 
     // Loop-thread only: reads and mutates openSupportedDocuments, so a dispatched request task
@@ -983,7 +1328,8 @@ internal sealed class LanguageServerHost
         }
 
         openSupportedDocuments.Remove(documentUri);
-        languageService.CloseDocument(documentUri);
+        CancelDocumentRequests(documentUri);
+        CloseLanguageDocument(documentUri);
         return false;
     }
 
@@ -1030,6 +1376,8 @@ internal sealed class LanguageServerHost
                 ["hoverProvider"] = true,
                 ["documentSymbolProvider"] = true,
                 ["foldingRangeProvider"] = true,
+                ["semanticTokensProvider"] =
+                    LanguageServerSemanticTokens.CreateProviderCapability(),
                 ["codeActionProvider"] = new JsonObject
                 {
                     ["codeActionKinds"] = new JsonArray("quickfix"),
@@ -1042,11 +1390,15 @@ internal sealed class LanguageServerHost
             },
         };
 
-    // Semantic script features consume the project context, so the probe runs exactly where the
-    // utility stylesheet configures: document open plus the completion, hover, and resolve
-    // requests ([V01.01.12.23], #259).
+    // Semantic script features consume the project context, so the probe runs on document open,
+    // inside each debounced publication, and on the completion, hover, resolve, and semantic-token
+    // request tasks ([V01.01.12.23], #259).
     private static bool IsSemanticFeatureRequest(string method)
-        => method is "textDocument/completion" or "textDocument/hover" or "completionItem/resolve";
+        => method is
+            "textDocument/completion" or
+            "textDocument/hover" or
+            "completionItem/resolve" or
+            "textDocument/semanticTokens/full";
 
     /// <summary>
     /// Probes the document's project context, feeds it to the language service, and composes the
@@ -1054,15 +1406,68 @@ internal sealed class LanguageServerHost
     /// <see langword="null"/> when the status is silent or unchanged since the project's last
     /// reported state.
     /// </summary>
-    private JsonObject? ConfigureProjectContext(string documentUri)
+    private JsonObject? ConfigureProjectContext(
+        string documentUri,
+        CancellationToken cancellationToken = default)
     {
         if (languageService is not IScriptSemanticLanguageService scriptSemanticLanguageService)
         {
             return null;
         }
 
-        var (context, status) = projectContextReader.Read(documentUri);
+        var (context, status) = projectContextReader.Read(documentUri, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         scriptSemanticLanguageService.ConfigureProjectContext(documentUri, context);
+        return CreateProjectContextStatusNotification(status);
+    }
+
+    private JsonObject? ConfigureProjectContext(
+        string documentUri,
+        LanguageServerDocumentPublicationState documentState,
+        CancellationToken cancellationToken)
+    {
+        if (languageService is not IScriptSemanticLanguageService scriptSemanticLanguageService)
+        {
+            return null;
+        }
+
+        var (context, status) = projectContextReader.Read(documentUri, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!documentState.TryApplyFeatureRequest(
+                cancellationToken,
+                () => scriptSemanticLanguageService.ConfigureProjectContext(documentUri, context)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return CreateProjectContextStatusNotification(status);
+    }
+
+    private (bool IsCurrent, ViuProjectContextStatus? Status) ConfigureCurrentProjectContext(
+        string documentUri,
+        LanguageServerDocumentPublicationState state,
+        long generation,
+        CancellationTokenSource publicationCancellation,
+        CancellationToken cancellationToken)
+    {
+        if (languageService is not IScriptSemanticLanguageService scriptSemanticLanguageService)
+        {
+            return (state.IsCurrent(generation, publicationCancellation), null);
+        }
+
+        var (context, status) = projectContextReader.Read(documentUri, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        var isCurrent = state.TryApplyCurrent(
+            generation,
+            publicationCancellation,
+            () => scriptSemanticLanguageService.ConfigureProjectContext(documentUri, context));
+        return (isCurrent, isCurrent ? status : null);
+    }
+
+    private JsonObject? CreateProjectContextStatusNotification(ViuProjectContextStatus status)
+    {
         if (!status.TryCreateLogMessage(out var messageType, out var message) ||
             !TryRecordStatusTransition(status))
         {
@@ -1110,26 +1515,65 @@ internal sealed class LanguageServerHost
         }
     }
 
-    private void ConfigureUtilityStylesheet(string documentUri)
+    private void ConfigureUtilityStylesheet(
+        string documentUri,
+        CancellationToken cancellationToken)
     {
         if (languageService is IUtilityCssLanguageService utilityCssLanguageService)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var configuration =
                 ViuUtilityStylesheetContext.ReadForDocument(documentUri);
-            if (configuration is null)
-            {
-                utilityCssLanguageService.ConfigureUtilityStylesheet(
+            cancellationToken.ThrowIfCancellationRequested();
+            ApplyUtilityStylesheetConfiguration(
+                utilityCssLanguageService,
+                documentUri,
+                configuration);
+        }
+    }
+
+    private void ConfigureUtilityStylesheet(
+        string documentUri,
+        LanguageServerDocumentPublicationState documentState,
+        CancellationToken cancellationToken)
+    {
+        if (languageService is not IUtilityCssLanguageService utilityCssLanguageService)
+        {
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var configuration = ViuUtilityStylesheetContext.ReadForDocument(documentUri);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!documentState.TryApplyFeatureRequest(
+                cancellationToken,
+                () => ApplyUtilityStylesheetConfiguration(
+                    utilityCssLanguageService,
                     documentUri,
-                    null);
-            }
-            else
-            {
-                utilityCssLanguageService.ConfigureUtilityStylesheet(
-                    documentUri,
-                    configuration.StylesheetText,
-                    configuration.StylesheetIdentity,
-                    configuration.ReferenceGraph);
-            }
+                    configuration)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private static void ApplyUtilityStylesheetConfiguration(
+        IUtilityCssLanguageService utilityCssLanguageService,
+        string documentUri,
+        ViuUtilityStylesheetConfiguration? configuration)
+    {
+        if (configuration is null)
+        {
+            utilityCssLanguageService.ConfigureUtilityStylesheet(
+                documentUri,
+                null);
+        }
+        else
+        {
+            utilityCssLanguageService.ConfigureUtilityStylesheet(
+                documentUri,
+                configuration.StylesheetText,
+                configuration.StylesheetIdentity,
+                configuration.ReferenceGraph);
         }
     }
 

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerPendingRequestCancellation.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerPendingRequestCancellation.cs
@@ -1,0 +1,8 @@
+using System.Threading;
+
+namespace Assimalign.Viu.LanguageServer;
+
+/// <summary>Identifies one in-flight request's document and cancellation source.</summary>
+internal sealed record LanguageServerPendingRequestCancellation(
+    string DocumentUri,
+    CancellationTokenSource Source);

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerSemanticClassificationPublication.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerSemanticClassificationPublication.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text.Json.Nodes;
+
+using Assimalign.Viu.LanguageService;
+
+namespace Assimalign.Viu.LanguageServer;
+
+/// <summary>
+/// Serializes Viu's exact C# classification names for the thin Visual Studio classification
+/// adapter. The standard semantic-token vocabulary remains available to ordinary Language Server
+/// Protocol clients, while this opt-in message avoids collapsing fields, locals, and constants into
+/// one <c>variable</c> token. [V01.01.12.07.11]
+/// </summary>
+internal static class LanguageServerSemanticClassificationPublication
+{
+    /// <summary>The custom notification method understood by the Viu Visual Studio client.</summary>
+    internal const string MethodName = "viu/publishSemanticClassifications";
+
+    /// <summary>Creates one versioned, authored-position classification publication.</summary>
+    internal static JsonObject Create(
+        string documentUri,
+        LanguageClassificationSnapshot? snapshot,
+        bool isClosed)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentUri);
+
+        var classifications = new JsonArray();
+        if (snapshot is not null)
+        {
+            foreach (var classification in snapshot.Classifications)
+            {
+                classifications.Add(
+                    (JsonNode)new JsonObject
+                    {
+                        ["range"] = CreateRange(classification.Range),
+                        ["classificationTypeName"] = classification.ClassificationTypeName,
+                    });
+            }
+        }
+
+        return new JsonObject
+        {
+            ["uri"] = documentUri,
+            ["version"] = snapshot?.Version is int version
+                ? JsonValue.Create(version)
+                : null,
+            ["textChecksum"] = snapshot?.TextChecksum,
+            ["isClosed"] = isClosed,
+            ["classifications"] = classifications,
+        };
+    }
+
+    private static JsonObject CreateRange(LanguageRange range)
+        => new()
+        {
+            ["start"] = CreatePosition(range.Start),
+            ["end"] = CreatePosition(range.End),
+        };
+
+    private static JsonObject CreatePosition(LanguagePosition position)
+        => new()
+        {
+            ["line"] = position.Line,
+            ["character"] = position.Character,
+        };
+}

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerSemanticTokens.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/LanguageServerSemanticTokens.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+using Assimalign.Viu.LanguageService;
+
+namespace Assimalign.Viu.LanguageServer;
+
+/// <summary>
+/// Translates host-neutral C# classifications to the
+/// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens">
+/// Language Server Protocol 3.17 semantic-token vocabulary and relative integer encoding</see>.
+/// [V01.01.12.07.11]
+/// </summary>
+internal static class LanguageServerSemanticTokens
+{
+    private static readonly IReadOnlyList<string> TokenTypes =
+    [
+        "namespace",
+        "type",
+        "class",
+        "enum",
+        "interface",
+        "struct",
+        "typeParameter",
+        "parameter",
+        "variable",
+        "property",
+        "enumMember",
+        "event",
+        "function",
+        "method",
+        "macro",
+        "label",
+        "comment",
+        "string",
+        "keyword",
+        "number",
+        "regexp",
+        "operator",
+        "decorator",
+    ];
+
+    /// <summary>Creates the server capability advertised for full-document semantic tokens.</summary>
+    internal static JsonObject CreateProviderCapability()
+    {
+        var tokenTypes = new JsonArray();
+        foreach (var tokenType in TokenTypes)
+        {
+            tokenTypes.Add((JsonNode?)JsonValue.Create(tokenType));
+        }
+
+        return new JsonObject
+        {
+            ["legend"] = new JsonObject
+            {
+                ["tokenTypes"] = tokenTypes,
+                ["tokenModifiers"] = new JsonArray(),
+            },
+            ["full"] = true,
+        };
+    }
+
+    /// <summary>Creates one full-document semantic-token response.</summary>
+    internal static JsonObject CreateResult(
+        IReadOnlyList<LanguageClassification> classifications)
+    {
+        ArgumentNullException.ThrowIfNull(classifications);
+
+        var tokens = new List<(LanguageRange Range, int TokenType)>();
+        foreach (var classification in classifications)
+        {
+            if (TryGetTokenType(classification.ClassificationTypeName, out var tokenType) &&
+                classification.Range.Start.Line == classification.Range.End.Line &&
+                classification.Range.End.Character > classification.Range.Start.Character)
+            {
+                tokens.Add((classification.Range, tokenType));
+            }
+        }
+
+        tokens.Sort(
+            static (left, right) =>
+            {
+                var lineComparison = left.Range.Start.Line.CompareTo(right.Range.Start.Line);
+                return lineComparison != 0
+                    ? lineComparison
+                    : left.Range.Start.Character.CompareTo(right.Range.Start.Character);
+            });
+
+        var data = new JsonArray();
+        var previousLine = 0;
+        var previousCharacter = 0;
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            var (range, tokenType) = tokens[index];
+            var line = range.Start.Line;
+            var character = range.Start.Character;
+            var deltaLine = index == 0 ? line : line - previousLine;
+            var deltaCharacter = index == 0 || deltaLine != 0
+                ? character
+                : character - previousCharacter;
+
+            data.Add((JsonNode?)JsonValue.Create(deltaLine));
+            data.Add((JsonNode?)JsonValue.Create(deltaCharacter));
+            data.Add((JsonNode?)JsonValue.Create(range.End.Character - character));
+            data.Add((JsonNode?)JsonValue.Create(tokenType));
+            data.Add((JsonNode?)JsonValue.Create(0));
+
+            previousLine = line;
+            previousCharacter = character;
+        }
+
+        return new JsonObject
+        {
+            ["data"] = data,
+        };
+    }
+
+    private static bool TryGetTokenType(string classificationTypeName, out int tokenType)
+    {
+        tokenType = classificationTypeName switch
+        {
+            LanguageClassificationTypeNames.NamespaceName => 0,
+            LanguageClassificationTypeNames.DelegateName => 1,
+            LanguageClassificationTypeNames.ClassName => 2,
+            LanguageClassificationTypeNames.EnumName => 3,
+            LanguageClassificationTypeNames.InterfaceName => 4,
+            LanguageClassificationTypeNames.StructName => 5,
+            LanguageClassificationTypeNames.TypeParameterName => 6,
+            LanguageClassificationTypeNames.ParameterName => 7,
+            LanguageClassificationTypeNames.LocalName or
+                LanguageClassificationTypeNames.FieldName or
+                LanguageClassificationTypeNames.ConstantName => 8,
+            LanguageClassificationTypeNames.PropertyName => 9,
+            LanguageClassificationTypeNames.EnumMemberName => 10,
+            LanguageClassificationTypeNames.EventName => 11,
+            LanguageClassificationTypeNames.MethodName => 13,
+            LanguageClassificationTypeNames.LabelName => 15,
+            _ => -1,
+        };
+
+        return tokenType >= 0;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/ViuProjectAssetsReader.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/ViuProjectAssetsReader.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Xml.Linq;
 
 namespace Assimalign.Viu.LanguageServer;
@@ -27,8 +28,11 @@ internal static class ViuProjectAssetsReader
     private const string NetCoreApplicationFrameworkName = "Microsoft.NETCore.App";
     private const string NetCoreApplicationTargetingPackName = "Microsoft.NETCore.App.Ref";
 
-    internal static ViuProjectAssets Read(string projectFilePath)
+    internal static ViuProjectAssets Read(
+        string projectFilePath,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var projectDirectory = Path.GetDirectoryName(projectFilePath) ?? string.Empty;
         var objDirectory = Path.Combine(projectDirectory, "obj");
         var assetsFilePath = Path.Combine(objDirectory, "project.assets.json");
@@ -45,6 +49,7 @@ internal static class ViuProjectAssetsReader
         try
         {
             assetsBytes = File.ReadAllBytes(assetsFilePath);
+            cancellationToken.ThrowIfCancellationRequested();
         }
         catch (Exception exception) when (
             exception is IOException or UnauthorizedAccessException)
@@ -63,7 +68,8 @@ internal static class ViuProjectAssetsReader
                 projectDirectory,
                 objDirectory,
                 assetsFilePath,
-                assetsBytes);
+                assetsBytes,
+                cancellationToken);
         }
         catch (JsonException exception)
         {
@@ -135,8 +141,10 @@ internal static class ViuProjectAssetsReader
         string projectDirectory,
         string objDirectory,
         string assetsFilePath,
-        byte[] assetsBytes)
+        byte[] assetsBytes,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         // Target selection: the RID-less entry of targets whose key equals the restored TFM. The
         // RID-specific targets (net10.0/browser-wasm) are ignored — compile assets are identical
         // by construction and the RID-less target always exists.
@@ -183,12 +191,14 @@ internal static class ViuProjectAssetsReader
             projectDirectory,
             targetFramework,
             references,
-            droppedProjectReferences);
+            droppedProjectReferences,
+            cancellationToken);
         failureDetail ??= ResolveFrameworkReferences(
             frameworkElement,
             targetFramework,
             packageFolders,
-            references);
+            references,
+            cancellationToken);
         if (failureDetail is not null)
         {
             return CreateUnresolvable(projectFilePath, failureDetail);
@@ -198,13 +208,17 @@ internal static class ViuProjectAssetsReader
             projectFilePath,
             projectDirectory,
             objDirectory);
-        var (sourceFilePaths, componentFilePaths) = EnumerateSourceCone(projectDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+        var (sourceFilePaths, componentFilePaths) = EnumerateSourceCone(
+            projectDirectory,
+            cancellationToken);
         var cacheStamp = ComputeCacheStamp(
             assetsBytes,
             rootNamespace,
             resolvedProjectDirectory,
             configuration,
-            sourceFilePaths.Concat(componentFilePaths));
+            sourceFilePaths.Concat(componentFilePaths),
+            cancellationToken);
 
         return new ViuProjectAssets
         {
@@ -257,10 +271,12 @@ internal static class ViuProjectAssetsReader
         string projectDirectory,
         string targetFramework,
         List<string> references,
-        List<string> droppedProjectReferences)
+        List<string> droppedProjectReferences,
+        CancellationToken cancellationToken)
     {
         foreach (var library in targetElement.EnumerateObject())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var libraryType = library.Value.ValueKind == JsonValueKind.Object &&
                 library.Value.TryGetProperty("type", out var typeElement) &&
                 typeElement.ValueKind == JsonValueKind.String
@@ -427,7 +443,8 @@ internal static class ViuProjectAssetsReader
         JsonElement frameworkElement,
         string targetFramework,
         IReadOnlyList<string> packageFolders,
-        List<string> references)
+        List<string> references,
+        CancellationToken cancellationToken)
     {
         if (!TryGetObject(frameworkElement, "frameworkReferences", out var frameworkReferences))
         {
@@ -436,6 +453,7 @@ internal static class ViuProjectAssetsReader
 
         foreach (var frameworkReference in frameworkReferences.EnumerateObject())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var failureDetail = string.Equals(
                 frameworkReference.Name,
                 NetCoreApplicationFrameworkName,
@@ -738,8 +756,8 @@ internal static class ViuProjectAssetsReader
         }
     }
 
-    private static (IReadOnlyList<string> SourceFilePaths, IReadOnlyList<string> ComponentFilePaths)
-        EnumerateSourceCone(string projectDirectory)
+    internal static (IReadOnlyList<string> SourceFilePaths, IReadOnlyList<string> ComponentFilePaths)
+        EnumerateSourceCone(string projectDirectory, CancellationToken cancellationToken)
     {
         // The SDK's default Compile glob (`**\*.cs` minus DefaultItemExcludes) and the Syntax
         // generator's AdditionalFiles glob (`**\*.viu;**\*.vue` minus the same): the excludes are
@@ -747,9 +765,9 @@ internal static class ViuProjectAssetsReader
         // AssemblyInfo — completion never needs it.
         var sourceFilePaths = new List<string>();
         var componentFilePaths = new List<string>();
-        CollectSourceFiles(projectDirectory, "*.cs", sourceFilePaths);
-        CollectSourceFiles(projectDirectory, "*.viu", componentFilePaths);
-        CollectSourceFiles(projectDirectory, "*.vue", componentFilePaths);
+        CollectSourceFiles(projectDirectory, "*.cs", sourceFilePaths, cancellationToken);
+        CollectSourceFiles(projectDirectory, "*.viu", componentFilePaths, cancellationToken);
+        CollectSourceFiles(projectDirectory, "*.vue", componentFilePaths, cancellationToken);
         sourceFilePaths.Sort(StringComparer.OrdinalIgnoreCase);
         componentFilePaths.Sort(StringComparer.OrdinalIgnoreCase);
         return (sourceFilePaths, componentFilePaths);
@@ -758,7 +776,8 @@ internal static class ViuProjectAssetsReader
     private static void CollectSourceFiles(
         string projectDirectory,
         string searchPattern,
-        List<string> results)
+        List<string> results,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -767,6 +786,7 @@ internal static class ViuProjectAssetsReader
                          searchPattern,
                          SearchOption.AllDirectories))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var relativePath = Path.GetRelativePath(projectDirectory, file);
                 if (IsUnderOutputDirectory(relativePath))
                 {
@@ -792,13 +812,15 @@ internal static class ViuProjectAssetsReader
         string rootNamespace,
         string projectDirectory,
         string? configuration,
-        IEnumerable<string> sourceFilePaths)
+        IEnumerable<string> sourceFilePaths,
+        CancellationToken cancellationToken)
     {
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         hash.AppendData(assetsBytes);
         AppendText(hash, $"\n{rootNamespace}|{projectDirectory}|{configuration}\n");
         foreach (var filePath in sourceFilePaths)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             long lastWriteTicks = 0;
             long length = 0;
             try

--- a/tooling/Assimalign.Viu.LanguageServer/src/Internal/ViuProjectContextReader.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/src/Internal/ViuProjectContextReader.cs
@@ -44,7 +44,9 @@ internal sealed class ViuProjectContextReader
         gate.Wait(cancellationToken);
         try
         {
-            var assets = ViuProjectAssetsReader.Read(projectFilePath);
+            cancellationToken.ThrowIfCancellationRequested();
+            var assets = ViuProjectAssetsReader.Read(projectFilePath, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             if (assets.Status.Kind is not (ViuProjectContextStatusKind.SemanticsActive or
                 ViuProjectContextStatusKind.AssetsStale))
             {
@@ -57,7 +59,7 @@ internal sealed class ViuProjectContextReader
             {
                 cone = new CachedProjectCone(
                     assets.CacheStamp,
-                    ReadSourceDocuments(assets));
+                    ReadSourceDocuments(assets, cancellationToken));
                 conesByProjectFilePath[projectFilePath] = cone;
             }
 
@@ -66,6 +68,7 @@ internal sealed class ViuProjectContextReader
                 cone.SourceDocuments.Count);
             foreach (var sourceDocument in cone.SourceDocuments)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!string.Equals(
                         sourceDocument.FilePath,
                         documentPath,
@@ -94,22 +97,33 @@ internal sealed class ViuProjectContextReader
     }
 
     private static IReadOnlyList<LanguageProjectSourceDocument> ReadSourceDocuments(
-        ViuProjectAssets assets)
+        ViuProjectAssets assets,
+        CancellationToken cancellationToken)
     {
         var documents = new List<LanguageProjectSourceDocument>(
             assets.SourceFilePaths.Count + assets.ComponentFilePaths.Count);
-        AppendSourceDocuments(assets.SourceFilePaths, isComponent: false, documents);
-        AppendSourceDocuments(assets.ComponentFilePaths, isComponent: true, documents);
+        AppendSourceDocuments(
+            assets.SourceFilePaths,
+            isComponent: false,
+            documents,
+            cancellationToken);
+        AppendSourceDocuments(
+            assets.ComponentFilePaths,
+            isComponent: true,
+            documents,
+            cancellationToken);
         return documents;
     }
 
     private static void AppendSourceDocuments(
         IReadOnlyList<string> filePaths,
         bool isComponent,
-        List<LanguageProjectSourceDocument> documents)
+        List<LanguageProjectSourceDocument> documents,
+        CancellationToken cancellationToken)
     {
         foreach (var filePath in filePaths)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 documents.Add(

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCancellationTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCancellationTests.cs
@@ -97,6 +97,93 @@ public class LanguageServerCancellationTests
     }
 
     [Fact]
+    public async Task RunAsync_DidCloseCancelsInFlightCompletionBeforeCachePopulationAndReopenSucceeds()
+    {
+        var languageService = new CloseRacingCompletionLanguageService();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService));
+
+        await session.SendAsync(OpenMessage());
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","id":"before-close","method":"textDocument/completion","params":{"textDocument":{"uri":"file:///Counter.viu"},"position":{"line":0,"character":0}}}
+            """);
+        await languageService.FirstCompletionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await session.SendAsync(CloseMessage());
+            await languageService.FirstCompletionCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await languageService.CloseObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            languageService.ReleaseFirstCompletion.Set();
+        }
+
+        using (JsonDocument canceled = await session.ReadResponseAsync("before-close"))
+        {
+            canceled.RootElement.TryGetProperty("result", out _).ShouldBeFalse();
+            canceled.RootElement
+                .GetProperty("error")
+                .GetProperty("code")
+                .GetInt32()
+                .ShouldBe(-32800);
+        }
+
+        languageService.CachePopulationCount.ShouldBe(0);
+
+        await session.SendAsync(OpenMessage());
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","id":"after-reopen","method":"textDocument/completion","params":{"textDocument":{"uri":"file:///Counter.viu"},"position":{"line":0,"character":0}}}
+            """);
+        using (JsonDocument reopened = await session.ReadResponseAsync("after-reopen"))
+        {
+            var items = reopened.RootElement.GetProperty("result").GetProperty("items");
+            items.GetArrayLength().ShouldBe(1);
+            items[0].GetProperty("label").GetString().ShouldBe("cache-population:1");
+        }
+
+        languageService.CachePopulationCount.ShouldBe(1);
+
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","id":"shutdown","method":"shutdown","params":null}
+            """);
+        using (JsonDocument shutdown = await session.ReadResponseAsync("shutdown"))
+        {
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","method":"exit"}
+            """);
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_DiagnosticPublication_PassesHostCancellationToken()
+    {
+        var inputBytes = Encoding.UTF8.GetBytes(
+            Frame(OpenMessage()) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """));
+        await using var input = new MemoryStream(inputBytes);
+        await using var output = new MemoryStream();
+        using var cancellationSource = new CancellationTokenSource();
+        var languageService = new ChangeCountingLanguageService();
+        var host = new LanguageServerHost(languageService);
+
+        await host.RunAsync(input, output, cancellationSource.Token);
+
+        languageService.DiagnosticsCancellationCanBeCanceled.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task RunAsync_DidChangeBeforeCompletionRequest_ObservesAppliedChange()
     {
         var inputBytes = Encoding.UTF8.GetBytes(
@@ -180,6 +267,11 @@ public class LanguageServerCancellationTests
     private static string OpenMessage()
         => """
            {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Counter.viu","languageId":"viu","version":1,"text":"@script\n"}}}
+           """;
+
+    private static string CloseMessage()
+        => """
+           {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///Counter.viu"}}}
            """;
 
     private static async Task<List<JsonDocument>> ReadAllMessagesAsync(Stream stream)
@@ -272,12 +364,119 @@ public class LanguageServerCancellationTests
     }
 
     /// <summary>
+    /// Models the semantic cache boundary: the first completion reaches the cache only if close
+    /// fails to cancel it, while a completion from a reopened document may populate normally.
+    /// </summary>
+    private sealed class CloseRacingCompletionLanguageService : ILanguageService
+    {
+        private int cachePopulationCount;
+        private int completionCount;
+
+        internal TaskCompletionSource FirstCompletionStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource FirstCompletionCanceled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource CloseObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal ManualResetEventSlim ReleaseFirstCompletion { get; } = new(initialState: false);
+
+        internal int CachePopulationCount => Volatile.Read(ref cachePopulationCount);
+
+        public void OpenDocument(string documentUri, string text, int? version)
+        {
+        }
+
+        public bool ChangeDocument(
+            string documentUri,
+            int? version,
+            IReadOnlyList<LanguageDocumentChange> changes)
+            => true;
+
+        public bool CloseDocument(string documentUri)
+        {
+            CloseObserved.TrySetResult();
+            return true;
+        }
+
+        public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => Array.Empty<LanguageDiagnostic>();
+
+        public IReadOnlyList<LanguageCompletionItem> GetCompletions(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref completionCount) == 1)
+            {
+                FirstCompletionStarted.TrySetResult();
+                WaitHandle.WaitAny(
+                    [ReleaseFirstCompletion.WaitHandle, cancellationToken.WaitHandle],
+                    TimeSpan.FromSeconds(10));
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    FirstCompletionCanceled.TrySetResult();
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            var population = Interlocked.Increment(ref cachePopulationCount);
+            return
+            [
+                new LanguageCompletionItem(
+                    $"cache-population:{population}",
+                    LanguageCompletionItemKind.Property,
+                    "Cache lifecycle probe",
+                    "Reports semantic cache population after close and reopen.",
+                    $"cache-population:{population}",
+                    IsSnippet: false,
+                    SortText: "01"),
+            ];
+        }
+
+        public LanguageHover? GetHover(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public string? ResolveCompletionDocumentation(
+            string documentUri,
+            string completionLabel,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public IReadOnlyList<LanguageDocumentSymbol> GetDocumentSymbols(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => Array.Empty<LanguageDocumentSymbol>();
+
+        public IReadOnlyList<LanguageFoldingRange> GetFoldingRanges(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => Array.Empty<LanguageFoldingRange>();
+
+        public IReadOnlyList<LanguageCodeAction> GetCodeActions(
+            string documentUri,
+            LanguageRange range,
+            CancellationToken cancellationToken = default)
+            => Array.Empty<LanguageCodeAction>();
+    }
+
+    /// <summary>
     /// A service whose completion reports how many document changes it observed at call time,
     /// proving a dispatched request sees every notification read before it.
     /// </summary>
     private sealed class ChangeCountingLanguageService : ILanguageService
     {
         private int changeCount;
+
+        internal bool DiagnosticsCancellationCanBeCanceled { get; private set; }
 
         public void OpenDocument(string documentUri, string text, int? version)
         {
@@ -297,7 +496,10 @@ public class LanguageServerCancellationTests
         public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
             string documentUri,
             CancellationToken cancellationToken = default)
-            => Array.Empty<LanguageDiagnostic>();
+        {
+            DiagnosticsCancellationCanBeCanceled = cancellationToken.CanBeCanceled;
+            return Array.Empty<LanguageDiagnostic>();
+        }
 
         public IReadOnlyList<LanguageCompletionItem> GetCompletions(
             string documentUri,

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCapabilityTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCapabilityTests.cs
@@ -13,8 +13,9 @@ namespace Assimalign.Viu.LanguageServer.Tests;
 
 /// <summary>
 /// Pins the tier-two capability declarations and the client-capability honesty rules: the server
-/// advertises resolve/symbol/folding/code-action support, and emits hover content in the format the
-/// client actually advertised — Visual Studio advertises plaintext and renders Markdown literally
+/// advertises resolve/symbol/folding/semantic-token/code-action support, and emits hover content in
+/// the format the client actually advertised — Visual Studio advertises plaintext and renders
+/// Markdown literally
 /// (https://github.com/microsoft/VSExtensibility/issues/271), so plaintext is also the
 /// no-initialize default.
 /// </summary>
@@ -51,6 +52,44 @@ public class LanguageServerCapabilityTests
             .ShouldBeTrue();
         capabilities.GetProperty("documentSymbolProvider").GetBoolean().ShouldBeTrue();
         capabilities.GetProperty("foldingRangeProvider").GetBoolean().ShouldBeTrue();
+        var semanticTokens = capabilities.GetProperty("semanticTokensProvider");
+        semanticTokens.GetProperty("full").GetBoolean().ShouldBeTrue();
+        semanticTokens
+            .GetProperty("legend")
+            .GetProperty("tokenTypes")
+            .EnumerateArray()
+            .Select(tokenType => tokenType.GetString())
+            .ShouldBe(
+            [
+                "namespace",
+                "type",
+                "class",
+                "enum",
+                "interface",
+                "struct",
+                "typeParameter",
+                "parameter",
+                "variable",
+                "property",
+                "enumMember",
+                "event",
+                "function",
+                "method",
+                "macro",
+                "label",
+                "comment",
+                "string",
+                "keyword",
+                "number",
+                "regexp",
+                "operator",
+                "decorator",
+            ]);
+        semanticTokens
+            .GetProperty("legend")
+            .GetProperty("tokenModifiers")
+            .GetArrayLength()
+            .ShouldBe(0);
         capabilities
             .GetProperty("codeActionProvider")
             .GetProperty("codeActionKinds")

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCompletionKindTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerCompletionKindTests.cs
@@ -18,14 +18,20 @@ namespace Assimalign.Viu.LanguageServer.Tests;
 /// Pins the completion-kind boundary. The host performs no kind translation of its own: the service
 /// already speaks the Language Server Protocol's <c>CompletionItemKind</c> numbering, and the host
 /// serializes that value verbatim. A namespace therefore reaches the editor as <c>Module</c> (9),
-/// the value editors render with the namespace glyph — Visual Studio draws it as <c>{}</c>.
+/// the value editors render with the namespace glyph — Visual Studio draws it as <c>{}</c>. A
+/// utility color reaches it as <c>Color</c> (16) with the computed theme value in item data, so the
+/// value remains available to a Viu-aware client without parsing emitted CSS. Stock clients can use
+/// the standard color-category presentation without interpreting the opaque data
+/// Snippet insert text also crosses unchanged: an escaped dollar sign keeps the authored
+/// <c>$event</c> identifier literal while the numbered placeholder remains active
+/// ([V01.01.12.07.12], #333; [V01.01.12.07.13], #334).
 /// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind">
 /// Language Server Protocol 3.17, <c>CompletionItemKind</c></see>.
 /// </summary>
 public class LanguageServerCompletionKindTests
 {
     [Fact]
-    public async Task RunAsync_NamespaceCompletion_SerializesTheModuleKind()
+    public async Task RunAsync_Completions_SerializeKindsColorPayloadAndSnippetEscape()
     {
         var inputBytes = Encoding.UTF8.GetBytes(
             Frame(
@@ -58,6 +64,17 @@ public class LanguageServerCompletionKindTests
         var items = completion.RootElement.GetProperty("result").GetProperty("items");
         FindItem(items, "System")!.Value.GetProperty("kind").GetInt32().ShouldBe(9);
         FindItem(items, "String")!.Value.GetProperty("kind").GetInt32().ShouldBe(7);
+        var color = FindItem(items, "bg-blue-500")!.Value;
+        color.GetProperty("kind").GetInt32().ShouldBe(16);
+        color.GetProperty("data").GetProperty("colorValue").GetString()
+            .ShouldBe("oklch(62.3% 0.214 259.815)");
+        var eventLambda = FindItem(items, "$event lambda")!.Value;
+        eventLambda.GetProperty("insertText").GetString().ShouldBe("\\$event => $1");
+        eventLambda.GetProperty("insertTextFormat").GetInt32().ShouldBe(2);
+        var asynchronousEventLambda = FindItem(items, "async $event lambda")!.Value;
+        asynchronousEventLambda.GetProperty("insertText").GetString()
+            .ShouldBe("async \\$event => $1");
+        asynchronousEventLambda.GetProperty("insertTextFormat").GetInt32().ShouldBe(2);
 
         foreach (var message in messages)
         {
@@ -89,6 +106,11 @@ public class LanguageServerCompletionKindTests
             CancellationToken cancellationToken = default)
             => Array.Empty<LanguageDiagnostic>();
 
+        public IReadOnlyList<LanguageClassification> GetClassifications(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => Array.Empty<LanguageClassification>();
+
         public IReadOnlyList<LanguageCompletionItem> GetCompletions(
             string documentUri,
             LanguagePosition position,
@@ -111,6 +133,31 @@ public class LanguageServerCompletionKindTests
                     "String",
                     IsSnippet: false,
                     SortText: "01:String"),
+                new LanguageCompletionItem(
+                    "bg-blue-500",
+                    LanguageCompletionItemKind.Color,
+                    "Viu utility class",
+                    Documentation: string.Empty,
+                    "bg-blue-500",
+                    IsSnippet: false,
+                    SortText: "02:bg-blue-500",
+                    ColorValue: "oklch(62.3% 0.214 259.815)"),
+                new LanguageCompletionItem(
+                    "$event lambda",
+                    LanguageCompletionItemKind.Snippet,
+                    "Template event lambda",
+                    Documentation: string.Empty,
+                    "\\$event => $1",
+                    IsSnippet: true,
+                    SortText: "03:event-lambda"),
+                new LanguageCompletionItem(
+                    "async $event lambda",
+                    LanguageCompletionItemKind.Snippet,
+                    "Asynchronous template event lambda",
+                    Documentation: string.Empty,
+                    "async \\$event => $1",
+                    IsSnippet: true,
+                    SortText: "04:async-event-lambda"),
             ];
 
         public LanguageHover? GetHover(

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerHostSession.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerHostSession.cs
@@ -70,6 +70,37 @@ internal sealed class LanguageServerHostSession : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Reads framed messages until a matching notification arrives, retaining every notification
+    /// in <see cref="Notifications"/> and returning an independently owned matching clone.
+    /// </summary>
+    internal async Task<JsonDocument> ReadNotificationAsync(
+        string method,
+        Func<JsonElement, bool> matches)
+    {
+        while (true)
+        {
+            var message = await responseReader.ReadAsync().AsTask().WaitAsync(ReadTimeout)
+                ?? throw new InvalidOperationException(
+                    "The host output ended before the awaited notification arrived.");
+            if (!message.RootElement.TryGetProperty("method", out var notificationMethod) ||
+                notificationMethod.ValueKind != JsonValueKind.String)
+            {
+                message.Dispose();
+                throw new InvalidOperationException(
+                    "An unexpected response arrived while awaiting a notification.");
+            }
+
+            notifications.Add(message);
+            if (notificationMethod.GetString() == method &&
+                message.RootElement.TryGetProperty("params", out var parameters) &&
+                matches(parameters))
+            {
+                return JsonDocument.Parse(message.RootElement.GetRawText());
+            }
+        }
+    }
+
     /// <summary>Waits for the host loop to return and yields its exit code.</summary>
     internal Task<int> CompleteAsync() => run.WaitAsync(ReadTimeout);
 

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerPublicationSchedulingTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerPublicationSchedulingTests.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.LanguageService;
+
+namespace Assimalign.Viu.LanguageServer.Tests;
+
+/// <summary>
+/// Pins coalesced, cancellation-aware document publication outside the protocol loop.
+/// [V01.01.12.07.11] [V01.01.12.07.15]
+/// </summary>
+public class LanguageServerPublicationSchedulingTests
+{
+    [Fact]
+    public async Task RunAsync_DidChangeBurst_CancelsStaleRoundAndPublishesOnlyLastVersion()
+    {
+        var languageService = new BlockingPublicationLanguageService();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService));
+
+        await InitializeAsync(session);
+        await session.SendAsync(OpenMessage());
+        await languageService.InitialPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await session.SendAsync(ChangeMessage(version: 2));
+            await languageService.ChangedPublicationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await session.SendAsync(ChangeMessage(version: 3));
+            await languageService.StalePublicationCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await session.SendAsync(ChangeMessage(version: 4));
+
+            await languageService.FinalPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            using JsonDocument finalPublication = await session.ReadNotificationAsync(
+                LanguageServerSemanticClassificationPublication.MethodName,
+                parameters =>
+                    parameters.GetProperty("version").ValueKind == JsonValueKind.Number &&
+                    parameters.GetProperty("version").GetInt32() == 4);
+        }
+        finally
+        {
+            languageService.ReleaseAll.Set();
+        }
+
+        using (JsonDocument shutdown = await ShutdownAsync(session))
+        {
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        var publishedVersions = session.Notifications
+            .Where(message =>
+                message.RootElement.TryGetProperty("method", out var method) &&
+                method.GetString() == LanguageServerSemanticClassificationPublication.MethodName)
+            .Select(message => message.RootElement
+                .GetProperty("params")
+                .GetProperty("version")
+                .GetInt32())
+            .ToArray();
+        publishedVersions.ShouldBe([1, 4]);
+        languageService.CanceledPublicationCount.ShouldBeGreaterThanOrEqualTo(1);
+
+        await session.SendAsync(ExitMessage());
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_FeatureRequestDuringPublication_RespondsBeforePublicationCompletes()
+    {
+        var languageService = new BlockingPublicationLanguageService();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService));
+
+        await InitializeAsync(session);
+        await session.SendAsync(OpenMessage());
+        await languageService.InitialPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await session.SendAsync(ChangeMessage(version: 2));
+        await languageService.ChangedPublicationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await session.SendAsync(
+                """
+                {"jsonrpc":"2.0","id":"feature","method":"textDocument/completion","params":{"textDocument":{"uri":"file:///Counter.viu"},"position":{"line":0,"character":0}}}
+                """);
+            await languageService.FeatureRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            using JsonDocument feature = await session.ReadResponseAsync("feature")
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            feature.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+        finally
+        {
+            languageService.ReleaseAll.Set();
+        }
+
+        using (JsonDocument shutdown = await ShutdownAsync(session))
+        {
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        await session.SendAsync(ExitMessage());
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_PreDebounceBurst_InvokesPublicationOnlyForLastVersion()
+    {
+        var languageService = new BlockingPublicationLanguageService();
+        var publicationDelay = new ControlledPublicationDelay();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService, publicationDelay.WaitAsync));
+
+        await InitializeAsync(session);
+        await session.SendAsync(OpenMessage());
+        await languageService.InitialPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await session.SendAsync(ChangeMessage(version: 2));
+        await session.SendAsync(ChangeMessage(version: 3));
+        await session.SendAsync(ChangeMessage(version: 4));
+        await session.SendAsync(FoldingRangeMessage("burst-applied"));
+        using (JsonDocument barrier = await session.ReadResponseAsync("burst-applied"))
+        {
+            barrier.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        languageService.PublicationVersions.ShouldBe([1]);
+        publicationDelay.Release();
+        await languageService.FinalPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using JsonDocument finalPublication = await session.ReadNotificationAsync(
+            LanguageServerSemanticClassificationPublication.MethodName,
+            parameters =>
+                parameters.GetProperty("version").ValueKind == JsonValueKind.Number &&
+                parameters.GetProperty("version").GetInt32() == 4);
+
+        using (JsonDocument shutdown = await ShutdownAsync(session))
+        {
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        languageService.PublicationVersions.ShouldBe([1, 4]);
+        await session.SendAsync(ExitMessage());
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_DidCloseDuringPublication_CancelsBeforeClosedStateAndKeepsLoopResponsive()
+    {
+        var languageService = new BlockingPublicationLanguageService();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService));
+
+        await InitializeAsync(session);
+        await session.SendAsync(OpenMessage());
+        await languageService.InitialPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await session.SendAsync(ChangeMessage(version: 2));
+        await languageService.ChangedPublicationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await session.SendAsync(CloseMessage());
+            await session.SendAsync(FoldingRangeMessage("after-close"));
+            using JsonDocument response = await session.ReadResponseAsync("after-close")
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            response.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+            await languageService.StalePublicationCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            languageService.ReleaseAll.Set();
+        }
+
+        session.Notifications.Any(
+            message =>
+                message.RootElement.TryGetProperty("method", out var method) &&
+                method.GetString() == LanguageServerSemanticClassificationPublication.MethodName &&
+                message.RootElement.GetProperty("params").GetProperty("isClosed").GetBoolean())
+            .ShouldBeTrue();
+        session.Notifications.Any(
+            message =>
+                message.RootElement.TryGetProperty("method", out var method) &&
+                method.GetString() == LanguageServerSemanticClassificationPublication.MethodName &&
+                message.RootElement.GetProperty("params").GetProperty("version").ValueKind ==
+                    JsonValueKind.Number &&
+                message.RootElement.GetProperty("params").GetProperty("version").GetInt32() == 2)
+            .ShouldBeFalse();
+
+        using (JsonDocument shutdown = await ShutdownAsync(session))
+        {
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        await session.SendAsync(ExitMessage());
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShutdownDuringPublication_CancelsBeforeDraining()
+    {
+        var languageService = new BlockingPublicationLanguageService();
+        await using var session = new LanguageServerHostSession(
+            new LanguageServerHost(languageService));
+
+        await InitializeAsync(session);
+        await session.SendAsync(OpenMessage());
+        await languageService.InitialPublicationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await session.SendAsync(ChangeMessage(version: 2));
+        await languageService.ChangedPublicationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            using JsonDocument shutdown = await ShutdownAsync(session)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+            await languageService.StalePublicationCanceled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            languageService.ReleaseAll.Set();
+        }
+
+        await session.SendAsync(ExitMessage());
+        (await session.CompleteAsync()).ShouldBe(0);
+    }
+
+    private static async Task InitializeAsync(LanguageServerHostSession session)
+    {
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","id":"initialize","method":"initialize","params":{"initializationOptions":{"semanticClassificationNotifications":true},"capabilities":{}}}
+            """);
+        using JsonDocument response = await session.ReadResponseAsync("initialize");
+        response.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+    }
+
+    private static async Task<JsonDocument> ShutdownAsync(LanguageServerHostSession session)
+    {
+        await session.SendAsync(
+            """
+            {"jsonrpc":"2.0","id":"shutdown","method":"shutdown","params":null}
+            """);
+        return await session.ReadResponseAsync("shutdown");
+    }
+
+    private static string OpenMessage()
+        => """
+           {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Counter.viu","languageId":"viu","version":1,"text":"@script {\n    int Value;\n}\n"}}}
+           """;
+
+    private static string ChangeMessage(int version)
+        => "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didChange\",\"params\":{" +
+           "\"textDocument\":{\"uri\":\"file:///Counter.viu\",\"version\":" + version + "}," +
+           "\"contentChanges\":[{\"text\":\"@script {\\n    int Value" + version +
+           ";\\n}\\n\"}]}}";
+
+    private static string CloseMessage()
+        => """
+           {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///Counter.viu"}}}
+           """;
+
+    private static string FoldingRangeMessage(string identifier)
+        => "{\"jsonrpc\":\"2.0\",\"id\":\"" + identifier +
+           "\",\"method\":\"textDocument/foldingRange\",\"params\":{" +
+           "\"textDocument\":{\"uri\":\"file:///Counter.viu\"}}}";
+
+    private static string ExitMessage()
+        => """
+           {"jsonrpc":"2.0","method":"exit"}
+           """;
+
+    private sealed class BlockingPublicationLanguageService : ILanguageService
+    {
+        private readonly object synchronization = new();
+        private readonly List<int> publicationVersions = [];
+        private int version;
+        private int canceledPublicationCount;
+
+        internal TaskCompletionSource InitialPublicationCompleted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource ChangedPublicationStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource StalePublicationCanceled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource FinalPublicationCompleted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource FeatureRequestStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal ManualResetEventSlim ReleaseAll { get; } = new(initialState: false);
+
+        internal ManualResetEventSlim ChangedPublicationExited { get; } = new(initialState: false);
+
+        internal int CanceledPublicationCount => Volatile.Read(ref canceledPublicationCount);
+
+        internal int[] PublicationVersions
+        {
+            get
+            {
+                lock (synchronization)
+                {
+                    return publicationVersions.ToArray();
+                }
+            }
+        }
+
+        public void OpenDocument(string documentUri, string text, int? version)
+            => Volatile.Write(ref this.version, version ?? 0);
+
+        public bool ChangeDocument(
+            string documentUri,
+            int? version,
+            IReadOnlyList<LanguageDocumentChange> changes)
+        {
+            Volatile.Write(ref this.version, version ?? 0);
+            return true;
+        }
+
+        public bool CloseDocument(string documentUri) => true;
+
+        public LanguageClassificationSnapshot? GetClassificationSnapshot(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+        {
+            var observedVersion = Volatile.Read(ref version);
+            return new LanguageClassificationSnapshot(
+                observedVersion,
+                $"checksum-{observedVersion}",
+                []);
+        }
+
+        public LanguageDocumentPublication GetDocumentPublication(
+            string documentUri,
+            bool includeSemanticClassifications,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var observedVersion = Volatile.Read(ref version);
+            lock (synchronization)
+            {
+                publicationVersions.Add(observedVersion);
+            }
+
+            var diagnostics = GetDiagnostics(observedVersion, cancellationToken);
+            return new LanguageDocumentPublication(
+                includeSemanticClassifications
+                    ? new LanguageClassificationSnapshot(
+                        observedVersion,
+                        $"checksum-{observedVersion}",
+                        [])
+                    : null,
+                diagnostics);
+        }
+
+        public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => GetDiagnostics(Volatile.Read(ref version), cancellationToken);
+
+        private IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
+            int observedVersion,
+            CancellationToken cancellationToken)
+        {
+            if (observedVersion == 1)
+            {
+                InitialPublicationCompleted.TrySetResult();
+                return [];
+            }
+
+            if (observedVersion >= 4)
+            {
+                FinalPublicationCompleted.TrySetResult();
+                return [];
+            }
+
+            ChangedPublicationStarted.TrySetResult();
+            try
+            {
+                WaitHandle.WaitAny(
+                    [ReleaseAll.WaitHandle, cancellationToken.WaitHandle],
+                    TimeSpan.FromSeconds(10));
+                cancellationToken.ThrowIfCancellationRequested();
+                return [];
+            }
+            catch (OperationCanceledException)
+            {
+                Interlocked.Increment(ref canceledPublicationCount);
+                StalePublicationCanceled.TrySetResult();
+                throw;
+            }
+            finally
+            {
+                ChangedPublicationExited.Set();
+            }
+        }
+
+        public IReadOnlyList<LanguageCompletionItem> GetCompletions(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+        {
+            FeatureRequestStarted.TrySetResult();
+            if (!ChangedPublicationExited.Wait(TimeSpan.FromSeconds(5), cancellationToken))
+            {
+                throw new TimeoutException("The canceled publication did not leave its semantic gate.");
+            }
+
+            return [];
+        }
+
+        public LanguageHover? GetHover(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public string? ResolveCompletionDocumentation(
+            string documentUri,
+            string completionLabel,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public IReadOnlyList<LanguageDocumentSymbol> GetDocumentSymbols(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageFoldingRange> GetFoldingRanges(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageCodeAction> GetCodeActions(
+            string documentUri,
+            LanguageRange range,
+            CancellationToken cancellationToken = default)
+            => [];
+    }
+
+    private sealed class ControlledPublicationDelay
+    {
+        private readonly TaskCompletionSource released =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task WaitAsync(CancellationToken cancellationToken)
+            => released.Task.WaitAsync(cancellationToken);
+
+        internal void Release() => released.TrySetResult();
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticClassificationPublicationTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticClassificationPublicationTests.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.LanguageService;
+
+namespace Assimalign.Viu.LanguageServer.Tests;
+
+/// <summary>
+/// Pins the opt-in server notification that preserves exact C# editor classification names for the
+/// thin Visual Studio adapter. [V01.01.12.07.11]
+/// </summary>
+public class LanguageServerSemanticClassificationPublicationTests
+{
+    [Fact]
+    public async Task RunAsync_OptedInClient_PublishesExactVersionedNamesAndClose()
+    {
+        byte[] inputBytes = Encoding.UTF8.GetBytes(
+            Frame(
+                """
+                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"initializationOptions":{"semanticClassificationNotifications":true},"capabilities":{}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Card.viu","languageId":"viu","version":1,"text":"@script {\n    int value;\n}\n"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///Card.viu","version":2},"contentChanges":[{"text":"@script {\n    int changed;\n}\n"}]}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///Card.viu"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """));
+
+        await using var input = new MemoryStream(inputBytes);
+        await using var output = new MemoryStream();
+        var host = new LanguageServerHost(new SnapshotLanguageService());
+
+        await host.RunAsync(input, output);
+
+        output.Position = 0;
+        List<JsonDocument> messages = await ReadAllMessagesAsync(output);
+        JsonElement[] publications = messages
+            .Where(message =>
+                message.RootElement.TryGetProperty("method", out JsonElement method) &&
+                method.GetString() == LanguageServerSemanticClassificationPublication.MethodName)
+            .Select(message => message.RootElement.GetProperty("params"))
+            .ToArray();
+        publications.Length.ShouldBe(2);
+        AssertOpenPublication(publications[0], 1, "checksum-1");
+        publications[1].GetProperty("uri").GetString().ShouldBe("file:///Card.viu");
+        publications[1].GetProperty("version").ValueKind.ShouldBe(JsonValueKind.Null);
+        publications[1].GetProperty("textChecksum").ValueKind.ShouldBe(JsonValueKind.Null);
+        publications[1].GetProperty("isClosed").GetBoolean().ShouldBeTrue();
+        publications[1].GetProperty("classifications").GetArrayLength().ShouldBe(0);
+
+        foreach (JsonDocument message in messages)
+        {
+            message.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_OrdinaryClient_DoesNotReceiveCustomClassificationNotification()
+    {
+        byte[] inputBytes = Encoding.UTF8.GetBytes(
+            Frame(
+                """
+                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Card.viu","languageId":"viu","version":1,"text":"@script {\n}\n"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """));
+
+        await using var input = new MemoryStream(inputBytes);
+        await using var output = new MemoryStream();
+        var host = new LanguageServerHost(new SnapshotLanguageService());
+
+        await host.RunAsync(input, output);
+
+        output.Position = 0;
+        List<JsonDocument> messages = await ReadAllMessagesAsync(output);
+        messages.Any(message =>
+                message.RootElement.TryGetProperty("method", out JsonElement method) &&
+                method.GetString() == LanguageServerSemanticClassificationPublication.MethodName)
+            .ShouldBeFalse();
+
+        foreach (JsonDocument message in messages)
+        {
+            message.Dispose();
+        }
+    }
+
+    private static void AssertOpenPublication(
+        JsonElement publication,
+        int expectedVersion,
+        string expectedChecksum)
+    {
+        publication.GetProperty("uri").GetString().ShouldBe("file:///Card.viu");
+        publication.GetProperty("version").GetInt32().ShouldBe(expectedVersion);
+        publication.GetProperty("textChecksum").GetString().ShouldBe(expectedChecksum);
+        publication.GetProperty("isClosed").GetBoolean().ShouldBeFalse();
+        publication
+            .GetProperty("classifications")
+            .EnumerateArray()
+            .Select(classification => classification
+                .GetProperty("classificationTypeName")
+                .GetString())
+            .ShouldBe(
+            [
+                LanguageClassificationTypeNames.PropertyName,
+                LanguageClassificationTypeNames.FieldName,
+                LanguageClassificationTypeNames.LocalName,
+            ]);
+        JsonElement range = publication
+            .GetProperty("classifications")[0]
+            .GetProperty("range");
+        range.GetProperty("start").GetProperty("line").GetInt32().ShouldBe(1);
+        range.GetProperty("start").GetProperty("character").GetInt32().ShouldBe(4);
+        range.GetProperty("end").GetProperty("character").GetInt32().ShouldBe(9);
+    }
+
+    private static async Task<List<JsonDocument>> ReadAllMessagesAsync(Stream stream)
+    {
+        var reader = new LanguageServerProtocolMessageReader(stream);
+        var messages = new List<JsonDocument>();
+        while (true)
+        {
+            JsonDocument? message = await reader.ReadAsync();
+            if (message is null)
+            {
+                return messages;
+            }
+
+            messages.Add(message);
+        }
+    }
+
+    private static string Frame(string payload)
+        => $"Content-Length: {Encoding.UTF8.GetByteCount(payload)}\r\n\r\n{payload}";
+
+    private sealed class SnapshotLanguageService : ILanguageService
+    {
+        private int? version;
+
+        public void OpenDocument(string documentUri, string text, int? version) =>
+            this.version = version;
+
+        public bool ChangeDocument(
+            string documentUri,
+            int? version,
+            IReadOnlyList<LanguageDocumentChange> changes)
+        {
+            this.version = version;
+            return true;
+        }
+
+        public bool CloseDocument(string documentUri)
+        {
+            this.version = null;
+            return true;
+        }
+
+        public LanguageClassificationSnapshot? GetClassificationSnapshot(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => CreateClassificationSnapshot(version);
+
+        public LanguageDocumentPublication GetDocumentPublication(
+            string documentUri,
+            bool includeSemanticClassifications,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var capturedVersion = version;
+            return new LanguageDocumentPublication(
+                includeSemanticClassifications
+                    ? CreateClassificationSnapshot(capturedVersion)
+                    : null,
+                []);
+        }
+
+        private static LanguageClassificationSnapshot CreateClassificationSnapshot(int? version)
+            => new(
+                version,
+                $"checksum-{version}",
+                [
+                    new LanguageClassification(
+                        new LanguageRange(
+                            new LanguagePosition(1, 4),
+                            new LanguagePosition(1, 9)),
+                        LanguageClassificationTypeNames.PropertyName),
+                    new LanguageClassification(
+                        new LanguageRange(
+                            new LanguagePosition(1, 10),
+                            new LanguagePosition(1, 15)),
+                        LanguageClassificationTypeNames.FieldName),
+                    new LanguageClassification(
+                        new LanguageRange(
+                            new LanguagePosition(1, 16),
+                            new LanguagePosition(1, 21)),
+                        LanguageClassificationTypeNames.LocalName),
+                ]);
+
+        public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageCompletionItem> GetCompletions(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public LanguageHover? GetHover(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public string? ResolveCompletionDocumentation(
+            string documentUri,
+            string completionLabel,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public IReadOnlyList<LanguageDocumentSymbol> GetDocumentSymbols(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageFoldingRange> GetFoldingRanges(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageCodeAction> GetCodeActions(
+            string documentUri,
+            LanguageRange range,
+            CancellationToken cancellationToken = default)
+            => [];
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticStatusTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticStatusTests.cs
@@ -17,7 +17,8 @@ namespace Assimalign.Viu.LanguageServer.Tests;
 
 /// <summary>
 /// Pins the project-context status plumbing ([V01.01.12.23], #259): the host probes on document
-/// open and on semantic feature requests, feeds the resolved context to
+/// open, in debounced publication rounds, and on semantic feature requests, feeds the resolved
+/// context to
 /// <see cref="IScriptSemanticLanguageService"/>, and reports each (project, status, detail) via
 /// <c>window/logMessage</c> exactly once — never once per keystroke.
 /// </summary>
@@ -150,6 +151,57 @@ public class LanguageServerSemanticStatusTests
         }
     }
 
+    [Fact]
+    public async Task RunAsync_DidChange_RefreshesProjectContextBeforeDiagnostics()
+    {
+        const string InitialSiblingText = "// initial sibling";
+        const string RefreshedSiblingText = "// refreshed sibling with a changed length";
+        var directory = CreateFixtureRoot("did-change-refresh");
+        try
+        {
+            var projectFilePath = Path.Combine(directory, "Application.csproj");
+            File.WriteAllText(projectFilePath, "<Project Sdk=\"Assimalign.Viu.Sdk\" />");
+            var siblingFilePath = Path.Combine(directory, "Sibling.cs");
+            File.WriteAllText(siblingFilePath, InitialSiblingText);
+            var componentPath = Path.Combine(directory, "Card.viu");
+            File.WriteAllText(componentPath, "@script\n");
+            WriteMinimalResolvableAssetsFile(directory);
+            File.SetLastWriteTimeUtc(projectFilePath, DateTime.UtcNow.AddMinutes(-10));
+            var documentUri = new Uri(componentPath).AbsoluteUri;
+
+            var languageService = new ContextRecordingLanguageService(
+                () => File.WriteAllText(siblingFilePath, RefreshedSiblingText));
+            await using var session = new LanguageServerHostSession(
+                new LanguageServerHost(languageService));
+
+            await session.SendAsync(CreateOpenMessage(documentUri, "@script\n"));
+            await session.SendAsync(CreateChangeMessage(documentUri, "@script { }\n"));
+            await languageService.RefreshedDiagnosticsCompleted.Task.WaitAsync(
+                TimeSpan.FromSeconds(5));
+            languageService.DiagnosticSiblingTexts.ShouldBe(
+                [InitialSiblingText, RefreshedSiblingText]);
+
+            await session.SendAsync(
+                """
+                {"jsonrpc":"2.0","id":"shutdown","method":"shutdown","params":null}
+                """);
+            using (JsonDocument shutdown = await session.ReadResponseAsync("shutdown"))
+            {
+                shutdown.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+            }
+
+            await session.SendAsync(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """);
+            (await session.CompleteAsync()).ShouldBe(0);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     private static string CreateFixtureRoot(string scenario)
     {
         var directory = Path.Combine(
@@ -217,6 +269,29 @@ public class LanguageServerSemanticStatusTests
                 },
             });
 
+    private static string CreateChangeMessage(string documentUri, string text)
+        => JsonSerializer.Serialize(
+            new
+            {
+                jsonrpc = "2.0",
+                method = "textDocument/didChange",
+                @params = new
+                {
+                    textDocument = new
+                    {
+                        uri = documentUri,
+                        version = 2,
+                    },
+                    contentChanges = new[]
+                    {
+                        new
+                        {
+                            text,
+                        },
+                    },
+                },
+            });
+
     private static List<JsonElement> FindLogMessages(List<JsonDocument> messages)
         => messages
             .Where(
@@ -263,6 +338,11 @@ public class LanguageServerSemanticStatusTests
     {
         private readonly object synchronization = new();
         private readonly List<(string DocumentUri, LanguageProjectContext? Context)> configured = [];
+        private readonly List<string?> diagnosticSiblingTexts = [];
+        private readonly Action? documentChanged;
+
+        internal ContextRecordingLanguageService(Action? documentChanged = null)
+            => this.documentChanged = documentChanged;
 
         internal IReadOnlyList<(string DocumentUri, LanguageProjectContext? Context)> ConfiguredContexts
         {
@@ -274,6 +354,20 @@ public class LanguageServerSemanticStatusTests
                 }
             }
         }
+
+        internal IReadOnlyList<string?> DiagnosticSiblingTexts
+        {
+            get
+            {
+                lock (synchronization)
+                {
+                    return diagnosticSiblingTexts.ToArray();
+                }
+            }
+        }
+
+        internal TaskCompletionSource RefreshedDiagnosticsCompleted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void ConfigureProjectContext(string documentUri, LanguageProjectContext? context)
         {
@@ -291,14 +385,32 @@ public class LanguageServerSemanticStatusTests
             string documentUri,
             int? version,
             IReadOnlyList<LanguageDocumentChange> changes)
-            => true;
+        {
+            documentChanged?.Invoke();
+            return true;
+        }
 
         public bool CloseDocument(string documentUri) => true;
 
         public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
             string documentUri,
             CancellationToken cancellationToken = default)
-            => Array.Empty<LanguageDiagnostic>();
+        {
+            lock (synchronization)
+            {
+                var context = configured.Count == 0
+                    ? null
+                    : configured[configured.Count - 1].Context;
+                diagnosticSiblingTexts.Add(
+                    context?.SourceDocuments.SingleOrDefault()?.Text);
+                if (diagnosticSiblingTexts.Count >= 2)
+                {
+                    RefreshedDiagnosticsCompleted.TrySetResult();
+                }
+
+                return Array.Empty<LanguageDiagnostic>();
+            }
+        }
 
         public IReadOnlyList<LanguageCompletionItem> GetCompletions(
             string documentUri,

--- a/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticTokenTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/LanguageServerSemanticTokenTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.LanguageService;
+
+namespace Assimalign.Viu.LanguageServer.Tests;
+
+/// <summary>
+/// Pins the
+/// <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens">
+/// Language Server Protocol 3.17 full semantic-token response</see> for projected C#
+/// classifications. The integer stream uses the standard relative encoding and the legend
+/// advertised at initialize.
+/// </summary>
+public class LanguageServerSemanticTokenTests
+{
+    [Fact]
+    public async Task RunAsync_FullSemanticTokenRequest_EncodesSortedAuthoredClassifications()
+    {
+        var inputBytes = Encoding.UTF8.GetBytes(
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Card.viu","languageId":"viu","version":1,"text":"@script {\n    int Value;\n}\n"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","id":"tokens","method":"textDocument/semanticTokens/full","params":{"textDocument":{"uri":"file:///Card.viu"}}}
+                """) +
+            Frame(
+                """
+                {"jsonrpc":"2.0","method":"exit"}
+                """));
+
+        await using var input = new MemoryStream(inputBytes);
+        await using var output = new MemoryStream();
+        var host = new LanguageServerHost(new ClassificationLanguageService());
+
+        await host.RunAsync(input, output);
+
+        output.Position = 0;
+        var messages = await ReadAllMessagesAsync(output);
+        var data = messages
+            .Single(message => message.RootElement.TryGetProperty("id", out _))
+            .RootElement
+            .GetProperty("result")
+            .GetProperty("data")
+            .EnumerateArray()
+            .Select(value => value.GetInt32());
+        data.ShouldBe(
+        [
+            1, 10, 10, 0, 0,
+            1, 4, 5, 9, 0,
+            0, 11, 4, 7, 0,
+        ]);
+
+        foreach (var message in messages)
+        {
+            message.Dispose();
+        }
+    }
+
+    private static async Task<List<JsonDocument>> ReadAllMessagesAsync(Stream stream)
+    {
+        var reader = new LanguageServerProtocolMessageReader(stream);
+        var messages = new List<JsonDocument>();
+        while (true)
+        {
+            var message = await reader.ReadAsync();
+            if (message is null)
+            {
+                return messages;
+            }
+
+            messages.Add(message);
+        }
+    }
+
+    private static string Frame(string payload)
+        => $"Content-Length: {Encoding.UTF8.GetByteCount(payload)}\r\n\r\n{payload}";
+
+    private sealed class ClassificationLanguageService : ILanguageService
+    {
+        public void OpenDocument(string documentUri, string text, int? version)
+        {
+        }
+
+        public bool ChangeDocument(
+            string documentUri,
+            int? version,
+            IReadOnlyList<LanguageDocumentChange> changes)
+            => true;
+
+        public bool CloseDocument(string documentUri) => true;
+
+        public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageClassification> GetClassifications(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            =>
+            [
+                new LanguageClassification(
+                    new LanguageRange(new LanguagePosition(2, 15), new LanguagePosition(2, 19)),
+                    LanguageClassificationTypeNames.ParameterName),
+                new LanguageClassification(
+                    new LanguageRange(new LanguagePosition(1, 10), new LanguagePosition(1, 20)),
+                    LanguageClassificationTypeNames.NamespaceName),
+                new LanguageClassification(
+                    new LanguageRange(new LanguagePosition(2, 4), new LanguagePosition(2, 9)),
+                    LanguageClassificationTypeNames.PropertyName),
+            ];
+
+        public IReadOnlyList<LanguageCompletionItem> GetCompletions(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public LanguageHover? GetHover(
+            string documentUri,
+            LanguagePosition position,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public string? ResolveCompletionDocumentation(
+            string documentUri,
+            string completionLabel,
+            CancellationToken cancellationToken = default)
+            => null;
+
+        public IReadOnlyList<LanguageDocumentSymbol> GetDocumentSymbols(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageFoldingRange> GetFoldingRanges(
+            string documentUri,
+            CancellationToken cancellationToken = default)
+            => [];
+
+        public IReadOnlyList<LanguageCodeAction> GetCodeActions(
+            string documentUri,
+            LanguageRange range,
+            CancellationToken cancellationToken = default)
+            => [];
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageServer/test/ViuProjectAssetsReaderTests.cs
+++ b/tooling/Assimalign.Viu.LanguageServer/test/ViuProjectAssetsReaderTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading;
 
 using Shouldly;
 
@@ -151,6 +152,27 @@ public class ViuProjectAssetsReaderTests
             assets.ProjectDirectory.ShouldBe(projectDirectory + Path.DirectorySeparatorChar);
             assets.Configuration.ShouldBe("Debug");
             assets.CacheStamp.ShouldNotBeNullOrEmpty();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void EnumerateSourceCone_CanceledScan_ThrowsBeforeCollectingFiles()
+    {
+        var root = CreateFixtureRoot();
+        try
+        {
+            CreateFile(Path.Combine(root, "Component.cs"), "// component");
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Should.Throw<OperationCanceledException>(
+                () => ViuProjectAssetsReader.EnumerateSourceCone(
+                    root,
+                    cancellationSource.Token));
         }
         finally
         {

--- a/tooling/Assimalign.Viu.LanguageService/src/Abstraction/ILanguageService.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Abstraction/ILanguageService.cs
@@ -36,7 +36,11 @@ public interface ILanguageService
     /// <returns><see langword="true"/> when an open document was removed.</returns>
     bool CloseDocument(string documentUri);
 
-    /// <summary>Gets parser diagnostics for an open document.</summary>
+    /// <summary>
+    /// Gets authored-position parser, template, projected C#, style, and component-contract
+    /// diagnostics for an open document. Generated component scaffold spans are suppressed.
+    /// [V01.01.12.07.15]
+    /// </summary>
     /// <param name="documentUri">The document URI used by the editor.</param>
     /// <param name="cancellationToken">
     /// The token that cancels the computation. Cancellation is cooperative; a canceled call throws
@@ -46,6 +50,69 @@ public interface ILanguageService
     IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
         string documentUri,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets semantic classifications for authored C# identifiers in an open document's script
+    /// block. Generated component scaffold spans are suppressed. [V01.01.12.07.11]
+    /// </summary>
+    /// <param name="documentUri">The document URI used by the editor.</param>
+    /// <param name="cancellationToken">
+    /// The token that cancels the computation. Cancellation is cooperative; a canceled call throws
+    /// <see cref="System.OperationCanceledException"/> and leaves no service state modified.
+    /// </param>
+    /// <returns>
+    /// The classifications in authored source order, or an empty list when the document is not open
+    /// or project semantics are unavailable.
+    /// </returns>
+    IReadOnlyList<LanguageClassification> GetClassifications(
+        string documentUri,
+        CancellationToken cancellationToken = default)
+        => [];
+
+    /// <summary>
+    /// Gets semantic classifications and the immutable open-document identity they describe. The
+    /// identity lets an asynchronous editor adapter reject stale spans without loading the language
+    /// parser or Roslyn into the editor process. [V01.01.12.07.11]
+    /// </summary>
+    /// <param name="documentUri">The document URI used by the editor.</param>
+    /// <param name="cancellationToken">
+    /// The token that cancels the computation. Cancellation is cooperative; a canceled call throws
+    /// <see cref="System.OperationCanceledException"/> and leaves no service state modified.
+    /// </param>
+    /// <returns>
+    /// The atomic classification snapshot, or <see langword="null"/> when the document is not open.
+    /// Implementations that do not provide semantic classification snapshots may retain this default.
+    /// </returns>
+    LanguageClassificationSnapshot? GetClassificationSnapshot(
+        string documentUri,
+        CancellationToken cancellationToken = default)
+        => null;
+
+    /// <summary>
+    /// Gets the complete semantic publication for one immutable open-document snapshot. A service
+    /// can share its projection and compilation work across classifications and diagnostics.
+    /// Implementations retaining the default publish diagnostics only; an implementation that
+    /// supplies classifications must override this member so both layers come from one snapshot
+    /// rather than sequentially composing independently captured reads.
+    /// [V01.01.12.07.11] [V01.01.12.07.15]
+    /// </summary>
+    /// <param name="documentUri">The document URI used by the editor.</param>
+    /// <param name="includeSemanticClassifications">
+    /// <see langword="true"/> when the host negotiated semantic-classification publication;
+    /// otherwise, <see langword="false"/> so the service can skip that semantic bind.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token that cancels the complete publication computation. Cancellation is cooperative
+    /// and leaves no partially published service state.
+    /// </param>
+    /// <returns>The classifications and diagnostics computed for the captured snapshot.</returns>
+    LanguageDocumentPublication GetDocumentPublication(
+        string documentUri,
+        bool includeSemanticClassifications,
+        CancellationToken cancellationToken = default)
+        => new(
+            ClassificationSnapshot: null,
+            Diagnostics: GetDiagnostics(documentUri, cancellationToken));
 
     /// <summary>Gets context-sensitive completion items at a document position.</summary>
     /// <param name="documentUri">The document URI used by the editor.</param>

--- a/tooling/Assimalign.Viu.LanguageService/src/Assimalign.Viu.LanguageService.csproj
+++ b/tooling/Assimalign.Viu.LanguageService/src/Assimalign.Viu.LanguageService.csproj
@@ -14,6 +14,10 @@
          exact scope id the build's source generator derives, so the editor-built generated document
          is identical to the generator's by construction. -->
     <ViuProjectReference Include="Assimalign.Viu.Compiler.Css" />
+    <!-- Component style-class completion ([V01.01.12.07.13], #334) reads selectors from the same
+         recoverable CSS tree the compiler scopes and emits. Already in the closure transitively;
+         declared here because this project now compiles directly against its syntax types. -->
+    <ViuProjectReference Include="Assimalign.Viu.Syntax.Css" />
     <!-- Template element folding ([V01.01.12.07.07]) parses the template block's markup with the same
          recoverable template parser the build compiles templates with, so the elements the editor folds
          are exactly the elements the build sees. Already in the closure transitively; declared here

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageDiagnosticProvider.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageDiagnosticProvider.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Materializes the shared single-file-component projection's host-neutral diagnostics at authored
+/// document coordinates, including compilation-wide component-usage validation ([V01.01.12.07.15],
+/// #336). The language server and Visual Studio remain transport adapters over this result.
+/// </summary>
+internal static class LanguageDiagnosticProvider
+{
+    /// <summary>Gets template, style, and component-usage diagnostics for one live projection.</summary>
+    /// <param name="projection">The single projection shared by the publication round.</param>
+    /// <param name="componentCatalog">
+    /// The build-equivalent component declaration catalog, or <see langword="null"/> when the host
+    /// has not resolved a compilation closure.
+    /// </param>
+    /// <param name="cancellationToken">The token cancelling diagnostic materialization.</param>
+    /// <returns>The authored-position language diagnostics.</returns>
+    internal static IReadOnlyList<LanguageDiagnostic> GetProjectionDiagnostics(
+        SingleFileComponentProjectionResult projection,
+        ComponentDeclarationCatalog? componentCatalog,
+        CancellationToken cancellationToken)
+    {
+        var diagnostics = new List<DiagnosticInfo>(
+            projection.Diagnostics.Count + projection.ComponentUsages.Count);
+        foreach (var diagnostic in projection.Diagnostics)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // The incremental syntax workspace remains authoritative for container recovery and
+            // tag-based compatibility. Re-running the full projection over an incomplete edit can
+            // produce secondary VIU10xx, VIU1201-VIU1203, or VIU1206 errors that replace or duplicate
+            // those stable diagnostics. The build's VIU1204, VIU1205, and VIU1207-VIU1209 rules are
+            // primary authored-member diagnostics and are additive alongside the nested template/style
+            // bands; VIU14xx is appended below after a compilation-wide catalog resolves.
+            if (diagnostic.Descriptor.Id.StartsWith("VIU11", StringComparison.Ordinal) ||
+                diagnostic.Descriptor.Id.StartsWith("VIU13", StringComparison.Ordinal) ||
+                diagnostic.Descriptor.Id is
+                    "VIU1204" or
+                    "VIU1205" or
+                    "VIU1207" or
+                    "VIU1208" or
+                    "VIU1209")
+            {
+                diagnostics.Add(diagnostic);
+            }
+        }
+
+        // A loose file or semantic-engine miss has no compilation-wide declaration closure.
+        // Treating the empty fallback catalog as authoritative would falsely report every component
+        // as unresolved; VIU14xx activates only after the engine resolves the catalog. A resolved,
+        // genuinely empty catalog remains a value here and correctly reports unresolved usages.
+        if (componentCatalog is { } resolvedCatalog)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ComponentUsageValidator.Validate(
+                projection.ComponentUsages,
+                resolvedCatalog,
+                diagnostics);
+        }
+
+        var result = new LanguageDiagnostic[diagnostics.Count];
+        for (var index = 0; index < diagnostics.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result[index] = ToLanguageDiagnostic(diagnostics[index]);
+        }
+
+        return result;
+    }
+
+    private static LanguageDiagnostic ToLanguageDiagnostic(DiagnosticInfo diagnostic)
+        => new(
+            new LanguageRange(
+                new LanguagePosition(
+                    diagnostic.Location.StartLine,
+                    diagnostic.Location.StartCharacter),
+                new LanguagePosition(
+                    diagnostic.Location.EndLine,
+                    diagnostic.Location.EndCharacter)),
+            diagnostic.Descriptor.DefaultSeverity switch
+            {
+                SingleFileComponentDiagnosticSeverity.Information =>
+                    LanguageDiagnosticSeverity.Information,
+                SingleFileComponentDiagnosticSeverity.Warning =>
+                    LanguageDiagnosticSeverity.Warning,
+                _ => LanguageDiagnosticSeverity.Error,
+            },
+            diagnostic.Descriptor.Id,
+            diagnostic.Message,
+            "viu");
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageDocumentProjection.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageDocumentProjection.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+
+using Assimalign.Viu.Compiler.Css;
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Projects one live language-service document through the same single-file-component pipeline the
+/// build uses. The host-fed project context supplies the build's namespace and path inputs when it is
+/// available; a loose document still receives deterministic parser, template, script, and style
+/// diagnostics through the context-free name resolver ([V01.01.12.07.15], #336).
+/// </summary>
+internal static class LanguageDocumentProjection
+{
+    /// <summary>Projects <paramref name="document"/> into the shared host-neutral model.</summary>
+    /// <param name="document">The immutable live document snapshot.</param>
+    /// <param name="context">The resolved project context, or <see langword="null"/> for a loose file.</param>
+    /// <param name="cancellationToken">The token cancelling the projection.</param>
+    /// <returns>The build-identical projection result.</returns>
+    internal static SingleFileComponentProjectionResult Project(
+        LanguageDocument document,
+        LanguageProjectContext? context,
+        CancellationToken cancellationToken)
+    {
+        var filePath = GetFilePath(document.DocumentUri);
+        var name = SingleFileComponentNameResolver.Resolve(
+            filePath,
+            context?.ProjectDirectory,
+            context?.RootNamespace);
+        var input = new SingleFileComponentProjectionInput(
+            document.Syntax.Format == LanguageDocumentFormat.Vue
+                ? SingleFileComponentFormat.Vue
+                : SingleFileComponentFormat.Viu,
+            filePath,
+            GetLeafFileName(filePath),
+            document.Text,
+            name.Namespace,
+            name.ClassName,
+            name.HintName,
+            StyleScopeId.Resolve(filePath, context?.ProjectDirectory),
+            HotReloadComponentIdentifier: null,
+            HasCanonicalPeer: false);
+        return SingleFileComponentProjection.Project(input, cancellationToken);
+    }
+
+    /// <summary>Resolves an editor URI into the file path used by projection and line mapping.</summary>
+    /// <param name="documentUri">The editor document URI.</param>
+    /// <returns>The local file path for a file URI; otherwise the URI text itself.</returns>
+    internal static string GetFilePath(string documentUri)
+        => Uri.TryCreate(documentUri, UriKind.Absolute, out var uri) && uri.IsFile
+            ? uri.LocalPath
+            : documentUri;
+
+    private static string GetLeafFileName(string filePath)
+    {
+        var lastSeparator = filePath.LastIndexOfAny(['/', '\\']);
+        return lastSeparator >= 0 ? filePath.Substring(lastSeparator + 1) : filePath;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageTextChecksum.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/LanguageTextChecksum.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Computes the stable text identity carried beside asynchronous semantic classifications.
+/// </summary>
+internal static class LanguageTextChecksum
+{
+    /// <summary>Computes a base-64 SHA-256 checksum over the text's UTF-8 representation.</summary>
+    internal static string Compute(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        using var algorithm = SHA256.Create();
+        return Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(text)));
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptCompletionContext.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptCompletionContext.cs
@@ -16,8 +16,11 @@ namespace Assimalign.Viu.LanguageService;
 /// <em>statement</em> inside a method body (depth greater than 0).
 /// </para>
 /// <para>
-/// Only the contexts the service can act on differently are distinguished. Everything that is not a
-/// using directive is <see cref="ScriptCompletionContextKind.Expression"/>, including a
+/// Only the contexts the service can act on differently are distinguished. A cursor inside a comment
+/// or literal text segment is <see cref="ScriptCompletionContextKind.Suppressed"/>; an interpolated
+/// string's expression holes remain <see cref="ScriptCompletionContextKind.Expression"/>. Everything
+/// else that is not a using directive is also <see cref="ScriptCompletionContextKind.Expression"/>,
+/// including a
 /// member-declaration position between members: a field initializer (<c>private int _total = _seed
 /// + 1;</c>) begins on such a line, so the service cannot suppress instance members there without
 /// also breaking the initializer — and the component's own members, private ones included, are
@@ -46,7 +49,22 @@ internal static class ScriptCompletionContext
             return ScriptCompletionContextKind.Expression;
         }
 
-        if (!TryScan(blockContent, contentOffset, out var depth, out var lineStart) || depth != 0)
+        if (!TryScan(
+                blockContent,
+                contentOffset,
+                out var depth,
+                out var lineStart,
+                out var isInterpolationExpression))
+        {
+            return ScriptCompletionContextKind.Suppressed;
+        }
+
+        if (isInterpolationExpression)
+        {
+            return ScriptCompletionContextKind.Expression;
+        }
+
+        if (depth != 0)
         {
             return ScriptCompletionContextKind.Expression;
         }
@@ -107,12 +125,20 @@ internal static class ScriptCompletionContext
         => character is ' ' or '\t';
 
     // Scans the content prefix, reporting the brace depth and current line start at the cursor.
-    // Returns false when the cursor sits inside a comment or a literal, where no completion source
-    // is context-sensitive and the caller keeps its unchanged default.
-    private static bool TryScan(string content, int offset, out int depth, out int lineStart)
+    // Returns false when the cursor sits inside a comment or a literal text segment, where
+    // completion is suppressed rather than leaking the surrounding member/expression catalog into
+    // prose. Interpolation holes are scanned as code and reported separately so they cannot be
+    // mistaken for a top-level using directive even when a verbatim string crosses a line boundary.
+    private static bool TryScan(
+        string content,
+        int offset,
+        out int depth,
+        out int lineStart,
+        out bool isInterpolationExpression)
     {
         depth = 0;
         lineStart = 0;
+        isInterpolationExpression = false;
         var index = 0;
         while (index < offset)
         {
@@ -140,7 +166,9 @@ internal static class ScriptCompletionContext
 
                 case '/' when index + 1 < content.Length && content[index + 1] == '/':
                     index = SkipLineComment(content, index);
-                    if (index > offset)
+                    // The newline is not part of the line comment, but a caret at its offset is
+                    // still immediately before it and therefore still inside the comment.
+                    if (index >= offset)
                     {
                         return false;
                     }
@@ -157,12 +185,18 @@ internal static class ScriptCompletionContext
 
                 case '"':
                 case '\'':
-                case '@' when index + 1 < content.Length && content[index + 1] == '"':
-                case '$' when index + 1 < content.Length &&
-                    content[index + 1] is '"' or '@' or '$':
-                    if (!TrySkipLiteral(content, ref index, ref lineStart) || index > offset)
+                case '@':
+                case '$':
+                    var literalResult = ScanLiteral(content, ref index, ref lineStart, offset);
+                    if (literalResult == LiteralScanResult.CursorInLiteral)
                     {
                         return false;
+                    }
+
+                    if (literalResult == LiteralScanResult.CursorInInterpolation)
+                    {
+                        isInterpolationExpression = true;
+                        return true;
                     }
 
                     continue;
@@ -196,23 +230,30 @@ internal static class ScriptCompletionContext
         return true;
     }
 
-    // Skips one literal: raw (`"""`), verbatim (`@"`), interpolated (any run of `$` and `@`
-    // prefixes), regular, or character. Braces inside a literal — including an interpolation hole's
-    // own braces, which are balanced within the literal — never move the depth, which is why the
-    // whole literal is skipped as a unit.
-    private static bool TrySkipLiteral(string content, ref int index, ref int lineStart)
+    // Scans one literal: raw (`"""`), verbatim (`@"`), interpolated (either `$@"` or `@$"`),
+    // regular, or character. A completed literal advances index so its caller can resume scanning
+    // code. A cursor within literal text is suppressed, while a cursor within an interpolation hole
+    // stays active code. Recursive calls preserve that distinction for strings nested in holes and
+    // interpolated strings nested in those strings.
+    private static LiteralScanResult ScanLiteral(
+        string content,
+        ref int index,
+        ref int lineStart,
+        int offset)
     {
         var start = index;
         var isVerbatim = false;
+        var dollarCount = 0;
         while (index < content.Length && content[index] is '$' or '@')
         {
             isVerbatim |= content[index] == '@';
+            dollarCount += content[index] == '$' ? 1 : 0;
             index++;
         }
 
         if (index >= content.Length)
         {
-            return false;
+            return LiteralScanResult.CursorInLiteral;
         }
 
         var quote = content[index];
@@ -221,21 +262,32 @@ internal static class ScriptCompletionContext
             // A bare `@` or `$` that introduces no literal (a verbatim identifier, most commonly):
             // resume the ordinary scan at the character after the prefix run.
             index = start + 1;
-            return true;
+            return LiteralScanResult.Completed;
         }
 
         if (quote == '"' && !isVerbatim && Matches(content, index, content.Length, "\"\"\""))
         {
-            return TrySkipRawStringLiteral(content, ref index, ref lineStart);
+            return ScanRawStringLiteral(
+                content,
+                ref index,
+                ref lineStart,
+                offset,
+                dollarCount);
         }
 
+        var isInterpolated = quote == '"' && dollarCount > 0;
         index++;
-        while (index < content.Length)
+        while (true)
         {
+            if (index >= offset || index >= content.Length)
+            {
+                return LiteralScanResult.CursorInLiteral;
+            }
+
             var character = content[index];
             if (character == '\\' && !isVerbatim)
             {
-                index += 2;
+                index = Math.Min(index + 2, content.Length);
                 continue;
             }
 
@@ -249,7 +301,59 @@ internal static class ScriptCompletionContext
                 }
 
                 index++;
-                return true;
+                return LiteralScanResult.Completed;
+            }
+
+            if (isInterpolated && character == '{')
+            {
+                var braceEnd = index;
+                while (braceEnd < content.Length && content[braceEnd] == '{')
+                {
+                    braceEnd++;
+                }
+
+                var braceCount = braceEnd - index;
+                if ((braceCount & 1) == 0)
+                {
+                    // Each doubled opening brace is literal text.
+                    index = braceEnd;
+                    continue;
+                }
+
+                // For an odd run, every pair is literal and its final brace opens the hole.
+                // A caret before that final brace remains in literal text; immediately after it is
+                // an expression position.
+                var openingBrace = braceEnd - 1;
+                if (offset <= openingBrace)
+                {
+                    return LiteralScanResult.CursorInLiteral;
+                }
+
+                index = braceEnd;
+                var interpolationResult = ScanInterpolationHole(
+                    content,
+                    ref index,
+                    ref lineStart,
+                    offset,
+                    closingBraceCount: 1);
+                if (interpolationResult != LiteralScanResult.Completed)
+                {
+                    return interpolationResult;
+                }
+
+                continue;
+            }
+
+            if (isInterpolated && character == '}')
+            {
+                // Closing braces in a text segment are escaped in pairs. An unmatched brace is
+                // invalid C#, but it is still literal text for completion-suppression purposes.
+                while (index < content.Length && content[index] == '}')
+                {
+                    index++;
+                }
+
+                continue;
             }
 
             if (character == '\n')
@@ -260,17 +364,20 @@ internal static class ScriptCompletionContext
                     // A single-line literal never crosses a newline; Roslyn's own recovery ends it
                     // at the line break, and so does this scan.
                     index++;
-                    return true;
+                    return LiteralScanResult.Completed;
                 }
             }
 
             index++;
         }
-
-        return false;
     }
 
-    private static bool TrySkipRawStringLiteral(string content, ref int index, ref int lineStart)
+    private static LiteralScanResult ScanRawStringLiteral(
+        string content,
+        ref int index,
+        ref int lineStart,
+        int offset,
+        int dollarCount)
     {
         var quoteCount = 0;
         while (index < content.Length && content[index] == '"')
@@ -279,12 +386,54 @@ internal static class ScriptCompletionContext
             index++;
         }
 
-        while (index < content.Length)
+        while (true)
         {
+            if (index >= offset || index >= content.Length)
+            {
+                return LiteralScanResult.CursorInLiteral;
+            }
+
             if (content[index] == '\n')
             {
                 lineStart = index + 1;
                 index++;
+                continue;
+            }
+
+            if (dollarCount > 0 && content[index] == '{')
+            {
+                var braceEnd = index;
+                while (braceEnd < content.Length && content[braceEnd] == '{')
+                {
+                    braceEnd++;
+                }
+
+                if (braceEnd - index >= dollarCount)
+                {
+                    // In a raw interpolated string, the dollar count is the delimiter width. Any
+                    // preceding braces in the same run are literal text; the final delimiter-width
+                    // braces open the hole.
+                    if (offset < braceEnd)
+                    {
+                        return LiteralScanResult.CursorInLiteral;
+                    }
+
+                    index = braceEnd;
+                    var interpolationResult = ScanInterpolationHole(
+                        content,
+                        ref index,
+                        ref lineStart,
+                        offset,
+                        dollarCount);
+                    if (interpolationResult != LiteralScanResult.Completed)
+                    {
+                        return interpolationResult;
+                    }
+
+                    continue;
+                }
+
+                index = braceEnd;
                 continue;
             }
 
@@ -303,10 +452,104 @@ internal static class ScriptCompletionContext
 
             if (run >= quoteCount)
             {
-                return true;
+                return index > offset
+                    ? LiteralScanResult.CursorInLiteral
+                    : LiteralScanResult.Completed;
             }
         }
+    }
 
-        return false;
+    private static LiteralScanResult ScanInterpolationHole(
+        string content,
+        ref int index,
+        ref int lineStart,
+        int offset,
+        int closingBraceCount)
+    {
+        var braceDepth = 0;
+        while (true)
+        {
+            if (index >= offset || index >= content.Length)
+            {
+                return LiteralScanResult.CursorInInterpolation;
+            }
+
+            var character = content[index];
+            switch (character)
+            {
+                case '\n':
+                    index++;
+                    lineStart = index;
+                    continue;
+
+                case '{':
+                    braceDepth++;
+                    index++;
+                    continue;
+
+                case '}':
+                    if (braceDepth > 0)
+                    {
+                        braceDepth--;
+                        index++;
+                        continue;
+                    }
+
+                    var braceEnd = index;
+                    while (braceEnd < content.Length && content[braceEnd] == '}')
+                    {
+                        braceEnd++;
+                    }
+
+                    if (braceEnd - index < closingBraceCount)
+                    {
+                        index = braceEnd;
+                        continue;
+                    }
+
+                    index += closingBraceCount;
+                    return LiteralScanResult.Completed;
+
+                case '/' when index + 1 < content.Length && content[index + 1] == '/':
+                    index = SkipLineComment(content, index);
+                    if (index >= offset)
+                    {
+                        return LiteralScanResult.CursorInLiteral;
+                    }
+
+                    continue;
+
+                case '/' when index + 1 < content.Length && content[index + 1] == '*':
+                    if (!TrySkipBlockComment(content, ref index) || index > offset)
+                    {
+                        return LiteralScanResult.CursorInLiteral;
+                    }
+
+                    continue;
+
+                case '"':
+                case '\'':
+                case '@':
+                case '$':
+                    var literalResult = ScanLiteral(content, ref index, ref lineStart, offset);
+                    if (literalResult != LiteralScanResult.Completed)
+                    {
+                        return literalResult;
+                    }
+
+                    continue;
+
+                default:
+                    index++;
+                    continue;
+            }
+        }
+    }
+
+    private enum LiteralScanResult
+    {
+        Completed,
+        CursorInLiteral,
+        CursorInInterpolation,
     }
 }

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptCompletionContextKind.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptCompletionContextKind.cs
@@ -8,6 +8,13 @@ namespace Assimalign.Viu.LanguageService;
 internal enum ScriptCompletionContextKind
 {
     /// <summary>
+    /// A position inside a C# comment or a literal's text segment. No completion source is offered
+    /// because its text is not an expression or declaration context; interpolation holes remain
+    /// expression positions. [V01.01.12.07.14]
+    /// </summary>
+    Suppressed,
+
+    /// <summary>
     /// A position where an identifier is legal — a class-body member declaration, a method body, or
     /// a field initializer. Every source applies: the semantic symbol lookup (which honors the
     /// position's own accessibility, so the component's private members complete inside its own

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptComponentContractReader.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptComponentContractReader.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Reads template-facing component contracts from the same Roslyn compilation that backs projected
+/// script features. The parameter rules are the compiler's [SFC-USE-5] symbol rules; event metadata
+/// is retained for editor completion. [V01.01.12.07.12]
+/// </summary>
+internal static class ScriptComponentContractReader
+{
+    private const string ComponentsAssemblyName = "Assimalign.Viu.Components";
+    private const string ComponentInterfaceName = "Assimalign.Viu.Components.IComponent";
+    private const string ParameterAttributeName = "Assimalign.Viu.Components.ParameterAttribute";
+    private const string EventAttributeName = "Assimalign.Viu.Components.EventAttribute";
+
+    private static readonly SymbolDisplayFormat TypeFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    private static readonly SymbolDisplayFormat EventDetailFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        memberOptions: SymbolDisplayMemberOptions.IncludeParameters |
+            SymbolDisplayMemberOptions.IncludeType,
+        parameterOptions: SymbolDisplayParameterOptions.IncludeType |
+            SymbolDisplayParameterOptions.IncludeName |
+            SymbolDisplayParameterOptions.IncludeParamsRefOut,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    internal static IReadOnlyList<TemplateComponentDeclaration> Read(
+        Compilation compilation,
+        CancellationToken cancellationToken)
+    {
+        var componentInterface = compilation.GetTypeByMetadataName(ComponentInterfaceName);
+        var parameterAttribute = compilation.GetTypeByMetadataName(ParameterAttributeName);
+        var eventAttribute = compilation.GetTypeByMetadataName(EventAttributeName);
+        if (componentInterface is null || parameterAttribute is null)
+        {
+            return Array.Empty<TemplateComponentDeclaration>();
+        }
+
+        var declarations = new List<TemplateComponentDeclaration>();
+        var context = new ScanContext(
+            componentInterface,
+            parameterAttribute,
+            eventAttribute,
+            declarations,
+            cancellationToken);
+        ScanAssembly(compilation.Assembly, context);
+        foreach (var reference in compilation.References)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly &&
+                ReferencesComponents(assembly))
+            {
+                ScanAssembly(assembly, context);
+            }
+        }
+
+        declarations.Sort(static (left, right) => string.CompareOrdinal(
+            left.CompilerDeclaration.Name,
+            right.CompilerDeclaration.Name));
+        return declarations;
+    }
+
+    private static bool ReferencesComponents(IAssemblySymbol assembly)
+    {
+        if (string.Equals(assembly.Name, ComponentsAssemblyName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        foreach (var module in assembly.Modules)
+        {
+            foreach (var identity in module.ReferencedAssemblies)
+            {
+                if (string.Equals(identity.Name, ComponentsAssemblyName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void ScanAssembly(IAssemblySymbol assembly, in ScanContext context)
+        => ScanNamespace(assembly.GlobalNamespace, context);
+
+    private static void ScanNamespace(INamespaceSymbol containing, in ScanContext context)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+        foreach (var member in containing.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol nested:
+                    ScanNamespace(nested, context);
+                    break;
+                case INamedTypeSymbol type:
+                    ScanType(type, context);
+                    break;
+            }
+        }
+    }
+
+    private static void ScanType(INamedTypeSymbol type, in ScanContext context)
+    {
+        foreach (var nested in type.GetTypeMembers())
+        {
+            ScanType(nested, context);
+        }
+
+        // Source-generator projections are read from their projection model instead. That model is
+        // the compiler's authoritative syntactic declaration surface even while an attribute is
+        // incomplete or unresolved in the live Roslyn compilation.
+        if (IsProjectedSingleFileComponent(type) ||
+            type.TypeKind != TypeKind.Class ||
+            type.IsAbstract ||
+            type.IsGenericType ||
+            !ImplementsComponent(type, context.ComponentInterface))
+        {
+            return;
+        }
+
+        List<ComponentParameterDeclaration>? parameters = null;
+        List<TemplateComponentEvent>? events = null;
+        var declaresImperativeParameters = false;
+        foreach (var member in type.GetMembers())
+        {
+            if (member is IPropertySymbol { IsStatic: false } property)
+            {
+                if (property.SetMethod is not null &&
+                    ReadParameter(property, context.ParameterAttribute) is { } declaration)
+                {
+                    (parameters ??= new List<ComponentParameterDeclaration>()).Add(declaration);
+                }
+                else if (string.Equals(property.Name, "Parameters", StringComparison.Ordinal))
+                {
+                    declaresImperativeParameters = true;
+                }
+            }
+            else if (member is IMethodSymbol { IsStatic: false } method &&
+                context.EventAttribute is not null &&
+                ReadEvent(method, context.EventAttribute) is { } componentEvent)
+            {
+                (events ??= new List<TemplateComponentEvent>()).Add(componentEvent);
+            }
+        }
+
+        parameters?.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+        events?.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+        context.Declarations.Add(
+            new TemplateComponentDeclaration(
+                new ComponentDeclarationEntry(
+                    type.Name,
+                    parameters is null
+                        ? EquatableArray<ComponentParameterDeclaration>.Empty
+                        : new EquatableArray<ComponentParameterDeclaration>(parameters.ToArray()))
+                {
+                    IsParameterSurfaceKnown = !declaresImperativeParameters,
+                },
+                events ?? (IReadOnlyList<TemplateComponentEvent>)Array.Empty<TemplateComponentEvent>()));
+    }
+
+    private static bool IsProjectedSingleFileComponent(INamedTypeSymbol type)
+    {
+        foreach (var location in type.Locations)
+        {
+            if (!location.IsInSource)
+            {
+                continue;
+            }
+
+            var filePath = location.SourceTree?.FilePath;
+            if (filePath is not null &&
+                (filePath.EndsWith(".viu", StringComparison.OrdinalIgnoreCase) ||
+                    filePath.EndsWith(".vue", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ComponentParameterDeclaration? ReadParameter(
+        IPropertySymbol property,
+        INamedTypeSymbol parameterAttribute)
+    {
+        foreach (var attribute in property.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, parameterAttribute))
+            {
+                continue;
+            }
+
+            var name = ReadDeclaredName(attribute, ComponentDeclarationNames.Derive(property.Name));
+            var isRequired = property.IsRequired;
+            foreach (var named in attribute.NamedArguments)
+            {
+                if (string.Equals(named.Key, "IsRequired", StringComparison.Ordinal) &&
+                    named.Value.Value is bool required)
+                {
+                    isRequired |= required;
+                }
+            }
+
+            return new ComponentParameterDeclaration(
+                name,
+                property.Name,
+                property.Type.ToDisplayString(TypeFormat),
+                Classify(property.Type),
+                isRequired,
+                property.IsRequired);
+        }
+
+        return null;
+    }
+
+    private static TemplateComponentEvent? ReadEvent(
+        IMethodSymbol method,
+        INamedTypeSymbol eventAttribute)
+    {
+        foreach (var attribute in method.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, eventAttribute))
+            {
+                return new TemplateComponentEvent(
+                    ReadDeclaredName(attribute, ComponentDeclarationNames.Derive(method.Name)),
+                    method.ToDisplayString(EventDetailFormat));
+            }
+        }
+
+        return null;
+    }
+
+    private static string ReadDeclaredName(AttributeData attribute, string derivedName)
+    {
+        var name = derivedName;
+        if (attribute.ConstructorArguments.Length == 1 &&
+            attribute.ConstructorArguments[0].Value is string positional &&
+            positional.Length > 0)
+        {
+            name = positional;
+        }
+
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (string.Equals(named.Key, "Name", StringComparison.Ordinal) &&
+                named.Value.Value is string explicitName &&
+                explicitName.Length > 0)
+            {
+                name = explicitName;
+            }
+        }
+
+        return name;
+    }
+
+    private static ComponentValueKind Classify(ITypeSymbol type)
+        => type switch
+        {
+            { SpecialType: SpecialType.System_String } => ComponentValueKind.Text,
+            { SpecialType: SpecialType.System_Object } => ComponentValueKind.Any,
+            { IsValueType: true } => ComponentValueKind.Value,
+            { TypeKind: TypeKind.TypeParameter } => ComponentValueKind.Unknown,
+            _ => ComponentValueKind.Reference,
+        };
+
+    private static bool ImplementsComponent(
+        INamedTypeSymbol type,
+        INamedTypeSymbol componentInterface)
+    {
+        foreach (var implemented in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(implemented, componentInterface))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private readonly struct ScanContext(
+        INamedTypeSymbol componentInterface,
+        INamedTypeSymbol parameterAttribute,
+        INamedTypeSymbol? eventAttribute,
+        List<TemplateComponentDeclaration> declarations,
+        CancellationToken cancellationToken)
+    {
+        internal INamedTypeSymbol ComponentInterface { get; } = componentInterface;
+
+        internal INamedTypeSymbol ParameterAttribute { get; } = parameterAttribute;
+
+        internal INamedTypeSymbol? EventAttribute { get; } = eventAttribute;
+
+        internal List<TemplateComponentDeclaration> Declarations { get; } = declarations;
+
+        internal CancellationToken CancellationToken { get; } = cancellationToken;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptComponentContractSnapshot.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptComponentContractSnapshot.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>Component contracts and the live projection from which the current contract was read.</summary>
+internal sealed record ScriptComponentContractSnapshot(
+    IReadOnlyList<TemplateComponentDeclaration> Declarations,
+    SingleFileComponentProjectionResult Projection);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticClassification.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticClassification.cs
@@ -1,0 +1,10 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>One classified identifier in a generated or plain C# syntax tree.</summary>
+/// <param name="Span">The syntax-tree span.</param>
+/// <param name="ClassificationTypeName">The C# editor classification-type name.</param>
+internal readonly record struct ScriptSemanticClassification(
+    TextSpan Span,
+    string ClassificationTypeName);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticClassifier.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticClassifier.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Classifies C# identifier tokens from their bound symbols, using the same symbol distinctions the
+/// ordinary C# editor exposes without taking a dependency on Roslyn Workspaces or Features.
+/// [V01.01.12.07.11]
+/// </summary>
+internal static class ScriptSemanticClassifier
+{
+    /// <summary>Classifies every bound identifier in a syntax tree in source order.</summary>
+    internal static IReadOnlyList<ScriptSemanticClassification> Classify(
+        SemanticModel semanticModel,
+        SyntaxNode root,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(semanticModel);
+        ArgumentNullException.ThrowIfNull(root);
+
+        var classifications = new List<ScriptSemanticClassification>();
+        foreach (var token in root.DescendantTokens())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!token.IsKind(SyntaxKind.IdentifierToken) ||
+                TryGetSymbol(semanticModel, token, cancellationToken) is not { } symbol ||
+                ToClassificationTypeName(symbol) is not { } classificationTypeName)
+            {
+                continue;
+            }
+
+            classifications.Add(new ScriptSemanticClassification(token.Span, classificationTypeName));
+        }
+
+        return classifications;
+    }
+
+    private static ISymbol? TryGetSymbol(
+        SemanticModel semanticModel,
+        SyntaxToken token,
+        CancellationToken cancellationToken)
+    {
+        var node = token.Parent;
+        if (node is null)
+        {
+            return null;
+        }
+
+        ISymbol? declared = node switch
+        {
+            BaseTypeDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            DelegateDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            MethodDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            LocalFunctionStatementSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            PropertyDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            EventDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            VariableDeclaratorSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            ParameterSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            TypeParameterSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            EnumMemberDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            LabeledStatementSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            CatchDeclarationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            SingleVariableDesignationSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            ForEachStatementSyntax declaration when declaration.Identifier == token
+                => semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            _ => null,
+        };
+        if (declared is not null)
+        {
+            return declared;
+        }
+
+        if (node is IdentifierNameSyntax identifierName &&
+            semanticModel.GetAliasInfo(identifierName, cancellationToken) is { } alias)
+        {
+            return alias.Target;
+        }
+
+        var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken);
+        return symbolInfo.Symbol ??
+            (symbolInfo.CandidateSymbols.Length > 0 ? symbolInfo.CandidateSymbols[0] : null);
+    }
+
+    private static string? ToClassificationTypeName(ISymbol symbol)
+        => symbol switch
+        {
+            IAliasSymbol alias => ToClassificationTypeName(alias.Target),
+            INamespaceSymbol => LanguageClassificationTypeNames.NamespaceName,
+            INamedTypeSymbol { TypeKind: TypeKind.Class } => LanguageClassificationTypeNames.ClassName,
+            INamedTypeSymbol { TypeKind: TypeKind.Delegate } => LanguageClassificationTypeNames.DelegateName,
+            INamedTypeSymbol { TypeKind: TypeKind.Enum } => LanguageClassificationTypeNames.EnumName,
+            INamedTypeSymbol { TypeKind: TypeKind.Interface } => LanguageClassificationTypeNames.InterfaceName,
+            INamedTypeSymbol { TypeKind: TypeKind.Struct } => LanguageClassificationTypeNames.StructName,
+            ITypeParameterSymbol => LanguageClassificationTypeNames.TypeParameterName,
+            IMethodSymbol { MethodKind: MethodKind.Constructor or MethodKind.StaticConstructor }
+                method => ToClassificationTypeName(method.ContainingType),
+            IMethodSymbol => LanguageClassificationTypeNames.MethodName,
+            IPropertySymbol => LanguageClassificationTypeNames.PropertyName,
+            IFieldSymbol { ContainingType.TypeKind: TypeKind.Enum }
+                => LanguageClassificationTypeNames.EnumMemberName,
+            IFieldSymbol { IsConst: true } => LanguageClassificationTypeNames.ConstantName,
+            IFieldSymbol => LanguageClassificationTypeNames.FieldName,
+            IEventSymbol => LanguageClassificationTypeNames.EventName,
+            IParameterSymbol => LanguageClassificationTypeNames.ParameterName,
+            ILocalSymbol { IsConst: true } => LanguageClassificationTypeNames.ConstantName,
+            ILocalSymbol or IRangeVariableSymbol => LanguageClassificationTypeNames.LocalName,
+            ILabelSymbol => LanguageClassificationTypeNames.LabelName,
+            _ => null,
+        };
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticEngine.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticEngine.cs
@@ -30,17 +30,19 @@ namespace Assimalign.Viu.LanguageService;
 /// CompletionService upgrade recorded as a later seam-compatible swap.
 /// </summary>
 /// <remarks>
-/// The base compilation is cached per project and revalidated by the context's
-/// <see cref="LanguageProjectContext.CacheStamp"/>: an equal stamp reuses the cache untouched, a
-/// changed single file swaps only its tree via
-/// <see cref="CSharpCompilation.ReplaceSyntaxTree"/>, and anything else rebuilds. Each request
-/// forks immutably — the open document's live text is projected, emitted, parsed, and added with
-/// <see cref="CSharpCompilation.AddSyntaxTrees"/> — so a keystroke never mutates the cache.
+/// The base compilation is cached per project and excluded live-document path. Sibling text is
+/// compared directly, while root/options and reference path, length, and write-time fingerprints
+/// identify the environment: one changed sibling swaps only its tree via
+/// <see cref="CSharpCompilation.ReplaceSyntaxTree"/>, and an environment change rebuilds. Each
+/// request forks immutably — the open document's live text is projected, emitted, parsed, and
+/// added with <see cref="CSharpCompilation.AddSyntaxTrees"/> — so a keystroke never mutates the
+/// stable cache or reprojects its siblings.
 /// Thread-safe the way <see cref="ScriptDeclarationReader"/> is: language-service reads compute
 /// outside the service lock, so the engine serializes semantic requests under its own gate
 /// (bounded work; concurrent requests wait rather than duplicate a cone build), while the
-/// per-document resolution cache is lock-free so documentation resolution and document close never
-/// wait behind a compile. Every failure that is not a cancellation is an engine miss reported as
+/// per-document resolution cache keeps documentation resolution lock-free. Document close takes the
+/// same gate so it evicts compilation and component-contract state atomically. Every failure that is
+/// not a cancellation is an engine miss reported as
 /// <see langword="null"/> — the caller's fallback is the existing syntax-only path, never an
 /// error. Parse options pin <see cref="LanguageVersion.Preview"/> (the repo-wide language surface)
 /// with the context's <see cref="LanguageProjectContext.PreprocessorSymbols"/>, so members the
@@ -94,16 +96,25 @@ internal sealed class ScriptSemanticEngine
     // A cancellation-aware gate rather than a monitor lock: a request queued behind a cone
     // build honors $/cancelRequest while waiting instead of only after acquisition.
     private readonly SemaphoreSlim gate = new(1, 1);
-    // Keyed like every host path key: ordinal-ignore-case, matching Windows path semantics.
-    private readonly Dictionary<string, ProjectCompilationState> projectStates =
-        new(StringComparer.OrdinalIgnoreCase);
+    // A project context excludes its one live document, so the live path is part of the base-cone
+    // identity. This prevents equal-stamped contexts for two open documents from sharing a base
+    // compilation that contains the wrong disk sibling.
+    private readonly Dictionary<ProjectCompilationKey, ProjectCompilationState> projectStates =
+        new(ProjectCompilationKeyComparer.Instance);
+    // The stable state owns referenced/source/sibling contracts. This second cache adds exactly the
+    // current live component contract and is replaced per live text snapshot.
+    private readonly Dictionary<ProjectCompilationKey, ComponentContractCacheEntry> componentContractCaches =
+        new(ProjectCompilationKeyComparer.Instance);
     // Label -> symbol maps from each document's most recent semantic completion, published
-    // wholesale and read lock-free so ResolveDocumentation and CloseDocument never wait behind a
-    // cone build on the engine gate.
+    // wholesale and read lock-free so ResolveDocumentation never waits behind a cone build on the
+    // engine gate.
     private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, ResolutionEntry>> resolutionCaches =
         new(StringComparer.OrdinalIgnoreCase);
     private int projectStateBuildCount;
     private int sourceTreeBuildCount;
+    private int componentContractBuildCount;
+    private int liveDocumentRequestBuildCount;
+    private int componentProjectionBuildCount;
 
     /// <summary>Gets how many times a project's base compilation was built from scratch.</summary>
     internal int ProjectStateBuildCount
@@ -200,6 +211,310 @@ internal sealed class ScriptSemanticEngine
         }
     }
 
+    /// <summary>Gets how many stable project/reference/sibling contract closures were materialized.</summary>
+    internal int ComponentContractBuildCount
+    {
+        get
+        {
+            gate.Wait();
+            try
+            {
+                return componentContractBuildCount;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+    }
+
+    /// <summary>Gets how many immutable live-document compilation forks were created.</summary>
+    internal int LiveDocumentRequestBuildCount
+    {
+        get
+        {
+            gate.Wait();
+            try
+            {
+                return liveDocumentRequestBuildCount;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+    }
+
+    /// <summary>Gets how many single-file-component projections were materialized.</summary>
+    internal int ComponentProjectionBuildCount
+    {
+        get
+        {
+            gate.Wait();
+            try
+            {
+                return componentProjectionBuildCount;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Classifies authored identifiers in the live document's projected C# tree, or returns
+    /// <see langword="null"/> when project semantics cannot be constructed. [V01.01.12.07.11]
+    /// </summary>
+    internal IReadOnlyList<LanguageClassification>? GetClassifications(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            gate.Wait(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return GetClassificationsCore(
+                    context,
+                    documentFilePath,
+                    documentText,
+                    cancellationToken);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Semantic classification is additive. Any reference, projection, or binding failure
+            // degrades to the language service's empty semantic layer; lexical color remains.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads every source, projected-component, and referenced-assembly component contract visible
+    /// to the live document's semantic compilation. [V01.01.12.07.12]
+    /// </summary>
+    internal IReadOnlyList<TemplateComponentDeclaration>? GetComponentContracts(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+        => GetComponentContractSnapshot(
+            context,
+            documentFilePath,
+            documentText,
+            cancellationToken)?.Declarations;
+
+    /// <summary>
+    /// Reads the component contracts and live projection shared by template hover, completion, and
+    /// publication, or returns <see langword="null"/> when semantic construction fails.
+    /// </summary>
+    internal ScriptComponentContractSnapshot? GetComponentContractSnapshot(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            gate.Wait(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var state = GetOrCreateProjectState(
+                    context,
+                    documentFilePath,
+                    cancellationToken);
+                if (TryGetCachedComponentContracts(
+                        state,
+                        documentText,
+                        out var cached))
+                {
+                    return cached;
+                }
+
+                var request = CreateLiveDocumentRequest(
+                    state,
+                    context,
+                    documentFilePath,
+                    documentText,
+                    cancellationToken);
+                return GetOrCreateComponentContracts(
+                    request,
+                    documentText,
+                    cancellationToken);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Computes the semantic layers for one publication round from a single immutable live-document
+    /// fork. Optional layers stay off when the client or document does not require them.
+    /// [V01.01.12.07.11] [V01.01.12.07.15]
+    /// </summary>
+    internal ScriptSemanticPublication? GetPublicationSemantics(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        bool includeClassifications,
+        bool includeDiagnostics,
+        bool includeComponentContracts,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            gate.Wait(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var state = GetOrCreateProjectState(
+                    context,
+                    documentFilePath,
+                    cancellationToken);
+                var request = CreateLiveDocumentRequest(
+                    state,
+                    context,
+                    documentFilePath,
+                    documentText,
+                    cancellationToken);
+                var classifications = includeClassifications
+                    ? GetClassificationsCore(request, documentText, cancellationToken)
+                    : Array.Empty<LanguageClassification>();
+                var diagnostics = includeDiagnostics
+                    ? GetDiagnosticsCore(request, documentText, cancellationToken)
+                    : Array.Empty<LanguageDiagnostic>();
+                var componentContracts = includeComponentContracts
+                    ? GetOrCreateComponentContracts(
+                        request,
+                        documentText,
+                        cancellationToken)
+                    : null;
+                return new ScriptSemanticPublication(
+                    classifications,
+                    diagnostics,
+                    componentContracts?.Declarations,
+                    request.Projection);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Every semantic publication layer is additive. A failed fork leaves the parser and
+            // projection diagnostics available and lexical classification intact.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets compiler diagnostics whose generated spans map back into the authored C# regions of the
+    /// live document. Generated component scaffold and template-render spans are suppressed.
+    /// [V01.01.12.07.15]
+    /// </summary>
+    internal IReadOnlyList<LanguageDiagnostic>? GetDiagnostics(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            gate.Wait(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return GetDiagnosticsCore(
+                    context,
+                    documentFilePath,
+                    documentText,
+                    cancellationToken);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Script diagnostics are an additive semantic layer. A reference, projection, or
+            // binding failure leaves the parser/template/style diagnostics available unchanged.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the Roslyn symbol at one authored C# position and returns its signature and source
+    /// or reference-assembly documentation, mapped back to the authored token. [V01.01.12.07.16]
+    /// </summary>
+    internal LanguageHover? GetHover(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        int documentOffset,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            gate.Wait(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return GetHoverCore(
+                    context,
+                    documentFilePath,
+                    documentText,
+                    documentOffset,
+                    cancellationToken);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // Hover is additive. A semantic miss lets the caller retain its syntax-only hover path.
+            return null;
+        }
+    }
+
     /// <summary>
     /// Resolves deferred documentation for a label from the document's most recent semantic
     /// completion: the symbol's signature plus its XML documentation summary (source-declared
@@ -221,10 +536,21 @@ internal sealed class ScriptSemanticEngine
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        return FormatSymbolDocumentation(
+            entry.Detail,
+            entry.Symbol,
+            cancellationToken);
+    }
+
+    private static string FormatSymbolDocumentation(
+        string detail,
+        ISymbol symbol,
+        CancellationToken cancellationToken)
+    {
         string? summary = null;
         try
         {
-            var documentationXml = entry.Symbol.GetDocumentationCommentXml(
+            var documentationXml = symbol.GetDocumentationCommentXml(
                 preferredCulture: CultureInfo.InvariantCulture,
                 expandIncludes: false,
                 cancellationToken: cancellationToken);
@@ -240,14 +566,36 @@ internal sealed class ScriptSemanticEngine
         }
 
         return summary is null
-            ? $"```csharp\n{entry.Detail}\n```"
-            : $"```csharp\n{entry.Detail}\n```\n\n{summary}";
+            ? $"```csharp\n{detail}\n```"
+            : $"```csharp\n{detail}\n```\n\n{summary}";
     }
 
-    /// <summary>Clears the per-document state a closed document leaves behind.</summary>
+    /// <summary>Clears the semantic and component-contract state a closed document leaves behind.</summary>
     /// <param name="documentUri">The editor document URI.</param>
     internal void CloseDocument(string documentUri)
-        => resolutionCaches.TryRemove(documentUri, out _);
+    {
+        resolutionCaches.TryRemove(documentUri, out _);
+        var documentFilePath = GetDocumentFilePath(documentUri);
+        gate.Wait();
+        try
+        {
+            var keys = projectStates.Keys
+                .Where(key => string.Equals(
+                    key.LiveDocumentFilePath,
+                    documentFilePath,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            foreach (var key in keys)
+            {
+                projectStates.Remove(key);
+                componentContractCaches.Remove(key);
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
 
     private ScriptSemanticCompletionResult? GetCompletionsCore(
         LanguageProjectContext context,
@@ -259,39 +607,23 @@ internal sealed class ScriptSemanticEngine
         ScriptCompletionContextKind contextKind,
         CancellationToken cancellationToken)
     {
-        var state = GetOrCreateProjectState(context, cancellationToken);
-
-        // Fork-per-request, here and only here: the live text is projected, emitted, parsed, and
-        // added to an immutable fork — the cached base compilation is never mutated per keystroke.
-        var generatedText = EmitComponent(
+        var request = CreateLiveDocumentRequest(
+            context,
             documentFilePath,
             documentText,
-            context,
             cancellationToken);
-        var mapper = GeneratedScriptDocumentMapper.Create(
-            documentText,
-            generatedText,
-            documentFilePath);
-        if (!mapper.TryMapFileOffsetToGenerated(documentOffset, out var generatedPosition))
+        if (!request.Mapper.TryMapFileOffsetToGenerated(documentOffset, out var generatedPosition))
         {
             return null;
         }
 
-        var currentTree = CSharpSyntaxTree.ParseText(
-            generatedText,
-            CreateParseOptions(context),
-            documentFilePath,
-            cancellationToken: cancellationToken);
-        var requestCompilation = state.BaseCompilation.AddSyntaxTrees(currentTree);
-        var semanticModel = requestCompilation.GetSemanticModel(currentTree);
-        var root = currentTree.GetRoot(cancellationToken);
-        if (!TryFindMemberAccessTarget(root, generatedPosition, out var target))
+        if (!TryFindMemberAccessTarget(request.Root, generatedPosition, out var target))
         {
             return null;
         }
 
         var symbols = LookupCompletionSymbols(
-            semanticModel,
+            request.SemanticModel,
             generatedPosition,
             target,
             cancellationToken);
@@ -313,7 +645,7 @@ internal sealed class ScriptSemanticEngine
         var resolutionEntries = new Dictionary<string, ResolutionEntry>(StringComparer.Ordinal);
         var items = CreateCompletionItems(
             symbols,
-            semanticModel,
+            request.SemanticModel,
             generatedPosition,
             typedPrefix,
             contextKind == ScriptCompletionContextKind.UsingDirective,
@@ -330,6 +662,311 @@ internal sealed class ScriptSemanticEngine
             items,
             target is not null,
             target?.ToString());
+    }
+
+    private IReadOnlyList<LanguageClassification> GetClassificationsCore(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        var request = CreateLiveDocumentRequest(
+            context,
+            documentFilePath,
+            documentText,
+            cancellationToken);
+        return GetClassificationsCore(request, documentText, cancellationToken);
+    }
+
+    private static IReadOnlyList<LanguageClassification> GetClassificationsCore(
+        LiveDocumentRequest request,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        var generated = ScriptSemanticClassifier.Classify(
+            request.SemanticModel,
+            request.Root,
+            cancellationToken);
+        var authored = new List<LanguageClassification>(generated.Count);
+        foreach (var classification in generated)
+        {
+            if (!request.Mapper.TryMapGeneratedSpanToFile(
+                    classification.Span.Start,
+                    classification.Span.Length,
+                    out var fileStart,
+                    out var fileLength))
+            {
+                continue;
+            }
+
+            authored.Add(
+                new LanguageClassification(
+                    new LanguageRange(
+                        TextCoordinateConverter.GetPosition(documentText, fileStart),
+                        TextCoordinateConverter.GetPosition(documentText, fileStart + fileLength)),
+                    classification.ClassificationTypeName));
+        }
+
+        return authored;
+    }
+
+    private IReadOnlyList<LanguageDiagnostic> GetDiagnosticsCore(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        var request = CreateLiveDocumentRequest(
+            context,
+            documentFilePath,
+            documentText,
+            cancellationToken);
+        return GetDiagnosticsCore(request, documentText, cancellationToken);
+    }
+
+    private static IReadOnlyList<LanguageDiagnostic> GetDiagnosticsCore(
+        LiveDocumentRequest request,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        var generated = request.SemanticModel.GetDiagnostics(
+            cancellationToken: cancellationToken);
+        var authored = new List<LanguageDiagnostic>(generated.Length);
+        foreach (var diagnostic in generated)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!diagnostic.Location.IsInSource ||
+                !ReferenceEquals(diagnostic.Location.SourceTree, request.Tree))
+            {
+                continue;
+            }
+
+            var generatedSpan = diagnostic.Location.SourceSpan;
+            if (!request.Mapper.TryMapGeneratedSpanToFile(
+                    generatedSpan.Start,
+                    generatedSpan.Length,
+                    out var fileStart,
+                    out var fileLength))
+            {
+                continue;
+            }
+
+            authored.Add(
+                new LanguageDiagnostic(
+                    new LanguageRange(
+                        TextCoordinateConverter.GetPosition(documentText, fileStart),
+                        TextCoordinateConverter.GetPosition(documentText, fileStart + fileLength)),
+                    diagnostic.Severity switch
+                    {
+                        Microsoft.CodeAnalysis.DiagnosticSeverity.Error =>
+                            LanguageDiagnosticSeverity.Error,
+                        Microsoft.CodeAnalysis.DiagnosticSeverity.Warning =>
+                            LanguageDiagnosticSeverity.Warning,
+                        Microsoft.CodeAnalysis.DiagnosticSeverity.Info =>
+                            LanguageDiagnosticSeverity.Information,
+                        _ => LanguageDiagnosticSeverity.Hint,
+                    },
+                    diagnostic.Id,
+                    diagnostic.GetMessage(CultureInfo.InvariantCulture),
+                    "csharp"));
+        }
+
+        return authored;
+    }
+
+    private LanguageHover? GetHoverCore(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        int documentOffset,
+        CancellationToken cancellationToken)
+    {
+        var request = CreateLiveDocumentRequest(
+            context,
+            documentFilePath,
+            documentText,
+            cancellationToken);
+        if (!request.Mapper.TryMapFileOffsetToGenerated(
+                documentOffset,
+                out var generatedPosition) ||
+            generatedPosition >= request.Root.FullSpan.End)
+        {
+            return null;
+        }
+
+        var token = request.Root.FindToken(generatedPosition);
+        if (!token.Span.Contains(generatedPosition) || token.Span.Length == 0)
+        {
+            return null;
+        }
+
+        var symbol = ResolveHoverSymbol(
+            request.SemanticModel,
+            token,
+            cancellationToken);
+        if (symbol is null)
+        {
+            return null;
+        }
+
+        if (!request.Mapper.TryMapGeneratedSpanToFile(
+                token.Span.Start,
+                token.Span.Length,
+                out var fileStart,
+                out var fileLength))
+        {
+            return null;
+        }
+
+        if (symbol is IAliasSymbol alias)
+        {
+            symbol = alias.Target;
+        }
+
+        var detail = symbol.ToMinimalDisplayString(
+            request.SemanticModel,
+            generatedPosition,
+            DetailFormat);
+        return new LanguageHover(
+            FormatSymbolDocumentation(detail, symbol, cancellationToken),
+            new LanguageRange(
+                TextCoordinateConverter.GetPosition(documentText, fileStart),
+                TextCoordinateConverter.GetPosition(documentText, fileStart + fileLength)));
+    }
+
+    private static ISymbol? ResolveHoverSymbol(
+        SemanticModel semanticModel,
+        SyntaxToken token,
+        CancellationToken cancellationToken)
+    {
+        var declaredSymbol = token.Parent switch
+        {
+            BaseTypeDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            DelegateDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            MethodDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            ConstructorDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            DestructorDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            PropertyDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            EventDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            VariableDeclaratorSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            ParameterSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            TypeParameterSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            EnumMemberDeclarationSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            LocalFunctionStatementSyntax declaration when declaration.Identifier == token =>
+                semanticModel.GetDeclaredSymbol(declaration, cancellationToken),
+            _ => null,
+        };
+        if (declaredSymbol is not null)
+        {
+            return declaredSymbol;
+        }
+
+        for (var node = token.Parent; node is not null; node = node.Parent)
+        {
+            if (node is PredefinedTypeSyntax)
+            {
+                return semanticModel.GetTypeInfo(node, cancellationToken).Type;
+            }
+
+            if (node is not SimpleNameSyntax &&
+                node is not MemberAccessExpressionSyntax &&
+                node is not QualifiedNameSyntax &&
+                node is not AliasQualifiedNameSyntax &&
+                node is not MemberBindingExpressionSyntax &&
+                node is not ObjectCreationExpressionSyntax)
+            {
+                if (node is StatementSyntax or MemberDeclarationSyntax)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            var symbolInformation = semanticModel.GetSymbolInfo(node, cancellationToken);
+            var symbol = symbolInformation.Symbol ??
+                (symbolInformation.CandidateSymbols.Length > 0
+                    ? symbolInformation.CandidateSymbols[0]
+                    : null);
+            if (symbol is not null)
+            {
+                return symbol;
+            }
+
+            if (node is TypeSyntax or ExpressionSyntax)
+            {
+                var type = semanticModel.GetTypeInfo(node, cancellationToken).Type;
+                if (type is not null && type.TypeKind != TypeKind.Error)
+                {
+                    return type;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates the immutable per-request projection/compilation used by semantic completion,
+    /// classification, diagnostics, hover, and component-contract reads. The cached base
+    /// compilation is never mutated.
+    /// </summary>
+    private LiveDocumentRequest CreateLiveDocumentRequest(
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+        => CreateLiveDocumentRequest(
+            GetOrCreateProjectState(context, documentFilePath, cancellationToken),
+            context,
+            documentFilePath,
+            documentText,
+            cancellationToken);
+
+    private LiveDocumentRequest CreateLiveDocumentRequest(
+        ProjectCompilationState state,
+        LanguageProjectContext context,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        liveDocumentRequestBuildCount++;
+        componentProjectionBuildCount++;
+        var projection = ProjectComponent(
+            documentFilePath,
+            documentText,
+            context,
+            cancellationToken);
+        var generatedText = SingleFileComponentSourceEmitter.Emit(projection.Model);
+        var mapper = GeneratedScriptDocumentMapper.Create(
+            documentText,
+            generatedText,
+            documentFilePath);
+        var tree = CSharpSyntaxTree.ParseText(
+            generatedText,
+            CreateParseOptions(context),
+            documentFilePath,
+            cancellationToken: cancellationToken);
+        var compilation = state.BaseCompilation.AddSyntaxTrees(tree);
+        return new LiveDocumentRequest(
+            state,
+            compilation,
+            tree,
+            compilation.GetSemanticModel(tree),
+            tree.GetRoot(cancellationToken),
+            mapper,
+            projection);
     }
 
     // Classifies the completion position from the parsed generated tree: returns false for a dot
@@ -501,6 +1138,16 @@ internal sealed class ScriptSemanticEngine
         ISymbol symbol,
         SyntaxTree currentTree)
     {
+        // Namespace symbols aggregate every declaration across source and referenced metadata. A
+        // generated component under `Assimalign.*` therefore gives the referenced `Assimalign`
+        // namespace one unmapped scaffold location; treating that aggregate as scaffold removes the
+        // entire namespace from `using ` completion. Only declaration/member symbols can themselves
+        // be generated scaffold. [V01.01.12.07.14]
+        if (symbol is INamespaceSymbol)
+        {
+            return false;
+        }
+
         foreach (Location location in symbol.Locations)
         {
             if (location.IsInSource
@@ -607,18 +1254,15 @@ internal sealed class ScriptSemanticEngine
     // Reads projectStates, so every caller must hold the synchronization gate.
     private ProjectCompilationState GetOrCreateProjectState(
         LanguageProjectContext context,
+        string liveDocumentFilePath,
         CancellationToken cancellationToken)
     {
+        var key = new ProjectCompilationKey(
+            context.ProjectFilePath,
+            liveDocumentFilePath);
         var environmentSignature = ComputeEnvironmentSignature(context);
-        if (projectStates.TryGetValue(context.ProjectFilePath, out var state))
+        if (projectStates.TryGetValue(key, out var state))
         {
-            if (string.Equals(state.CacheStamp, context.CacheStamp, StringComparison.Ordinal))
-            {
-                // Equal stamps make contexts interchangeable (the LanguageProjectContext
-                // contract), so every derived state is reusable untouched.
-                return state;
-            }
-
             if (string.Equals(
                     state.EnvironmentSignature,
                     environmentSignature,
@@ -626,13 +1270,13 @@ internal sealed class ScriptSemanticEngine
                 HasSameDocumentSet(state, context))
             {
                 RefreshChangedTrees(state, context, cancellationToken);
-                state.CacheStamp = context.CacheStamp;
                 return state;
             }
         }
 
-        state = BuildProjectState(context, environmentSignature, cancellationToken);
-        projectStates[context.ProjectFilePath] = state;
+        state = BuildProjectState(key, context, environmentSignature, cancellationToken);
+        projectStates[key] = state;
+        componentContractCaches.Remove(key);
         return state;
     }
 
@@ -665,6 +1309,7 @@ internal sealed class ScriptSemanticEngine
         LanguageProjectContext context,
         CancellationToken cancellationToken)
     {
+        var changed = false;
         foreach (var document in context.SourceDocuments)
         {
             var existing = state.Trees[document.FilePath];
@@ -674,16 +1319,24 @@ internal sealed class ScriptSemanticEngine
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var tree = CreateSourceTree(document, context, cancellationToken);
-            state.BaseCompilation = state.BaseCompilation.ReplaceSyntaxTree(existing.Tree, tree);
-            state.Trees[document.FilePath] = new SourceTreeState(
-                document.Text,
-                document.IsComponent,
-                tree);
+            if (!changed)
+            {
+                // Invalidate before the first mutable tree swap. A cancellation after one sibling
+                // changes can then leave only an incomplete base cone, never a stale closure over it.
+                InvalidateComponentContracts(state);
+                changed = true;
+            }
+
+            var sourceTree = CreateSourceTreeState(document, context, cancellationToken);
+            state.BaseCompilation = state.BaseCompilation.ReplaceSyntaxTree(
+                existing.Tree,
+                sourceTree.Tree);
+            state.Trees[document.FilePath] = sourceTree;
         }
     }
 
     private ProjectCompilationState BuildProjectState(
+        ProjectCompilationKey key,
         LanguageProjectContext context,
         string environmentSignature,
         CancellationToken cancellationToken)
@@ -696,10 +1349,10 @@ internal sealed class ScriptSemanticEngine
         foreach (var document in context.SourceDocuments)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            trees[document.FilePath] = new SourceTreeState(
-                document.Text,
-                document.IsComponent,
-                CreateSourceTree(document, context, cancellationToken));
+            trees[document.FilePath] = CreateSourceTreeState(
+                document,
+                context,
+                cancellationToken);
         }
 
         var compilation = CSharpCompilation.Create(
@@ -712,7 +1365,7 @@ internal sealed class ScriptSemanticEngine
             context,
             cancellationToken);
         return new ProjectCompilationState(
-            context.CacheStamp,
+            key,
             environmentSignature,
             trees,
             compilation);
@@ -762,20 +1415,39 @@ internal sealed class ScriptSemanticEngine
         return references;
     }
 
-    private SyntaxTree CreateSourceTree(
+    private SourceTreeState CreateSourceTreeState(
         LanguageProjectSourceDocument document,
         LanguageProjectContext context,
         CancellationToken cancellationToken)
     {
         sourceTreeBuildCount++;
-        var text = document.IsComponent
-            ? EmitComponent(document.FilePath, document.Text, context, cancellationToken)
-            : document.Text;
-        return CSharpSyntaxTree.ParseText(
+        SingleFileComponentProjectionResult? projection = null;
+        string text;
+        if (document.IsComponent)
+        {
+            componentProjectionBuildCount++;
+            projection = ProjectComponent(
+                document.FilePath,
+                document.Text,
+                context,
+                cancellationToken);
+            text = SingleFileComponentSourceEmitter.Emit(projection.Value.Model);
+        }
+        else
+        {
+            text = document.Text;
+        }
+
+        var tree = CSharpSyntaxTree.ParseText(
             text,
             CreateParseOptions(context),
             document.FilePath,
             cancellationToken: cancellationToken);
+        return new SourceTreeState(
+            document.Text,
+            document.IsComponent,
+            tree,
+            projection);
     }
 
     // The generator-identical projection: the same facade, emitter, name resolver, and scope-id
@@ -783,7 +1455,7 @@ internal sealed class ScriptSemanticEngine
     // ProjectDirectory/RootNamespace the build publishes — identical generated text by
     // construction. Hot-reload metadata stays off (the deterministic Release shape) and the
     // canonical-peer filter is a multi-file generator concern the projection never reads.
-    private static string EmitComponent(
+    private static SingleFileComponentProjectionResult ProjectComponent(
         string filePath,
         string text,
         LanguageProjectContext context,
@@ -804,8 +1476,120 @@ internal sealed class ScriptSemanticEngine
             StyleScopeId.Resolve(filePath, context.ProjectDirectory),
             HotReloadComponentIdentifier: null,
             HasCanonicalPeer: false);
-        var projection = SingleFileComponentProjection.Project(input, cancellationToken);
-        return SingleFileComponentSourceEmitter.Emit(projection.Model);
+        return SingleFileComponentProjection.Project(input, cancellationToken);
+    }
+
+    private bool TryGetCachedComponentContracts(
+        ProjectCompilationState state,
+        string documentText,
+        out ScriptComponentContractSnapshot snapshot)
+    {
+        if (componentContractCaches.TryGetValue(state.Key, out var cached) &&
+            cached.ProjectContractVersion == state.ComponentContractVersion &&
+            string.Equals(cached.DocumentText, documentText, StringComparison.Ordinal))
+        {
+            snapshot = cached.Snapshot;
+            return true;
+        }
+
+        snapshot = null!;
+        return false;
+    }
+
+    private ScriptComponentContractSnapshot GetOrCreateComponentContracts(
+        LiveDocumentRequest request,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        if (TryGetCachedComponentContracts(
+                request.ProjectState,
+                documentText,
+                out var cached))
+        {
+            return cached;
+        }
+
+        var stableDeclarations = GetOrCreateStableComponentContracts(
+            request.ProjectState,
+            cancellationToken);
+        var declarations = new List<TemplateComponentDeclaration>(stableDeclarations.Count + 1);
+        declarations.AddRange(stableDeclarations);
+        AppendProjectedComponentContract(
+            declarations,
+            request.Projection.Model);
+        declarations.Sort(static (left, right) => string.CompareOrdinal(
+            left.CompilerDeclaration.Name,
+            right.CompilerDeclaration.Name));
+        IReadOnlyList<TemplateComponentDeclaration> result = declarations.ToArray();
+        var snapshot = new ScriptComponentContractSnapshot(result, request.Projection);
+        componentContractCaches[request.ProjectState.Key] =
+            new ComponentContractCacheEntry(
+                request.ProjectState.ComponentContractVersion,
+                documentText,
+                snapshot);
+        return snapshot;
+    }
+
+    private IReadOnlyList<TemplateComponentDeclaration> GetOrCreateStableComponentContracts(
+        ProjectCompilationState state,
+        CancellationToken cancellationToken)
+    {
+        if (state.StableComponentContracts is { } cached)
+        {
+            return cached;
+        }
+
+        componentContractBuildCount++;
+        var declarations = new List<TemplateComponentDeclaration>(
+            ScriptComponentContractReader.Read(
+                state.BaseCompilation,
+                cancellationToken));
+        foreach (var sourceTree in state.Trees.Values)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (sourceTree.Projection is { } projection)
+            {
+                AppendProjectedComponentContract(declarations, projection.Model);
+            }
+        }
+
+        declarations.Sort(static (left, right) => string.CompareOrdinal(
+            left.CompilerDeclaration.Name,
+            right.CompilerDeclaration.Name));
+        IReadOnlyList<TemplateComponentDeclaration> result = declarations.ToArray();
+        state.StableComponentContracts = result;
+        return result;
+    }
+
+    private static void AppendProjectedComponentContract(
+        List<TemplateComponentDeclaration> declarations,
+        SingleFileComponentModel model)
+    {
+        var events = new List<TemplateComponentEvent>(model.Declarations.Events.Count);
+        foreach (var componentEvent in model.Declarations.Events)
+        {
+            var modifierPrefix = string.IsNullOrEmpty(componentEvent.Modifiers)
+                ? string.Empty
+                : componentEvent.Modifiers + " ";
+            events.Add(
+                new TemplateComponentEvent(
+                    componentEvent.Name,
+                    modifierPrefix +
+                        "void " +
+                        componentEvent.MethodName +
+                        componentEvent.ParameterList));
+        }
+
+        declarations.Add(
+            new TemplateComponentDeclaration(
+                new ComponentDeclarationEntry(
+                    model.ClassName,
+                    model.Declarations.Parameters)
+                {
+                    IsParameterSurfaceKnown =
+                        !model.Declarations.DeclaresImperativeParameters,
+                },
+                events));
     }
 
     private static SingleFileComponentFormat GetComponentFormat(string filePath)
@@ -819,13 +1603,54 @@ internal sealed class ScriptSemanticEngine
         return lastSeparator >= 0 ? filePath.Substring(lastSeparator + 1) : filePath;
     }
 
+    private static string GetDocumentFilePath(string documentUri)
+        => Uri.TryCreate(documentUri, UriKind.Absolute, out var uri) && uri.IsFile
+            ? uri.LocalPath
+            : documentUri;
+
+    private void InvalidateComponentContracts(ProjectCompilationState state)
+    {
+        state.ComponentContractVersion++;
+        state.StableComponentContracts = null;
+        componentContractCaches.Remove(state.Key);
+    }
+
     private static string ComputeEnvironmentSignature(LanguageProjectContext context)
     {
         var builder = new StringBuilder();
         builder.Append(context.RootNamespace).Append('\n').Append(context.ProjectDirectory);
+        foreach (var symbol in context.PreprocessorSymbols)
+        {
+            builder.Append('\n').Append("symbol|").Append(symbol);
+        }
+
         foreach (var path in context.ReferenceAssemblyPaths)
         {
-            builder.Append('\n').Append(path);
+            long length = 0;
+            long lastWriteTicks = 0;
+            try
+            {
+                var information = new FileInfo(path);
+                length = information.Exists ? information.Length : 0;
+                lastWriteTicks = information.Exists
+                    ? information.LastWriteTimeUtc.Ticks
+                    : 0;
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException)
+            {
+                // An unreadable reference already degrades semantic construction to a miss. Its
+                // zero fingerprint still changes when the host later supplies a readable file.
+            }
+
+            builder
+                .Append('\n')
+                .Append("reference|")
+                .Append(path)
+                .Append('|')
+                .Append(length)
+                .Append('|')
+                .Append(lastWriteTicks);
         }
 
         return builder.ToString();
@@ -896,28 +1721,78 @@ internal sealed class ScriptSemanticEngine
     private sealed class ProjectCompilationState
     {
         internal ProjectCompilationState(
-            string cacheStamp,
+            ProjectCompilationKey key,
             string environmentSignature,
             Dictionary<string, SourceTreeState> trees,
             CSharpCompilation baseCompilation)
         {
-            CacheStamp = cacheStamp;
+            Key = key;
             EnvironmentSignature = environmentSignature;
             Trees = trees;
             BaseCompilation = baseCompilation;
         }
 
-        internal string CacheStamp { get; set; }
+        internal ProjectCompilationKey Key { get; }
 
         internal string EnvironmentSignature { get; }
 
         internal Dictionary<string, SourceTreeState> Trees { get; }
 
         internal CSharpCompilation BaseCompilation { get; set; }
+
+        internal int ComponentContractVersion { get; set; }
+
+        internal IReadOnlyList<TemplateComponentDeclaration>? StableComponentContracts { get; set; }
     }
 
     /// <summary>One sibling document's cached parse.</summary>
-    private sealed record SourceTreeState(string Text, bool IsComponent, SyntaxTree Tree);
+    private sealed record SourceTreeState(
+        string Text,
+        bool IsComponent,
+        SyntaxTree Tree,
+        SingleFileComponentProjectionResult? Projection);
+
+    /// <summary>One live document snapshot's stable-plus-current component-contract closure.</summary>
+    private sealed record ComponentContractCacheEntry(
+        int ProjectContractVersion,
+        string DocumentText,
+        ScriptComponentContractSnapshot Snapshot);
+
+    /// <summary>One immutable live-document semantic fork over a cached project compilation.</summary>
+    private sealed record LiveDocumentRequest(
+        ProjectCompilationState ProjectState,
+        CSharpCompilation Compilation,
+        SyntaxTree Tree,
+        SemanticModel SemanticModel,
+        SyntaxNode Root,
+        GeneratedScriptDocumentMapper Mapper,
+        SingleFileComponentProjectionResult Projection);
+
+    /// <summary>Identifies one project cone after excluding its current live document.</summary>
+    private readonly record struct ProjectCompilationKey(
+        string ProjectFilePath,
+        string LiveDocumentFilePath);
+
+    /// <summary>Compares project and live-document paths using the host's Windows path semantics.</summary>
+    private sealed class ProjectCompilationKeyComparer : IEqualityComparer<ProjectCompilationKey>
+    {
+        internal static ProjectCompilationKeyComparer Instance { get; } = new();
+
+        public bool Equals(ProjectCompilationKey left, ProjectCompilationKey right)
+            => string.Equals(
+                    left.ProjectFilePath,
+                    right.ProjectFilePath,
+                    StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(
+                    left.LiveDocumentFilePath,
+                    right.LiveDocumentFilePath,
+                    StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(ProjectCompilationKey value)
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(value.ProjectFilePath),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(value.LiveDocumentFilePath));
+    }
 
     /// <summary>One resolvable label from a document's most recent semantic completion.</summary>
     private sealed record ResolutionEntry(string Detail, ISymbol Symbol);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticPublication.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ScriptSemanticPublication.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>Semantic layers computed from one immutable live-document compilation fork.</summary>
+internal sealed record ScriptSemanticPublication(
+    IReadOnlyList<LanguageClassification> Classifications,
+    IReadOnlyList<LanguageDiagnostic> Diagnostics,
+    IReadOnlyList<TemplateComponentDeclaration>? ComponentContracts,
+    SingleFileComponentProjectionResult Projection);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/StyleClassCompletionProvider.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/StyleClassCompletionProvider.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Assimalign.Viu.Syntax;
+using Assimalign.Viu.Syntax.Css;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Extracts authored class selectors from the component's style blocks and merges them with the
+/// shared utility registry's bounded completion result. [V01.01.12.07.13]
+/// </summary>
+internal static class StyleClassCompletionProvider
+{
+    /// <summary>
+    /// Adds matching component-local selectors before utility candidates, preserving first-wins
+    /// label deduplication and the language-service completion limit.
+    /// </summary>
+    internal static IReadOnlyList<LanguageCompletionItem> Merge(
+        string documentText,
+        LanguageDocumentSyntax syntax,
+        UtilityClassCompletionContext context,
+        IReadOnlyList<LanguageCompletionItem> utilityCompletions,
+        CancellationToken cancellationToken)
+    {
+        var editRange = new LanguageRange(
+            TextCoordinateConverter.GetPosition(documentText, context.TokenStart),
+            TextCoordinateConverter.GetPosition(documentText, context.TokenEnd));
+        var completions = new List<LanguageCompletionItem>();
+        var seenLabels = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var className in ExtractClassNames(syntax, cancellationToken))
+        {
+            if (!className.StartsWith(context.Prefix, StringComparison.Ordinal) ||
+                !seenLabels.Add(className))
+            {
+                continue;
+            }
+
+            completions.Add(new LanguageCompletionItem(
+                className,
+                LanguageCompletionItemKind.Property,
+                "Component style class",
+                $"**`.{className}`** is declared in this component's style block.",
+                className,
+                IsSnippet: false,
+                SortText: "00000:component-style:" + className,
+                EditRange: editRange,
+                FilterText: className));
+            if (completions.Count == LanguageCompletionLimits.MaximumItems)
+            {
+                return completions;
+            }
+        }
+
+        foreach (var utility in utilityCompletions)
+        {
+            if (!seenLabels.Add(utility.Label))
+            {
+                continue;
+            }
+
+            completions.Add(utility);
+            if (completions.Count == LanguageCompletionLimits.MaximumItems)
+            {
+                break;
+            }
+        }
+
+        return completions;
+    }
+
+    /// <summary>Returns whether the cursor is within a CSS block comment in a style block.</summary>
+    internal static bool IsInsideComment(string content, int relativeOffset)
+    {
+        if (relativeOffset < 0 || relativeOffset > content.Length)
+        {
+            return false;
+        }
+
+        var isComment = false;
+        var quote = '\0';
+        var escaped = false;
+        for (var index = 0; index < relativeOffset; index++)
+        {
+            var character = content[index];
+            if (isComment)
+            {
+                if (character == '*' &&
+                    index + 1 < relativeOffset &&
+                    content[index + 1] == '/')
+                {
+                    isComment = false;
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (quote != '\0')
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                }
+                else if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == quote)
+                {
+                    quote = '\0';
+                }
+
+                continue;
+            }
+
+            if (character is '\'' or '"')
+            {
+                quote = character;
+            }
+            else if (character == '/' &&
+                     index + 1 < relativeOffset &&
+                     content[index + 1] == '*')
+            {
+                isComment = true;
+                index++;
+            }
+        }
+
+        return isComment;
+    }
+
+    private static IReadOnlyList<string> ExtractClassNames(
+        LanguageDocumentSyntax syntax,
+        CancellationToken cancellationToken)
+    {
+        var classNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var style in syntax.Styles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (style.Lang is not null &&
+                !string.Equals(style.Lang, "css", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var parse = new CssSyntaxParser().ParseSyntax(style.Content, cancellationToken);
+            foreach (var stylesheet in parse.Nodes.OfType<CssStylesheetNode>())
+            {
+                AppendRuleClassNames(stylesheet.Rules, classNames, cancellationToken);
+            }
+        }
+
+        return classNames.OrderBy(name => name, StringComparer.Ordinal).ToArray();
+    }
+
+    private static void AppendRuleClassNames(
+        SyntaxList<CssSyntaxNode> rules,
+        HashSet<string> classNames,
+        CancellationToken cancellationToken)
+    {
+        foreach (var rule in rules)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            switch (rule)
+            {
+                case CssQualifiedRuleNode qualified:
+                    AppendSelectorClassNames(qualified.Selectors, classNames);
+                    break;
+                case CssAtRuleNode atRule when !string.Equals(
+                    atRule.Name,
+                    "keyframes",
+                    StringComparison.OrdinalIgnoreCase):
+                    AppendRuleClassNames(atRule.Body, classNames, cancellationToken);
+                    break;
+            }
+        }
+    }
+
+    private static void AppendSelectorClassNames(
+        CssSelectorListNode selectorList,
+        HashSet<string> classNames)
+    {
+        foreach (var selector in selectorList.Selectors)
+        {
+            foreach (var part in selector.Parts)
+            {
+                if (part is CssSimpleSelectorNode
+                    {
+                        Selector: CssSimpleSelectorKind.Class,
+                        Text.Length: > 1,
+                    } simple)
+                {
+                    classNames.Add(simple.Text.Substring(1));
+                }
+                else if (part is CssPseudoSelectorNode { Argument: { } argument })
+                {
+                    AppendSelectorClassNames(argument, classNames);
+                }
+            }
+        }
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/StyleClassHoverProvider.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/StyleClassHoverProvider.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading;
+
+using Assimalign.Viu.Syntax;
+using Assimalign.Viu.Syntax.Css;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Resolves a class token in template markup to the declaration authored in this component's style
+/// blocks ([V01.01.12.07.16], #337). Parsing uses the shared CSS syntax tree, so hover follows the
+/// same selector grammar as scoped-style and CSS-module compilation.
+/// </summary>
+internal static class StyleClassHoverProvider
+{
+    private static readonly CssSyntaxParser Parser = new();
+
+    /// <summary>Gets the first source-order declaration for a template class token.</summary>
+    /// <param name="document">The immutable live document.</param>
+    /// <param name="context">The class-attribute token context.</param>
+    /// <param name="cancellationToken">The token cancelling CSS parsing.</param>
+    /// <returns>The authored declaration hover, or <see langword="null"/> when none is declared.</returns>
+    internal static LanguageHover? GetHover(
+        LanguageDocument document,
+        UtilityClassCompletionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context.TokenText.Length == 0)
+        {
+            return null;
+        }
+
+        foreach (var style in document.Syntax.Styles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (style.Lang is not null &&
+                !string.Equals(style.Lang, "css", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var parse = Parser.ParseSyntax(style.Content, cancellationToken);
+            if (parse.Nodes.Count == 0 ||
+                parse.Nodes[0] is not CssStylesheetNode stylesheet)
+            {
+                continue;
+            }
+
+            var rule = FindRule(stylesheet.Rules, context.TokenText);
+            if (rule is null)
+            {
+                continue;
+            }
+
+            return new LanguageHover(
+                $"**`.{context.TokenText}`** — declared in this component's style block.\n\n" +
+                    $"```css\n{rule.Location.Source.Trim()}\n```",
+                new LanguageRange(
+                    TextCoordinateConverter.GetPosition(document.Text, context.TokenStart),
+                    TextCoordinateConverter.GetPosition(document.Text, context.TokenEnd)));
+        }
+
+        return null;
+    }
+
+    private static CssQualifiedRuleNode? FindRule(
+        SyntaxList<CssSyntaxNode> nodes,
+        string className)
+    {
+        foreach (var node in nodes)
+        {
+            if (node is CssQualifiedRuleNode rule &&
+                ContainsClass(rule.Selectors, className))
+            {
+                return rule;
+            }
+
+            if (node is CssAtRuleNode atRule)
+            {
+                var nested = FindRule(atRule.Body, className);
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ContainsClass(
+        CssSelectorListNode selectors,
+        string className)
+    {
+        foreach (var selector in selectors.Selectors)
+        {
+            foreach (var part in selector.Parts)
+            {
+                if (part is CssSimpleSelectorNode
+                    {
+                        Selector: CssSimpleSelectorKind.Class,
+                        Text: var text,
+                    } &&
+                    string.Equals(text, "." + className, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                if (part is CssPseudoSelectorNode { Argument: { } argument } &&
+                    ContainsClass(argument, className))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateCompletionProvider.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateCompletionProvider.cs
@@ -1,0 +1,661 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+using Assimalign.Viu.Syntax.SingleFileComponent;
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Provides expression- and contract-aware completion inside a template block. The provider keeps
+/// authored tag casing intact so its native/component decision is identical to [SFC-CG-8], then
+/// resolves component contracts through the same [SFC-USE-5] catalog as the compiler.
+/// [V01.01.12.07.12]
+/// </summary>
+internal static class TemplateCompletionProvider
+{
+    private static readonly IReadOnlyList<LanguageCompletionItem> HandlerSnippets =
+    [
+        new LanguageCompletionItem(
+            "$event lambda",
+            LanguageCompletionItemKind.Snippet,
+            "Template event lambda",
+            "Handles the event with an inline expression whose `$event` parameter is the dispatched event value.",
+            "\\$event => $1",
+            IsSnippet: true,
+            SortText: "10:event-lambda"),
+        new LanguageCompletionItem(
+            "async $event lambda",
+            LanguageCompletionItemKind.Snippet,
+            "Asynchronous template event lambda",
+            "Handles the event with an asynchronous inline expression whose `$event` parameter is the dispatched event value.",
+            "async \\$event => $1",
+            IsSnippet: true,
+            SortText: "11:async-event-lambda"),
+    ];
+
+    /// <summary>Returns whether the cursor is inside an HTML comment in template content.</summary>
+    internal static bool IsInsideComment(string content, int relativeOffset)
+    {
+        if (relativeOffset < 0 || relativeOffset > content.Length)
+        {
+            return false;
+        }
+
+        AnalyzeMarkupPrefix(
+            content,
+            relativeOffset,
+            out _,
+            out _,
+            out var isComment);
+        return isComment;
+    }
+
+    /// <summary>
+    /// Returns contextual template completions, an empty list when the cursor is in a suppressed or
+    /// expression-only context, or <see langword="null"/> when the structural template catalog should
+    /// answer the request.
+    /// </summary>
+    internal static IReadOnlyList<LanguageCompletionItem>? GetCompletions(
+        LanguageDocument document,
+        SingleFileComponentTemplateBlock template,
+        int documentOffset,
+        ScriptDeclarationReader declarationReader,
+        ScriptSemanticEngine semanticEngine,
+        LanguageProjectContext? projectContext,
+        string documentFilePath,
+        CancellationToken cancellationToken)
+    {
+        var relativeOffset = documentOffset - template.ContentLocation.Start.Offset;
+        if (relativeOffset < 0 || relativeOffset > template.Content.Length)
+        {
+            return null;
+        }
+
+        AnalyzeMarkupPrefix(
+            template.Content,
+            relativeOffset,
+            out var currentTagStart,
+            out var isInterpolation,
+            out var isComment);
+        if (isComment)
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
+        if (currentTagStart >= 0 &&
+            TryReadTagContext(
+                template.Content,
+                currentTagStart,
+                relativeOffset,
+                out var tagContext))
+        {
+            if (tagContext.IsAttributeValue)
+            {
+                return IsEventAttribute(tagContext.AttributeName)
+                    ? GetHandlerCompletions(
+                        document.Syntax,
+                        tagContext.AttributeValuePrefix,
+                        declarationReader)
+                    : Array.Empty<LanguageCompletionItem>();
+            }
+
+            if (IsEventAttributePrefix(tagContext.AttributeNamePrefix))
+            {
+                return GetEventCompletions(
+                    tagContext,
+                    semanticEngine,
+                    projectContext,
+                    documentFilePath,
+                    document.Text,
+                    cancellationToken);
+            }
+
+            if (IsBindingAttributePrefix(tagContext.AttributeNamePrefix))
+            {
+                return GetBindingCompletions(
+                    tagContext,
+                    semanticEngine,
+                    projectContext,
+                    documentFilePath,
+                    document.Text,
+                    cancellationToken);
+            }
+
+            if (tagContext.AttributeNamePrefix.StartsWith("v-", StringComparison.Ordinal))
+            {
+                return FilterByPrefix(
+                    ViuCompletionCatalog.TemplateDirectives,
+                    tagContext.AttributeNamePrefix);
+            }
+
+            return null;
+        }
+
+        return isInterpolation
+            ? GetMemberCompletions(
+                document.Syntax,
+                GetTrailingIdentifier(template.Content, relativeOffset),
+                declarationReader,
+                methodsOnly: false)
+            : null;
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> GetHandlerCompletions(
+        LanguageDocumentSyntax syntax,
+        string valuePrefix,
+        ScriptDeclarationReader declarationReader)
+    {
+        var completions = GetMemberCompletions(
+                syntax,
+                GetTrailingIdentifier(valuePrefix, valuePrefix.Length),
+                declarationReader,
+                methodsOnly: true)
+            .ToList();
+        completions.AddRange(HandlerSnippets);
+        return completions;
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> GetEventCompletions(
+        TemplateTagContext tagContext,
+        ScriptSemanticEngine semanticEngine,
+        LanguageProjectContext? projectContext,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        if (TryResolveComponent(
+                tagContext.TagName,
+                semanticEngine,
+                projectContext,
+                documentFilePath,
+                documentText,
+                cancellationToken,
+                out var component))
+        {
+            var usesLongForm = tagContext.AttributeNamePrefix.StartsWith(
+                "v-on:",
+                StringComparison.Ordinal);
+            var prefix = usesLongForm ? "v-on:" : "@";
+            return component.Events
+                .Select(
+                    templateEvent => new LanguageCompletionItem(
+                        prefix + templateEvent.Name,
+                        LanguageCompletionItemKind.Snippet,
+                        templateEvent.Detail,
+                        $"Registers the component's `{templateEvent.Name}` event.",
+                        prefix + templateEvent.Name + "=\"$1\"",
+                        IsSnippet: true,
+                        SortText: "00:" + templateEvent.Name))
+                .Where(
+                    item => item.Label.StartsWith(
+                        tagContext.AttributeNamePrefix,
+                        StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        // [SFC-CG-8]: PascalCase collisions and unresolved lowercase static tags remain component
+        // candidates. The native event vocabulary is valid only for a confirmed native tag.
+        if (char.IsUpper(tagContext.TagName[0]) ||
+            !CompilerDomKnowledge.IsNativeTag(tagContext.TagName))
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
+        if (tagContext.AttributeNamePrefix.StartsWith("v-on:", StringComparison.Ordinal))
+        {
+            var typedEvent = tagContext.AttributeNamePrefix.Substring("v-on:".Length);
+            return ViuCompletionCatalog.TemplateEvents
+                .Where(
+                    item => item.Label.AsSpan(1).StartsWith(
+                        typedEvent,
+                        StringComparison.OrdinalIgnoreCase))
+                .Select(
+                    item => item with
+                    {
+                        Label = "v-on:" + item.Label.Substring(1),
+                        InsertText = "v-on:" + item.InsertText.Substring(1),
+                    })
+                .ToArray();
+        }
+
+        return FilterByPrefix(
+            ViuCompletionCatalog.TemplateEvents,
+            tagContext.AttributeNamePrefix);
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> GetBindingCompletions(
+        TemplateTagContext tagContext,
+        ScriptSemanticEngine semanticEngine,
+        LanguageProjectContext? projectContext,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken)
+    {
+        var usesLongForm = tagContext.AttributeNamePrefix.StartsWith(
+            "v-bind:",
+            StringComparison.Ordinal);
+        var bindingPrefix = usesLongForm ? "v-bind:" : ":";
+        if (TryResolveComponent(
+                tagContext.TagName,
+                semanticEngine,
+                projectContext,
+                documentFilePath,
+                documentText,
+                cancellationToken,
+                out var component))
+        {
+            return component.CompilerDeclaration.Parameters
+                .Select(
+                    parameter => new LanguageCompletionItem(
+                        bindingPrefix + parameter.Name,
+                        LanguageCompletionItemKind.Property,
+                        parameter.TypeText + " component parameter",
+                        parameter.IsRequired
+                            ? $"Binds the required `{parameter.Name}` parameter on `{tagContext.TagName}`."
+                            : $"Binds the `{parameter.Name}` parameter on `{tagContext.TagName}`.",
+                        bindingPrefix + parameter.Name + "=\"$1\"",
+                        IsSnippet: true,
+                        SortText: "00:" + parameter.Name))
+                .Where(
+                    item => item.Label.StartsWith(
+                        tagContext.AttributeNamePrefix,
+                        StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        // [SFC-CG-8]: an uppercase collision remains a component candidate even when its declaration
+        // is currently missing, so never fall through from <Button> to HTML <button> attributes.
+        if (char.IsUpper(tagContext.TagName[0]))
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
+        IEnumerable<string> attributes;
+        if (CompilerDomKnowledge.IsHtmlTag(tagContext.TagName))
+        {
+            attributes = CompilerDomKnowledge.EnumerateKnownHtmlAttributes();
+        }
+        else if (CompilerDomKnowledge.IsSvgTag(tagContext.TagName))
+        {
+            attributes = CompilerDomKnowledge.EnumerateKnownSvgAttributes();
+        }
+        else if (CompilerDomKnowledge.IsMathMlTag(tagContext.TagName))
+        {
+            attributes = CompilerDomKnowledge.EnumerateKnownMathMlAttributes();
+        }
+        else
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
+        return attributes
+            .Select(
+                attribute => new LanguageCompletionItem(
+                    bindingPrefix + attribute,
+                    LanguageCompletionItemKind.Property,
+                    "Native element attribute",
+                    $"Binds the `{attribute}` attribute on the native `{tagContext.TagName}` element.",
+                    bindingPrefix + attribute + "=\"$1\"",
+                    IsSnippet: true,
+                    SortText: "10:" + attribute))
+            .Where(
+                item => item.Label.StartsWith(
+                    tagContext.AttributeNamePrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            .OrderBy(item => item.Label, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool TryResolveComponent(
+        string tagName,
+        ScriptSemanticEngine semanticEngine,
+        LanguageProjectContext? projectContext,
+        string documentFilePath,
+        string documentText,
+        CancellationToken cancellationToken,
+        out TemplateComponentDeclaration declaration)
+    {
+        declaration = null!;
+        if (projectContext is null ||
+            (!char.IsUpper(tagName[0]) && CompilerDomKnowledge.IsNativeTag(tagName)))
+        {
+            return false;
+        }
+
+        var contracts = semanticEngine.GetComponentContracts(
+            projectContext,
+            documentFilePath,
+            documentText,
+            cancellationToken);
+        return contracts is not null &&
+            new TemplateComponentCatalog(contracts).TryResolve(tagName, out declaration);
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> GetMemberCompletions(
+        LanguageDocumentSyntax syntax,
+        string typedPrefix,
+        ScriptDeclarationReader declarationReader,
+        bool methodsOnly)
+    {
+        var completions = new List<LanguageCompletionItem>();
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        AppendMembers(syntax.Script, declarationReader, methodsOnly, completions, seenNames);
+        AppendMembers(syntax.ScriptSetup, declarationReader, methodsOnly, completions, seenNames);
+        if (typedPrefix.Length == 0)
+        {
+            return completions;
+        }
+
+        var filtered = completions
+            .Where(
+                item => item.Label.StartsWith(
+                    typedPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        return filtered.Length == 0 ? completions : filtered;
+    }
+
+    private static void AppendMembers(
+        SingleFileComponentScriptBlock? script,
+        ScriptDeclarationReader declarationReader,
+        bool methodsOnly,
+        List<LanguageCompletionItem> completions,
+        HashSet<string> seenNames)
+    {
+        if (script is null)
+        {
+            return;
+        }
+
+        foreach (var member in declarationReader.Read(script.Content))
+        {
+            if ((methodsOnly && member.Kind != ScriptDeclaredMemberKind.Method) ||
+                !seenNames.Add(member.Name))
+            {
+                continue;
+            }
+
+            completions.Add(new LanguageCompletionItem(
+                member.Name,
+                member.Kind switch
+                {
+                    ScriptDeclaredMemberKind.Property => LanguageCompletionItemKind.Property,
+                    ScriptDeclaredMemberKind.Method => LanguageCompletionItemKind.Method,
+                    _ => LanguageCompletionItemKind.Field,
+                },
+                member.Detail,
+                member.DocumentationSummary ??
+                    $"Declared in this file's @script block as `{member.Detail} {member.Name}`.",
+                member.Name,
+                IsSnippet: false,
+                SortText: "00:" + member.Name));
+        }
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> FilterByPrefix(
+        IReadOnlyList<LanguageCompletionItem> candidates,
+        string prefix)
+        => candidates
+            .Where(
+                item => item.Label.StartsWith(
+                    prefix,
+                    StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+    private static bool IsEventAttribute(string attributeName)
+        => attributeName.StartsWith('@') ||
+           attributeName.StartsWith("v-on:", StringComparison.Ordinal);
+
+    private static bool IsEventAttributePrefix(string prefix)
+        => prefix.StartsWith('@') ||
+           prefix.StartsWith("v-on:", StringComparison.Ordinal);
+
+    private static bool IsBindingAttributePrefix(string prefix)
+        => prefix.StartsWith(':') ||
+           prefix.StartsWith("v-bind:", StringComparison.Ordinal);
+
+    private static string GetTrailingIdentifier(string text, int offset)
+    {
+        var start = offset;
+        while (start > 0 &&
+               (char.IsLetterOrDigit(text[start - 1]) || text[start - 1] == '_'))
+        {
+            start--;
+        }
+
+        return text.Substring(start, offset - start);
+    }
+
+    private static void AnalyzeMarkupPrefix(
+        string content,
+        int offset,
+        out int currentTagStart,
+        out bool isInterpolation,
+        out bool isComment)
+    {
+        currentTagStart = -1;
+        isInterpolation = false;
+        isComment = false;
+        var quote = '\0';
+        for (var index = 0; index < offset; index++)
+        {
+            if (isComment)
+            {
+                if (StartsWith(content, index, "-->"))
+                {
+                    isComment = false;
+                    index += 2;
+                }
+
+                continue;
+            }
+
+            if (currentTagStart >= 0)
+            {
+                var character = content[index];
+                if (quote != '\0')
+                {
+                    if (character == quote)
+                    {
+                        quote = '\0';
+                    }
+
+                    continue;
+                }
+
+                if (character is '\'' or '"')
+                {
+                    quote = character;
+                }
+                else if (character == '>')
+                {
+                    currentTagStart = -1;
+                }
+
+                continue;
+            }
+
+            if (isInterpolation)
+            {
+                if (StartsWith(content, index, "}}"))
+                {
+                    isInterpolation = false;
+                    index++;
+                }
+
+                continue;
+            }
+
+            if (StartsWith(content, index, "<!--"))
+            {
+                isComment = true;
+                index += 3;
+            }
+            else if (StartsWith(content, index, "{{"))
+            {
+                isInterpolation = true;
+                index++;
+            }
+            else if (content[index] == '<')
+            {
+                currentTagStart = index;
+            }
+        }
+    }
+
+    private static bool TryReadTagContext(
+        string content,
+        int tagStart,
+        int offset,
+        out TemplateTagContext context)
+    {
+        context = null!;
+        var cursor = tagStart + 1;
+        if (cursor >= offset || content[cursor] is '/' or '!' or '?')
+        {
+            return false;
+        }
+
+        while (cursor < offset && char.IsWhiteSpace(content[cursor]))
+        {
+            cursor++;
+        }
+
+        var tagNameStart = cursor;
+        while (cursor < offset && IsNameCharacter(content[cursor]))
+        {
+            cursor++;
+        }
+
+        if (tagNameStart == cursor)
+        {
+            return false;
+        }
+
+        var tagName = content.Substring(tagNameStart, cursor - tagNameStart);
+        if (cursor == offset && !char.IsWhiteSpace(content[offset - 1]))
+        {
+            context = new TemplateTagContext(tagName, string.Empty, string.Empty, false);
+            return true;
+        }
+
+        while (cursor < offset)
+        {
+            while (cursor < offset && char.IsWhiteSpace(content[cursor]))
+            {
+                cursor++;
+            }
+
+            if (cursor >= offset)
+            {
+                context = new TemplateTagContext(tagName, string.Empty, string.Empty, false);
+                return true;
+            }
+
+            if (content[cursor] == '/')
+            {
+                cursor++;
+                continue;
+            }
+
+            var attributeStart = cursor;
+            while (cursor < offset &&
+                   !char.IsWhiteSpace(content[cursor]) &&
+                   content[cursor] is not '=' and not '/' and not '>')
+            {
+                cursor++;
+            }
+
+            var attributeName = content.Substring(attributeStart, cursor - attributeStart);
+            if (cursor == offset)
+            {
+                context = new TemplateTagContext(tagName, attributeName, string.Empty, false);
+                return true;
+            }
+
+            while (cursor < offset && char.IsWhiteSpace(content[cursor]))
+            {
+                cursor++;
+            }
+
+            if (cursor >= offset || content[cursor] != '=')
+            {
+                continue;
+            }
+
+            cursor++;
+            while (cursor < offset && char.IsWhiteSpace(content[cursor]))
+            {
+                cursor++;
+            }
+
+            if (cursor >= offset)
+            {
+                context = new TemplateTagContext(tagName, attributeName, string.Empty, true);
+                return true;
+            }
+
+            var quote = content[cursor] is '\'' or '"' ? content[cursor++] : '\0';
+            var valueStart = cursor;
+            if (quote != '\0')
+            {
+                while (cursor < offset && content[cursor] != quote)
+                {
+                    cursor++;
+                }
+
+                if (cursor == offset)
+                {
+                    context = new TemplateTagContext(
+                        tagName,
+                        attributeName,
+                        content.Substring(valueStart, cursor - valueStart),
+                        true);
+                    return true;
+                }
+
+                cursor++;
+            }
+            else
+            {
+                while (cursor < offset && !char.IsWhiteSpace(content[cursor]))
+                {
+                    cursor++;
+                }
+
+                if (cursor == offset)
+                {
+                    context = new TemplateTagContext(
+                        tagName,
+                        attributeName,
+                        content.Substring(valueStart, cursor - valueStart),
+                        true);
+                    return true;
+                }
+            }
+        }
+
+        context = new TemplateTagContext(tagName, string.Empty, string.Empty, false);
+        return true;
+    }
+
+    private static bool StartsWith(string text, int offset, string value)
+        => offset + value.Length <= text.Length &&
+           text.AsSpan(offset, value.Length).SequenceEqual(value.AsSpan());
+
+    private static bool IsNameCharacter(char character)
+        => char.IsLetterOrDigit(character) || character is '-' or '_' or ':' or '.';
+
+    private sealed record TemplateTagContext(
+        string TagName,
+        string AttributeNamePrefix,
+        string AttributeValuePrefix,
+        bool IsAttributeValue)
+    {
+        internal string AttributeName => AttributeNamePrefix;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentCatalog.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentCatalog.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// The editor view of the compiler's component declaration catalog. Native/component precedence is
+/// applied before the compiler name ladder, matching [SFC-CG-8]: PascalCase wins a collision, while a
+/// lowercase native spelling remains native.
+/// </summary>
+internal sealed class TemplateComponentCatalog
+{
+    private static readonly HashSet<string> RuntimeSelectedTags = new(StringComparer.Ordinal)
+    {
+        "component",
+        "Component",
+    };
+
+    private readonly IReadOnlyList<TemplateComponentDeclaration> declarations;
+
+    internal TemplateComponentCatalog(
+        IReadOnlyList<TemplateComponentDeclaration>? declarations)
+    {
+        this.declarations = declarations ?? Array.Empty<TemplateComponentDeclaration>();
+        CompilerCatalog = this.declarations.Count == 0
+            ? ComponentDeclarationCatalog.Empty
+            : new ComponentDeclarationCatalog(
+                new EquatableArray<ComponentDeclarationEntry>(
+                    this.declarations
+                        .Select(declaration => declaration.CompilerDeclaration)
+                        .ToArray()));
+    }
+
+    /// <summary>The exact catalog consumed by <see cref="ComponentUsageValidator"/>.</summary>
+    internal ComponentDeclarationCatalog CompilerCatalog { get; }
+
+    /// <summary>
+    /// Resolves an authored static component tag after applying native and runtime-selected tag
+    /// precedence. Missing and ambiguous compiler-catalog entries both return false.
+    /// </summary>
+    internal bool TryResolve(
+        string authoredTag,
+        out TemplateComponentDeclaration declaration)
+    {
+        declaration = null!;
+        if (string.IsNullOrEmpty(authoredTag) ||
+            RuntimeSelectedTags.Contains(authoredTag) ||
+            (!char.IsUpper(authoredTag[0]) && CompilerDomKnowledge.IsNativeTag(authoredTag)) ||
+            !CompilerCatalog.TryResolve(authoredTag, out var resolved))
+        {
+            return false;
+        }
+
+        foreach (var candidate in declarations)
+        {
+            if (candidate.CompilerDeclaration.Equals(resolved))
+            {
+                declaration = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentDeclaration.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentDeclaration.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+using Assimalign.Viu.Compiler.SingleFileComponent;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// One component contract read from the same semantic compilation that backs projected C# editor
+/// features. The compiler declaration preserves the exact [SFC-USE-5] identity and parameter surface;
+/// events remain editor metadata because component-usage validation does not consume them.
+/// </summary>
+internal sealed record TemplateComponentDeclaration(
+    ComponentDeclarationEntry CompilerDeclaration,
+    IReadOnlyList<TemplateComponentEvent> Events);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentEvent.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateComponentEvent.cs
@@ -1,0 +1,6 @@
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>One template-facing event on a semantically resolved component contract.</summary>
+internal sealed record TemplateComponentEvent(
+    string Name,
+    string Detail);

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateHoverProvider.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/TemplateHoverProvider.cs
@@ -1,0 +1,356 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Assimalign.Viu.Compiler.SingleFileComponent;
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Produces authored template hover for resolved component contracts, native elements, and
+/// directives ([V01.01.12.07.16], #337). Component identity and property names reuse the compiler's
+/// usage manifest and declaration catalog, so hover follows [SFC-CG-8]/[SFC-USE-5] rather than an
+/// editor-only name heuristic.
+/// </summary>
+internal static class TemplateHoverProvider
+{
+    /// <summary>Gets template hover at one authored offset.</summary>
+    /// <param name="document">The immutable live document.</param>
+    /// <param name="projection">The live projection shared with component-contract resolution.</param>
+    /// <param name="catalog">The build-equivalent component declaration catalog.</param>
+    /// <param name="offset">The zero-based authored document offset.</param>
+    /// <returns>The template hover, or <see langword="null"/> when the token has no contract.</returns>
+    internal static LanguageHover? GetHover(
+        LanguageDocument document,
+        SingleFileComponentProjectionResult projection,
+        TemplateComponentCatalog catalog,
+        int offset)
+    {
+        var template = document.Syntax.Template;
+        if (template is not null &&
+            TemplateCompletionProvider.IsInsideComment(
+                template.Content,
+                offset - template.ContentLocation.Start.Offset))
+        {
+            return null;
+        }
+
+        foreach (var usage in projection.ComponentUsages)
+        {
+            if (!catalog.TryResolve(usage.Tag, out var declaration))
+            {
+                continue;
+            }
+
+            if (ContainsOffset(usage.Location, offset))
+            {
+                return CreateComponentHover(usage, declaration);
+            }
+
+            foreach (var property in usage.Properties)
+            {
+                if (!ContainsOffset(property.Location, offset))
+                {
+                    continue;
+                }
+
+                var propertyHover = CreateComponentPropertyHover(
+                    usage,
+                    property,
+                    declaration);
+                if (propertyHover is not null)
+                {
+                    return propertyHover;
+                }
+            }
+        }
+
+        if (!TryGetTokenRange(document.Text, offset, out var tokenStart, out var tokenEnd) ||
+            !IsInsideTag(document.Text, tokenStart))
+        {
+            return null;
+        }
+
+        var token = document.Text.Substring(tokenStart, tokenEnd - tokenStart);
+        var directive = FindDirectiveDocumentation(token);
+        if (directive is not null)
+        {
+            return CreateCatalogHover(document.Text, tokenStart, tokenEnd, token, directive);
+        }
+
+        if (!IsTagName(document.Text, tokenStart))
+        {
+            return null;
+        }
+
+        // [SFC-CG-8]: an uppercase collision remains a component candidate when its declaration
+        // is unavailable, so <Button> must never fall through to case-insensitive HTML <button>
+        // documentation.
+        if (char.IsUpper(token[0]))
+        {
+            return null;
+        }
+
+        var builtIn = FindByLabel(ViuCompletionCatalog.TemplateTags, token);
+        if (CompilerDomKnowledge.IsNativeTag(token))
+        {
+            var family = CompilerDomKnowledge.IsHtmlTag(token)
+                ? "HTML"
+                : CompilerDomKnowledge.IsSvgTag(token)
+                    ? "SVG"
+                    : "MathML";
+            var documentation = builtIn is null
+                ? string.Empty
+                : $"\n\n{builtIn.Documentation}";
+            return new LanguageHover(
+                $"**`<{token}>`** is a native {family} element. Viu emits it directly through the host's element renderer." +
+                    documentation,
+                CreateRange(document.Text, tokenStart, tokenEnd));
+        }
+
+        return builtIn is null
+            ? null
+            : CreateCatalogHover(document.Text, tokenStart, tokenEnd, $"<{token}>", builtIn);
+    }
+
+    private static LanguageHover CreateComponentHover(
+        ComponentUsage usage,
+        TemplateComponentDeclaration declaration)
+    {
+        var compilerDeclaration = declaration.CompilerDeclaration;
+        var markdown = new StringBuilder()
+            .Append("**`<")
+            .Append(usage.Tag)
+            .Append(">`** resolves to component `")
+            .Append(compilerDeclaration.Name)
+            .Append("`.");
+
+        if (!compilerDeclaration.IsParameterSurfaceKnown)
+        {
+            markdown.Append("\n\nParameters are declared imperatively and cannot be enumerated at design time.");
+        }
+        else if (compilerDeclaration.Parameters.Count > 0)
+        {
+            markdown.Append("\n\n**Parameters**");
+            foreach (var parameter in compilerDeclaration.Parameters)
+            {
+                markdown
+                    .Append("\n- `")
+                    .Append(parameter.Name)
+                    .Append("`: `")
+                    .Append(parameter.TypeText)
+                    .Append(' ')
+                    .Append(parameter.PropertyName)
+                    .Append('`');
+                if (parameter.IsRequired)
+                {
+                    markdown.Append(" (required)");
+                }
+            }
+        }
+
+        if (declaration.Events.Count > 0)
+        {
+            markdown.Append("\n\n**Events**");
+            foreach (var componentEvent in declaration.Events)
+            {
+                markdown
+                    .Append("\n- `@")
+                    .Append(componentEvent.Name)
+                    .Append("`: `")
+                    .Append(componentEvent.Detail)
+                    .Append('`');
+            }
+        }
+
+        return new LanguageHover(markdown.ToString(), ToLanguageRange(usage.Location));
+    }
+
+    private static LanguageHover? CreateComponentPropertyHover(
+        ComponentUsage usage,
+        ComponentUsageProperty property,
+        TemplateComponentDeclaration declaration)
+    {
+        if (property.Kind == ComponentUsagePropertyKind.Listener)
+        {
+            var canonicalName = ComponentDeclarationNames.Canonicalize(property.Name);
+            foreach (var componentEvent in declaration.Events)
+            {
+                if (!string.Equals(
+                        ComponentDeclarationNames.Canonicalize(componentEvent.Name),
+                        canonicalName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return new LanguageHover(
+                    $"**`@{property.AuthoredName}`** — event on component `<{usage.Tag}>`.\n\n" +
+                        $"```csharp\n{componentEvent.Detail}\n```",
+                    ToLanguageRange(property.Location));
+            }
+
+            return null;
+        }
+
+        if (property.Kind is not (ComponentUsagePropertyKind.Static or ComponentUsagePropertyKind.Bound) ||
+            !declaration.CompilerDeclaration.IsParameterSurfaceKnown)
+        {
+            return null;
+        }
+
+        var propertyName = ComponentDeclarationNames.Canonicalize(property.Name);
+        foreach (var parameter in declaration.CompilerDeclaration.Parameters)
+        {
+            if (!string.Equals(
+                    ComponentDeclarationNames.Canonicalize(parameter.Name),
+                    propertyName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var requirement = parameter.IsRequired ? " Required." : string.Empty;
+            return new LanguageHover(
+                $"**`{property.AuthoredName}`** — parameter on component `<{usage.Tag}>`.{requirement}\n\n" +
+                    $"```csharp\n{parameter.TypeText} {parameter.PropertyName}\n```",
+                ToLanguageRange(property.Location));
+        }
+
+        return null;
+    }
+
+    private static LanguageCompletionItem? FindDirectiveDocumentation(string token)
+    {
+        var baseToken = token;
+        var modifier = baseToken.IndexOf('.');
+        if (modifier >= 0)
+        {
+            baseToken = baseToken.Substring(0, modifier);
+        }
+
+        if (baseToken.StartsWith("v-bind", StringComparison.Ordinal) ||
+            baseToken.StartsWith(':'))
+        {
+            return FindByLabel(ViuCompletionCatalog.TemplateBindings, baseToken) ??
+                FindByLabel(ViuCompletionCatalog.TemplateDirectives, "v-bind");
+        }
+
+        if (baseToken.StartsWith("v-on", StringComparison.Ordinal) ||
+            baseToken.StartsWith('@'))
+        {
+            return FindByLabel(ViuCompletionCatalog.TemplateEvents, baseToken) ??
+                FindByLabel(ViuCompletionCatalog.TemplateDirectives, "v-on");
+        }
+
+        if (baseToken.StartsWith("v-slot", StringComparison.Ordinal) ||
+            baseToken.StartsWith('#'))
+        {
+            return FindByLabel(ViuCompletionCatalog.TemplateDirectives, "v-slot");
+        }
+
+        var colon = baseToken.IndexOf(':');
+        if (colon >= 0)
+        {
+            baseToken = baseToken.Substring(0, colon);
+        }
+
+        return baseToken.StartsWith("v-", StringComparison.Ordinal)
+            ? FindByLabel(ViuCompletionCatalog.TemplateDirectives, baseToken)
+            : null;
+    }
+
+    private static LanguageCompletionItem? FindByLabel(
+        IReadOnlyList<LanguageCompletionItem> items,
+        string label)
+    {
+        foreach (var item in items)
+        {
+            if (string.Equals(item.Label, label, StringComparison.Ordinal))
+            {
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    private static LanguageHover CreateCatalogHover(
+        string documentText,
+        int tokenStart,
+        int tokenEnd,
+        string displayToken,
+        LanguageCompletionItem item)
+        => new(
+            $"**`{displayToken}`** — {item.Detail}.\n\n{item.Documentation}",
+            CreateRange(documentText, tokenStart, tokenEnd));
+
+    private static bool ContainsOffset(LocationInfo location, int offset)
+        => offset >= location.StartOffset && offset <= location.EndOffset;
+
+    private static LanguageRange ToLanguageRange(LocationInfo location)
+        => new(
+            new LanguagePosition(location.StartLine, location.StartCharacter),
+            new LanguagePosition(location.EndLine, location.EndCharacter));
+
+    private static LanguageRange CreateRange(string text, int start, int end)
+        => new(
+            TextCoordinateConverter.GetPosition(text, start),
+            TextCoordinateConverter.GetPosition(text, end));
+
+    private static bool TryGetTokenRange(
+        string text,
+        int offset,
+        out int start,
+        out int end)
+    {
+        start = offset;
+        end = offset;
+        if (offset == text.Length && offset > 0)
+        {
+            offset--;
+        }
+        else if (offset < text.Length &&
+                 !IsTokenCharacter(text[offset]) &&
+                 offset > 0 &&
+                 IsTokenCharacter(text[offset - 1]))
+        {
+            offset--;
+        }
+
+        if (offset < 0 || offset >= text.Length || !IsTokenCharacter(text[offset]))
+        {
+            return false;
+        }
+
+        start = offset;
+        while (start > 0 && IsTokenCharacter(text[start - 1]))
+        {
+            start--;
+        }
+
+        end = offset + 1;
+        while (end < text.Length && IsTokenCharacter(text[end]))
+        {
+            end++;
+        }
+
+        return true;
+    }
+
+    private static bool IsTokenCharacter(char character)
+        => char.IsLetterOrDigit(character) ||
+           character is '_' or '-' or '.' or ':' or '@' or '#';
+
+    private static bool IsInsideTag(string text, int offset)
+    {
+        var open = text.LastIndexOf('<', Math.Max(offset - 1, 0));
+        var close = text.LastIndexOf('>', Math.Max(offset - 1, 0));
+        return open > close;
+    }
+
+    private static bool IsTagName(string text, int tokenStart)
+        => tokenStart > 0 &&
+           (text[tokenStart - 1] == '<' ||
+            (text[tokenStart - 1] == '/' && tokenStart > 1 && text[tokenStart - 2] == '<'));
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/UtilityColorValueResolver.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/UtilityColorValueResolver.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+
+using Assimalign.Viu.UtilityCss;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Resolves the color token used by emitted utility CSS back to the active theme's computed value,
+/// keeping editor swatches on the same registry/theme path as build-time utility generation.
+/// [V01.01.12.07.13]
+/// </summary>
+internal sealed class UtilityColorValueResolver
+{
+    private readonly IReadOnlyDictionary<string, string> valuesByCustomProperty;
+    private readonly IReadOnlyList<string> inlineValues;
+
+    private UtilityColorValueResolver(
+        IReadOnlyDictionary<string, string> valuesByCustomProperty,
+        IReadOnlyList<string> inlineValues)
+    {
+        this.valuesByCustomProperty = valuesByCustomProperty;
+        this.inlineValues = inlineValues;
+    }
+
+    /// <summary>Builds a resolver from every active <c>--color-*</c> theme property.</summary>
+    internal static UtilityColorValueResolver Create(UtilityTheme theme)
+    {
+        var valuesByCustomProperty = new Dictionary<string, string>(StringComparer.Ordinal);
+        var inlineValues = new List<string>();
+        foreach (var property in theme.Properties)
+        {
+            if (!property.Name.StartsWith("--color-", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            valuesByCustomProperty[theme.FormatCustomPropertyName(property.Name)] = property.Value;
+            if (!inlineValues.Contains(property.Value))
+            {
+                inlineValues.Add(property.Value);
+            }
+        }
+
+        return new UtilityColorValueResolver(valuesByCustomProperty, inlineValues);
+    }
+
+    /// <summary>
+    /// Returns the active theme value used by <paramref name="metadata"/>, including inline-theme
+    /// emission where the CSS carries the value directly instead of a custom-property reference.
+    /// </summary>
+    internal string? Resolve(UtilityClassMetadata metadata)
+    {
+        var searchStart = 0;
+        while (searchStart < metadata.Css.Length)
+        {
+            var variableStart = metadata.Css.IndexOf("var(--", searchStart, StringComparison.Ordinal);
+            if (variableStart < 0)
+            {
+                break;
+            }
+
+            var nameStart = variableStart + "var(".Length;
+            var nameEnd = nameStart;
+            while (nameEnd < metadata.Css.Length &&
+                   metadata.Css[nameEnd] is not ')' and not ',' &&
+                   !char.IsWhiteSpace(metadata.Css[nameEnd]))
+            {
+                nameEnd++;
+            }
+
+            var customPropertyName = metadata.Css.Substring(nameStart, nameEnd - nameStart);
+            if (valuesByCustomProperty.TryGetValue(customPropertyName, out var value))
+            {
+                return value;
+            }
+
+            searchStart = nameEnd;
+        }
+
+        foreach (var inlineValue in inlineValues)
+        {
+            if (metadata.Css.Contains(inlineValue, StringComparison.Ordinal))
+            {
+                return inlineValue;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/Internal/ViuLanguageService.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/Internal/ViuLanguageService.cs
@@ -80,6 +80,18 @@ internal sealed class ViuLanguageService :
     // answers unchanged.
     private readonly Dictionary<string, LanguageProjectContext> projectContexts =
         new(StringComparer.OrdinalIgnoreCase);
+    private int standaloneDocumentProjectionBuildCount;
+
+    /// <summary>Gets all component projections built by this workspace.</summary>
+    internal int ComponentProjectionBuildCount
+        => scriptSemantics.ComponentProjectionBuildCount +
+            Volatile.Read(ref standaloneDocumentProjectionBuildCount);
+
+    /// <summary>Gets how many stable component-contract closures this workspace built.</summary>
+    internal int ComponentContractBuildCount => scriptSemantics.ComponentContractBuildCount;
+
+    /// <summary>Gets how many project-scoped semantic states this workspace built.</summary>
+    internal int ProjectStateBuildCount => scriptSemantics.ProjectStateBuildCount;
 
     public void ConfigureProjectContext(
         string documentUri,
@@ -178,8 +190,8 @@ internal sealed class ViuLanguageService :
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(documentUri);
 
-        // The engine's per-document state is lock-free, so clearing it outside the service lock
-        // can never stall document synchronization behind a long semantic computation.
+        // Eviction serializes with semantic work. Keep it outside the service lock so close cannot
+        // invert the service/engine lock order while a feature request holds the engine gate.
         scriptSemantics.CloseDocument(documentUri);
         lock (synchronization)
         {
@@ -192,21 +204,133 @@ internal sealed class ViuLanguageService :
     public IReadOnlyList<LanguageDiagnostic> GetDiagnostics(
         string documentUri,
         CancellationToken cancellationToken = default)
+        => GetDocumentPublication(
+            documentUri,
+            includeSemanticClassifications: false,
+            cancellationToken).Diagnostics;
+
+    public LanguageDocumentPublication GetDocumentPublication(
+        string documentUri,
+        bool includeSemanticClassifications,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(documentUri);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var (document, _) = CaptureSnapshot(documentUri);
-        if (document is null)
+        LanguageDocument? document;
+        LanguageProjectContext? context;
+        lock (synchronization)
         {
-            return Array.Empty<LanguageDiagnostic>();
+            document = documents.TryGet(documentUri, out var openDocument)
+                ? openDocument
+                : null;
+            context = projectContexts.TryGetValue(documentUri, out var configured)
+                ? configured
+                : null;
         }
 
+        if (document is null)
+        {
+            return new LanguageDocumentPublication(
+                ClassificationSnapshot: null,
+                Diagnostics: Array.Empty<LanguageDiagnostic>());
+        }
+
+        // Keep the incremental parser's recovery order and Vue-compatibility contract intact.
+        // Nested compiler diagnostics are appended below instead of replacing this baseline.
         var diagnostics = document.Syntax.Errors
             .Select(ToLanguageDiagnostic)
             .ToList();
         AddVueCompatibilityDiagnostics(document.Syntax, diagnostics);
-        return diagnostics;
+
+        var hasCSharpScript =
+            IsCSharpScript(document.Syntax.Script) ||
+            IsCSharpScript(document.Syntax.ScriptSetup);
+        ScriptSemanticPublication? semanticPublication = null;
+        if (context is not null &&
+            (hasCSharpScript || document.Syntax.Template is not null))
+        {
+            semanticPublication = scriptSemantics.GetPublicationSemantics(
+                context,
+                GetDocumentFilePath(documentUri),
+                document.Text,
+                includeSemanticClassifications && hasCSharpScript,
+                includeDiagnostics: hasCSharpScript,
+                includeComponentContracts: document.Syntax.Template is not null,
+                cancellationToken);
+        }
+
+        ComponentDeclarationCatalog? componentCatalog =
+            semanticPublication?.ComponentContracts is not { } componentContracts
+            ? null
+            : new TemplateComponentCatalog(componentContracts).CompilerCatalog;
+        var projection = semanticPublication?.Projection ??
+            ProjectDocument(document, context, cancellationToken);
+        diagnostics.AddRange(
+            LanguageDiagnosticProvider.GetProjectionDiagnostics(
+                projection,
+                componentCatalog,
+                cancellationToken));
+        if (semanticPublication is not null)
+        {
+            diagnostics.AddRange(semanticPublication.Diagnostics);
+        }
+
+        var classificationSnapshot = includeSemanticClassifications
+            ? new LanguageClassificationSnapshot(
+                document.Version,
+                LanguageTextChecksum.Compute(document.Text),
+                semanticPublication?.Classifications ?? Array.Empty<LanguageClassification>())
+            : null;
+        return new LanguageDocumentPublication(classificationSnapshot, diagnostics);
+    }
+
+    public IReadOnlyList<LanguageClassification> GetClassifications(
+        string documentUri,
+        CancellationToken cancellationToken = default)
+        => GetClassificationSnapshot(documentUri, cancellationToken)?.Classifications
+            ?? Array.Empty<LanguageClassification>();
+
+    public LanguageClassificationSnapshot? GetClassificationSnapshot(
+        string documentUri,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentUri);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        LanguageDocument? document;
+        LanguageProjectContext? context;
+        lock (synchronization)
+        {
+            document = documents.TryGet(documentUri, out var openDocument)
+                ? openDocument
+                : null;
+            context = projectContexts.TryGetValue(documentUri, out var configured)
+                ? configured
+                : null;
+        }
+
+        if (document is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<LanguageClassification> classifications =
+            context is not null &&
+            (IsCSharpScript(document.Syntax.Script) ||
+             IsCSharpScript(document.Syntax.ScriptSetup))
+                ? scriptSemantics.GetClassifications(
+                        context,
+                        GetDocumentFilePath(documentUri),
+                        document.Text,
+                        cancellationToken)
+                    ?? Array.Empty<LanguageClassification>()
+                : Array.Empty<LanguageClassification>();
+
+        return new LanguageClassificationSnapshot(
+            document.Version,
+            LanguageTextChecksum.Compute(document.Text),
+            classifications);
     }
 
     public IReadOnlyList<LanguageCompletionItem> GetCompletions(
@@ -227,26 +351,54 @@ internal sealed class ViuLanguageService :
         var block = FindBlock(document.Syntax, offset);
         var template = block as SingleFileComponentTemplateBlock;
         if (template is not null &&
+            TemplateCompletionProvider.IsInsideComment(
+                template.Content,
+                offset - template.ContentLocation.Start.Offset))
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
+        if (template is not null &&
             UtilityClassCompletionContext.TryCreate(
                 template.Content,
                 template.ContentLocation.Start.Offset,
                 offset,
                 out var utilityContext))
         {
-            return GetUtilityClassCompletions(
+            var utilityCompletions = GetUtilityClassCompletions(
                 document.Text,
                 utilityContext,
                 stylesheetContext,
                 cancellationToken);
+            return StyleClassCompletionProvider.Merge(
+                document.Text,
+                document.Syntax,
+                utilityContext,
+                utilityCompletions,
+                cancellationToken);
         }
 
-        // docs/UTILITY-CSS-DESIGN.md section 10: completion activates only in supported static
-        // class attributes and literal class-binding strings. Every other attribute value and
-        // every interpolation is a C# expression this service cannot complete, and the line-prefix
-        // heuristics below cannot see the quote: `:class="Shell"` reads as the single token
-        // `:class="Shell` and answers with attribute names while the cursor is inside the value.
-        if (template is not null &&
-            IsExpressionContext(document.Text, template, offset))
+        if (template is not null)
+        {
+            var contextualCompletions = TemplateCompletionProvider.GetCompletions(
+                document,
+                template,
+                offset,
+                scriptDeclarations,
+                scriptSemantics,
+                CaptureProjectContext(documentUri),
+                GetDocumentFilePath(documentUri),
+                cancellationToken);
+            if (contextualCompletions is not null)
+            {
+                return contextualCompletions;
+            }
+        }
+
+        if (block is SingleFileComponentStyleBlock styleBlock &&
+            StyleClassCompletionProvider.IsInsideComment(
+                styleBlock.Content,
+                offset - styleBlock.ContentLocation.Start.Offset))
         {
             return Array.Empty<LanguageCompletionItem>();
         }
@@ -312,7 +464,7 @@ internal sealed class ViuLanguageService :
 
         // Resolution needs only the per-document utility context, never the open document:
         // the label is the complete candidate text, and recomputing against the current
-        // stylesheet context mirrors the hover path exactly, so a stylesheet edit between
+        // stylesheet context is the same one the hover path uses, so a stylesheet edit between
         // completion and resolve can never serve stale documentation.
         var (_, stylesheetContext) = CaptureSnapshot(documentUri);
         var resolution = UtilityRegistry.Resolve(
@@ -450,6 +602,17 @@ internal sealed class ViuLanguageService :
                 offset,
                 out var utilityContext))
         {
+            // Match completion precedence: a class authored in this component owns its name, while
+            // the utility registry remains the emitted-CSS fallback for undeclared class tokens.
+            var styleHover = StyleClassHoverProvider.GetHover(
+                document,
+                utilityContext,
+                cancellationToken);
+            if (styleHover is not null)
+            {
+                return styleHover;
+            }
+
             var utilityHover = GetUtilityClassHover(
                 document.Text,
                 utilityContext,
@@ -467,6 +630,51 @@ internal sealed class ViuLanguageService :
             IsExpressionContext(document.Text, template, offset))
         {
             return null;
+        }
+
+        var projectContext = CaptureProjectContext(documentUri);
+        if (block is SingleFileComponentScriptBlock script &&
+            IsCSharpScript(script) &&
+            projectContext is not null)
+        {
+            var scriptHover = scriptSemantics.GetHover(
+                projectContext,
+                GetDocumentFilePath(documentUri),
+                document.Text,
+                offset,
+                cancellationToken);
+            if (scriptHover is not null)
+            {
+                return scriptHover;
+            }
+        }
+
+        if (template is not null)
+        {
+            if (TemplateCompletionProvider.IsInsideComment(
+                    template.Content,
+                    offset - template.ContentLocation.Start.Offset))
+            {
+                return null;
+            }
+
+            ScriptComponentContractSnapshot? componentContractSnapshot = null;
+            if (projectContext is not null)
+            {
+                componentContractSnapshot = scriptSemantics.GetComponentContractSnapshot(
+                    projectContext,
+                    GetDocumentFilePath(documentUri),
+                    document.Text,
+                    cancellationToken);
+            }
+
+            var projection = componentContractSnapshot?.Projection ??
+                ProjectDocument(document, projectContext, cancellationToken);
+            return TemplateHoverProvider.GetHover(
+                document,
+                projection,
+                new TemplateComponentCatalog(componentContractSnapshot?.Declarations),
+                offset);
         }
 
         var tokenRange = GetTokenRange(document.Text, offset);
@@ -490,6 +698,15 @@ internal sealed class ViuLanguageService :
                 TextCoordinateConverter.GetPosition(document.Text, tokenRange.End)));
     }
 
+    private SingleFileComponentProjectionResult ProjectDocument(
+        LanguageDocument document,
+        LanguageProjectContext? context,
+        CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref standaloneDocumentProjectionBuildCount);
+        return LanguageDocumentProjection.Project(document, context, cancellationToken);
+    }
+
     /// <summary>
     /// Captures the immutable per-document state a read computes over. The lock is held only for
     /// the two dictionary lookups; the compute runs outside it over the immutable
@@ -505,6 +722,16 @@ internal sealed class ViuLanguageService :
                 ? openDocument
                 : null;
             return (document, GetUtilityContext(documentUri));
+        }
+    }
+
+    private LanguageProjectContext? CaptureProjectContext(string documentUri)
+    {
+        lock (synchronization)
+        {
+            return projectContexts.TryGetValue(documentUri, out var context)
+                ? context
+                : null;
         }
     }
 
@@ -608,23 +835,6 @@ internal sealed class ViuLanguageService :
         return Array.Empty<LanguageCompletionItem>();
     }
 
-    private static bool IsExpressionContext(
-        string documentText,
-        SingleFileComponentTemplateBlock template,
-        int offset)
-    {
-        if (UtilityCandidateScanner.IsInsideAttributeValue(
-                template.Content,
-                offset - template.ContentLocation.Start.Offset))
-        {
-            return true;
-        }
-
-        // Mustache interpolations do not nest, so the nearest unmatched opener decides.
-        var prefix = documentText.AsSpan(0, offset);
-        return prefix.LastIndexOf("{{".AsSpan()) > prefix.LastIndexOf("}}".AsSpan());
-    }
-
     private static IReadOnlyList<LanguageCompletionItem> GetTemplateCompletions(string linePrefix)
     {
         var trimmed = linePrefix.TrimStart();
@@ -653,6 +863,23 @@ internal sealed class ViuLanguageService :
         completions.AddRange(ViuCompletionCatalog.TemplateEvents);
         completions.AddRange(ViuCompletionCatalog.TemplateBindings);
         return completions;
+    }
+
+    private static bool IsExpressionContext(
+        string documentText,
+        SingleFileComponentTemplateBlock template,
+        int offset)
+    {
+        if (UtilityCandidateScanner.IsInsideAttributeValue(
+                template.Content,
+                offset - template.ContentLocation.Start.Offset))
+        {
+            return true;
+        }
+
+        // Mustache interpolations do not nest, so the nearest unmatched opener decides.
+        var prefix = documentText.AsSpan(0, offset);
+        return prefix.LastIndexOf("{{".AsSpan()) > prefix.LastIndexOf("}}".AsSpan());
     }
 
     private static IReadOnlyList<LanguageCompletionItem> GetUtilityClassCompletions(
@@ -688,6 +915,7 @@ internal sealed class ViuLanguageService :
             metadataByCandidate);
         cancellationToken.ThrowIfCancellationRequested();
 
+        var colorResolver = UtilityColorValueResolver.Create(stylesheetContext.Theme);
         return metadataByCandidate.Values
             .OrderBy(metadata => metadata.SortOrder)
             .ThenBy(metadata => metadata.CandidateText, StringComparer.Ordinal)
@@ -695,7 +923,8 @@ internal sealed class ViuLanguageService :
             .Select(
                 metadata => CreateUtilityCompletion(
                     metadata,
-                    editRange))
+                    editRange,
+                    colorResolver))
             .ToArray();
     }
 
@@ -793,10 +1022,15 @@ internal sealed class ViuLanguageService :
 
     private static LanguageCompletionItem CreateUtilityCompletion(
         UtilityClassMetadata metadata,
-        LanguageRange editRange) =>
-        new(
+        LanguageRange editRange,
+        UtilityColorValueResolver colorResolver)
+    {
+        var colorValue = colorResolver.Resolve(metadata);
+        return new LanguageCompletionItem(
             metadata.CandidateText,
-            LanguageCompletionItemKind.Property,
+            colorValue is null
+                ? LanguageCompletionItemKind.Property
+                : LanguageCompletionItemKind.Color,
             "Viu utility class",
             // Utility documentation is deferred to ResolveCompletionDocumentation: interpolating
             // and serializing up to 500 CSS bodies per keystroke dominated the completion payload
@@ -806,7 +1040,9 @@ internal sealed class ViuLanguageService :
             IsSnippet: false,
             SortText: $"{metadata.SortOrder:D5}:{metadata.CandidateText}",
             EditRange: editRange,
-            FilterText: metadata.CandidateText);
+            FilterText: metadata.CandidateText,
+            ColorValue: colorValue);
+    }
 
     private static UtilityClassMetadata? FindProjectRule(
         UtilityProjectStylesheetCompilationResult compilation,
@@ -938,6 +1174,11 @@ internal sealed class ViuLanguageService :
         var contextKind = ScriptCompletionContext.Classify(
             script.Content,
             offset - script.ContentLocation.Start.Offset);
+        if (contextKind == ScriptCompletionContextKind.Suppressed)
+        {
+            return Array.Empty<LanguageCompletionItem>();
+        }
+
         var word = GetTrailingIdentifier(linePrefix);
         var semantic = GetScriptSemanticCompletions(
             documentUri,
@@ -1069,6 +1310,11 @@ internal sealed class ViuLanguageService :
         => Uri.TryCreate(documentUri, UriKind.Absolute, out var uri) && uri.IsFile
             ? uri.LocalPath
             : documentUri;
+
+    private static bool IsCSharpScript(SingleFileComponentScriptBlock? script)
+        => script is not null &&
+           (script.Lang is null ||
+            string.Equals(script.Lang, "csharp", StringComparison.Ordinal));
 
     private IReadOnlyList<LanguageCompletionItem> GetSyntaxOnlyScriptCompletions(
         string linePrefix,

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageClassification.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageClassification.cs
@@ -1,0 +1,20 @@
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// One semantically classified authored span in a Viu single-file-component document.
+/// </summary>
+/// <param name="Range">
+/// The half-open authored range. Generated component scaffold spans are never returned.
+/// </param>
+/// <param name="ClassificationTypeName">
+/// The C# editor classification-type name, such as <c>property name</c> or
+/// <c>parameter name</c>.
+/// </param>
+/// <remarks>
+/// Classification names are editor-neutral strings so the language-server host can translate them
+/// to its protocol vocabulary without loading editor or Roslyn workspace assemblies into the host.
+/// [V01.01.12.07.11]
+/// </remarks>
+public readonly record struct LanguageClassification(
+    LanguageRange Range,
+    string ClassificationTypeName);

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageClassificationSnapshot.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageClassificationSnapshot.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Captures semantic classifications together with the exact open-document snapshot they describe.
+/// </summary>
+/// <param name="Version">
+/// The editor-supplied document version, or <see langword="null"/> when the client supplied none.
+/// </param>
+/// <param name="TextChecksum">
+/// The SHA-256 checksum of the UTF-8 document text. Hosts use it to reject a classification response
+/// after the editor has already advanced to a newer snapshot.
+/// </param>
+/// <param name="Classifications">
+/// The authored-position C# classifications, preserving the exact classification-type names used by
+/// the C# editor. [V01.01.12.07.11]
+/// </param>
+public sealed record LanguageClassificationSnapshot(
+    int? Version,
+    string TextChecksum,
+    IReadOnlyList<LanguageClassification> Classifications);

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageClassificationTypeNames.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageClassificationTypeNames.cs
@@ -1,0 +1,60 @@
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Classification-type names emitted for projected C# identifiers.
+/// </summary>
+/// <remarks>
+/// These are the classification names used by the C# editor. Keeping them in the host-neutral
+/// language-service contract lets a projected <c>@script</c> span carry the same semantic category
+/// as the identical token in a plain C# document. [V01.01.12.07.11]
+/// </remarks>
+public static class LanguageClassificationTypeNames
+{
+    /// <summary>A namespace name.</summary>
+    public const string NamespaceName = "namespace name";
+
+    /// <summary>A class name, including an attribute class name.</summary>
+    public const string ClassName = "class name";
+
+    /// <summary>A delegate type name.</summary>
+    public const string DelegateName = "delegate name";
+
+    /// <summary>An enum type name.</summary>
+    public const string EnumName = "enum name";
+
+    /// <summary>An interface type name.</summary>
+    public const string InterfaceName = "interface name";
+
+    /// <summary>A struct type name.</summary>
+    public const string StructName = "struct name";
+
+    /// <summary>A type-parameter name.</summary>
+    public const string TypeParameterName = "type parameter name";
+
+    /// <summary>A method or local-function name.</summary>
+    public const string MethodName = "method name";
+
+    /// <summary>A property name in either a declaration or a reference.</summary>
+    public const string PropertyName = "property name";
+
+    /// <summary>A field name.</summary>
+    public const string FieldName = "field name";
+
+    /// <summary>A constant name.</summary>
+    public const string ConstantName = "constant name";
+
+    /// <summary>An enum-member name.</summary>
+    public const string EnumMemberName = "enum member name";
+
+    /// <summary>An event name.</summary>
+    public const string EventName = "event name";
+
+    /// <summary>A parameter name in either a declaration or a reference.</summary>
+    public const string ParameterName = "parameter name";
+
+    /// <summary>A local or range-variable name in either a declaration or a reference.</summary>
+    public const string LocalName = "local name";
+
+    /// <summary>A label name.</summary>
+    public const string LabelName = "label name";
+}

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageCompletionItem.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageCompletionItem.cs
@@ -17,6 +17,11 @@ namespace Assimalign.Viu.LanguageService;
 /// The text the editor uses to filter the item, or <see langword="null"/> to filter by
 /// <paramref name="Label"/>.
 /// </param>
+/// <param name="ColorValue">
+/// The computed CSS color represented by this completion, or <see langword="null"/> when the item
+/// has no color presentation. The value is carried independently of documentation so language
+/// clients can render a swatch without parsing a Markdown code block. [V01.01.12.07.13]
+/// </param>
 public sealed record LanguageCompletionItem(
     string Label,
     LanguageCompletionItemKind Kind,
@@ -26,4 +31,5 @@ public sealed record LanguageCompletionItem(
     bool IsSnippet,
     string SortText,
     LanguageRange? EditRange = null,
-    string? FilterText = null);
+    string? FilterText = null,
+    string? ColorValue = null);

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageCompletionItemKind.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageCompletionItemKind.cs
@@ -42,4 +42,10 @@ public enum LanguageCompletionItemKind
 
     /// <summary>An editor snippet.</summary>
     Snippet = 15,
+
+    /// <summary>
+    /// A CSS color value. Its protocol-stable value is serialized without translation so clients
+    /// can apply their standard color presentation. [V01.01.12.07.13]
+    /// </summary>
+    Color = 16,
 }

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageDocumentPublication.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageDocumentPublication.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Assimalign.Viu.LanguageService;
+
+/// <summary>
+/// Captures every expensive semantic result published after one document synchronization round.
+/// The shared snapshot lets a host compute classifications and diagnostics from one immutable live
+/// document fork, then publish both without mixing document versions. [V01.01.12.07.11]
+/// [V01.01.12.07.15]
+/// </summary>
+/// <param name="ClassificationSnapshot">
+/// The versioned semantic classifications when the host requested them; otherwise,
+/// <see langword="null"/>.
+/// </param>
+/// <param name="Diagnostics">
+/// The parser, projection, C#, style, and component-contract diagnostics at authored positions.
+/// </param>
+public sealed record LanguageDocumentPublication(
+    LanguageClassificationSnapshot? ClassificationSnapshot,
+    IReadOnlyList<LanguageDiagnostic> Diagnostics);

--- a/tooling/Assimalign.Viu.LanguageService/src/LanguageProjectContext.cs
+++ b/tooling/Assimalign.Viu.LanguageService/src/LanguageProjectContext.cs
@@ -32,9 +32,9 @@ namespace Assimalign.Viu.LanguageService;
 /// editor compilation exactly as the build sees them.
 /// </param>
 /// <param name="CacheStamp">
-/// An opaque fingerprint of the restore artifacts and source cone. Two contexts with equal stamps
-/// are interchangeable, so the service can reuse any state derived from an earlier equal-stamped
-/// context.
+/// The host's opaque reuse hint for the restore artifacts and source cone. The service also compares
+/// sibling text and each reference assembly's path, length, and write time, so an output replaced in
+/// place invalidates derived state even when the host has not yet published a new stamp.
 /// </param>
 public sealed record LanguageProjectContext(
     string ProjectFilePath,

--- a/tooling/Assimalign.Viu.LanguageService/test/DiagnosticPublicationTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/DiagnosticPublicationTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins authored-position publication for template, projected C#, style, and component-usage
+/// diagnostics ([V01.01.12.07.15], #336).
+/// </summary>
+public sealed class DiagnosticPublicationTests
+{
+    [Fact]
+    public void GetDiagnostics_TemplateCompilerError_MapsIntoTemplateBlock()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div\n" +
+            "</template>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var diagnostic = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri)
+            .First(item => item.Code.StartsWith("VIU11", StringComparison.Ordinal));
+
+        diagnostic.Source.ShouldBe("viu");
+        diagnostic.Severity.ShouldBe(LanguageDiagnosticSeverity.Error);
+        diagnostic.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(2, 0),
+                new LanguagePosition(2, 0)));
+    }
+
+    [Fact]
+    public void GetDiagnostics_ProjectedScriptBindingError_MapsRoslynSpanIntoScriptBlock()
+    {
+        const string scriptLine = "    public int Count => MissingValue;";
+        var source = $"@script {{\n{scriptLine}\n}}\n";
+        var missingStart = scriptLine.IndexOf("MissingValue", StringComparison.Ordinal);
+        var service = CreateSemanticService(source);
+
+        var diagnostic = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri)
+            .Single(item => item.Code == "CS0103");
+
+        diagnostic.Source.ShouldBe("csharp");
+        diagnostic.Severity.ShouldBe(LanguageDiagnosticSeverity.Error);
+        diagnostic.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, missingStart),
+                new LanguagePosition(1, missingStart + "MissingValue".Length)));
+    }
+
+    [Theory]
+    [InlineData(
+        "VIU1204",
+        "Context",
+        "<template>\n" +
+        "    <div />\n" +
+        "</template>\n" +
+        "@script {\n" +
+        "    private object Context = new();\n" +
+        "}\n")]
+    [InlineData(
+        "VIU1205",
+        "SaveAsync",
+        "@script {\n" +
+        "    private async void SaveAsync()\n" +
+        "    {\n" +
+        "        await global::System.Threading.Tasks.Task.Yield();\n" +
+        "    }\n" +
+        "}\n")]
+    [InlineData(
+        "VIU1207",
+        "Title",
+        "<template><div /></template>\n" +
+        "@script {\n" +
+        "    public object Parameters { get; } = new();\n" +
+        "    [Parameter] public string Title { get; set; } = \"\";\n" +
+        "}\n")]
+    [InlineData(
+        "VIU1208",
+        "Heading",
+        "<template><div /></template>\n" +
+        "@script {\n" +
+        "    [Parameter] public string Title { get; set; } = \"\";\n" +
+        "    [Parameter(\"title\")] public string Heading { get; set; } = \"\";\n" +
+        "}\n")]
+    [InlineData(
+        "VIU1209",
+        "Title",
+        "<template><div /></template>\n" +
+        "@script {\n" +
+        "    [Parameter] public string Title => \"\";\n" +
+        "}\n")]
+    public void GetDiagnostics_ScriptProjectionRule_PublishesOnlyBuildRuleAtAuthoredMember(
+        string expectedCode,
+        string authoredMember,
+        string source)
+    {
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var scriptBandDiagnostics = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri)
+            .Where(item => item.Code.StartsWith("VIU12", StringComparison.Ordinal))
+            .ToArray();
+
+        var diagnostic = scriptBandDiagnostics.ShouldHaveSingleItem();
+        diagnostic.Code.ShouldBe(expectedCode);
+        diagnostic.Source.ShouldBe("viu");
+        diagnostic.Severity.ShouldBe(LanguageDiagnosticSeverity.Error);
+        diagnostic.Range.ShouldBe(GetAuthoredRange(source, authoredMember));
+    }
+
+    [Fact]
+    public void GetDiagnostics_StyleParserError_MapsIntoStyleBlock()
+    {
+        const string styleLine = ".card { color red; margin: 0; }";
+        var source = $"<style>\n{styleLine}\n</style>\n";
+        var errorStart = styleLine.IndexOf("color red", StringComparison.Ordinal);
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var diagnostic = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri)
+            .First(item => item.Code.StartsWith("VIU13", StringComparison.Ordinal));
+
+        diagnostic.Source.ShouldBe("viu");
+        diagnostic.Severity.ShouldBe(LanguageDiagnosticSeverity.Error);
+        diagnostic.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, errorStart),
+                new LanguagePosition(1, errorStart + "color red".Length)));
+    }
+
+    [Fact]
+    public void GetDiagnostics_UnresolvedComponent_MapsViu1404ToAuthoredTag()
+    {
+        const string templateLine = "  <MissingCard />";
+        var source = $"<template>\n{templateLine}\n</template>\n";
+        var tagStart = templateLine.IndexOf("MissingCard", StringComparison.Ordinal);
+        var service = CreateSemanticService(source);
+
+        var diagnostic = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri)
+            .Single(item => item.Code == "VIU1404");
+
+        diagnostic.Source.ShouldBe("viu");
+        diagnostic.Severity.ShouldBe(LanguageDiagnosticSeverity.Error);
+        diagnostic.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, tagStart),
+                new LanguagePosition(1, tagStart + "MissingCard".Length)));
+    }
+
+    [Fact]
+    public void GetDiagnostics_LooseFileComponent_DoesNotTreatEmptyCatalogAsAuthoritative()
+    {
+        const string source =
+            "<template>\n" +
+            "  <ProjectComponent />\n" +
+            "</template>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var diagnostics = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri);
+
+        diagnostics.ShouldNotContain(item => item.Code.StartsWith("VIU14", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetDiagnostics_UnresolvedProjectCatalog_DoesNotTreatSemanticMissAsEmptyCatalog()
+    {
+        const string source =
+            "<template>\n" +
+            "  <ProjectComponent />\n" +
+            "</template>\n";
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IScriptSemanticLanguageService>()
+            .ConfigureProjectContext(
+                ScriptSemanticFixture.DocumentUri,
+                new LanguageProjectContext(
+                    ScriptSemanticFixture.ProjectFilePath,
+                    ScriptSemanticFixture.ProjectDirectory,
+                    ScriptSemanticFixture.RootNamespace,
+                    ["C:/workspace/App/missing-reference.dll"],
+                    Array.Empty<LanguageProjectSourceDocument>(),
+                    Array.Empty<string>(),
+                    "unresolved"));
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var diagnostics = service.GetDiagnostics(ScriptSemanticFixture.DocumentUri);
+
+        diagnostics.ShouldNotContain(item => item.Code.StartsWith("VIU14", StringComparison.Ordinal));
+    }
+
+    private static ILanguageService CreateSemanticService(string source)
+    {
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IScriptSemanticLanguageService>()
+            .ConfigureProjectContext(
+                ScriptSemanticFixture.DocumentUri,
+                ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        return service;
+    }
+
+    private static LanguageRange GetAuthoredRange(string source, string authoredMember)
+    {
+        var offset = source.IndexOf(authoredMember, StringComparison.Ordinal);
+        offset.ShouldBeGreaterThanOrEqualTo(0);
+        var prefix = source.Substring(0, offset);
+        var line = prefix.Count(character => character == '\n');
+        var previousLineBreak = prefix.LastIndexOf('\n');
+        var character = offset - previousLineBreak - 1;
+        return new LanguageRange(
+            new LanguagePosition(line, character),
+            new LanguagePosition(line, character + authoredMember.Length));
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/HoverPublicationTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/HoverPublicationTests.cs
@@ -1,0 +1,213 @@
+using System;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins the editor-neutral hover surfaces published for every authored single-file-component block
+/// ([V01.01.12.07.16], #337). Host adapters transport these ranges and Markdown bodies unchanged.
+/// </summary>
+public sealed class HoverPublicationTests
+{
+    [Fact]
+    public void GetHover_ProjectedScriptSymbol_ReturnsRoslynSignatureAtAuthoredReference()
+    {
+        const string source =
+            "@script {\n" +
+            "    /// <summary>Number of authored items.</summary>\n" +
+            "    public int Count { get; } = 1;\n" +
+            "    public int Read() => Count;\n" +
+            "}\n";
+        const string reference = "Count";
+        var referenceStart = "    public int Read() => ".Length;
+        var service = CreateSemanticService(source);
+
+        var hover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(3, referenceStart + 2));
+
+        hover.ShouldNotBeNull();
+        hover!.Markdown.ShouldContain("int Count");
+        hover.Markdown.ShouldContain("Number of authored items.");
+        hover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(3, referenceStart),
+                new LanguagePosition(3, referenceStart + reference.Length)));
+    }
+
+    [Fact]
+    public void GetHover_ComponentTagParameterAndEvent_ReturnResolvedContract()
+    {
+        const string componentSource =
+            "<template><article></article></template>\n" +
+            "@script {\n" +
+            "    using Assimalign.Viu.Components;\n" +
+            "    [Parameter(IsRequired = true)]\n" +
+            "    public string Title { get; set; } = string.Empty;\n" +
+            "    [Event]\n" +
+            "    public partial void Selected(int identifier);\n" +
+            "}\n";
+        const string templateLine =
+            "  <FeatureCard title=\"Welcome\" @selected=\"Handle\" />";
+        var source =
+            $"<template>\n{templateLine}\n</template>\n" +
+            "@script {\n" +
+            "    public void Handle(int identifier) { }\n" +
+            "}\n";
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IScriptSemanticLanguageService>()
+            .ConfigureProjectContext(
+                ScriptSemanticFixture.DocumentUri,
+                ScriptSemanticFixture.CreateContext(
+                    new LanguageProjectSourceDocument(
+                        "C:/workspace/App/FeatureCard.viu",
+                        componentSource,
+                        IsComponent: true)));
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var tagStart = templateLine.IndexOf("FeatureCard", StringComparison.Ordinal);
+        var parameterStart = templateLine.IndexOf("title", StringComparison.Ordinal);
+        var eventStart = templateLine.IndexOf("selected", StringComparison.Ordinal);
+        var tagHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, tagStart + 2));
+        var parameterHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, parameterStart + 2));
+        var eventHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, eventStart + 2));
+
+        tagHover.ShouldNotBeNull();
+        tagHover!.Markdown.ShouldContain("resolves to component `FeatureCard`");
+        tagHover.Markdown.ShouldContain("`title`: `string Title`");
+        tagHover.Markdown.ShouldContain("`@selected`");
+        tagHover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, tagStart),
+                new LanguagePosition(1, tagStart + "FeatureCard".Length)));
+
+        parameterHover.ShouldNotBeNull();
+        parameterHover!.Markdown.ShouldContain("parameter on component `<FeatureCard>`");
+        parameterHover.Markdown.ShouldContain("Required.");
+        parameterHover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, parameterStart),
+                new LanguagePosition(1, parameterStart + "title".Length)));
+
+        eventHover.ShouldNotBeNull();
+        eventHover!.Markdown.ShouldContain("event on component `<FeatureCard>`");
+        eventHover.Markdown.ShouldContain("Selected(int identifier)");
+        eventHover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, eventStart),
+                new LanguagePosition(1, eventStart + "selected".Length)));
+    }
+
+    [Fact]
+    public void GetHover_NativeElementAndDirective_ReturnTemplateDocumentation()
+    {
+        const string templateLine = "  <section v-show=\"Visible\"></section>";
+        var source = $"<template>\n{templateLine}\n</template>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var elementStart = templateLine.IndexOf("section", StringComparison.Ordinal);
+        var directiveStart = templateLine.IndexOf("v-show", StringComparison.Ordinal);
+
+        var elementHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, elementStart + 2));
+        var directiveHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, directiveStart + 2));
+
+        elementHover.ShouldNotBeNull();
+        elementHover!.Markdown.ShouldContain("native HTML element");
+        elementHover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, elementStart),
+                new LanguagePosition(1, elementStart + "section".Length)));
+        directiveHover.ShouldNotBeNull();
+        directiveHover!.Markdown.ShouldContain("Toggles element visibility");
+        directiveHover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, directiveStart),
+                new LanguagePosition(1, directiveStart + "v-show".Length)));
+    }
+
+    [Fact]
+    public void GetHover_TemplateHtmlComment_ReturnsNoHoverForElementOrDirective()
+    {
+        const string templateLine = "  <!-- <button v-if=\"Legacy\"> -->";
+        var source = $"<template>\n{templateLine}\n</template>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var elementStart = templateLine.IndexOf("button", StringComparison.Ordinal);
+        var directiveStart = templateLine.IndexOf("v-if", StringComparison.Ordinal);
+
+        var elementHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, elementStart + 2));
+        var directiveHover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, directiveStart + 2));
+
+        elementHover.ShouldBeNull();
+        directiveHover.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetHover_UnresolvedUppercaseNativeCollision_DoesNotDescribeNativeElement()
+    {
+        const string templateLine = "  <Button></Button>";
+        var source = $"<template>\n{templateLine}\n</template>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var tagStart = templateLine.IndexOf("Button", StringComparison.Ordinal);
+
+        var hover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, tagStart + 2));
+
+        hover.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetHover_StyleBlockClassCollidingWithUtility_ReturnsAuthoredDeclarationAtTemplateToken()
+    {
+        const string templateLine = "  <div class=\"flex\"></div>";
+        const string declaration = ".flex { display: block; }";
+        var source =
+            $"<template>\n{templateLine}\n</template>\n" +
+            $"<style>\n{declaration}\n</style>\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var classStart = templateLine.IndexOf("flex", StringComparison.Ordinal);
+
+        var hover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            new LanguagePosition(1, classStart + 4));
+
+        hover.ShouldNotBeNull();
+        hover!.Markdown.ShouldContain("declared in this component's style block");
+        hover.Markdown.ShouldContain(declaration);
+        hover.Range.ShouldBe(
+            new LanguageRange(
+                new LanguagePosition(1, classStart),
+                new LanguagePosition(1, classStart + "flex".Length)));
+    }
+
+    private static ILanguageService CreateSemanticService(string source)
+    {
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IScriptSemanticLanguageService>()
+            .ConfigureProjectContext(
+                ScriptSemanticFixture.DocumentUri,
+                ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        return service;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptCommentCompletionTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptCommentCompletionTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins completion suppression inside C# comments in <c>@script</c>. Comment prose is never an
+/// expression or declaration position, regardless of whether project semantics are active.
+/// [V01.01.12.07.14]
+/// </summary>
+public class ScriptCommentCompletionTests
+{
+    public static IEnumerable<object[]> CommentPositions()
+    {
+        yield return ["    // Con", "// Con"];
+        yield return ["    /* Con */", "/* Con"];
+        yield return ["    /* first\n       Con\n    */", "Con\n"];
+    }
+
+    [Theory]
+    [MemberData(nameof(CommentPositions))]
+    public void GetCompletions_CursorInsideScriptComment_ReturnsNothing(
+        string comment,
+        string caretMarker)
+    {
+        var source =
+            "<template>\n  <div>x</div>\n</template>\n" +
+            "@script {\n" +
+            "public void Handle()\n" +
+            "{\n" +
+            comment + "\n" +
+            "}\n" +
+            "}\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var caretOffset = source.IndexOf(caretMarker, StringComparison.Ordinal) + caretMarker.Length;
+
+        var completions = service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            TextCoordinateConverter.GetPosition(source, caretOffset));
+
+        completions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetCompletions_AfterClosedScriptComment_StillOffersMemberCompletions()
+    {
+        const string source =
+            "<template>\n  <div>x</div>\n</template>\n" +
+            "@script {\n" +
+            "/* prose */\n" +
+            "Con\n" +
+            "}\n";
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        var caretOffset = source.IndexOf("Con\n", StringComparison.Ordinal) + "Con".Length;
+
+        var completions = service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            TextCoordinateConverter.GetPosition(source, caretOffset));
+
+        completions.ShouldContain(completion => completion.Label == "Context");
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptComponentContractTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptComponentContractTests.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins the compiler-backed component contract seam used by template completion and hover.
+/// </summary>
+public class ScriptComponentContractTests
+{
+    [Fact]
+    public void GetComponentContracts_SiblingSingleFileComponent_UsesProjectionDeclarations()
+    {
+        const string componentSource =
+            "<template>\n" +
+            "    <button>{{ Label }}</button>\n" +
+            "</template>\n" +
+            "@script {\n" +
+            "    [Parameter(IsRequired = true)]\n" +
+            "    public string Label { get; set; } = string.Empty;\n" +
+            "}\n";
+        var engine = new ScriptSemanticEngine();
+        var context = ScriptSemanticFixture.CreateContext(
+            new LanguageProjectSourceDocument(
+                "C:/workspace/App/Button.viu",
+                componentSource,
+                IsComponent: true));
+
+        var contracts = engine.GetComponentContracts(
+            context,
+            ScriptSemanticFixture.DocumentFilePath,
+            "<template>\n  <Button />\n</template>\n",
+            default);
+
+        contracts.ShouldNotBeNull();
+        var button = contracts!.Single(
+            declaration => declaration.CompilerDeclaration.Name == "Button");
+        var label = button.CompilerDeclaration.Parameters.Single();
+        label.Name.ShouldBe("label");
+        label.PropertyName.ShouldBe("Label");
+        label.TypeText.ShouldBe("string");
+        label.IsRequired.ShouldBeTrue();
+        button.CompilerDeclaration.IsParameterSurfaceKnown.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetComponentContracts_RepeatedReadsReuseAndSiblingOrReferenceChangeInvalidates()
+    {
+        const string alphaSource =
+            "<template><div /></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Alpha { get; set; } = string.Empty;\n" +
+            "}\n";
+        var sibling = new LanguageProjectSourceDocument(
+            "C:/workspace/App/Button.viu",
+            alphaSource,
+            IsComponent: true);
+        var engine = new ScriptSemanticEngine();
+        const string liveSource = "<template>\n  <Button />\n</template>\n";
+
+        var first = engine.GetComponentContracts(
+            ScriptSemanticFixture.CreateContext("stamp-1", sibling),
+            ScriptSemanticFixture.DocumentFilePath,
+            liveSource,
+            default);
+        var repeated = engine.GetComponentContracts(
+            ScriptSemanticFixture.CreateContext("stamp-1", sibling),
+            ScriptSemanticFixture.DocumentFilePath,
+            liveSource,
+            default);
+
+        first.ShouldNotBeNull();
+        repeated.ShouldNotBeNull();
+        engine.ComponentContractBuildCount.ShouldBe(1);
+
+        var betaSibling = sibling with
+        {
+            Text = alphaSource.Replace("Alpha", "Beta"),
+        };
+        var afterSiblingEdit = engine.GetComponentContracts(
+            ScriptSemanticFixture.CreateContext("stamp-2", betaSibling),
+            ScriptSemanticFixture.DocumentFilePath,
+            liveSource,
+            default);
+
+        afterSiblingEdit.ShouldNotBeNull();
+        afterSiblingEdit!
+            .Single(declaration => declaration.CompilerDeclaration.Name == "Button")
+            .CompilerDeclaration.Parameters
+            .ShouldContain(parameter => parameter.PropertyName == "Beta");
+        engine.ComponentContractBuildCount.ShouldBe(2);
+
+        var changedReferences = ScriptSemanticFixture.ReferenceAssemblyPaths()
+            .Concat([typeof(System.Text.Json.JsonDocument).Assembly.Location])
+            .ToArray();
+        var referenceChangedContext = new LanguageProjectContext(
+            ScriptSemanticFixture.ProjectFilePath,
+            ScriptSemanticFixture.ProjectDirectory,
+            ScriptSemanticFixture.RootNamespace,
+            changedReferences,
+            new List<LanguageProjectSourceDocument> { betaSibling },
+            ScriptSemanticFixture.PreprocessorSymbols,
+            "stamp-3");
+        engine.GetComponentContracts(
+                referenceChangedContext,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                default)
+            .ShouldNotBeNull();
+        engine.ComponentContractBuildCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GetComponentContracts_LiveDocumentEdit_ReusesStableProjectClosure()
+    {
+        const string siblingSource =
+            "<template><div /></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string SiblingValue { get; set; } = string.Empty;\n" +
+            "}\n";
+        const string liveAlphaSource =
+            "<template><Button />{{ Alpha }}</template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Alpha { get; set; } = string.Empty;\n" +
+            "}\n";
+        var liveBetaSource = liveAlphaSource.Replace("Alpha", "Beta");
+        var context = ScriptSemanticFixture.CreateContext(
+            "stable-context",
+            new LanguageProjectSourceDocument(
+                "C:/workspace/App/Button.viu",
+                siblingSource,
+                IsComponent: true));
+        var engine = new ScriptSemanticEngine();
+
+        var alphaContracts = engine.GetComponentContracts(
+            context,
+            ScriptSemanticFixture.DocumentFilePath,
+            liveAlphaSource,
+            default);
+        var betaContracts = engine.GetComponentContracts(
+            context,
+            ScriptSemanticFixture.DocumentFilePath,
+            liveBetaSource,
+            default);
+
+        alphaContracts.ShouldNotBeNull();
+        betaContracts.ShouldNotBeNull();
+        alphaContracts!
+            .Single(declaration => declaration.CompilerDeclaration.Name == "AppShell")
+            .CompilerDeclaration.Parameters
+            .ShouldContain(parameter => parameter.PropertyName == "Alpha");
+        betaContracts!
+            .Single(declaration => declaration.CompilerDeclaration.Name == "AppShell")
+            .CompilerDeclaration.Parameters
+            .ShouldContain(parameter => parameter.PropertyName == "Beta");
+        betaContracts
+            .Single(declaration => declaration.CompilerDeclaration.Name == "Button")
+            .CompilerDeclaration.Parameters
+            .ShouldContain(parameter => parameter.PropertyName == "SiblingValue");
+        engine.ProjectStateBuildCount.ShouldBe(1);
+        engine.ComponentContractBuildCount.ShouldBe(1);
+        engine.ComponentProjectionBuildCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GetComponentContracts_SameStampReferenceReplacement_InvalidatesStableProjectClosure()
+    {
+        var temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "viu-component-contract-cache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temporaryDirectory);
+        try
+        {
+            var referencePath = Path.Combine(temporaryDirectory, "Referenced.Components.dll");
+            WriteComponentReference(referencePath, "Alpha");
+            File.SetLastWriteTimeUtc(referencePath, DateTime.UtcNow.AddMinutes(-2));
+            var referencePaths = ScriptSemanticFixture.ReferenceAssemblyPaths()
+                .Concat([referencePath])
+                .ToArray();
+            var context = new LanguageProjectContext(
+                ScriptSemanticFixture.ProjectFilePath,
+                ScriptSemanticFixture.ProjectDirectory,
+                ScriptSemanticFixture.RootNamespace,
+                referencePaths,
+                Array.Empty<LanguageProjectSourceDocument>(),
+                ScriptSemanticFixture.PreprocessorSymbols,
+                "unchanged-stamp");
+            var engine = new ScriptSemanticEngine();
+            const string liveSource = "<template><ReferencedWidget /></template>\n";
+
+            var alphaContracts = engine.GetComponentContracts(
+                context,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                default);
+
+            WriteComponentReference(referencePath, "Beta");
+            File.SetLastWriteTimeUtc(referencePath, DateTime.UtcNow.AddMinutes(2));
+            var betaContracts = engine.GetComponentContracts(
+                context,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                default);
+
+            alphaContracts.ShouldNotBeNull();
+            betaContracts.ShouldNotBeNull();
+            alphaContracts!
+                .Single(declaration => declaration.CompilerDeclaration.Name == "ReferencedWidget")
+                .CompilerDeclaration.Parameters
+                .ShouldContain(parameter => parameter.PropertyName == "Alpha");
+            betaContracts!
+                .Single(declaration => declaration.CompilerDeclaration.Name == "ReferencedWidget")
+                .CompilerDeclaration.Parameters
+                .ShouldContain(parameter => parameter.PropertyName == "Beta");
+            engine.ProjectStateBuildCount.ShouldBe(2);
+            engine.ComponentContractBuildCount.ShouldBe(2);
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CloseDocument_ComponentContractCache_EvictsDocumentProjectState()
+    {
+        var engine = new ScriptSemanticEngine();
+        var context = ScriptSemanticFixture.CreateContext("close-eviction");
+        const string liveSource = "<template><div /></template>\n";
+
+        engine.GetComponentContracts(
+                context,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                default)
+            .ShouldNotBeNull();
+        engine.ProjectStateBuildCount.ShouldBe(1);
+        engine.ComponentContractBuildCount.ShouldBe(1);
+
+        engine.CloseDocument(ScriptSemanticFixture.DocumentUri);
+        using var staleRequestCancellation = new CancellationTokenSource();
+        staleRequestCancellation.Cancel();
+
+        Should.Throw<OperationCanceledException>(
+            () => engine.GetComponentContracts(
+                context,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                staleRequestCancellation.Token));
+        engine.ProjectStateBuildCount.ShouldBe(1);
+        engine.ComponentContractBuildCount.ShouldBe(1);
+
+        engine.GetComponentContracts(
+                context,
+                ScriptSemanticFixture.DocumentFilePath,
+                liveSource,
+                default)
+            .ShouldNotBeNull();
+
+        engine.ProjectStateBuildCount.ShouldBe(2);
+        engine.ComponentContractBuildCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetHover_CanceledAfterClose_DoesNotPopulateSemanticCacheAndReopenBuildsFreshState()
+    {
+        const string siblingSource =
+            "<template><button>{{ Label }}</button></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Label { get; set; } = string.Empty;\n" +
+            "}\n";
+        const string liveSource = "<template><Button></Button></template>\n";
+        var context = ScriptSemanticFixture.CreateContext(
+            "close-race-cache",
+            new LanguageProjectSourceDocument(
+                "C:/workspace/App/Button.viu",
+                siblingSource,
+                IsComponent: true));
+        var service = (ViuLanguageService)LanguageServices.Create();
+        service.ConfigureProjectContext(ScriptSemanticFixture.DocumentUri, context);
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, liveSource, 1);
+        var hoverPosition = TextCoordinateConverter.GetPosition(
+            liveSource,
+            liveSource.IndexOf("Button", StringComparison.Ordinal) + 1);
+
+        service.CloseDocument(ScriptSemanticFixture.DocumentUri).ShouldBeTrue();
+        using var staleRequestCancellation = new CancellationTokenSource();
+        staleRequestCancellation.Cancel();
+
+        Should.Throw<OperationCanceledException>(
+            () => service.GetHover(
+                ScriptSemanticFixture.DocumentUri,
+                hoverPosition,
+                staleRequestCancellation.Token));
+        service.ProjectStateBuildCount.ShouldBe(0);
+        service.ComponentContractBuildCount.ShouldBe(0);
+
+        service.ConfigureProjectContext(ScriptSemanticFixture.DocumentUri, context);
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, liveSource, 2);
+
+        service.GetHover(ScriptSemanticFixture.DocumentUri, hoverPosition).ShouldNotBeNull();
+        service.ProjectStateBuildCount.ShouldBe(1);
+        service.ComponentContractBuildCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void CompletionThenHover_IdenticalDocumentAndContext_ShareComponentContractCache()
+    {
+        const string siblingSource =
+            "<template><button>{{ Label }}</button></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Label { get; set; } = string.Empty;\n" +
+            "}\n";
+        const string liveSource = "<template><Button :la></Button></template>\n";
+        const string completionMarker = "<Button :la";
+        var service = (ViuLanguageService)LanguageServices.Create();
+        service.ConfigureProjectContext(
+            ScriptSemanticFixture.DocumentUri,
+            ScriptSemanticFixture.CreateContext(
+                "shared-feature-cache",
+                new LanguageProjectSourceDocument(
+                    "C:/workspace/App/Button.viu",
+                    siblingSource,
+                    IsComponent: true)));
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, liveSource, 1);
+        var completionOffset = liveSource.IndexOf(
+            completionMarker,
+            StringComparison.Ordinal) + completionMarker.Length;
+        var hoverOffset = liveSource.IndexOf("Button", StringComparison.Ordinal) + 1;
+
+        var completions = service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            TextCoordinateConverter.GetPosition(liveSource, completionOffset));
+
+        completions.ShouldContain(completion => completion.Label == ":label");
+        service.ComponentContractBuildCount.ShouldBe(1);
+        service.ComponentProjectionBuildCount.ShouldBe(2);
+
+        var hover = service.GetHover(
+            ScriptSemanticFixture.DocumentUri,
+            TextCoordinateConverter.GetPosition(liveSource, hoverOffset));
+
+        hover.ShouldNotBeNull();
+        service.ComponentContractBuildCount.ShouldBe(1);
+        service.ComponentProjectionBuildCount.ShouldBe(2);
+    }
+
+    private static void WriteComponentReference(string filePath, string propertyName)
+    {
+        var source =
+            "using Assimalign.Viu.Components;\n" +
+            "\n" +
+            "public sealed class ReferencedWidget : IComponent\n" +
+            "{\n" +
+            "    [Parameter]\n" +
+            $"    public string {propertyName} {{ get; set; }} = string.Empty;\n" +
+            "\n" +
+            "    public ComponentRenderer Setup(ComponentContext context)\n" +
+            "        => throw new System.NotSupportedException();\n" +
+            "}\n";
+        var compilation = CSharpCompilation.Create(
+            "Referenced.Components",
+            [CSharpSyntaxTree.ParseText(source)],
+            ScriptSemanticFixture.ReferenceAssemblyPaths()
+                .Select(path => MetadataReference.CreateFromFile(path)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(
+                string.Join(Environment.NewLine, emitResult.Diagnostics));
+        }
+
+        File.WriteAllBytes(filePath, stream.ToArray());
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptInterpolatedStringCompletionTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptInterpolatedStringCompletionTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins completion gating across the literal and expression segments of interpolated strings.
+/// Literal prose remains suppressed, while every interpolation hole is ordinary C# code even when
+/// strings and further interpolation holes are nested inside it. [V01.01.12.07.14]
+/// </summary>
+public class ScriptInterpolatedStringCompletionTests
+{
+    private const string CaretMarker = "[|]";
+
+    [Fact]
+    public void GetCompletions_CursorInsideInterpolatedStringText_ReturnsNothing()
+    {
+        var completions = GetCompletions(
+            "public string Message => $\"Literal Con[|] {Context}\";");
+
+        completions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetCompletions_CursorInsideInterpolationHole_OffersExpressionCompletions()
+    {
+        var completions = GetCompletions(
+            "public string Message => $\"Literal {Con[|]}\";");
+
+        completions.ShouldContain(completion => completion.Label == "Context");
+    }
+
+    [Fact]
+    public void GetCompletions_CursorInsideStringNestedInInterpolationHole_ReturnsNothing()
+    {
+        var completions = GetCompletions(
+            "public string Message => $\"Outer {string.Concat(\"Con[|]\")}\";");
+
+        completions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetCompletions_CursorInsideNestedInterpolationHole_OffersExpressionCompletions()
+    {
+        var completions = GetCompletions(
+            "public string Message => $\"Outer {string.Concat($\"Inner {Con[|]}\")}\";");
+
+        completions.ShouldContain(completion => completion.Label == "Context");
+    }
+
+    [Theory]
+    [InlineData("@$")]
+    [InlineData("$@")]
+    public void GetCompletions_VerbatimInterpolatedHoleAfterDoubledQuote_OffersExpressionCompletions(
+        string prefix)
+    {
+        var completions = GetCompletions(
+            $"public string Message => {prefix}\"C:\\data\\ \"\"quoted\"\" {{Con[|]}}\";");
+
+        completions.ShouldContain(completion => completion.Label == "Context");
+    }
+
+    [Theory]
+    [InlineData("@$")]
+    [InlineData("$@")]
+    public void GetCompletions_VerbatimInterpolatedTextAfterDoubledQuote_ReturnsNothing(
+        string prefix)
+    {
+        var completions = GetCompletions(
+            $"public string Message => {prefix}\"Literal \"\"quoted\"\" Con[|] {{Context}}\";");
+
+        completions.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("@$")]
+    [InlineData("$@")]
+    public void GetCompletions_AfterClosedVerbatimInterpolatedString_OffersExpressionCompletions(
+        string prefix)
+    {
+        var completions = GetCompletions(
+            $"public string Message => {prefix}\"C:\\data\\\" + Con[|];");
+
+        completions.ShouldContain(completion => completion.Label == "Context");
+    }
+
+    private static IReadOnlyList<LanguageCompletionItem> GetCompletions(
+        string memberWithCaret)
+    {
+        var markedSource =
+            "<template>\n  <div>x</div>\n</template>\n" +
+            "@script {\n" +
+            memberWithCaret + "\n" +
+            "}\n";
+        var caretOffset = markedSource.IndexOf(CaretMarker, StringComparison.Ordinal);
+        caretOffset.ShouldBeGreaterThanOrEqualTo(0);
+        var source = markedSource.Remove(caretOffset, CaretMarker.Length);
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        return service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            TextCoordinateConverter.GetPosition(source, caretOffset));
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticClassificationTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticClassificationTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins projected <c>@script</c> identifier classifications against the identical plain-C# syntax
+/// bound by the same references. Each reported W5.7 construct must carry the same C# editor
+/// classification-type name on both sides of the projection. [V01.01.12.07.11]
+/// </summary>
+public class ScriptSemanticClassificationTests
+{
+    private const string VueDocumentUri = "file:///C:/workspace/App/AppShell.vue";
+
+    private const string ScriptBody =
+        "using Assimalign.Viu.Components;\n" +
+        "[Parameter(IsRequired = true)]\n" +
+        "public string Title { get; set; } = string.Empty;\n" +
+        "private void Navigate(string path)\n" +
+        "{\n" +
+        "    var local = Title + path;\n" +
+        "    Title = local;\n" +
+        "}\n";
+
+    private const string ComponentSource =
+        "<template>\n" +
+        "  <div>{{ Title }}</div>\n" +
+        "</template>\n" +
+        "@script {\n" +
+        ScriptBody +
+        "}\n";
+
+    private static readonly string PlainSource =
+        ScriptBody[.."using Assimalign.Viu.Components;\n".Length] +
+        "public sealed class PlainComponent\n" +
+        "{\n" +
+        ScriptBody["using Assimalign.Viu.Components;\n".Length..] +
+        "}\n";
+
+    public static IEnumerable<object[]> ReportedConstructs()
+    {
+        yield return Case("using Assimalign", "Assimalign", LanguageClassificationTypeNames.NamespaceName);
+        yield return Case("[Parameter(", "Parameter", LanguageClassificationTypeNames.ClassName);
+        yield return Case("IsRequired =", "IsRequired", LanguageClassificationTypeNames.PropertyName);
+        yield return Case("Title { get", "Title", LanguageClassificationTypeNames.PropertyName);
+        yield return Case("Empty;", "Empty", LanguageClassificationTypeNames.FieldName);
+        yield return Case("string path)", "path", LanguageClassificationTypeNames.ParameterName);
+        yield return Case("Title + path", "Title", LanguageClassificationTypeNames.PropertyName);
+        yield return Case("Title + path", "path", LanguageClassificationTypeNames.ParameterName);
+        yield return Case("var local =", "local", LanguageClassificationTypeNames.LocalName);
+        yield return Case("Title = local", "local", LanguageClassificationTypeNames.LocalName);
+    }
+
+    [Theory]
+    [MemberData(nameof(ReportedConstructs))]
+    public void GetClassifications_ProjectedConstruct_MatchesPlainCSharpBaseline(
+        string marker,
+        string token,
+        string expectedClassificationTypeName)
+    {
+        var service = LanguageServices.Create();
+        ((IScriptSemanticLanguageService)service).ConfigureProjectContext(
+            ScriptSemanticFixture.DocumentUri,
+            ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, ComponentSource, 1);
+
+        var projected = service.GetClassifications(ScriptSemanticFixture.DocumentUri);
+        var projectedStart = FindTokenStart(ComponentSource, marker, token);
+        var projectedTypeName = FindAuthoredClassification(
+            ComponentSource,
+            projected,
+            projectedStart);
+        var plainTypeName = FindPlainClassification(PlainSource, marker, token);
+
+        plainTypeName.ShouldBe(expectedClassificationTypeName);
+        projectedTypeName.ShouldBe(plainTypeName);
+    }
+
+    [Fact]
+    public void GetClassifications_GeneratedScaffold_IsNeverReturnedAtAuthoredPositions()
+    {
+        var service = LanguageServices.Create();
+        ((IScriptSemanticLanguageService)service).ConfigureProjectContext(
+            ScriptSemanticFixture.DocumentUri,
+            ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, ComponentSource, 1);
+
+        var classifications = service.GetClassifications(ScriptSemanticFixture.DocumentUri);
+
+        classifications.ShouldAllBe(classification =>
+            classification.Range.Start.Line >= 4 && classification.Range.Start.Line <= 11);
+    }
+
+    [Fact]
+    public void GetClassifications_VueScriptSetupOnly_ClassifiesAuthoredCSharp()
+    {
+        const string source =
+            "<script setup lang=\"csharp\">\n" +
+            "public int Count { get; set; }\n" +
+            "</script>\n";
+        var service = LanguageServices.Create();
+        ((IScriptSemanticLanguageService)service).ConfigureProjectContext(
+            VueDocumentUri,
+            ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(VueDocumentUri, source, 1);
+
+        var classifications = service.GetClassifications(VueDocumentUri);
+        var countStart = source.IndexOf("Count", StringComparison.Ordinal);
+
+        FindAuthoredClassification(source, classifications, countStart)
+            .ShouldBe(LanguageClassificationTypeNames.PropertyName);
+    }
+
+    [Fact]
+    public void GetClassificationSnapshot_DocumentChange_PublishesMatchingVersionTextAndExactNames()
+    {
+        var service = LanguageServices.Create();
+        ((IScriptSemanticLanguageService)service).ConfigureProjectContext(
+            ScriptSemanticFixture.DocumentUri,
+            ScriptSemanticFixture.CreateContext());
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, ComponentSource, 1);
+
+        LanguageClassificationSnapshot? first =
+            service.GetClassificationSnapshot(ScriptSemanticFixture.DocumentUri);
+        const string updatedSource =
+            "@script {\n" +
+            "public string Name { get; set; } = string.Empty;\n" +
+            "}\n";
+        service.ChangeDocument(
+                ScriptSemanticFixture.DocumentUri,
+                2,
+                [new LanguageDocumentChange(null, updatedSource)])
+            .ShouldBeTrue();
+        LanguageClassificationSnapshot? second =
+            service.GetClassificationSnapshot(ScriptSemanticFixture.DocumentUri);
+
+        first.ShouldNotBeNull();
+        first.Version.ShouldBe(1);
+        first.TextChecksum.ShouldBe(LanguageTextChecksum.Compute(ComponentSource));
+        first.Classifications.ShouldContain(classification =>
+            classification.ClassificationTypeName == LanguageClassificationTypeNames.PropertyName);
+        second.ShouldNotBeNull();
+        second.Version.ShouldBe(2);
+        second.TextChecksum.ShouldBe(LanguageTextChecksum.Compute(updatedSource));
+        second.TextChecksum.ShouldNotBe(first.TextChecksum);
+        second.Classifications.ShouldContain(classification =>
+            classification.ClassificationTypeName == LanguageClassificationTypeNames.PropertyName);
+    }
+
+    [Fact]
+    public void LanguageTextChecksum_KnownText_UsesUtf8Sha256TransportIdentity()
+    {
+        LanguageTextChecksum.Compute("Viu\n")
+            .ShouldBe("cky5hMd4dzR9iJUWww+rP9qM9jfQl0FUB90suepnndI=");
+    }
+
+    private static object[] Case(string marker, string token, string expected)
+        => [marker, token, expected];
+
+    private static string FindAuthoredClassification(
+        string source,
+        IReadOnlyList<LanguageClassification> classifications,
+        int tokenStart)
+    {
+        return classifications.Single(classification =>
+        {
+            TextCoordinateConverter.TryGetOffset(
+                    source,
+                    classification.Range.Start,
+                    out var classificationStart)
+                .ShouldBeTrue();
+            return classificationStart == tokenStart;
+        }).ClassificationTypeName;
+    }
+
+    private static string FindPlainClassification(
+        string source,
+        string marker,
+        string token)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Preview));
+        var references = ScriptSemanticFixture.ReferenceAssemblyPaths()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "PlainClassificationBaseline",
+            [tree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var classifications = ScriptSemanticClassifier.Classify(
+            compilation.GetSemanticModel(tree),
+            tree.GetRoot(),
+            CancellationToken.None);
+        var tokenStart = FindTokenStart(source, marker, token);
+        return classifications.Single(classification => classification.Span.Start == tokenStart)
+            .ClassificationTypeName;
+    }
+
+    private static int FindTokenStart(string source, string marker, string token)
+    {
+        var markerStart = source.IndexOf(marker, StringComparison.Ordinal);
+        markerStart.ShouldBeGreaterThanOrEqualTo(0);
+        var tokenStart = source.IndexOf(token, markerStart, marker.Length, StringComparison.Ordinal);
+        tokenStart.ShouldBeGreaterThanOrEqualTo(markerStart);
+        return tokenStart;
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticEngineTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticEngineTests.cs
@@ -349,6 +349,69 @@ public class ScriptSemanticEngineTests
     }
 
     [Fact]
+    public void GetPublicationSemantics_AllLayersShareOneLiveDocumentFork()
+    {
+        const string siblingSource =
+            "<template><button>{{ Label }}</button></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Label { get; set; } = string.Empty;\n" +
+            "}\n";
+        var sibling = new LanguageProjectSourceDocument(
+            "C:\\workspace\\App\\Button.viu",
+            siblingSource,
+            IsComponent: true);
+        var engine = new ScriptSemanticEngine();
+
+        var publication = engine.GetPublicationSemantics(
+            ScriptSemanticFixture.CreateContext(sibling),
+            DocumentFilePath,
+            ComponentSource,
+            includeClassifications: true,
+            includeDiagnostics: true,
+            includeComponentContracts: true,
+            CancellationToken.None);
+
+        publication.ShouldNotBeNull();
+        publication!.Classifications.ShouldNotBeEmpty();
+        publication.ComponentContracts.ShouldNotBeNull();
+        publication.ComponentContracts!.ShouldContain(
+            declaration => declaration.CompilerDeclaration.Name == "Button");
+        engine.LiveDocumentRequestBuildCount.ShouldBe(1);
+        engine.ComponentContractBuildCount.ShouldBe(1);
+        engine.ComponentProjectionBuildCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetDocumentPublication_ProjectionDiagnosticsReuseSemanticLiveProjection()
+    {
+        const string siblingSource =
+            "<template><button>{{ Label }}</button></template>\n" +
+            "@script {\n" +
+            "    [Parameter]\n" +
+            "    public string Label { get; set; } = string.Empty;\n" +
+            "}\n";
+        var sibling = new LanguageProjectSourceDocument(
+            "C:\\workspace\\App\\Button.viu",
+            siblingSource,
+            IsComponent: true);
+        var service = (ViuLanguageService)LanguageServices.Create();
+        service.OpenDocument(DocumentUri, ComponentSource, 1);
+        service.ConfigureProjectContext(
+            DocumentUri,
+            ScriptSemanticFixture.CreateContext(sibling));
+
+        var publication = service.GetDocumentPublication(
+            DocumentUri,
+            includeSemanticClassifications: true,
+            CancellationToken.None);
+
+        publication.ClassificationSnapshot.ShouldNotBeNull();
+        publication.ClassificationSnapshot!.Classifications.ShouldNotBeEmpty();
+        service.ComponentProjectionBuildCount.ShouldBe(2);
+    }
+
+    [Fact]
     public void GetCompletions_UnreadableReferencePath_ReturnsNullMiss()
     {
         var engine = new ScriptSemanticEngine();

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticFixture.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptSemanticFixture.cs
@@ -32,10 +32,21 @@ internal static class ScriptSemanticFixture
         string cacheStamp,
         IReadOnlyList<string> preprocessorSymbols,
         params LanguageProjectSourceDocument[] sourceDocuments)
+        => CreateContext(
+            cacheStamp,
+            RootNamespace,
+            preprocessorSymbols,
+            sourceDocuments);
+
+    internal static LanguageProjectContext CreateContext(
+        string cacheStamp,
+        string rootNamespace,
+        IReadOnlyList<string> preprocessorSymbols,
+        params LanguageProjectSourceDocument[] sourceDocuments)
         => new(
             ProjectFilePath,
             ProjectDirectory,
-            RootNamespace,
+            rootNamespace,
             ReferenceAssemblyPaths(),
             sourceDocuments,
             preprocessorSymbols,

--- a/tooling/Assimalign.Viu.LanguageService/test/ScriptUsingDirectiveCompletionTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/ScriptUsingDirectiveCompletionTests.cs
@@ -74,6 +74,44 @@ public class ScriptUsingDirectiveCompletionTests
     }
 
     [Fact]
+    public void GetCompletions_RootNamespaceSharesReferencedNamespace_PreservesAggregateNamespaceAndTypes()
+    {
+        // The W5.7 regression's real cause was not a missing framework reference: the generated
+        // component's own `Assimalign.*` namespace added one unmapped scaffold location to Roslyn's
+        // aggregate Assimalign namespace symbol, and the scaffold filter discarded the whole symbol
+        // including its referenced Components declarations.
+        var context = ScriptSemanticFixture.CreateContext(
+            "assimalign-root",
+            "Assimalign.Viu.Examples.Showcase",
+            ScriptSemanticFixture.PreprocessorSymbols);
+        var service = CreateService(ComponentSource, context);
+
+        var completions = service.GetCompletions(DocumentUri, UsingDirectivePosition());
+
+        completions.ShouldContain(completion =>
+            completion.Label == "Assimalign" &&
+            completion.Kind == LanguageCompletionItemKind.Module);
+
+        const string referencedTypeSource =
+            "<template>\n  <div>x</div>\n</template>\n" +
+            "@script {\n" +
+            "using Assimalign.Viu.Components.\n" +
+            "}\n";
+        var referencedTypeService = CreateService(referencedTypeSource, context);
+
+        var referencedTypeCompletions = referencedTypeService.GetCompletions(
+            DocumentUri,
+            PositionAfter(referencedTypeSource, "using Assimalign.Viu.Components."));
+
+        referencedTypeCompletions.ShouldContain(completion =>
+            completion.Label == "ParameterAttribute" &&
+            completion.Kind == LanguageCompletionItemKind.Class);
+        referencedTypeCompletions.ShouldContain(completion =>
+            completion.Label == "IComponent" &&
+            completion.Kind == LanguageCompletionItemKind.Class);
+    }
+
+    [Fact]
     public void GetCompletions_UsingDirectiveWithActiveContext_SortsNamespacesAboveTypes()
     {
         var service = CreateService(ComponentSource, ScriptSemanticFixture.CreateContext());

--- a/tooling/Assimalign.Viu.LanguageService/test/StyleClassAndColorCompletionTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/StyleClassAndColorCompletionTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins component-style selector merging and utility color payloads
+/// ([V01.01.12.07.13], #334).
+/// </summary>
+public class StyleClassAndColorCompletionTests
+{
+    private const string DocumentUri = "file:///C:/workspace/App/Card.viu";
+
+    [Fact]
+    public void GetCompletions_ClassAttribute_MergesStyleSelectorsAndUtilities()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div class=\"ga\"></div>\n" +
+            "</template>\n" +
+            "<style scoped>\n" +
+            "  .gallery, .gap-local:hover { display: grid; }\n" +
+            "  @media (width >= 40rem) { .gallery-wide { gap: 1rem; } }\n" +
+            "</style>\n";
+
+        var completions = CompleteAfter(source, "class=\"ga");
+
+        completions.ShouldContain(
+            item => item.Label == "gallery" &&
+                    item.Detail == "Component style class");
+        completions.ShouldContain(item => item.Label == "gallery-wide");
+        completions.ShouldContain(item => item.Label == "gap-local");
+        completions.ShouldContain(
+            item => item.Label == "gap-4" &&
+                    item.Detail == "Viu utility class");
+    }
+
+    [Fact]
+    public void GetCompletions_StyleSelectorCollidesWithUtility_UsesComponentSelectorOnce()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div class=\"gap-4\"></div>\n" +
+            "</template>\n" +
+            "<style>\n" +
+            "  .gap-4 { gap: 2rem; }\n" +
+            "</style>\n";
+
+        var completions = CompleteAfter(source, "class=\"gap-4");
+        var collision = completions.Where(item => item.Label == "gap-4").ToArray();
+
+        collision.Length.ShouldBe(1);
+        collision[0].Detail.ShouldBe("Component style class");
+    }
+
+    [Fact]
+    public void GetCompletions_ColorUtility_CarriesComputedThemeColor()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div class=\"bg-blue-\"></div>\n" +
+            "</template>\n";
+
+        var completion = CompleteAfter(source, "bg-blue-")
+            .Single(item => item.Label == "bg-blue-500");
+
+        completion.Kind.ShouldBe(LanguageCompletionItemKind.Color);
+        completion.ColorValue.ShouldBe("oklch(62.3% 0.214 259.815)");
+    }
+
+    [Fact]
+    public void GetCompletions_NonColorUtility_HasNoColorPayload()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div class=\"gap-\"></div>\n" +
+            "</template>\n";
+
+        var completion = CompleteAfter(source, "gap-")
+            .Single(item => item.Label == "gap-4");
+
+        completion.ColorValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetCompletions_ProjectThemeColor_CarriesAuthoredComputedValue()
+    {
+        const string source =
+            "<template>\n" +
+            "  <div class=\"bg-brand\"></div>\n" +
+            "</template>\n";
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IUtilityCssLanguageService>()
+            .ConfigureUtilityStylesheet(
+                DocumentUri,
+                "@theme { --color-brand: #123456; }");
+        service.OpenDocument(DocumentUri, source, 1);
+
+        var completion = service.GetCompletions(
+                DocumentUri,
+                PositionAfter(source, "bg-brand"))
+            .Single(item => item.Label == "bg-brand");
+
+        completion.ColorValue.ShouldBe("#123456");
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<LanguageCompletionItem> CompleteAfter(
+        string source,
+        string marker)
+    {
+        var service = LanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+        return service.GetCompletions(DocumentUri, PositionAfter(source, marker));
+    }
+
+    private static LanguagePosition PositionAfter(string source, string marker)
+    {
+        var markerOffset = source.IndexOf(marker, StringComparison.Ordinal);
+        markerOffset.ShouldBeGreaterThanOrEqualTo(0);
+        return TextCoordinateConverter.GetPosition(source, markerOffset + marker.Length);
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/TemplateContractCompletionTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/TemplateContractCompletionTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Assimalign.Viu.LanguageService.Tests;
+
+/// <summary>
+/// Pins template vocabulary and contract completion ([V01.01.12.07.12], #333), including the
+/// [SFC-CG-8] authored-case precedence shared with [SFC-USE-5] identity resolution.
+/// </summary>
+public class TemplateContractCompletionTests
+{
+    private const string ButtonComponentSource =
+        "<template>\n" +
+        "  <button>{{ Label }}</button>\n" +
+        "</template>\n" +
+        "@script {\n" +
+        "    using Assimalign.Viu.Components;\n" +
+        "\n" +
+        "    [Parameter(IsRequired = true)]\n" +
+        "    public string Label { get; set; } = string.Empty;\n" +
+        "\n" +
+        "    [Event]\n" +
+        "    public partial void Submitted(string value);\n" +
+        "}\n";
+
+    [Fact]
+    public void GetCompletions_DirectiveName_OffersSupportedDirectiveVocabulary()
+    {
+        const string source = "<template>\n  <div v-></div>\n</template>\n";
+        var completions = CompleteAfter(source, "<div v-");
+
+        completions.ShouldContain(item => item.Label == "v-if");
+        completions.ShouldContain(item => item.Label == "v-for");
+        completions.ShouldContain(item => item.Label == "v-model");
+    }
+
+    [Fact]
+    public void GetCompletions_NativeEventName_OffersEventVocabulary()
+    {
+        const string source = "<template>\n  <button @key></button>\n</template>\n";
+        var completions = CompleteAfter(source, "<button @key");
+
+        completions.ShouldContain(item => item.Label == "@keydown");
+        completions.ShouldContain(item => item.Label == "@keyup");
+    }
+
+    [Fact]
+    public void GetCompletions_UnresolvedLowercaseStaticTag_ReturnsNoNativeEvents()
+    {
+        const string source =
+            "<template>\n  <feature-card @key></feature-card>\n</template>\n";
+
+        CompleteAfter(source, "<feature-card @key").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetCompletions_LowercaseNativeButton_OffersNativeAttributes()
+    {
+        const string source = "<template>\n  <button :ty></button>\n</template>\n";
+        var completions = CompleteAfter(source, "<button :ty");
+
+        completions.ShouldContain(item => item.Label == ":type");
+        completions.ShouldNotContain(item => item.Label == ":label");
+    }
+
+    [Fact]
+    public void GetCompletions_PascalCaseButtonCollision_OffersComponentParametersNotNativeAttributes()
+    {
+        const string source = "<template>\n  <Button :></Button>\n</template>\n";
+        var service = CreateServiceWithButtonComponent();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var completions = service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            PositionAfter(source, "<Button :"));
+
+        var label = completions.Single(item => item.Label == ":label");
+        label.Detail.ShouldBe("string component parameter");
+        label.Documentation.ShouldContain("required");
+        completions.ShouldNotContain(item => item.Label == ":type");
+        completions.ShouldNotContain(item => item.Label == ":disabled");
+    }
+
+    [Fact]
+    public void GetCompletions_ComponentEventName_OffersDeclaredEventSnippet()
+    {
+        const string source = "<template>\n  <Button @sub></Button>\n</template>\n";
+        var service = CreateServiceWithButtonComponent();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+
+        var completion = service.GetCompletions(
+                ScriptSemanticFixture.DocumentUri,
+                PositionAfter(source, "<Button @sub"))
+            .Single(item => item.Label == "@submitted");
+
+        completion.Kind.ShouldBe(LanguageCompletionItemKind.Snippet);
+        completion.IsSnippet.ShouldBeTrue();
+        completion.InsertText.ShouldBe("@submitted=\"$1\"");
+        completion.Detail.ShouldContain("Submitted(string value)");
+    }
+
+    [Fact]
+    public void GetCompletions_TemplateHtmlComment_ReturnsNoCompletions()
+    {
+        const string source =
+            "<template>\n" +
+            "  <!-- <div class=\"gap-\" v-if=\"Visible\"></div> -->\n" +
+            "</template>\n";
+
+        CompleteAfter(source, "gap-").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetCompletions_StyleCssComment_ReturnsNoCompletions()
+    {
+        const string source =
+            "<style>\n" +
+            "  /* dis */\n" +
+            "</style>\n";
+
+        CompleteAfter(source, "dis").ShouldBeEmpty();
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<LanguageCompletionItem> CompleteAfter(
+        string source,
+        string marker)
+    {
+        var service = LanguageServices.Create();
+        service.OpenDocument(ScriptSemanticFixture.DocumentUri, source, 1);
+        return service.GetCompletions(
+            ScriptSemanticFixture.DocumentUri,
+            PositionAfter(source, marker));
+    }
+
+    private static ILanguageService CreateServiceWithButtonComponent()
+    {
+        var service = LanguageServices.Create();
+        service.ShouldBeAssignableTo<IScriptSemanticLanguageService>()
+            .ConfigureProjectContext(
+                ScriptSemanticFixture.DocumentUri,
+                ScriptSemanticFixture.CreateContext(
+                    new LanguageProjectSourceDocument(
+                        "C:/workspace/App/Button.viu",
+                        ButtonComponentSource,
+                        IsComponent: true)));
+        return service;
+    }
+
+    private static LanguagePosition PositionAfter(string source, string marker)
+    {
+        var markerOffset = source.IndexOf(marker, StringComparison.Ordinal);
+        markerOffset.ShouldBeGreaterThanOrEqualTo(0);
+        return TextCoordinateConverter.GetPosition(source, markerOffset + marker.Length);
+    }
+}

--- a/tooling/Assimalign.Viu.LanguageService/test/TemplateExpressionContextTests.cs
+++ b/tooling/Assimalign.Viu.LanguageService/test/TemplateExpressionContextTests.cs
@@ -9,9 +9,9 @@ namespace Assimalign.Viu.LanguageService.Tests;
 
 /// <summary>
 /// Pins the completion context model for template markup. Utility completion activates only in static
-/// class attributes and literal class-binding strings (docs/UTILITY-CSS-DESIGN.md section 10); every
-/// other attribute value holds a C# expression this service cannot complete, and answering one with
-/// markup-name completions puts attribute names inside an attribute value.
+/// class attributes and literal class-binding strings (docs/UTILITY-CSS-DESIGN.md section 10).
+/// [V01.01.12.07.12] adds deliberately bounded C# completion for handler values and interpolations;
+/// every other expression value stays suppressed so markup names cannot leak into it.
 /// </summary>
 public class TemplateExpressionContextTests
 {
@@ -30,8 +30,27 @@ public class TemplateExpressionContextTests
     }
 
     [Fact]
-    public void GetCompletions_EventHandlerExpression_ReturnsNoCompletions()
-        => CompleteAfter("    <button @click=\"Increment\"></button>", "Incre").ShouldBeEmpty();
+    public void GetCompletions_EventHandlerExpression_OffersMethodsAndLambdaSnippetsOnly()
+    {
+        var completions = CompleteAfterWithScript(
+            "    <button @click=\"Increment\"></button>",
+            "Incre",
+            "public int Count { get; set; }\npublic void Increment() { }");
+
+        completions.ShouldContain(
+            item => item.Label == "Increment" &&
+                    item.Kind == LanguageCompletionItemKind.Method);
+        var eventLambda = completions.Single(item => item.Label == "$event lambda");
+        eventLambda.Kind.ShouldBe(LanguageCompletionItemKind.Snippet);
+        eventLambda.IsSnippet.ShouldBeTrue();
+        eventLambda.InsertText.ShouldBe("\\$event => $1");
+        var asynchronousEventLambda = completions.Single(
+            item => item.Label == "async $event lambda");
+        asynchronousEventLambda.Kind.ShouldBe(LanguageCompletionItemKind.Snippet);
+        asynchronousEventLambda.IsSnippet.ShouldBeTrue();
+        asynchronousEventLambda.InsertText.ShouldBe("async \\$event => $1");
+        completions.ShouldNotContain(item => item.Label == "Count");
+    }
 
     [Fact]
     public void GetCompletions_DirectiveExpression_ReturnsNoCompletions()
@@ -42,8 +61,17 @@ public class TemplateExpressionContextTests
         => CompleteAfter("    <div title=\"see :class\"></div>", "see :cl").ShouldBeEmpty();
 
     [Fact]
-    public void GetCompletions_TemplateInterpolation_ReturnsNoCompletions()
-        => CompleteAfter("    <p>{{ Count }}</p>", "{{ Cou").ShouldBeEmpty();
+    public void GetCompletions_TemplateInterpolation_OffersScriptMembers()
+    {
+        var completions = CompleteAfterWithScript(
+            "    <p>{{ Count }}</p>",
+            "{{ Cou",
+            "public int Count { get; set; }\npublic void Increment() { }");
+
+        completions.ShouldContain(
+            item => item.Label == "Count" &&
+                    item.Kind == LanguageCompletionItemKind.Property);
+    }
 
     [Fact]
     public void GetCompletions_StaticClassAttribute_StillOffersUtilityCandidates()
@@ -84,6 +112,22 @@ public class TemplateExpressionContextTests
         string typedPrefix)
     {
         var source = $"<template>\n{templateLine}\n</template>\n";
+        var caret = templateLine.IndexOf(typedPrefix, StringComparison.Ordinal) + typedPrefix.Length;
+        caret.ShouldBeGreaterThan(typedPrefix.Length - 1, "the probe text must occur in the line");
+
+        var service = LanguageServices.Create();
+        service.OpenDocument(DocumentUri, source, 1);
+        return service.GetCompletions(DocumentUri, new LanguagePosition(1, caret));
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<LanguageCompletionItem> CompleteAfterWithScript(
+        string templateLine,
+        string typedPrefix,
+        string scriptBody)
+    {
+        var source =
+            $"<template>\n{templateLine}\n</template>\n" +
+            $"@script {{\n{scriptBody}\n}}\n";
         var caret = templateLine.IndexOf(typedPrefix, StringComparison.Ordinal) + typedPrefix.Length;
         caret.ShouldBeGreaterThan(typedPrefix.Length - 1, "the probe text must occur in the line");
 

--- a/tooling/Assimalign.Viu.Syntax.Templates/src/CompilerDomKnowledge.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/src/CompilerDomKnowledge.cs
@@ -23,6 +23,12 @@ public static class CompilerDomKnowledge
     private static readonly HashSet<string> KnownSvgAttributeSet = Build(DomKnowledgeData.KnownSvgAttributes, StringComparer.Ordinal);
     private static readonly HashSet<string> KnownMathMlAttributeSet =
         Build(DomKnowledgeData.KnownMathMlAttributes, StringComparer.Ordinal);
+    private static readonly IReadOnlyList<string> KnownHtmlAttributes =
+        new List<string>(KnownHtmlAttributeSet).AsReadOnly();
+    private static readonly IReadOnlyList<string> KnownSvgAttributes =
+        new List<string>(KnownSvgAttributeSet).AsReadOnly();
+    private static readonly IReadOnlyList<string> KnownMathMlAttributes =
+        new List<string>(KnownMathMlAttributeSet).AsReadOnly();
 
     /// <summary>Whether <paramref name="tag"/> is a known HTML element.</summary>
     /// <param name="tag">The tag name (matched case-insensitively).</param>
@@ -48,9 +54,25 @@ public static class CompilerDomKnowledge
     /// <param name="attributeName">The attribute name (matched case-sensitively).</param>
     public static bool IsKnownHtmlAttribute(string attributeName) => KnownHtmlAttributeSet.Contains(attributeName);
 
+    /// <summary>
+    /// Enumerates the known HTML attributes from the shared DOM table. The order is unspecified;
+    /// consumers that present the names sort them for their own surface. Exposing the shared table
+    /// keeps template binding completion aligned with compiler classification [V01.01.12.07.12].
+    /// </summary>
+    /// <returns>Every known HTML attribute exactly once.</returns>
+    public static IEnumerable<string> EnumerateKnownHtmlAttributes() => KnownHtmlAttributes;
+
     /// <summary>Whether <paramref name="attributeName"/> is a known SVG attribute.</summary>
     /// <param name="attributeName">The attribute name (matched case-sensitively).</param>
     public static bool IsKnownSvgAttribute(string attributeName) => KnownSvgAttributeSet.Contains(attributeName);
+
+    /// <summary>
+    /// Enumerates the known SVG attributes from the shared DOM table. The order is unspecified;
+    /// consumers that present the names sort them for their own surface. Exposing the shared table
+    /// keeps template binding completion aligned with compiler classification [V01.01.12.07.12].
+    /// </summary>
+    /// <returns>Every known SVG attribute exactly once.</returns>
+    public static IEnumerable<string> EnumerateKnownSvgAttributes() => KnownSvgAttributes;
 
     /// <summary>
     /// Returns whether <paramref name="attributeName"/> belongs to Viu's bounded MathML Core attribute table.
@@ -66,6 +88,15 @@ public static class CompilerDomKnowledge
     /// [V01.01.05.10].
     /// </remarks>
     public static bool IsKnownMathMlAttribute(string attributeName) => KnownMathMlAttributeSet.Contains(attributeName);
+
+    /// <summary>
+    /// Enumerates the bounded MathML Core attributes from the shared DOM table. The order is
+    /// unspecified; consumers that present the names sort them for their own surface. Exposing the
+    /// shared table keeps template binding completion aligned with compiler classification
+    /// [V01.01.12.07.12].
+    /// </summary>
+    /// <returns>Every bounded MathML Core attribute exactly once.</returns>
+    public static IEnumerable<string> EnumerateKnownMathMlAttributes() => KnownMathMlAttributes;
 
     private static HashSet<string> Build(string list, StringComparer comparer)
     {

--- a/tooling/Assimalign.Viu.Syntax.Templates/test/CompilerDomKnowledgeTests.cs
+++ b/tooling/Assimalign.Viu.Syntax.Templates/test/CompilerDomKnowledgeTests.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+
+using Shouldly;
+
+using Xunit;
+
+using Assimalign.Viu.Syntax.Templates;
+
+namespace Assimalign.Viu.Syntax.Templates.Tests;
+
+/// <summary>
+/// Pins the shared DOM-table enumeration used by native binding completion
+/// ([V01.01.12.07.12], #333).
+/// </summary>
+public class CompilerDomKnowledgeTests
+{
+    [Fact]
+    public void EnumerateKnownHtmlAttributes_ReturnsUniquePredicateAcceptedNames()
+    {
+        var attributes = CompilerDomKnowledge.EnumerateKnownHtmlAttributes().ToArray();
+
+        attributes.ShouldContain("type");
+        attributes.ShouldContain("disabled");
+        attributes.Distinct().Count().ShouldBe(attributes.Length);
+        attributes.ShouldAllBe(attribute => CompilerDomKnowledge.IsKnownHtmlAttribute(attribute));
+    }
+
+    [Fact]
+    public void EnumerateKnownSvgAttributes_ReturnsUniquePredicateAcceptedNames()
+    {
+        var attributes = CompilerDomKnowledge.EnumerateKnownSvgAttributes().ToArray();
+
+        attributes.ShouldContain("viewBox");
+        attributes.ShouldContain("fill");
+        attributes.Distinct().Count().ShouldBe(attributes.Length);
+        attributes.ShouldAllBe(attribute => CompilerDomKnowledge.IsKnownSvgAttribute(attribute));
+    }
+
+    [Fact]
+    public void EnumerateKnownMathMlAttributes_ReturnsUniquePredicateAcceptedNames()
+    {
+        var attributes = CompilerDomKnowledge.EnumerateKnownMathMlAttributes().ToArray();
+
+        attributes.ShouldContain("displaystyle");
+        attributes.ShouldContain("mathcolor");
+        attributes.Distinct().Count().ShouldBe(attributes.Length);
+        attributes.ShouldAllBe(attribute => CompilerDomKnowledge.IsKnownMathMlAttribute(attribute));
+    }
+}


### PR DESCRIPTION
Seventh and final train of the stacked W05 delivery (base: the W5.6 runtime-inspection branch, #331). Implements the six work items distilled from the user's live editor-testing notes (`extensions/VisualStudio/EDITOR-ENHANCEMENTS.md`, screenshots under `assets/`).

## What this delivers

### `@script` classification parity — `[V01.01.12.07.11]`
Authored semantic classifications carrying the exact Visual Studio C# classification names (attributes, properties and references, using-directive namespaces, parameters, locals, initializers) over a versioned, checksummed custom LSP notification; checksum-mismatched or missing data keeps the lexical fallback; standard LSP semantic tokens remain for ordinary clients.

### Template IntelliSense — `[V01.01.12.07.12]`
Handler positions complete eligible script methods and lambda snippets; directive, resolved-component event/parameter, native event/attribute, and interpolation member completion; component-vs-native precedence follows the compiler contract pinned by `[SFC-CG-8]`/`[SFC-USE-5]` — `<Button` completes the component's parameters, not `<button>` attributes.

### Style classes + color swatches — `[V01.01.12.07.13]`
Class completion merges the component's own `<style>` selectors with the utility catalog; color utilities carry concrete color values through completion data, rendered by a delegating VS Async Completion item-manager wrapper (UI-thread image registration; only uniquely matched color items change icons).

### Completion regressions — `[V01.01.12.07.14]`
`Assimalign.*` completion restored — root cause: the scaffold filter saw one generated declaration on the *aggregate* namespace symbol and filtered the entire namespace, taking every referenced `Assimalign.*` symbol with it; namespaces are now exempt while generated members stay filtered, pinned by a packaged-reference regression. Completion is suppressed in comments (all three blocks) and string literals, while interpolated-string holes — including both `@$`/`$@` verbatim forms — keep completion active.

### Diagnostics squiggles — `[V01.01.12.07.15]`
Authored-position publication of parser/template/style diagnostics, catalog-gated VIU14xx usage diagnostics, script-band projection rules (VIU1204/1205/1207–1209 — previously the editor showed a clean file that failed the build), and mapped Roslyn C# diagnostics with build-matching severities.

### Hover — `[V01.01.12.07.16]`
Mapped Roslyn quick-info in `@script`; component contracts, native element/directive documentation, utility emitted-CSS previews, local style declarations with local precedence; comment spans never document as live markup.

## Editor responsiveness (review hardening)
An adversarially-verified review confirmed nine findings, all fixed with fail-first regressions. The substantial ones: `didChange` publication now debounces and runs off the protocol loop with per-document cancellation (a keystroke burst previously queued 3+ full Roslyn passes per edit *inline*, stalling completion and `$/cancelRequest`); one shared live projection feeds classification, contracts, and diagnostics; stable project state is cached with sibling/reference invalidation (a burst now costs one build: debounce calls `[1]` then `[1,4]` pinned). Plus interpolation-hole completion, verbatim-interpolated lexing, comment hover, a missing `using`, VS package-pin floors for the new `Shell.Framework` reference, and a nullable middle-layer signature.

## Verification
- `dotnet build Assimalign.Viu.slnx -warnaserror`: 0/0. Full suite: **2,970 passed, 0 failed** (LanguageService 211/211, LanguageServer 73/73, VisualStudio 215/215).
- **VSIX pipeline builds clean** (13 entries) — run unsandboxed after fixing the package floors.
- Pack-Release 17+12; template matrix 8/8; interop 9/9 (`+0`); publish size unchanged (9.0% headroom); E2E Chromium 3/3 **and Firefox 3/3** (the environmental Playwright driver failure was fixed with a forced reinstall).

## Needs live-IDE confirmation (cannot be automated here)
1. Theme classification rendering for the five reported constructs (light + dark).
2. Completion trigger behavior and `$event` snippet expansion in the completion UI.
3. Swatch colors, alpha treatment, and candidate alignment.
4. Squiggles/Error List ranges refreshing after edits.
5. Quick Info rendering and ranges across blocks.

Closes #332
Closes #333
Closes #334
Closes #335
Closes #336
Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)