### PR TITLE
fix(packaging): stop the .vue consumer gate failing after every check passes

### DIFF
--- a/scripts/Test-PackagedVueConsumer.ps1
+++ b/scripts/Test-PackagedVueConsumer.ps1
@@ -184,6 +184,12 @@ function Invoke-DotNetExpectFailure {
         throw "Expected dotnet to fail: dotnet $($Arguments -join ' ')"
     }
 
+    # The non-zero code is the asserted result and is fully consumed here, so clear it. The
+    # shadow-diagnostic build is the script's last native command; leaving $LASTEXITCODE at 1
+    # made the GitHub Actions pwsh shell -- which exits with $LASTEXITCODE when the variable is
+    # set -- fail the step after every check had passed. Failures are signalled by throw.
+    $global:LASTEXITCODE = 0
+
     return $output -join [System.Environment]::NewLine
 }
 


### PR DESCRIPTION
The Packaging workflow has failed on every run since 07:34 today (last green 07:30), including on an unrelated version-bump branch. It is not flaky and it is not the version bump — it is a swallowed exit code.

## Root cause

`Invoke-DotNetExpectFailure` in `scripts/Test-PackagedVueConsumer.ps1` asserts that a `dotnet build` **fails** (it verifies the `VIU1004` `.viu`-over-`.vue` shadow diagnostic and the `VIU1201` mapping). It captures and checks the output, but leaves `$LASTEXITCODE` at that expected non-zero value.

That shadow-diagnostic build is the script's **last native command**. The GitHub Actions `pwsh` shell exits the step with `$LASTEXITCODE` when the variable is set, so the step failed roughly 70 ms after printing:

> `Packaged .vue consumer passed compile, source-map, diagnostic, shadow, and base-package asset checks.`

Everything the gate actually validates was passing. The three steps queued behind it — standalone utility dependency boundary, utility artifact shapes, and package shapes — were skipped for the same reason.

## Fix

Clear the expected code where it is asserted and fully consumed. Real failures continue to surface by `throw`, which terminates the script and fails the step as before.

## Verification

Reproduced under the runner's exit semantics (`. script; if ((Test-Path -LiteralPath variable:/LASTEXITCODE)) { exit $LASTEXITCODE }`):

| | before | after |
| --- | --- | --- |
| All script checks | pass | pass |
| `INNER-LASTEXITCODE` | **1** | **0** |
| Step exit | **1** | **0** |

The two previously skipped utility steps were also run locally against the packed feed — `Viu Utilities independence validation passed.` and `Viu Utilities artifact-shape validation passed.` — and neither leaves a stray exit code, so the job should now complete green through `Assert package shapes`.

Relates to `[V01.01.06.09.01]` (#253), which introduced the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)