### PR TITLE
chore(build): bump the central version to 10.0.0-beta.26

### DIFF
--- a/build/Targets/Build.Version.props
+++ b/build/Targets/Build.Version.props
@@ -10,7 +10,7 @@
             semver is welcome) while the numeric core feeds AssemblyVersion /
             FileVersion (where the C# compiler enforces numeric-only via CS7034).
         -->
-        <ViuPatchVersion>0-alpha.1</ViuPatchVersion>
+        <ViuPatchVersion>0-beta.26</ViuPatchVersion>
 
         <!-- Numeric core. Suitable for AssemblyVersion / FileVersion. -->
         <_ViuPatchCore>$(ViuPatchVersion.Split('-')[0])</_ViuPatchCore>


### PR DESCRIPTION
Unblocks consuming the W05 work from the GitHub Packages feed.

## Why

`main` declared `10.0.0-alpha.1`. The feed already carries `10.0.0-alpha.1`, `beta.23`, `beta.24`, and `beta.25` (all published 2026-08-11), so `main` could neither publish (`alpha.1` is taken) nor supersede the feed (`alpha.1` ranks below `beta.25` in SemVer). Consumers resolving newest therefore got `beta.25` — which was built **before** the W05 merges:

- `Assimalign.Viu.Browser.Router` beta.25 contains only `ApplicationRouterExtensions` and `RouterLinkDomBridge`; `BrowserRouterHistory` is absent.
- In beta.25 that type is still in the `Assimalign.Viu.Router` assembly/namespace — the pre-#331 layout, before the history move to the Browser.Router leaf.
- `Assimalign.Viu.DevTools` is absent from the feed entirely, and beta.25's `Core` has no `RuntimeInspection`/`RuntimeExecution`/`ComponentRenderOperation` — all added in #331.

The user-visible symptom: `BrowserRouterHistory.CreateWebHash()` does not resolve in a feed-consuming app, even though the call is correct against `main`.

## Verification at `10.0.0-beta.26`

- `scripts/Install-Local.ps1` packs **17 packages**, including `Assimalign.Viu.DevTools`.
- `Assimalign.Viu.Browser.Router.10.0.0-beta.26` carries `Assimalign.Viu.Browser.Router.BrowserRouterHistory` with `InitializeAsync`, `CreateWeb`, and `CreateWebHash` (assembly metadata inspected directly).
- `scripts/Test-EndToEnd.ps1 -PublishOnly` builds and trim-publishes the packaged-consumer `EndToEndBrowserApp` fixture — which calls `BrowserRouterHistory.CreateWebHash()` across the package boundary through an isolated NuGet configuration with no project references — green, with the Release publish confirmed free of hot-reload metadata and development transport.

## Follow-up (not in this PR)

`beta.23`–`beta.25` were published today from a tree that is not `main`, which means they bypassed `release.yml` (tag == `ViuVersion`, publish only from a published GitHub Release). Publishing this version should go through that path: tag `v10.0.0-beta.26` and cut a Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)